### PR TITLE
[TORCH][MLIR] Add E2E support for aten.expand

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -446,6 +446,22 @@ class BroadcastToModule(torch.nn.Module):
 def BroadcastToModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1, 1))
 
+class ExpandModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, 1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x.expand([1, -1, -1, 4])
+
+
+@register_test_case(module_factory=lambda: ExpandModule())
+def ExpandModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 1, 1))
 
 class OnesModuleInt(torch.nn.Module):
     def __init__(self):

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -92,7 +92,7 @@ public:
       } else if (isa<AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
                      AtenTransposeIntOp, TensorStaticInfoCastOp,
                      AtenBroadcastToOp, AtenContiguousOp, AtenPermuteOp,
-                     AtenViewOp>(op)) {
+                     AtenViewOp, AtenExpandOp>(op)) {
         // AtenContiguousOp might return a view, so this is conservatively
         // correct. We could potentially be more precise and identify the cases
         // that it does not return a view and treat those as having value


### PR DESCRIPTION
This commit adds decomposition of `aten.Expand` to `aten.BroadcastTo`
op.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>