### PR TITLE
[MLIR][TORCH] Add E2E support for `torch.aten.view`

### DIFF
--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -36,6 +36,7 @@ from . import elementwise
 from . import reduction
 from . import argmax
 from . import matmul
+from . import view
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend', 'tosa', 'external']

--- a/e2e_testing/torchscript/view.py
+++ b/e2e_testing/torchscript/view.py
@@ -1,0 +1,48 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+class ViewExpandModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([6, 4], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(2, 3, 4)
+
+@register_test_case(module_factory=lambda: ViewExpandModule())
+def ViewExpandModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6, 4))
+
+# ==============================================================================
+
+class ViewDynamicExpandModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, 30, 384], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(2, 4, 5, 6, 12, 32)
+
+@register_test_case(module_factory=lambda: ViewDynamicExpandModule())
+def ViewDynamicExpandModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 4, 30, 384))
+

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -91,7 +91,8 @@ public:
         copyToValueTensorOps.push_back(copyToValueTensor);
       } else if (isa<AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
                      AtenTransposeIntOp, TensorStaticInfoCastOp,
-                     AtenBroadcastToOp, AtenContiguousOp, AtenPermuteOp>(op)) {
+                     AtenBroadcastToOp, AtenContiguousOp, AtenPermuteOp,
+                     AtenViewOp>(op)) {
         // AtenContiguousOp might return a view, so this is conservatively
         // correct. We could potentially be more precise and identify the cases
         // that it does not return a view and treat those as having value


### PR DESCRIPTION
- This commit adds lowering of `aten.View` to `linalg.TensorExpandShape`.
- This lowering will be successful only when one or more static
  dimensions are expanded.
- It also fixes a typo in `ConvertAtenFlattenUsingIntsOp` conversion
  pattern.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>