### PR TITLE
Bring some more order to the e2e error reporting situation.

### DIFF
--- a/python/torch_mlir_e2e_test/linalg_on_tensors_backends/abc.py
+++ b/python/torch_mlir_e2e_test/linalg_on_tensors_backends/abc.py
@@ -23,6 +23,9 @@ Invoker = TypeVar('Invoker')
 
 class LinalgOnTensorsBackend(abc.ABC):
     """The interface to an linalg-on-tensors backend.
+
+    Backends are recommended to raise meaningful exceptions in case of error,
+    ideally with easy reproduction instructions.
     """
     @abc.abstractmethod
     def compile(self, module: Module) -> CompiledArtifact:

--- a/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -14,6 +14,8 @@ from torch_mlir.runtime import *
 import torch_mlir.all_passes_registration
 import torch_mlir.dialects.torch
 
+from torch_mlir_e2e_test.utils import run_pipeline_with_repro_report
+
 from .abc import LinalgOnTensorsBackend
 
 __all__ = [
@@ -113,9 +115,10 @@ class RefBackendLinalgOnTensorsBackend(LinalgOnTensorsBackend):
           An opaque, backend specific compiled artifact object that can be
           passed to `load`.
         """
-        with imported_module.context:
-            pm = PassManager.parse(LOWERING_PIPELINE)
-            pm.run(imported_module)
+
+        run_pipeline_with_repro_report(
+            imported_module, LOWERING_PIPELINE,
+            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend")
         return imported_module
 
     def load(self, module) -> RefBackendInvoker:

--- a/python/torch_mlir_e2e_test/torchscript/configs/linalg_on_tensors_backend.py
+++ b/python/torch_mlir_e2e_test/torchscript/configs/linalg_on_tensors_backend.py
@@ -14,11 +14,11 @@ import torch
 
 from torch_mlir_e2e_test.linalg_on_tensors_backends.abc import LinalgOnTensorsBackend
 from torch_mlir_e2e_test.torchscript.framework import TestConfig, Trace, TraceItem
+from torch_mlir_e2e_test.utils import run_pipeline_with_repro_report
 from .utils import (
     recursively_convert_to_numpy,
     recursively_convert_from_numpy,
     convert_torchscript_module_to_torch_backend_contract_mlir,
-    run_pipeline_with_repro_report
 )
 
 
@@ -40,31 +40,10 @@ class LinalgOnTensorsBackendTestConfig(TestConfig):
         run_pipeline_with_repro_report(
             module,
             "torch-backend-to-linalg-on-tensors-backend-pipeline",
-            "Lower Torch Backend IR -> Linalg-on-Tensors Backend IR",
-            program.__class__.__name__)
+            "Lower Torch Backend IR -> Linalg-on-Tensors Backend IR")
 
-        try:
-            sys.stderr = StringIO()
-            asm_for_error_report = module.operation.get_asm(
-                large_elements_limit=10, enable_debug_info=True)
-            return self.backend.compile(module)
-        except Exception as e:
-            filename = os.path.join(tempfile.gettempdir(),
-                                    program.__class__.__name__ + ".mlir")
-            with open(filename, 'w') as f:
-                f.write(asm_for_error_report)
-            raise Exception(f"""
-Linalg-on-Tensors Backend lowering for {self.backend.__class__.__name__} failed with the following diagnostics:
-## Exception:
-{e}
+        return self.backend.compile(module)
 
-## Stderr:
-{sys.stderr.getvalue()}
-
-## Input IR has been saved in {filename}
-""") from None
-        finally:
-            sys.stderr = sys.__stderr__
 
 
     def run(self, artifact: Any, trace: Trace) -> Trace:

--- a/python/torch_mlir_e2e_test/tosa_backends/abc.py
+++ b/python/torch_mlir_e2e_test/tosa_backends/abc.py
@@ -23,6 +23,9 @@ Invoker = TypeVar('Invoker')
 
 class TosaBackend(abc.ABC):
     """The interface to an TOSA backend.
+
+    Backends are recommended to raise meaningful exceptions in case of error,
+    ideally with easy reproduction instructions.
     """
     @abc.abstractmethod
     def compile(self, module: Module) -> CompiledArtifact:

--- a/python/torch_mlir_e2e_test/tosa_backends/linalg_on_tensors.py
+++ b/python/torch_mlir_e2e_test/tosa_backends/linalg_on_tensors.py
@@ -8,6 +8,7 @@ from torch_mlir.passmanager import *
 # Imported for side effects.
 import torch_mlir.all_passes_registration
 
+from torch_mlir_e2e_test.utils import run_pipeline_with_repro_report
 from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import RefBackendLinalgOnTensorsBackend
 
 from .abc import TosaBackend
@@ -35,12 +36,11 @@ class LinalgOnTensorsTosaBackend(TosaBackend):
           An opaque, backend specific compiled artifact object that can be
           passed to `load`.
         """
-        # TODO: Error/repro reporting.
-        # We should store the program name as the symbol name of the MLIR
-        # module so we don't have to have access to the original program for it.
-        with imported_module.context:
-            pm = PassManager.parse("builtin.func(tosa-to-linalg-on-tensors)")
-            pm.run(imported_module)
+
+        run_pipeline_with_repro_report(
+            imported_module,
+            "builtin.func(tosa-to-linalg-on-tensors)",
+            "Lowering TOSA to Linalg-on-Tensors")
         return self.refbackend.compile(imported_module)
 
     def load(self, module):

--- a/python/torch_mlir_e2e_test/utils.py
+++ b/python/torch_mlir_e2e_test/utils.py
@@ -1,0 +1,56 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+from io import StringIO
+import os
+import sys
+import tempfile
+from torch_mlir.passmanager import PassManager
+from torch_mlir.ir import StringAttr
+
+def get_module_name_for_debug_dump(module):
+    """Gets a name suitable for a debug dump.
+
+    The name is not guaranteed to be unique.
+    """
+    if not "torch.debug_module_name" in module.operation.attributes:
+        return "UnnammedModule"
+    return StringAttr(module.operation.attributes["torch.debug_module_name"]).value
+
+def run_pipeline_with_repro_report(module,
+                                   pipeline: str,
+                                   description: str):
+    """Runs `pipeline` on `module`, with a nice repro report if it fails."""
+    module_name = get_module_name_for_debug_dump(module)
+    try:
+        original_stderr = sys.stderr 
+        sys.stderr = StringIO()
+        asm_for_error_report = module.operation.get_asm(
+            large_elements_limit=10, enable_debug_info=True)
+        # Lower module in place to make it ready for compiler backends.
+        with module.context:
+            pm = PassManager.parse(pipeline)
+            pm.run(module)
+    except Exception as e:
+        # TODO: More robust.
+        # - don't arbitrarily clutter up /tmp. When a test suite has many
+        #   tests, this can be a big disk cost (also, /tmp/ is frequently a
+        #   RAM fs, which increases worries about capacity).
+        # - don't have colliding filenames (hard to do without cluttering
+        #   up /tmp)
+        # - if we do have have colliding filenames, writes should at least
+        #   avoid being racy.
+        filename = os.path.join(tempfile.gettempdir(), module_name + ".mlir")
+        with open(filename, 'w') as f:
+            f.write(asm_for_error_report)
+        raise Exception(f"""
+{description} failed with the following diagnostics:
+{sys.stderr.getvalue()}
+
+Error can be reproduced with:
+$ torch-mlir-opt -pass-pipeline='{pipeline}' {filename}
+""") from None
+    finally:
+        sys.stderr = original_stderr

--- a/test/python/importer/jit_ir/ivalue_import/debug-module-name.py
+++ b/test/python/importer/jit_ir/ivalue_import/debug-module-name.py
@@ -1,0 +1,23 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See LICENSE.pytorch for license information.
+
+import typing
+
+import torch
+from torch_mlir.dialects.torch.importer.jit_ir import ModuleBuilder
+
+# RUN: %PYTHON %s | torch-mlir-opt | FileCheck %s
+
+mb = ModuleBuilder()
+
+# CHECK: module attributes {torch.debug_module_name = "TestModule"}
+class TestModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+test_module = TestModule()
+recursivescriptmodule = torch.jit.script(test_module)
+# TODO: Automatically handle unpacking Python class RecursiveScriptModule into the underlying ScriptModule.
+mb.import_module(recursivescriptmodule._c)
+mb.module.operation.print()


### PR DESCRIPTION
- Move `run_pipeline_with_repro_report` to a more common place, and use it
  consistently
- Attach a `torch.debug_module_name` to the enclosing `builtin.module`
  op to allow for self-contained error reporting (not needing to pass
  the names around.
- Remove redundant error reporting in linalg_on_tensors_backend.py and
  tosa_backend.py (their respective backend abstract base classes now
  take care of the error reports themselves)
- Save off original value of sys.stderr, rather than always resetting to
  `sys.__stderr__`. This is just more hygienic, and allows nesting if
  desired.