### PR TITLE
add diagnostic and dump for refbackend pass

### DIFF
--- a/python/torch_mlir_e2e_test/torchscript/configs/linalg_on_tensors_backend.py
+++ b/python/torch_mlir_e2e_test/torchscript/configs/linalg_on_tensors_backend.py
@@ -120,28 +120,7 @@ $ torch-mlir-opt -{pipeline_str} {filename}
         finally:
             sys.stderr = sys.__stderr__
 
-        try:
-            sys.stderr = StringIO()
-            asm_for_error_report = mb.module.operation.get_asm(
-                large_elements_limit=10, enable_debug_info=True)
-            return self.backend.compile(mb.module)
-        except Exception as e:
-            filename = os.path.join(tempfile.gettempdir(),
-                                    scripted.original_name + '.mlir')
-            with open(filename, 'w') as f:
-                f.write(asm_for_error_report)
-            raise Exception(f"""
-torch-mlir linalg-on-tensors Backend lowering for {self.backend.__class__.__name__} failed with the following diagnostics:
-## Exception:
-{e}
-
-## Stderr:
-{sys.stderr.getvalue()}
-
-## Input IR has been saved in {filename}
-""") from None
-        finally:
-            sys.stderr = sys.__stderr__
+        return self.backend.compile(mb.module, scripted.original_name)
 
 
     def run(self, artifact: Any, trace: Trace) -> Trace:


### PR DESCRIPTION
I don't know if using the md5sum to generate a unique* name for the mlir dump is appropriate. If anyone has an alternate suggestion I'm open to it. I could replace every instance of compile(module) with compile(module, scripted.original_name) but that seems tedious for an end user.

The string replacements to generate the flag equivalents for the pass doesn't seem very robust either. Is this a case where we should define a pass pipeline instead? 

Example diagnostic:
FAIL - "ElementwiseSigmoidModule_basic"
    Compilation error:
    linalg-on-tensors backend IR -> backend specific compiled artifact object failed with the following diagnostics:
    ## Exception:
    invalid pass pipeline 'tensor-constant-bufferize,builtin.func(scf-bufferize),builtin.func(linalg-bufferize),builtin.func(std-bufferize),builtin.func(tensor-bufferize),func-bufferize,builtin.func(finalizing-bufferize),refback-munge-calling-conventions,builtin.func(convert-linalg-to-loops),builtin.func(lower-affine),builtin.func(convert-scf-to-std),builtin.func(refback-expand-ops-for-llvm),builtin.func(convert-math-to-llvm),convert-memref-to-llvm,bogus-pass,convert-std-to-llvm,reconcile-unrealized-casts'.

    ## Stderr:


    Error can be reproduced with:
    $ torch-mlir-opt -tensor-constant-bufferize -scf-bufferize -linalg-bufferize -std-bufferize -tensor-bufferize -func-bufferize -finalizing-bufferize -refback-munge-calling-conventions -convert-linalg-to-loops -lower-affine -convert-scf-to-std -refback-expand-ops-for-llvm -convert-math-to-llvm -convert-memref-to-llvm -bogus-pass -convert-std-to-llvm -reconcile-unrealized-casts /tmp/ElementwiseSigmoidModule.mlir