### PR TITLE
E2e for MiniLM-L6-H384-uncased-sst2

### DIFF
--- a/build_tools/torchscript_e2e_heavydep_tests/main.py
+++ b/build_tools/torchscript_e2e_heavydep_tests/main.py
@@ -14,7 +14,7 @@ from torch_mlir_e2e_test.torchscript.framework import SerializableTest, generate
 from torch_mlir_e2e_test.torchscript.annotations import extract_serializable_annotations
 
 from . import basic_mt
-from . import bert_seq_classification
+from . import minilm_sequence_classification
 
 
 def _get_argparse():


### PR DESCRIPTION
Replace the original BertSequenceClassification with this new one.
The ops needed to support are identical.