### PR TITLE
Enable python extensions when building out of tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,10 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   include(AddMLIR)
   include(HandleLLVMOptions)
 
-  include(AddMLIRPython)
-  declare_mlir_python_sources(MLIRPythonSources)
-
   # Don't try to compile the python extensions at the moment. We need
   # to import lots of dependencies from AddMLIRPython to make this work.
-  set(MLIR_ENABLE_BINDINGS_PYTHON 0)
+  set(MLIR_ENABLE_BINDINGS_PYTHON 1)
+  option(TORCH_MLIR_ENABLE_JIT_IR_IMPORTER "Enables JIT IR Importer" ON)
 
   set(TORCH-MLIR_BUILT_STANDALONE 1)
   set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_public_c_api_library(TorchMLIRCAPI
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/torch-mlir-c/
 
+  ENABLE_AGGREGATION
   LINK_COMPONENTS
   Core
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -41,7 +41,7 @@ declare_mlir_python_extension(TorchMLIRPythonExtensions.Main
   MODULE_NAME _torchMlir
   ADD_TO_PARENT TorchMLIRPythonExtensions
   SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/TorchMLIRModule.cpp
+    TorchMLIRModule.cpp
   EMBED_CAPI_LINK_LIBS
     TorchMLIRCAPI
   PRIVATE_LINK_LIBS


### PR DESCRIPTION
This depends on D111828.  6/7 tests pass.