### PR TITLE
Add raw TorchScript->Linalg example

### DIFF
--- a/examples/raw_torchscript_to_linalg.py
+++ b/examples/raw_torchscript_to_linalg.py
@@ -1,0 +1,83 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""
+Example of taking TorchScript as a string and compiling it using torch-mlir.
+This is useful for testing lowering of Torch ops that don't have a Python
+binding.
+
+To run the example, make sure the following are in your PYTHONPATH:
+    1. /path/to/torch-mlir/examples
+    2. /path/to/torch-mlir/build/tools/torch-mlir/python_packages/torch_mlir
+
+then, simply call `python raw_torchscript_to_linalg.py`.
+"""
+
+import numpy as np
+import torch
+from torch._C import CompilationUnit
+
+from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend \
+    import RefBackendLinalgOnTensorsBackend
+from torch_mlir.passmanager import PassManager
+
+from utils.annotator import Annotation
+from utils.torch_mlir_types import TorchTensorType
+from lazytensor.builder import build_module
+
+def _print_title(title: str):
+    print()
+    print(title)
+    print('-' * len(title))
+
+graph_str = """\
+graph(%p0 : Tensor, %p1 : Tensor):
+  %0 : int = prim::Constant[value=1]()
+  %1 : Tensor  = aten::add(%p0, %p1, %0)
+  return (%1)
+"""
+
+graph = torch._C.parse_ir(graph_str)
+_print_title('TorchScript Graph')
+print(graph)
+
+# Create a torch.jit.ScriptFunction out of the graph
+cu = CompilationUnit()
+func_name = 'my_method'
+script_function = cu.create_function(func_name, graph)
+
+# `build_module` takes the torch.jit.ScriptFunction and the
+# annotation on the operand types, and outputs an `ir.Module`
+# with a single function representing the ScriptFunction in
+# the torch MLIR dialect
+input_shape = (3, 4)
+input_dtype = torch.float
+func_annotation = Annotation([TorchTensorType(shape=input_shape, dtype=input_dtype),
+                              TorchTensorType(shape=input_shape, dtype=input_dtype)])
+mlir_module = build_module(script_function, func_annotation)
+
+_print_title("Torch-MLIR")
+mlir_module.dump()
+
+# Compile the torch MLIR and execute the compiled program
+with mlir_module.context:
+    pipeline = ','.join(['torch-function-to-torch-backend-pipeline',
+                         'torch-backend-to-linalg-on-tensors-backend-pipeline'])
+    pm = PassManager.parse(pipeline)
+pm.run(mlir_module)
+
+_print_title("Linalg-MLIR")
+print(mlir_module)
+
+backend = RefBackendLinalgOnTensorsBackend()
+compiled = backend.compile(mlir_module)
+jit_module = backend.load(compiled)
+
+_print_title("Running Compiled Graph")
+x = torch.randn(input_shape, dtype=input_dtype)
+y = torch.randn(input_shape, dtype=input_dtype)
+print('Expected output:')
+print(script_function(x, y))
+print('Output from compiled MLIR:')
+print(jit_module.my_method(x.numpy(), y.numpy()))


### PR DESCRIPTION
The purpose of this PR is to add a simple and quick way of performing an e2e test for PyTorch ops that don't have Python binding. An example of this is the op `prim.NumToTensor.Scalar` https://github.com/llvm/torch-mlir/pull/393. (We could eventually add something like this to the e2e test suite).

While there is a way to test raw MLIR in `torch-mlir`, those tests skip many passes that the e2e tests have to go through, such as the RefineTypes pass, which can lead to uncaught bugs.

This example works by taking TorchScript as a string, importing it into a `torch.jit.ScriptFunction`, then feeding this to `torch-mlir` so that it gets lowered and compiled using the `RefBackendLinalgOnTensorsBackend`. 

Below is the output of this example:

```
TorchScript Graph
-----------------
graph(%p0 : Tensor,
      %p1 : Tensor):
  %2 : int = prim::Constant[value=1]()
  %3 : Tensor = aten::add(%p0, %p1, %2)
  return (%3)


Torch-MLIR
----------
module  {
  func @my_method(%arg0: !torch.tensor {torch.type_bound = !torch.vtensor<[3,4],f32>}, %arg1: !torch.tensor {torch.type_bound = !torch.vtensor<[3,4],f32>}) -> !torch.tensor {
    %int1 = torch.constant.int 1
    %0 = torch.aten.add.Tensor %arg0, %arg1, %int1 : !torch.tensor, !torch.tensor, !torch.int -> !torch.tensor
    return %0 : !torch.tensor
  }
}

Linalg-MLIR
-----------
#map = affine_map<(d0, d1) -> (d0, d1)>
module  {
  func @my_method(%arg0: tensor<3x4xf32>, %arg1: tensor<3x4xf32>) -> tensor<?x?xf32> {
    %c1_i64 = arith.constant 1 : i64
    %0 = linalg.init_tensor [3, 4] : tensor<3x4xf32>
    %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<3x4xf32>, tensor<3x4xf32>) outs(%0 : tensor<3x4xf32>) {
    ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):  // no predecessors
      %3 = arith.sitofp %c1_i64 : i64 to f32
      %4 = arith.mulf %arg3, %3 : f32
      %5 = arith.addf %arg2, %4 : f32
      linalg.yield %5 : f32
    } -> tensor<3x4xf32>
    %2 = tensor.cast %1 : tensor<3x4xf32> to tensor<?x?xf32>
    return %2 : tensor<?x?xf32>
  }
}


Running Compiled Graph
----------------------
Expected output:
tensor([[ 0.1539, -3.9302, -0.7747, -1.1965],
        [ 2.5253, -0.2176, -1.0435, -1.2479],
        [-0.2396,  0.5140,  0.1770,  0.6730]])
Output from compiled MLIR:
[[ 0.15393919 -3.9302053  -0.7747382  -1.1964501 ]
 [ 2.5252578  -0.21755877 -1.043476   -1.247885  ]
 [-0.23960173  0.51403964  0.17700636  0.6729531 ]]
```