### PR TITLE
add i64 support to refbackend

### DIFF
--- a/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -36,11 +36,18 @@ class RefBackendInvoker:
         self.result = None
 
         @ctypes.CFUNCTYPE(None, ctypes.POINTER(UnrankedMemRefDescriptor))
-        def consume_return(a):
+        def consume_i64_return(a):
+            self.result = unranked_memref_to_numpy(a, np.int64)
+
+        @ctypes.CFUNCTYPE(None, ctypes.POINTER(UnrankedMemRefDescriptor))
+        def consume_f32_return(a):
             self.result = unranked_memref_to_numpy(a, np.float32)
 
-        self.ee.register_runtime("refbackend_consume_func_return",
-                                 consume_return)
+        self.ee.register_runtime("refbackend_consume_int64_func_return",
+                                 consume_i64_return)
+
+        self.ee.register_runtime("refbackend_consume_float32_func_return",
+                                 consume_f32_return)
 
     def __getattr__(self, function_name: str):
         def invoke(*args):

--- a/test/RefBackend/munge-calling-conventions.mlir
+++ b/test/RefBackend/munge-calling-conventions.mlir
@@ -1,11 +1,23 @@
-// RUN: torch-mlir-opt %s -refback-munge-calling-conventions | FileCheck %s
+// RUN: torch-mlir-opt %s -refback-munge-calling-conventions -split-input-file | FileCheck %s
 
 // CHECK-LABEL:   func @f(
 // CHECK-SAME:            %[[ARG0:.*]]: memref<*xf32>) attributes {llvm.emit_c_interface} {
 // CHECK:           %[[VAL:.*]] = memref.cast %[[ARG0]] : memref<*xf32> to memref<?xf32>
 // CHECK:           %[[RESULT:.*]] = memref.cast %[[VAL]] : memref<?xf32> to memref<*xf32>
-// CHECK:           call @refbackend_consume_func_return(%[[RESULT]]) : (memref<*xf32>) -> ()
+// CHECK:           call @refbackend_consume_float32_func_return(%[[RESULT]]) : (memref<*xf32>) -> ()
 // CHECK:           return
 func @f(%arg0: memref<?xf32>) -> memref<?xf32> {
   return %arg0 : memref<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   func @i(
+// CHECK-SAME:            %[[ARG0:.*]]: memref<*xi64>) attributes {llvm.emit_c_interface} {
+// CHECK:           %[[VAL:.*]] = memref.cast %[[ARG0]] : memref<*xi64> to memref<?xi64>
+// CHECK:           %[[RESULT:.*]] = memref.cast %[[VAL]] : memref<?xi64> to memref<*xi64>
+// CHECK:           call @refbackend_consume_int64_func_return(%[[RESULT]]) : (memref<*xi64>) -> ()
+// CHECK:           return
+func @i(%arg0: memref<?xi64>) -> memref<?xi64> {
+  return %arg0 : memref<?xi64>
 }


### PR DESCRIPTION
I'm concerned that both of the following show up regardless of the functions return type:
func private @refbackend_consume_int64_func_return(memref<*xi64>) attributes {llvm.emit_c_interface}
func private @refbackend_consume_float32_func_return(memref<*xf32>) attributes {llvm.emit_c_interface}



Please don't hesitate with criticisms, definitely out of my "elementType" here = )

