### PR TITLE
E2e support for `aten.softmax.int` and `aten.embedding`

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -259,3 +259,125 @@ class GatherModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: GatherModule())
 def GatherModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 3, 4), torch.tensor([[[1, 2, 3], [1, 2, 3]]]))
+
+class AddSizeIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, tensor):
+        # This is a workaround for not supporting scalar arguments.
+        # TODO: pass in dim as an argument to the forward method when scalar
+        # arguments are supported.
+        return tensor.add(tensor, alpha=tensor.size(1))
+
+
+@register_test_case(module_factory=lambda: AddSizeIntModule())
+def AddSizeIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 3))
+
+
+class AddSizeIntNegDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, tensor):
+        # This is a workaround for not supporting scalar arguments.
+        # TODO: pass in dim as an argument to the forward method when scalar
+        # arguments are supported.
+        return tensor.add(tensor, alpha=tensor.size(-2))
+
+
+@register_test_case(module_factory=lambda: AddSizeIntNegDimModule())
+def AddSizeIntNegDimModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 3))
+
+class EmbeddingModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        torch.manual_seed(0)
+        self.embed = torch.nn.Embedding(num_embeddings=100,
+                                        embedding_dim=50,
+                                        padding_idx=4)
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, indices):
+        return self.embed.forward(indices)
+
+
+@register_test_case(module_factory=lambda: EmbeddingModule())
+def EmbeddingModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(100, (3, 3)))
+
+
+class SoftmaxIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        torch.manual_seed(0)
+        self.softmax = torch.nn.Softmax(2)
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, tensor):
+        return self.softmax.forward(tensor)
+
+
+@register_test_case(module_factory=lambda: SoftmaxIntModule())
+def SoftmaxIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 2, 4))
+
+
+class SoftmaxIntNegDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        torch.manual_seed(0)
+        self.softmax = torch.nn.Softmax(-2)
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, tensor):
+        return self.softmax.forward(tensor)
+
+
+@register_test_case(module_factory=lambda: SoftmaxIntNegDimModule())
+def SoftmaxIntNegDimModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 2, 4))
+
+
+class SoftmaxIntArgTypeF64Module(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        torch.manual_seed(0)
+        self.softmax = torch.nn.Softmax(2)
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, tensor):
+        return self.softmax.forward(tensor)
+
+
+@register_test_case(module_factory=lambda: SoftmaxIntArgTypeF64Module())
+def SoftmaxIntArgTypeF64Module_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 2, 4).double())

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -937,6 +937,22 @@ def Torch_AtenMaxPool2dOp : Torch_Op<"aten.max_pool2d", [
   let assemblyFormat = "$self `,` $kernel_size `,` $stride `,` $padding `,` $dilation `,` $ceil_mode attr-dict `:` type($self) `,` type($kernel_size) `,` type($stride) `,` type($padding) `,` type($dilation) `,` type($ceil_mode) `->` type($result)";
 }
 
+def Torch_AtenSoftmaxIntOp : Torch_Op<"aten.softmax.int", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::softmax.int : (Tensor, int, int?) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    Torch_IntType:$dim,
+    TorchOptionalIntType:$dtype
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $dim `,` $dtype attr-dict `:` type($self) `,` type($dim) `,` type($dtype) `->` type($result)";
+}
+
 def Torch_AtenAdaptiveAvgPool2dOp : Torch_Op<"aten.adaptive_avg_pool2d", [
     AllowsTypeRefinement,
     HasValueSemantics
@@ -1591,6 +1607,7 @@ def Torch_AtenSizeIntOp : Torch_Op<"aten.size.int", [
     Torch_IntType:$result
   );
   let assemblyFormat = "$self `,` $dim attr-dict `:` type($self) `,` type($dim) `->` type($result)";
+  let hasFolder = 1;
 }
 
 def Torch_AtenStackOp : Torch_Op<"aten.stack", [

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -819,6 +819,7 @@ def Torch_TensorStaticInfoCastOp : Torch_Op<"tensor_static_info_cast", [
   let assemblyFormat = [{
     $operand attr-dict `:` type($operand) `to` type($result)
   }];
+  let hasCanonicalizer = 1;
 }
 
 def Torch_CopyToNonValueTensorOp : Torch_Op<"copy.to_tensor", [

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
@@ -54,6 +54,8 @@ std::unique_ptr<OperationPass<FuncOp>> createMaximizeValueSemanticsPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createRefinePublicReturnPass();
 
+std::unique_ptr<OperationPass<FuncOp>> createDecomposeComplexOpsPass();
+
 } // namespace Torch
 
 /// Registers all Torch transformation passes.

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -215,4 +215,20 @@ def RefinePublicReturn : Pass<"torch-refine-public-return", "ModuleOp"> {
   }];
 }
 
+def DecomposeComplexOps : Pass<"torch-decompose-complex-ops", "FuncOp"> {
+  let summary = "Decompose complicated torch operations";
+  let constructor = "mlir::torch::Torch::createDecomposeComplexOpsPass()";
+  let description = [{
+    Decompose torch operation that are losslessly represented as combinations of 
+    other operations, modulo appropropriate compiler fusion. Note that this pass 
+    is similar in spirit to ReduceOpVariants, but ReduceOpVariants is about 
+    systematic reductions of a large number of ops at once, guided mostly by 
+    traits.
+
+    An example of the transformations done in this pass is:
+    - convert aten.softmax to softmax(x, dim) 
+            => tmp=exp(x); tmp / sum(tmp, dim, keepdim=True)
+  }];
+}
+
 #endif // TORCHMLIR_TORCH_PASSES

--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+#ifndef TORCHMLIR_DIALECT_TORCH_UTILS_H
+#define TORCHMLIR_DIALECT_TORCH_UTILS_H
+
+#include "mlir/Support/LLVM.h"
+
+namespace mlir {
+namespace torch {
+namespace Torch {
+
+int64_t toPositiveDim(int64_t dim, int64_t inputRank);
+bool isValidDim(int64_t dim, int64_t inputRank);
+
+} // namespace Torch
+} // namespace torch
+} // namespace mlir
+
+#endif // TORCHMLIR_DIALECT_TORCH_UTILS_H

--- a/lib/Dialect/Torch/CMakeLists.txt
+++ b/lib/Dialect/Torch/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(IR)
 add_subdirectory(Transforms)
+add_subdirectory(Utils)

--- a/lib/Dialect/Torch/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Torch/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(TorchMLIRTorchPasses
   AdjustCallingConventions.cpp
+  DecomposeComplexOps.cpp
   Passes.cpp
   GlobalizeObjectGraph.cpp
   InlineGlobalSlots.cpp
@@ -23,6 +24,7 @@ add_mlir_library(TorchMLIRTorchPasses
   MLIRPass
   MLIRTransforms
   TorchMLIRTorchDialect
+  TorchMLIRTorchUtils
 )
 
 torch_mlir_target_includes(TorchMLIRTorchPasses)

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/StringExtras.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+// Decompose softmax into: exp(x) / sum(exp(x))
+namespace {
+class DecomposeAtenSoftmaxIntOp : public OpRewritePattern<AtenSoftmaxIntOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AtenSoftmaxIntOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value self = op.self();
+    Value dim = op.dim();
+    if (!op.dtype().getType().isa<Torch::NoneType>())
+      return rewriter.notifyMatchFailure(
+          op, "Unimplemented non-None dtype for softmax");
+
+    BaseTensorType tensorType = self.getType().cast<BaseTensorType>();
+    if (!tensorType.hasDtype() || !tensorType.getDtype().isa<mlir::FloatType>())
+      return rewriter.notifyMatchFailure(op, "Only support floating type");
+    // exp(x)
+    Value exp = rewriter.create<AtenExpOp>(loc, tensorType, self);
+
+    // sum(exp(x))
+    Value dimList = rewriter.create<PrimListConstructOp>(
+        loc, Torch::ListType::get(dim.getType()), dim);
+    Value keepDim = rewriter.create<ConstantBoolOp>(loc, true);
+    Value dtype = rewriter.create<ConstantNoneOp>(loc);
+    SmallVector<int64_t> sizes;
+    int64_t dimInt;
+    if (tensorType.hasSizes()) {
+      ArrayRef<int64_t> inputShape = tensorType.getSizes();
+      int64_t inputRank = inputShape.size();
+      if (matchPattern(dim, m_TorchConstantInt(&dimInt))) {
+        dimInt = toPositiveDim(dimInt, inputRank);
+        if (!isValidDim(dimInt, inputRank))
+          return rewriter.notifyMatchFailure(op, "dim is not a valid dim");
+        sizes.append(inputShape.begin(), inputShape.end());
+        sizes[dimInt] = 1;
+      } else {
+        sizes.resize(inputRank, kUnknownSize);
+      }
+    }
+    Type resultType = tensorType.getWithSizesAndDtype(
+        sizes.size() == 0 ? Optional<ArrayRef<int64_t>>()
+                          : llvm::makeArrayRef(sizes),
+        tensorType.getDtype());
+    Value sum = rewriter.create<AtenSumDimIntListOp>(loc, resultType, exp,
+                                                     dimList, keepDim, dtype);
+    // exp(x) / sum(exp(x))
+    Value result = rewriter.create<AtenDivTensorOp>(loc, tensorType, exp, sum);
+    rewriter.replaceOpWithNewOp<TensorStaticInfoCastOp>(op, op.getType(),
+                                                        result);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class DecomposeComplexOpsPass
+    : public DecomposeComplexOpsBase<DecomposeComplexOpsPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    ConversionTarget target(*context);
+    target.addLegalDialect<Torch::TorchDialect>();
+
+    patterns.add<DecomposeAtenSoftmaxIntOp>(context);
+    target.addIllegalOp<AtenSoftmaxIntOp>();
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::torch::Torch::createDecomposeComplexOpsPass() {
+  return std::make_unique<DecomposeComplexOpsPass>();
+}

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -90,7 +90,7 @@ public:
       if (auto copyToValueTensor = dyn_cast<CopyToValueTensorOp>(op)) {
         copyToValueTensorOps.push_back(copyToValueTensor);
       } else if (isa<AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
-                     AtenTransposeIntOp>(op)) {
+                     AtenTransposeIntOp, TensorStaticInfoCastOp>(op)) {
         viewLikeOps.push_back(op);
         llvm::append_range(workList, op->getResult(0).getUsers());
       } else {

--- a/lib/Dialect/Torch/Utils/CMakeLists.txt
+++ b/lib/Dialect/Torch/Utils/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_mlir_dialect_library(TorchMLIRTorchUtils
+  Utils.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Dialect/Torch/Utils
+  )

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+
+namespace mlir {
+namespace torch {
+namespace Torch {
+
+int64_t toPositiveDim(int64_t dim, int64_t inputRank) {
+  return dim >= 0 ? dim : dim + inputRank;
+}
+
+bool isValidDim(int64_t dim, int64_t inputRank) {
+  return dim >= 0 && dim < inputRank;
+}
+
+} // namespace Torch
+} // namespace torch
+} // namespace mlir

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -482,6 +482,9 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit(
             "aten::max_pool2d : (Tensor, int[], int[], int[], int[], bool) -> (Tensor)"
         )
+        emit(
+            "aten::softmax.int : (Tensor, int, int?) -> (Tensor)"
+        )
         emit("aten::adaptive_avg_pool2d : (Tensor, int[]) -> (Tensor)")
         emit("aten::topk : (Tensor, int, int, bool, bool) -> (Tensor, Tensor)")
         emit("aten::transpose.int : (Tensor, int, int) -> (Tensor)")
@@ -525,7 +528,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::repeat : (Tensor, int[]) -> (Tensor)")
         emit("aten::resize_ : (Tensor, int[], int?) -> (Tensor)")
         emit("aten::select.int : (Tensor, int, int) -> (Tensor)")
-        emit("aten::size.int : (Tensor, int) -> (int)")
+        emit("aten::size.int : (Tensor, int) -> (int)", has_folder=True)
         emit("aten::stack : (Tensor[], int) -> (Tensor)")
         emit("aten::sum : (Tensor, int?) -> (Tensor)")
         emit("aten::sum.dim_IntList : (Tensor, int[], bool, int?) -> (Tensor)")

--- a/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -24,13 +24,8 @@ __all__ = [
 
 
 def checkArgTypeIsSupported(ty):
-    if ty == np.float32:
-        return
-    elif ty == np.int64:
-        return
-    assert False, "Only tensor argument of float32 and int64 are supported but got " + str(
-        ty)
-
+    SUPPORTED = [np.float32, np.float64, np.int64]
+    assert ty in SUPPORTED, f"Only numpy arrays with dtypes in {SUPPORTED} are supported"
 
 class RefBackendInvoker:
     def __init__(self, module):
@@ -45,11 +40,18 @@ class RefBackendInvoker:
         def consume_f32_return(a):
             self.result = unranked_memref_to_numpy(a, np.float32)
 
+        @ctypes.CFUNCTYPE(None, ctypes.POINTER(UnrankedMemRefDescriptor))
+        def consume_f64_return(a):
+            self.result = unranked_memref_to_numpy(a, np.float64)
+
         self.ee.register_runtime("refbackend_consume_int64_func_return",
                                  consume_i64_return)
 
         self.ee.register_runtime("refbackend_consume_float32_func_return",
                                  consume_f32_return)
+
+        self.ee.register_runtime("refbackend_consume_float64_func_return",
+                                 consume_f64_return)
 
     def __getattr__(self, function_name: str):
         def invoke(*args):

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -489,3 +489,52 @@ func @torch.prim.dtype$int64(%t : !torch.tensor<*,si64>) -> !torch.int {
     %ret = torch.prim.dtype %t: !torch.tensor<*,si64> -> !torch.int
     return %ret : !torch.int
 }
+
+// CHECK-LABEL:   func @torch.aten.size.int$neg_dim(
+// CHECK-SAME:            %[[T:.*]]: !torch.tensor<[2,3],f32>) -> !torch.int {
+// CHECK:           %[[RET:.*]] = torch.constant.int 2
+// CHECK:           return %[[RET]] : !torch.int
+func @torch.aten.size.int$neg_dim(%t: !torch.tensor<[2,3],f32>) -> !torch.int {
+  %int-2 = torch.constant.int -2
+  %ret = torch.aten.size.int %t, %int-2 : !torch.tensor<[2,3],f32>, !torch.int -> !torch.int
+  return %ret : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.aten.size.int$pos_dim(
+// CHECK-SAME:            %[[T:.*]]: !torch.tensor<[2,3],f32>) -> !torch.int {
+// CHECK:           %[[RET:.*]] = torch.constant.int 3
+// CHECK:           return %[[RET]] : !torch.int
+func @torch.aten.size.int$pos_dim(%t: !torch.tensor<[2,3],f32>) -> !torch.int {
+  %int1 = torch.constant.int 1
+  %ret = torch.aten.size.int %t, %int1 : !torch.tensor<[2,3],f32>, !torch.int -> !torch.int
+  return %ret : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.aten.size.int$invalid_dim(
+// CHECK-SAME:            %[[T:.*]]: !torch.tensor<[2,3],f32>) -> !torch.int {
+// CHECK:           %[[CST3:.*]] = torch.constant.int 3
+// CHECK:           %[[RET:.*]] = torch.aten.size.int %[[T]], %[[CST3]] : !torch.tensor<[2,3],f32>, !torch.int -> !torch.int
+// CHECK:           return %[[RET]] : !torch.int
+func @torch.aten.size.int$invalid_dim(%t: !torch.tensor<[2,3],f32>) -> !torch.int {
+  %int3 = torch.constant.int 3
+  %ret = torch.aten.size.int %t, %int3 : !torch.tensor<[2,3],f32>, !torch.int -> !torch.int
+  return %ret : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.tensor_static_info_cast$downcast_first(
+// CHECK-SAME:            %[[T:.*]]: !torch.tensor) -> !torch.tensor {
+// CHECK:           return %[[T]] : !torch.tensor
+func @torch.tensor_static_info_cast$downcast_first(%t: !torch.tensor) -> !torch.tensor {
+  %downcast = torch.tensor_static_info_cast %t : !torch.tensor to !torch.tensor<[?,?],f64>
+  %upcast = torch.tensor_static_info_cast %downcast : !torch.tensor<[?,?],f64> to !torch.tensor
+  return %upcast: !torch.tensor
+}
+
+// CHECK-LABEL:   func @torch.tensor_static_info_cast$upcast_first(
+// CHECK-SAME:            %[[T:.*]]: !torch.tensor<[?,?],f64>) -> !torch.tensor<[?,?],f64> {
+// CHECK:           return %[[T]] : !torch.tensor<[?,?],f64>
+func @torch.tensor_static_info_cast$upcast_first(%t: !torch.tensor<[?,?],f64>) -> !torch.tensor<[?,?],f64> {
+  %upcast = torch.tensor_static_info_cast %t : !torch.tensor<[?,?],f64> to !torch.tensor
+  %downcast = torch.tensor_static_info_cast %upcast : !torch.tensor to !torch.tensor<[?,?],f64>
+  return %downcast: !torch.tensor<[?,?],f64>
+}

--- a/test/Dialect/Torch/refine-types.mlir
+++ b/test/Dialect/Torch/refine-types.mlir
@@ -925,3 +925,33 @@ builtin.func @torch.aten.embedding(%weight: !torch.tensor<[104,512],f32>, %indic
        %ret = torch.aten.embedding %weight, %indices, %int1, %false, %false : !torch.tensor<[104,512],f32>, !torch.tensor<[2,3], si64>, !torch.int, !torch.bool, !torch.bool -> !torch.tensor
        return %ret: !torch.tensor
 }
+
+// ----
+// CHECK-LABEL:   func @torch.aten.softmax.int(
+// CHECK-SAME:                                 %[[T:.*]]: !torch.tensor<[2,3],f32>,
+// CHECK-SAME:                                 %[[DIM:.*]]: !torch.int) -> !torch.tensor {
+// CHECK:           %[[DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[SOFTMAX:.*]] = torch.aten.softmax.int %[[T]], %[[DIM]], %[[DTYPE]] : !torch.tensor<[2,3],f32>, !torch.int, !torch.none -> !torch.tensor<[2,3],f32>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<[2,3],f32> to !torch.tensor
+// CHECK:           return %[[RET]] : !torch.tensor
+func @torch.aten.softmax.int(%t: !torch.tensor<[2,3],f32>, %dim: !torch.int) -> !torch.tensor {
+  %none = torch.constant.none
+  %ret = torch.aten.softmax.int %t, %dim, %none : !torch.tensor<[2,3],f32>, !torch.int, !torch.none -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+
+// ----
+// CHECK-LABEL:   func @torch.aten.softmax.int$specified_dtype(
+// CHECK-SAME:                                                 %[[T:.*]]: !torch.tensor<[2,3],f32>,
+// CHECK-SAME:                                                 %[[DIM:.*]]: !torch.int) -> !torch.tensor {
+// CHECK:           %[[DTYPE:.*]] = torch.constant.int 4
+// CHECK:           %[[SOFTMAX:.*]] = torch.aten.softmax.int %[[T]], %[[DIM]], %[[DTYPE]] : !torch.tensor<[2,3],f32>, !torch.int, !torch.int -> !torch.tensor<[2,3],si64>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<[2,3],si64> to !torch.tensor
+// CHECK:           return %[[RET]] : !torch.tensor
+// CHECK:         }
+func @torch.aten.softmax.int$specified_dtype(%t: !torch.tensor<[2,3],f32>, %dim: !torch.int) -> !torch.tensor {
+  %int4 = torch.constant.int 4
+  %ret = torch.aten.softmax.int %t, %dim, %int4: !torch.tensor<[2,3],f32>, !torch.int, !torch.int -> !torch.tensor
+  return %ret : !torch.tensor
+}


### PR DESCRIPTION
- Added a DecomposeComplexOps pass to decompose complex torchOps.
- Refactored `visitAtenArgmaxOp` and `visitAtenAnyDimOp` to
`visitReductionAlongDimIntOp`.
- Moved some helper functions into
torch-mlir/Dialect/Torch/Utils/Utils.h to be shared by multiple files.
- Added support for f64 tensor as argument and return types.