### PR TITLE
[TORCH][MLIR] Add E2E support for aten.permute.

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -221,6 +221,21 @@ class TransposeIntModule(torch.nn.Module):
 def TransposeIntModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 2))
 
+class PermuteModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    
+    @export
+    @annotate_args([
+        None,
+        ([3, 4, 2], torch.float32, True)
+    ])
+    def forward(self, x):
+        return x.permute(0, 2, 1)
+
+@register_test_case(module_factory=lambda: PermuteModule())
+def PermuteModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 2))
 
 class TransposeIntNegDimsModule(torch.nn.Module):
     def __init__(self):
@@ -240,6 +255,21 @@ def TransposeIntNegDimsModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 2))
 
 
+class PermuteNegativeIndexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    
+    @export
+    @annotate_args([
+        None,
+        ([3, 4, 2], torch.float32, True)
+    ])
+    def forward(self, x):
+        return x.permute(0, -1, 1)
+
+@register_test_case(module_factory=lambda: PermuteNegativeIndexModule())
+def PermuteNegativeIndexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 2))
 class TensorsConcatModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1016,6 +1016,20 @@ def Torch_AtenTransposeIntOp : Torch_Op<"aten.transpose.int", [
   let assemblyFormat = "$self `,` $dim0 `,` $dim1 attr-dict `:` type($self) `,` type($dim0) `,` type($dim1) `->` type($result)";
 }
 
+def Torch_AtenPermuteOp : Torch_Op<"aten.permute", [
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::permute : (Tensor, int[]) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    TorchIntListType:$dims
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $dims attr-dict `:` type($self) `,` type($dims) `->` type($result)";
+}
+
 def Torch_AtenBmmOp : Torch_Op<"aten.bmm", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -1974,6 +1974,73 @@ public:
 } // namespace
 
 namespace {
+class ConvertAtenPermuteOp : public OpConversionPattern<AtenPermuteOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenPermuteOp op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+      return failure();
+
+    AtenPermuteOp::Adaptor adaptor(operands);
+    SmallVector<int64_t> dimensions;
+    if (!matchPattern(op.dims(), m_TorchConstantIntList(dimensions)))
+      return rewriter.notifyMatchFailure(op, "all dimensions must be constant");
+
+    Value inVector = adaptor.self();
+    auto inType = inVector.getType().cast<RankedTensorType>();
+    int64_t inputRank = inType.getRank();
+    auto outType = getTypeConverter()
+                       ->convertType(op->getResult(0).getType())
+                       .cast<RankedTensorType>();
+    Type elementType = inType.getElementType();
+
+    // Check if the dimensions are a valid constants.
+    int64_t numDimensions = dimensions.size();
+    if (inputRank != numDimensions)
+      return rewriter.notifyMatchFailure(
+          op, "size of `dims` must be equal to the rank of the input");
+    for (unsigned i = 0; i < numDimensions; i++) {
+      if (dimensions[i] < 0)
+        dimensions[i] = toPositiveDim(dimensions[i], inputRank);
+      if (!isValidDim(dimensions[i], inputRank))
+        return rewriter.notifyMatchFailure(op, "dimension out of range");
+    }
+
+    Location loc = op.getLoc();
+
+    SmallVector<Value> outputDims;
+    for (unsigned i = 0; i < inputRank; i++)
+      outputDims.push_back(getDimOp(rewriter, loc, inVector, dimensions[i]));
+
+    Value outVector =
+        rewriter.create<linalg::InitTensorOp>(loc, outputDims, elementType);
+    SmallVector<AffineExpr> idExprs;
+    SmallVector<AffineExpr> swapExprs;
+    for (unsigned i = 0; i < inputRank; i++)
+      idExprs.push_back(getAffineDimExpr(i, rewriter.getContext()));
+    for (unsigned i = 0; i < inputRank; i++)
+      swapExprs.push_back(idExprs[dimensions[i]]);
+
+    SmallVector<AffineMap> indexingMaps =
+        AffineMap::inferFromExprList({idExprs, swapExprs});
+    SmallVector<StringRef> iteratorTypes(inputRank, "parallel");
+    auto transpose = rewriter
+                         .create<linalg::GenericOp>(
+                             loc, outVector.getType(), inVector, outVector,
+                             indexingMaps, iteratorTypes,
+                             [](OpBuilder &b, Location loc, ValueRange args) {
+                               b.create<linalg::YieldOp>(loc, args[0]);
+                             })
+                         .getResult(0);
+    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, outType, transpose);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class ConvertAtenCatOp : public OpConversionPattern<AtenCatOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
@@ -2376,6 +2443,8 @@ public:
     patterns.add<ConvertReductionOp>(typeConverter, context);
     target.addIllegalOp<AtenTransposeIntOp>();
     patterns.add<ConvertAtenTransposeIntOp>(typeConverter, context);
+    target.addIllegalOp<AtenPermuteOp>();
+    patterns.add<ConvertAtenPermuteOp>(typeConverter, context);
     target.addIllegalOp<AtenCatOp>();
     patterns.add<ConvertAtenCatOp>(typeConverter, context);
     target.addIllegalOp<AtenGatherOp>();

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -90,8 +90,8 @@ public:
       if (auto copyToValueTensor = dyn_cast<CopyToValueTensorOp>(op)) {
         copyToValueTensorOps.push_back(copyToValueTensor);
       } else if (isa<AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
-                     AtenTransposeIntOp, TensorStaticInfoCastOp,
-                 AtenBroadcastToOp > (op)) {
+                     AtenTransposeIntOp, AtenPermuteOp, TensorStaticInfoCastOp,
+                     AtenBroadcastToOp>(op)) {
         viewLikeOps.push_back(op);
         llvm::append_range(workList, op->getResult(0).getUsers());
       } else {

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -490,6 +490,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::adaptive_avg_pool2d : (Tensor, int[]) -> (Tensor)")
         emit("aten::topk : (Tensor, int, int, bool, bool) -> (Tensor, Tensor)")
         emit("aten::transpose.int : (Tensor, int, int) -> (Tensor)")
+        emit("aten::permute : (Tensor, int[]) -> (Tensor)")
         emit("aten::bmm : (Tensor, Tensor) -> (Tensor)")
         emit("aten::cumsum : (Tensor, int, int?) -> (Tensor)")
         emit("aten::floor_divide.Scalar : (Tensor, Scalar) -> (Tensor)")


### PR DESCRIPTION
This commit adds lowering of aten.permute to linalg.generic operation.

Signed-Off-By: Prateek Gupta <prateek@nod-labs.com>