### PR TITLE
Add type promotion code to refine types.

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source code is copied from PyTorch, and remains licensed under
+// the PyTorch BSD-style license available at
+// https://github.com/pytorch/pytorch/blob/master/LICENSE
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Support/LLVM.h"
+
+// For layering reasons, the parts of the core MLIR compiler code written in C++
+// never take a C++ dependency on Torch itself (any code depending on Torch C++
+// API should be using the Torch-MLIR CAPI). However, certain highly stable enum
+// values and logic are minimally needed to match PyTorch semantics, which we
+// choose to copy into our codebase. The amount of code copied here should be
+// kept to the absolute minimum and be restricted to highly stable logic and
+// never leak out to the rest of the codebase. The code should be copied
+// verbatim (modulo namespaces) from PyTorch. Notice that this file retains the
+// original PyTorch license and the code here should not be mixed with "code
+// that we [Torch-MLIR] write".
+
+namespace mlir {
+namespace torch {
+namespace torch_upstream {
+
+//===----------------------------------------------------------------------===//
+// ScalarType enum related code are copied from c10/core/ScalarType.h
+//===----------------------------------------------------------------------===//
+
+// at:: and c10:: parts of the macro are never used within the compiler -- we
+// only use this for the enum values.
+#define AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(_)                       \
+  _(uint8_t, Byte)                        /* 0 */                              \
+  _(int8_t, Char)                         /* 1 */                              \
+  _(int16_t, Short)                       /* 2 */                              \
+  _(int, Int)                             /* 3 */                              \
+  _(int64_t, Long)                        /* 4 */                              \
+  _(at::Half, Half)                       /* 5 */                              \
+  _(float, Float)                         /* 6 */                              \
+  _(double, Double)                       /* 7 */                              \
+  _(c10::complex<c10::Half>, ComplexHalf) /* 8 */                              \
+  _(c10::complex<float>, ComplexFloat)    /* 9 */                              \
+  _(c10::complex<double>, ComplexDouble)  /* 10 */                             \
+  _(bool, Bool)                           /* 11 */                             \
+  _(c10::qint8, QInt8)                    /* 12 */                             \
+  _(c10::quint8, QUInt8)                  /* 13 */                             \
+  _(c10::qint32, QInt32)                  /* 14 */                             \
+  _(at::BFloat16, BFloat16)               /* 15 */                             \
+  _(c10::quint4x2, QUInt4x2)              /* 16 */                             \
+  _(c10::quint2x4, QUInt2x4)              /* 17 */
+
+enum class ScalarType : int8_t {
+#define DEFINE_ENUM(_1, n) n,
+  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(DEFINE_ENUM)
+#undef DEFINE_ENUM
+      Undefined,
+  NumOptions
+};
+
+//===----------------------------------------------------------------------===//
+// Type promotion related functions and struct definitions are copied from
+// aten/src/ATen/native/TypeProperties.*
+//===----------------------------------------------------------------------===//
+struct ResultTypeState {
+  ScalarType dimResult = ScalarType::Undefined;
+  ScalarType wrappedResult = ScalarType::Undefined;
+  ScalarType zeroResult = ScalarType::Undefined;
+};
+
+ScalarType result_type(const ResultTypeState &in_state);
+ScalarType promote_skip_undefined(ScalarType a, ScalarType b);
+
+} // namespace torch_upstream
+} // namespace torch
+} // namespace mlir

--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -9,6 +9,7 @@
 #ifndef TORCHMLIR_DIALECT_TORCH_UTILS_H
 #define TORCHMLIR_DIALECT_TORCH_UTILS_H
 
+#include "mlir/IR/Value.h"
 #include "mlir/Support/LLVM.h"
 
 namespace mlir {
@@ -17,6 +18,7 @@ namespace Torch {
 
 int64_t toPositiveDim(int64_t dim, int64_t inputRank);
 bool isValidDim(int64_t dim, int64_t inputRank);
+bool getListConstructElements(Value v, SmallVectorImpl<Value> &elems);
 
 } // namespace Torch
 } // namespace torch

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -127,11 +127,8 @@ class DecomposeComplexOpsPass
     target.addIllegalOp<AtenSoftmaxIntOp>();
     patterns.add<DecomposeAtenMatmulOp>(context);
     target.addDynamicallyLegalOp<AtenMatmulOp>([](AtenMatmulOp op) {
-      Value lhs = op.self();
-      Value rhs = op.other();
-
-      int lhsRank = getTensorRank(lhs);
-      int rhsRank = getTensorRank(rhs);
+      int lhsRank = getTensorRank(op.self());
+      int rhsRank = getTensorRank(op.other());
 
       // Make aten.matmul legal if the following condition is satisfied.
       return (lhsRank != 2 || rhsRank != 2) && (lhsRank != 3 || rhsRank != 3);

--- a/lib/Dialect/Torch/Utils/CMakeLists.txt
+++ b/lib/Dialect/Torch/Utils/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(TorchMLIRTorchUtils
   Utils.cpp
+  TorchUpstream.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/torch-mlir/Dialect/Torch/Utils

--- a/lib/Dialect/Torch/Utils/TorchUpstream.cpp
+++ b/lib/Dialect/Torch/Utils/TorchUpstream.cpp
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// This source code is copied from PyTorch, and remains licensed under
+// the PyTorch BSD-style license available at
+// https://github.com/pytorch/pytorch/blob/master/LICENSE
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
+
+namespace mlir {
+namespace torch {
+namespace torch_upstream {
+
+//===----------------------------------------------------------------------===//
+// ScalarType enum related code are copied from c10/core/ScalarType.h.
+//===----------------------------------------------------------------------===//
+static inline bool isQIntType(ScalarType t) {
+  // Don't forget to extend this when adding new QInt types
+  return t == ScalarType::QInt8 || t == ScalarType::QUInt8 ||
+         t == ScalarType::QInt32 || t == ScalarType::QUInt4x2 ||
+         t == ScalarType::QUInt2x4;
+}
+
+//===----------------------------------------------------------------------===//
+// Type promotion related code are copied from
+// aten/src/ATen/native/TypeProperties.*.
+//===----------------------------------------------------------------------===//
+static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
+  // This is generated according to NumPy's promote_types
+  constexpr auto u1 = ScalarType::Byte;
+  constexpr auto i1 = ScalarType::Char;
+  constexpr auto i2 = ScalarType::Short;
+  constexpr auto i4 = ScalarType::Int;
+  constexpr auto i8 = ScalarType::Long;
+  constexpr auto f2 = ScalarType::Half;
+  constexpr auto f4 = ScalarType::Float;
+  constexpr auto f8 = ScalarType::Double;
+  constexpr auto c2 = ScalarType::ComplexHalf;
+  constexpr auto c4 = ScalarType::ComplexFloat;
+  constexpr auto c8 = ScalarType::ComplexDouble;
+  constexpr auto b1 = ScalarType::Bool;
+  constexpr auto bf = ScalarType::BFloat16;
+  constexpr auto ud = ScalarType::Undefined;
+  if (a == ud || b == ud) {
+    return ScalarType::Undefined;
+  }
+
+  // For QInt types, we only allow exact match
+  if (isQIntType(a) && a == b) {
+    return a;
+  }
+
+  if (isQIntType(a) || isQIntType(b)) {
+    assert(false && "promoteTypes with quantized numbers is not handled yet; "
+                    "figure out what the correct rules should be");
+  }
+
+  // this matrix has to be consistent with AT_FORALL_SCALAR_TYPES_WITH_COMPLEX
+  // so that's why we have to add undefined as we are not sure what is the
+  // corrent values for the type promotions in complex type cases.
+  static constexpr ScalarType _promoteTypesLookup[static_cast<int>(
+      ScalarType::NumOptions)][static_cast<int>(ScalarType::NumOptions)] = {
+      /*        u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1  q1  q2  q3  bf*/
+      /* u1 */ {u1, i2, i2, i4, i8, f2, f4, f8, ud, c4, c8, u1, ud, ud, ud, bf},
+      /* i1 */ {i2, i1, i2, i4, i8, f2, f4, f8, ud, c4, c8, i1, ud, ud, ud, bf},
+      /* i2 */ {i2, i2, i2, i4, i8, f2, f4, f8, ud, c4, c8, i2, ud, ud, ud, bf},
+      /* i4 */ {i4, i4, i4, i4, i8, f2, f4, f8, ud, c4, c8, i4, ud, ud, ud, bf},
+      /* i8 */ {i8, i8, i8, i8, i8, f2, f4, f8, ud, c4, c8, i8, ud, ud, ud, bf},
+      /* f2 */ {f2, f2, f2, f2, f2, f2, f4, f8, ud, c4, c8, f2, ud, ud, ud, f4},
+      /* f4 */ {f4, f4, f4, f4, f4, f4, f4, f8, ud, c4, c8, f4, ud, ud, ud, f4},
+      /* f8 */ {f8, f8, f8, f8, f8, f8, f8, f8, ud, c8, c8, f8, ud, ud, ud, f8},
+      /* c2 */ {ud, ud, ud, ud, ud, ud, ud, ud, c2, c4, c8, ud, ud, ud, ud, ud},
+      /* c4 */ {c4, c4, c4, c4, c4, c4, c4, c8, c4, c4, c8, c4, ud, ud, ud, c4},
+      /* c8 */ {c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, ud, ud, ud, c8},
+      /* b1 */ {u1, i1, i2, i4, i8, f2, f4, f8, ud, c4, c8, b1, ud, ud, ud, bf},
+      /* q1 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
+      /* q2 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
+      /* q3 */ {ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud, ud},
+      /* bf */ {bf, bf, bf, bf, bf, f4, f4, f8, ud, c4, c8, bf, ud, ud, ud, bf},
+  };
+  return _promoteTypesLookup[static_cast<int>(a)][static_cast<int>(b)];
+}
+
+static inline bool isFloatingType(ScalarType t) {
+  return (t == ScalarType::Double || t == ScalarType::Float ||
+          t == ScalarType::Half || t == ScalarType::BFloat16);
+}
+
+static inline bool isComplexType(ScalarType t) {
+  return (t == ScalarType::ComplexHalf || t == ScalarType::ComplexFloat ||
+          t == ScalarType::ComplexDouble);
+}
+
+static inline ScalarType combine_categories(ScalarType higher,
+                                            ScalarType lower) {
+  // NOLINTNEXTLINE(bugprone-branch-clone)
+  if (isComplexType(higher)) {
+    return higher;
+  } else if (!isComplexType(lower) && isFloatingType(higher)) {
+    return higher;
+  }
+  if (higher == ScalarType::Bool || isFloatingType(lower) ||
+      isComplexType(lower)) {
+    return promote_skip_undefined(higher, lower);
+  }
+  if (higher != ScalarType::Undefined) {
+    return higher;
+  }
+  return lower;
+}
+
+ScalarType promote_skip_undefined(ScalarType a, ScalarType b) {
+  if (a == ScalarType::Undefined) {
+    return b;
+  }
+  if (b == ScalarType::Undefined) {
+    return a;
+  }
+  return promoteTypes(a, b);
+}
+
+ScalarType result_type(const ResultTypeState &in_state) {
+  return combine_categories(
+      in_state.dimResult,
+      combine_categories(in_state.zeroResult, in_state.wrappedResult));
+}
+
+} // namespace torch_upstream
+} // namespace torch
+} // namespace mlir

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 
 namespace mlir {
 namespace torch {
@@ -19,6 +20,14 @@ int64_t toPositiveDim(int64_t dim, int64_t inputRank) {
 
 bool isValidDim(int64_t dim, int64_t inputRank) {
   return dim >= 0 && dim < inputRank;
+}
+
+bool getListConstructElements(Value v, SmallVectorImpl<Value> &elems) {
+  auto listConstruct = v.getDefiningOp<PrimListConstructOp>();
+  if (!listConstruct)
+    return false;
+  elems = llvm::to_vector<4>(listConstruct.elements());
+  return true;
 }
 
 } // namespace Torch

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -18,10 +18,92 @@ func @matmul_decompose_2d(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtenso
 }
 
 // -----
-
 // CHECK-LABEL:  func @matmul_decompose_3d(
 // CHECK:    torch.aten.bmm %arg0, %arg1 : !torch.vtensor<[?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
 func @matmul_decompose_3d(%arg0: !torch.vtensor<[?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {
   %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
   return %0 : !torch.tensor
+}
+
+// ----
+// CHECK-LABEL:   func @torch.aten.softmax.int(
+// CHECK-SAME:                                 %[[T:.*]]: !torch.tensor<[2,3],f32>,
+// CHECK-SAME:                                 %[[DIM:.*]]: !torch.int) -> !torch.tensor<[2,3],f32> {
+// CHECK:           %[[DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[EXP:.*]] = torch.aten.exp %[[T]] : !torch.tensor<[2,3],f32> -> !torch.tensor<[2,3],f32>
+// CHECK:           %[[DIM_LIST:.*]] = torch.prim.ListConstruct %[[DIM]] : (!torch.int) -> !torch.list<!torch.int>
+// CHECK:           %[[KEEP_DIM:.*]] = torch.constant.bool true
+// CHECK:           %[[SUM_DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[SUM:.*]] = torch.aten.sum.dim_IntList %[[EXP]], %[[DIM_LIST]], %[[KEEP_DIM]], %[[SUM_DTYPE]] :
+// CHECK-SAME:          !torch.tensor<[2,3],f32>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.tensor<[?,?],f32>
+// CHECK:           %[[SOFTMAX:.*]] = torch.aten.div.Tensor %[[EXP]], %[[SUM]] : !torch.tensor<[2,3],f32>, !torch.tensor<[?,?],f32> -> !torch.tensor<[2,3],f32>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<[2,3],f32> to !torch.tensor<[2,3],f32>
+// CHECK:           return %[[RET]] : !torch.tensor<[2,3],f32>
+func @torch.aten.softmax.int(%t: !torch.tensor<[2,3],f32>, %dim: !torch.int) -> !torch.tensor<[2,3],f32> {
+  %dtype = torch.constant.none
+  %ret = torch.aten.softmax.int %t, %dim, %dtype: !torch.tensor<[2,3],f32>, !torch.int, !torch.none -> !torch.tensor<[2,3],f32>
+  return %ret : !torch.tensor<[2,3],f32>
+}
+
+// ----
+// CHECK-LABEL:   func @torch.aten.softmax.int$cst_dim(
+// CHECK-SAME:                                         %[[T:.*]]: !torch.tensor<[2,3],f32>) -> !torch.tensor<[2,3],f32> {
+// CHECK:           %[[DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[DIM:.*]] = torch.constant.int 1
+// CHECK:           %[[EXP:.*]] = torch.aten.exp %[[T]] : !torch.tensor<[2,3],f32> -> !torch.tensor<[2,3],f32>
+// CHECK:           %[[DIM_LIST:.*]] = torch.prim.ListConstruct %[[DIM]] : (!torch.int) -> !torch.list<!torch.int>
+// CHECK:           %[[KEEP_DIM:.*]] = torch.constant.bool true
+// CHECK:           %[[SUM_DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[SUM:.*]] = torch.aten.sum.dim_IntList %[[EXP]], %[[DIM_LIST]], %[[KEEP_DIM]], %[[SUM_DTYPE]] :
+// CHECK-SAME           !torch.tensor<[2,3],f32>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.tensor<[2,1],f32>
+// CHECK:           %[[SOFTMAX:.*]] = torch.aten.div.Tensor %[[EXP]], %[[SUM]] : !torch.tensor<[2,3],f32>, !torch.tensor<[2,1],f32> -> !torch.tensor<[2,3],f32>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<[2,3],f32> to !torch.tensor<[2,3],f32>
+// CHECK:           return %[[RET]] : !torch.tensor<[2,3],f32>
+func @torch.aten.softmax.int$cst_dim(%t: !torch.tensor<[2,3],f32>) -> !torch.tensor<[2,3],f32> {
+  %none = torch.constant.none
+  %dim = torch.constant.int 1
+  %ret = torch.aten.softmax.int %t, %dim, %none : !torch.tensor<[2,3],f32>, !torch.int, !torch.none -> !torch.tensor<[2,3],f32>
+  return %ret : !torch.tensor<[2,3],f32>
+}
+
+// ----
+// CHECK-LABEL:   func @torch.aten.softmax.int$dyn_shape(
+// CHECK-SAME:                                           %[[T:.*]]: !torch.tensor<[?,?],f32>) -> !torch.tensor<[?,?],f32> {
+// CHECK:           %[[DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[DIM:.*]] = torch.constant.int 1
+// CHECK:           %[[EXP:.*]] = torch.aten.exp %[[T]] : !torch.tensor<[?,?],f32> -> !torch.tensor<[?,?],f32>
+// CHECK:           %[[DIM_LIST:.*]] = torch.prim.ListConstruct %[[DIM]] : (!torch.int) -> !torch.list<!torch.int>
+// CHECK:           %[[KEEP_DIM:.*]] = torch.constant.bool true
+// CHECK:           %[[SUM_DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[SUM:.*]] = torch.aten.sum.dim_IntList %[[EXP]], %[[DIM_LIST]], %[[KEEP_DIM]], %[[SUM_DTYPE]] :
+// CHECK-SAME:          !torch.tensor<[?,?],f32>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.tensor<[?,1],f32>
+// CHECK:           %[[SOFTMAX:.*]] = torch.aten.div.Tensor %[[EXP]], %[[SUM]] : !torch.tensor<[?,?],f32>, !torch.tensor<[?,1],f32> -> !torch.tensor<[?,?],f32>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<[?,?],f32> to !torch.tensor<[?,?],f32>
+// CHECK:           return %[[RET]] : !torch.tensor<[?,?],f32>
+func @torch.aten.softmax.int$dyn_shape(%t: !torch.tensor<[?,?],f32>) -> !torch.tensor<[?,?],f32> {
+  %none = torch.constant.none
+  %dim = torch.constant.int 1
+  %ret = torch.aten.softmax.int %t, %dim, %none : !torch.tensor<[?,?],f32>, !torch.int, !torch.none -> !torch.tensor<[?,?],f32>
+  return %ret : !torch.tensor<[?,?],f32>
+}
+
+// ----
+// CHECK-LABEL:   func @torch.aten.softmax.int$unknown_shape(
+// CHECK-SAME:                                               %[[T:.*]]: !torch.tensor<*,f32>) -> !torch.tensor<*,f32> {
+// CHECK:           %[[DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[DIM:.*]] = torch.constant.int 1
+// CHECK:           %[[EXP:.*]] = torch.aten.exp %[[T]] : !torch.tensor<*,f32> -> !torch.tensor<*,f32>
+// CHECK:           %[[DIM_LIST:.*]] = torch.prim.ListConstruct %[[DIM]] : (!torch.int) -> !torch.list<!torch.int>
+// CHECK:           %[[KEEP_DIM:.*]] = torch.constant.bool true
+// CHECK:           %[[SUM_DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[SUM:.*]] = torch.aten.sum.dim_IntList %[[EXP]], %[[DIM_LIST]], %[[KEEP_DIM]], %[[SUM_DTYPE]] :
+// CHECK-SAME:          !torch.tensor<*,f32>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.tensor<*,f32>
+// CHECK:           %[[SOFTMAX:.*]] = torch.aten.div.Tensor %[[EXP]], %[[SUM]] : !torch.tensor<*,f32>, !torch.tensor<*,f32> -> !torch.tensor<*,f32>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<*,f32> to !torch.tensor<*,f32>
+// CHECK:           return %[[RET]] : !torch.tensor<*,f32>
+func @torch.aten.softmax.int$unknown_shape(%t: !torch.tensor<*,f32>) -> !torch.tensor<*,f32> {
+  %none = torch.constant.none
+  %dim = torch.constant.int 1
+  %ret = torch.aten.softmax.int %t, %dim, %none : !torch.tensor<*,f32>, !torch.int, !torch.none -> !torch.tensor<*,f32>
+  return %ret : !torch.tensor<*,f32>
 }

--- a/test/Dialect/Torch/promote-types.mlir
+++ b/test/Dialect/Torch/promote-types.mlir
@@ -1,0 +1,109 @@
+// RUN: torch-mlir-opt -torch-refine-types -split-input-file %s | FileCheck %s
+
+// -----
+
+// CHECK-LABEL:   func @tensor_tensor$same_category_different_width(
+// CHECK-SAME:                                                      %[[VAL_0:.*]]: !torch.vtensor<[1],f32>,
+// CHECK-SAME:                                                      %[[VAL_1:.*]]: !torch.vtensor<[1],f64>,
+// CHECK-SAME:                                                      %[[VAL_2:.*]]: !torch.float) {
+// CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
+// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[?],f64>
+// CHECK:           return
+builtin.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1],f32>,
+                                            %t1: !torch.vtensor<[1],f64>,
+                                            %alpha: !torch.float) {
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func @tensor_tensor$different_category(
+// CHECK-SAME:                                           %[[VAL_0:.*]]: !torch.vtensor<[1],si32>,
+// CHECK-SAME:                                           %[[VAL_1:.*]]: !torch.vtensor<[1],f64>,
+// CHECK-SAME:                                           %[[VAL_2:.*]]: !torch.float) {
+// CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
+// CHECK-SAME:         !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[?],f64>
+// CHECK:           return
+builtin.func @tensor_tensor$different_category(%t0: !torch.vtensor<[1],si32>,
+                                 %t1: !torch.vtensor<[1],f64>,
+                                 %alpha: !torch.float) {
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func @tensor_tensor$same_category_zero_rank_wider(
+// CHECK-SAME:                                                      %[[VAL_0:.*]]: !torch.vtensor<[1],f32>,
+// CHECK-SAME:                                                      %[[VAL_1:.*]]: !torch.vtensor<[],f64>,
+// CHECK-SAME:                                                      %[[VAL_2:.*]]: !torch.int) {
+// CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
+// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[],f64>, !torch.int -> !torch.vtensor<[?],f32>
+// CHECK:           return
+builtin.func @tensor_tensor$same_category_zero_rank_wider(
+                                                  %t0: !torch.vtensor<[1],f32>,
+                                                  %t1: !torch.vtensor<[],f64>,
+                                                  %alpha: !torch.int) {
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[],f64>, !torch.int -> !torch.vtensor
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func @tensor_tensor$zero_rank_higher_category(
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: !torch.vtensor<[1],si64>,
+// CHECK-SAME:                                                  %[[VAL_1:.*]]: !torch.vtensor<[],f32>,
+// CHECK-SAME:                                                  %[[VAL_2:.*]]: !torch.int) {
+// CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
+// CHECK-SAME:         !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[?],f32>
+// CHECK:           return
+builtin.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si64>,
+                                        %t1: !torch.vtensor<[],f32>,
+                                        %alpha: !torch.int) {
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func @tensor_tensor$alpha_wider_no_contribution(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: !torch.vtensor<[1],f32>, %[[VAL_1:.*]]: !torch.vtensor<[1],f32>,
+// CHECK-SAME:                                    %[[VAL_2:.*]]: !torch.float) {
+// CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
+// CHECK-SAME:        !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor<[?],f32>
+// CHECK:           return
+builtin.func @tensor_tensor$alpha_wider_no_contribution(%t0: !torch.vtensor<[1],f32>,
+                               %t1: !torch.vtensor<[1],f32>,
+                               %alpha: !torch.float) {
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func @tensor_scalar$scalar_higher_category(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: !torch.vtensor<[1],si64>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: !torch.float,
+// CHECK-SAME:                                               %[[VAL_2:.*]]: !torch.int) {
+// CHECK:           %[[VAL_3:.*]] = torch.aten.add.Scalar %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
+// CHECK-SAME:        !torch.vtensor<[1],si64>, !torch.float, !torch.int -> !torch.vtensor<[1],f32>
+// CHECK:           return
+builtin.func @tensor_scalar$scalar_higher_category(%t0: !torch.vtensor<[1],si64>, %scalar: !torch.float, %alpha: !torch.int) {
+  %1 = torch.aten.add.Scalar %t0, %scalar, %alpha: !torch.vtensor<[1], si64>, !torch.float, !torch.int -> !torch.vtensor
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func @tensor_scalar$scalar_same_category_wider(
+// CHECK-SAME:                                                   %[[VAL_0:.*]]: !torch.vtensor<[1],si32>,
+// CHECK-SAME:                                                   %[[VAL_1:.*]]: !torch.int,
+// CHECK-SAME:                                                   %[[VAL_2:.*]]: !torch.int) {
+// CHECK:           %[[VAL_3:.*]] = torch.aten.add.Scalar %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
+// CHECK-SAME:        !torch.vtensor<[1],si32>, !torch.int, !torch.int -> !torch.vtensor<[1],si32>
+// CHECK:           return
+builtin.func @tensor_scalar$scalar_same_category_wider(%t0: !torch.vtensor<[1],si32>, %scalar: !torch.int, %alpha: !torch.int) {
+  %1 = torch.aten.add.Scalar %t0, %scalar, %alpha: !torch.vtensor<[1], si32>, !torch.int, !torch.int -> !torch.vtensor
+  return
+}


### PR DESCRIPTION
The types have different levels of categories: where
complex > floating > integral > boolean (> means left hand
side has higher category).

The operands have different levels of priorities where:
dimensioned tensor > 0-dim tensor > scalar == wrapped 0-dim tensor.
This is represented by the `ResultTypeState.dimResult`,
`ResultTypeState.zeroResult` and `ResultTypeState..wrappedResult` in
the source code.

For operands of the same priorities, the result type should be the
highest categories with sufficient width to hold all operands.

By default, only the highest priority operands participate in the type
promotion logic. Lower priority operands participate if they are in
a higher category than any higher priority operands.

For example, <[],f32> (lower priority) and <[1], si64> tensor would
result in <[?],f32> tensor because floating > integeral. Another example
<[],f64> (lower priority) and <[1], f32> tensor would result in
<[?], f32> tensor because f32 and f64 are the same category.

The ScalarType enum definition, type promotion table, ResultTypeState
struct definition and some helpers are copied from
aten/src/ATen/native/TypeProperties.*
Other references:
- https://pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc
- https://github.com/pytorch/pytorch/issues/9515

Other minor changes:
1. Fix `visitExpandLikeOp` to consider cases where the given sizes list
size is larger than the input rank.
2. Add back the somehow deleted `torch.aten.softmax.int` tests in
decompose-complex-ops.mlir.