### PR TITLE
Fix typo in lazytensor example passes

### DIFF
--- a/examples/lazytensor_tanh.py
+++ b/examples/lazytensor_tanh.py
@@ -52,7 +52,7 @@ cu = CompilationUnit()
 func_name = 'my_method'
 script_function = cu.create_function(func_name, graph)
 
-# `build_module` takes he torch.jit.ScriptFunction and the
+# `build_module` takes the torch.jit.ScriptFunction and the
 # annotation on the operand types, and outputs an `ir.Module`
 # with a single function representing the ScriptFunction in
 # the torch MLIR dialect
@@ -65,7 +65,7 @@ mlir_module.dump()
 
 # Compile the torch MLIR and execute the compiled program
 with mlir_module.context:
-    pm = PassManager.parse('torchscript-function-to-torch-backend-pipeline,torch-backend-to-linalg-on-tensors-backend-pipeline')
+    pm = PassManager.parse('torch-function-to-torch-backend-pipeline,torch-backend-to-linalg-on-tensors-backend-pipeline')
 pm.run(mlir_module)
 
 print("BEFORE LINALG-ON-TENSORS BACKEND PIPELINE")


### PR DESCRIPTION
This fixes a typo in the passes used for the `lazy tensor_tanh.py` example. 

Pass definition:

https://github.com/llvm/torch-mlir/blob/5009cbf55ca2210ee5d7822e73e674f039b139a2/lib/Dialect/Torch/Transforms/Passes.cpp#L30