### PR TITLE
Add lowering of aten.matmul op.

### DIFF
--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -35,6 +35,7 @@ from . import quantized_models
 from . import elementwise
 from . import reduction
 from . import argmax
+from . import matmul
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend', 'tosa', 'external']

--- a/e2e_testing/torchscript/matmul.py
+++ b/e2e_testing/torchscript/matmul.py
@@ -1,0 +1,132 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+class MatmulDot(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: MatmulDot())
+def Matmul_dot(module, tu: TestUtils):
+    module.forward(tu.rand(3), tu.rand(3))
+    
+# ==============================================================================
+
+class Matmul2D(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: Matmul2D())
+def Matmul_2d(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4), tu.rand(4, 5))
+    
+# ==============================================================================
+
+class MatmulVecMat(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: MatmulVecMat())
+def Matmul_vecmat(module, tu: TestUtils):
+    module.forward(tu.rand(4), tu.rand(4, 5))
+    
+# ==============================================================================
+
+class MatmulMatVec(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: MatmulMatVec())
+def Matmul_matvec(module, tu: TestUtils):
+    module.forward(tu.rand(4, 5), tu.rand(5))
+    
+# ==============================================================================
+
+class Matmul3D(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: Matmul3D())
+def Matmul_3d(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5), tu.rand(3, 5, 4))
+    
+# ==============================================================================
+
+class Matmul4d(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.float32, True),
+        ([-1, -1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: Matmul4d())
+def Matmul_4d(module, tu: TestUtils):
+    module.forward(tu.rand(4, 5, 6, 7), tu.rand(4, 5, 7, 6))
+    
+# ==============================================================================

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -857,6 +857,21 @@ def Torch_AtenMmOp : Torch_Op<"aten.mm", [
   let assemblyFormat = "$self `,` $mat2 attr-dict `:` type($self) `,` type($mat2) `->` type($result)";
 }
 
+def Torch_AtenMatmulOp : Torch_Op<"aten.matmul", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::matmul : (Tensor, Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchTensorType:$other
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $other attr-dict `:` type($self) `,` type($other) `->` type($result)";
+}
+
 def Torch_AtenConv2dOp : Torch_Op<"aten.conv2d", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -918,6 +918,153 @@ public:
 } // namespace
 
 namespace {
+class ConvertAtenMatmulOp : public OpConversionPattern<AtenMatmulOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenMatmulOp op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    Value lhs = operands[0];
+    Value rhs = operands[1];
+
+    unsigned lhsRank = lhs.getType().cast<RankedTensorType>().getRank();
+    unsigned rhsRank = rhs.getType().cast<RankedTensorType>().getRank();
+
+    Type newResultType = getTypeConverter()->convertType(op.getType());
+    Type elementType = newResultType.cast<TensorType>().getElementType();
+
+    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+      return failure();
+
+    // The different cases of torch_matmul op is mentioned here:
+    // https://pytorch.org/docs/stable/generated/torch.matmul.html
+
+    // First Case: Dot Product.
+    if (lhsRank == 1 && rhsRank == 1) {
+      Value lhsDim0 = getDimOp(rewriter, loc, lhs, 0);
+      Value rhsDim0 = getDimOp(rewriter, loc, rhs, 0);
+
+      checkDimEqualHelper(rewriter, loc, lhsDim0, rhsDim0);
+
+      Value zeroTensor = createZeroInitTensor(rewriter, loc, {}, elementType);
+      Value dotProd =
+          rewriter
+              .create<linalg::DotOp>(loc, zeroTensor.getType(),
+                                     ValueRange{lhs, rhs}, zeroTensor)
+              .getResult(0);
+      rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, dotProd);
+      return success();
+    }
+
+    // Second Case: Vec-Mat Multiplication.
+    if (lhsRank == 1 && rhsRank == 2) {
+      Value lhsDim0 = getDimOp(rewriter, loc, lhs, 0);
+      Value rhsDim0 = getDimOp(rewriter, loc, rhs, 0);
+      Value rhsDim1 = getDimOp(rewriter, loc, rhs, 1);
+      checkDimEqualHelper(rewriter, loc, lhsDim0, rhsDim0);
+
+      Value zeroTensor =
+          createZeroInitTensor(rewriter, loc, ValueRange{rhsDim1}, elementType);
+      Value matmul =
+          rewriter
+              .create<linalg::VecmatOp>(loc, zeroTensor.getType(),
+                                        ValueRange{lhs, rhs}, zeroTensor)
+              .getResult(0);
+      rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, matmul);
+      return success();
+    }
+
+    // Third Case: Matrix-Vec Multiplication.
+    if (lhsRank == 2 && rhsRank == 1) {
+      Value lhsDim0 = getDimOp(rewriter, loc, lhs, 0);
+      Value lhsDim1 = getDimOp(rewriter, loc, lhs, 1);
+      Value rhsDim0 = getDimOp(rewriter, loc, rhs, 0);
+      checkDimEqualHelper(rewriter, loc, lhsDim1, rhsDim0);
+
+      Value zeroTensor =
+          createZeroInitTensor(rewriter, loc, ValueRange{lhsDim0}, elementType);
+      Value matmul =
+          rewriter
+              .create<linalg::MatvecOp>(loc, zeroTensor.getType(),
+                                        ValueRange{lhs, rhs}, zeroTensor)
+              .getResult(0);
+      rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, matmul);
+      return success();
+    }
+
+    // Fourth Case: Batch-Matrix Multiplication.
+    // TODO: Broadcasting of batch dimension is remaining.
+    if (lhsRank >= 3 && rhsRank >= 3 && lhsRank == rhsRank) {
+
+      unsigned batchRank = lhsRank - 2;
+      SmallVector<Value, 4> resultShape;
+
+      SmallVector<AffineExpr> lhsExpr;
+      SmallVector<AffineExpr> rhsExpr;
+      SmallVector<AffineExpr> outExpr;
+      SmallVector<StringRef> iteratorTypes;
+
+      // Since broadcasting is a TODO, check whether the lhs and rhs batch
+      // dimension match.
+      for (unsigned i = 0; i < batchRank; i++) {
+        Value lhsBatch = getDimOp(rewriter, loc, lhs, i);
+        Value rhsBatch = getDimOp(rewriter, loc, rhs, i);
+        resultShape.push_back(lhsBatch);
+        lhsExpr.push_back(rewriter.getAffineDimExpr(i));
+        rhsExpr.push_back(rewriter.getAffineDimExpr(i));
+        outExpr.push_back(rewriter.getAffineDimExpr(i));
+        iteratorTypes.push_back(getParallelIteratorTypeName());
+        checkDimEqualHelper(rewriter, loc, lhsBatch, rhsBatch);
+      }
+
+      Value lhsDim0 = getDimOp(rewriter, loc, lhs, batchRank);
+      Value lhsDim1 = getDimOp(rewriter, loc, lhs, batchRank + 1);
+      Value rhsDim0 = getDimOp(rewriter, loc, rhs, batchRank);
+      Value rhsDim1 = getDimOp(rewriter, loc, rhs, batchRank + 1);
+      checkDimEqualHelper(rewriter, loc, lhsDim1, rhsDim0);
+
+      // Push the final matrix dimension.
+      resultShape.insert(resultShape.end(), {lhsDim0, rhsDim1});
+
+      lhsExpr.insert(lhsExpr.end(), {rewriter.getAffineDimExpr(batchRank),
+                                     rewriter.getAffineDimExpr(batchRank + 1)});
+      rhsExpr.insert(rhsExpr.end(), {rewriter.getAffineDimExpr(batchRank + 1),
+                                     rewriter.getAffineDimExpr(batchRank + 2)});
+      outExpr.insert(outExpr.end(), {rewriter.getAffineDimExpr(batchRank),
+                                     rewriter.getAffineDimExpr(batchRank + 2)});
+
+      Value initTensor0 =
+          createZeroInitTensor(rewriter, loc, resultShape, elementType);
+
+      auto indexingMaps =
+          AffineMap::inferFromExprList({lhsExpr, rhsExpr, outExpr});
+      iteratorTypes.insert(iteratorTypes.end(),
+                           {"parallel", "reduction", "parallel"});
+
+      Value finalRes =
+          rewriter
+              .create<linalg::GenericOp>(
+                  loc, newResultType, ValueRange{lhs, rhs}, initTensor0,
+                  /*indexingMaps=*/indexingMaps,
+                  /*iteratorTypes=*/iteratorTypes,
+                  [&](OpBuilder &b, Location loc, ValueRange args) {
+                    Value l = args[0], r = args[1], res = args[2];
+                    Value mul = b.create<arith::MulFOp>(loc, l, r);
+                    Value add = b.create<arith::AddFOp>(loc, mul, res);
+                    b.create<linalg::YieldOp>(loc, add);
+                  })
+              .getResult(0);
+
+      rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, finalRes);
+      return success();
+    }
+    return failure();
+  }
+};
+} // namespace
+
+namespace {
 class ConvertAtenBmmOp : public OpConversionPattern<AtenBmmOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
@@ -2264,6 +2411,8 @@ public:
     RewritePatternSet patterns(context);
     target.addIllegalOp<AtenMmOp>();
     patterns.add<ConvertAtenMmOp>(typeConverter, context);
+    target.addIllegalOp<AtenMatmulOp>();
+    patterns.add<ConvertAtenMatmulOp>(typeConverter, context);
     target.addIllegalOp<AtenBmmOp>();
     patterns.add<ConvertAtenBmmOp>(typeConverter, context);
     target.addIllegalOp<AtenLinearOp>();

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -470,6 +470,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         # Non-elementwise tensor compute ops
         emit("aten::linear : (Tensor, Tensor, Tensor?) -> (Tensor)")
         emit("aten::mm : (Tensor, Tensor) -> (Tensor)")
+        emit("aten::matmul : (Tensor, Tensor) -> (Tensor)")
         emit(
             "aten::conv2d : (Tensor, Tensor, Tensor?, int[], int[], int[], int) -> (Tensor)"
         )

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1,0 +1,27 @@
+// RUN: torch-mlir-opt -torch-decompose-complex-ops -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL:  func @matmul_no_decompose
+// CHECK:   torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
+func @matmul_no_decompose(%arg0: !torch.vtensor<[?,?,?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
+  return %0 : !torch.tensor
+}
+
+
+// -----
+
+// CHECK-LABEL:  func @matmul_decompose_2d
+// CHECK:    torch.aten.mm %arg0, %arg1 : !torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],f32> -> !torch.tensor
+func @matmul_decompose_2d(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtensor<[?,?],f32>) -> !torch.tensor {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],f32> -> !torch.tensor
+  return %0 : !torch.tensor
+}
+
+// -----
+
+// CHECK-LABEL:  func @matmul_decompose_3d(
+// CHECK:    torch.aten.bmm %arg0, %arg1 : !torch.vtensor<[?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
+func @matmul_decompose_3d(%arg0: !torch.vtensor<[?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
+  return %0 : !torch.tensor
+}

--- a/test/Dialect/Torch/refine-types.mlir
+++ b/test/Dialect/Torch/refine-types.mlir
@@ -955,3 +955,33 @@ func @torch.aten.softmax.int$specified_dtype(%t: !torch.tensor<[2,3],f32>, %dim:
   %ret = torch.aten.softmax.int %t, %dim, %int4: !torch.tensor<[2,3],f32>, !torch.int, !torch.int -> !torch.tensor
   return %ret : !torch.tensor
 }
+
+
+// ----
+// CHECK-LABEL:  func @aten_matmul_broadcast_matrix(
+// CHECK-SAME:   %[[LHS:.*]]: !torch.vtensor<[?,?,?,?,?],f32>, 
+// CHECK-SAME:   %[[RHS:.*]]: !torch.vtensor<[?,?,?],f32>)
+// CHECK-SAME:   -> !torch.tensor {
+// CHECK:    %[[MUL:.*]] = torch.aten.matmul %[[LHS]], %[[RHS]] : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor<[?,?,?,?,?],f32>
+// CHECK:    %[[CAST:.*]] = torch.tensor_static_info_cast %[[MUL]] : !torch.tensor<[?,?,?,?,?],f32> to !torch.tensor
+// CHECK:    return %[[CAST]] : !torch.tensor
+// CHECK:    }
+func @aten_matmul_broadcast_matrix(%arg0: !torch.vtensor<[?,?,?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
+  return %0 : !torch.tensor
+}
+
+
+// ----
+// CHECK-LABEL:  func @aten_matmul_broadcast_vector(
+// CHECK-SAME:   %[[LHS:.*]]: !torch.vtensor<[?,?,?,?,?],f32>, 
+// CHECK-SAME:   %[[RHS:.*]]: !torch.vtensor<[?],f32>)
+// CHECK-SAME:   -> !torch.tensor {
+// CHECK:    %[[MUL:.*]] = torch.aten.matmul %[[LHS]], %[[RHS]] : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?],f32> -> !torch.tensor<[?,?,?,?],f32>
+// CHECK:    %[[CAST:.*]] = torch.tensor_static_info_cast %[[MUL]] : !torch.tensor<[?,?,?,?],f32> to !torch.tensor
+// CHECK:    return %[[CAST]] : !torch.tensor
+// CHECK:    }
+func @aten_matmul_broadcast_vector(%arg0: !torch.vtensor<[?,?,?,?,?],f32>, %arg1: !torch.vtensor<[?],f32>) -> !torch.tensor {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?],f32> -> !torch.tensor
+  return %0 : !torch.tensor
+}


### PR DESCRIPTION
Lowering of `aten.matmul` op is added from torch to linalg dialect.
The different cases correspond to
https://pytorch.org/docs/stable/generated/torch.matmul.html.
TODO: Broadcasting in case of batch-matmul is yet to be taken care of.

Signed-off-by: Prashant Kumar <prashant@nod-labs.com>