### PR TITLE
Filter checks to only run on push to main branch.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -1,7 +1,9 @@
 name: Build and Test
 
-on: 
+on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Keeps redundent pull request and push workflows from running when pushing to branches in the main repo.