### PR TITLE
Add lowering for slice and select int

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -100,6 +100,8 @@ class MmTanhModule(torch.nn.Module):
     def matmul(self, lhs, rhs):
         return torch.mm(lhs, rhs)
 
+# ==============================================================================
+
 
 @register_test_case(module_factory=lambda: MmTanhModule())
 def MmTanhModule_basic(module, tu: TestUtils):
@@ -192,6 +194,8 @@ class AdaptiveAvgPool2dModule(torch.nn.Module):
 def AdaptiveAvgPool2dModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(10, 3, 8, 9))
 
+# ==============================================================================
+
 
 class FlattenStaticModule(torch.nn.Module):
     def __init__(self):
@@ -210,6 +214,8 @@ class FlattenStaticModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: FlattenStaticModule())
 def FlattenStaticModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(10, 3, 8, 9, 3, 4))
+
+# ==============================================================================
 
 
 class FlattenRank0Module(torch.nn.Module):
@@ -230,6 +236,8 @@ class FlattenRank0Module(torch.nn.Module):
 def FlattenRank0Module_basic(module, tu: TestUtils):
     module.forward(torch.tensor(4.0))
 
+# ==============================================================================
+
 
 class FlattenDynamicModule(torch.nn.Module):
     def __init__(self):
@@ -249,6 +257,8 @@ class FlattenDynamicModule(torch.nn.Module):
 def FlattenDynamicModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(10, 3, 8, 9, 3, 4))
 
+# ==============================================================================
+
 
 class MaxPool2dModule(torch.nn.Module):
     def __init__(self):
@@ -265,6 +275,8 @@ class MaxPool2dModule(torch.nn.Module):
     ])
     def forward(self, x):
         return self.mp2d(x)
+
+# ==============================================================================
 
 
 @register_test_case(module_factory=lambda: MaxPool2dModule())
@@ -283,6 +295,8 @@ class TransposeIntModule(torch.nn.Module):
     ])
     def forward(self, x):
         return torch.transpose(x, 0, 1)
+
+# ==============================================================================
 
 
 @register_test_case(module_factory=lambda: TransposeIntModule())
@@ -305,6 +319,8 @@ class PermuteModule(torch.nn.Module):
 def PermuteModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 2))
 
+# ==============================================================================
+
 class TransposeIntNegDimsModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -316,6 +332,8 @@ class TransposeIntNegDimsModule(torch.nn.Module):
     ])
     def forward(self, x):
         return torch.transpose(x, -1, -2)
+
+# ==============================================================================
 
 
 @register_test_case(module_factory=lambda: TransposeIntNegDimsModule())
@@ -334,6 +352,8 @@ class PermuteNegativeIndexModule(torch.nn.Module):
     ])
     def forward(self, x):
         return x.permute(0, -1, 1)
+
+# ==============================================================================
 
 @register_test_case(module_factory=lambda: PermuteNegativeIndexModule())
 def PermuteNegativeIndexModule_basic(module, tu: TestUtils):
@@ -357,6 +377,8 @@ class TensorsConcatModule(torch.nn.Module):
 def TensorsConcatModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 2, 4), tu.rand(2, 1, 4), tu.rand(2, 3, 4))
 
+# ==============================================================================
+
 
 class GatherModule(torch.nn.Module):
     def __init__(self):
@@ -375,6 +397,8 @@ class GatherModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: GatherModule())
 def GatherModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 3, 4), torch.tensor([[[1, 2, 3], [1, 2, 3]]]))
+
+# ==============================================================================
 
 class AddSizeIntModule(torch.nn.Module):
     def __init__(self):
@@ -395,6 +419,8 @@ class AddSizeIntModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: AddSizeIntModule())
 def AddSizeIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 3))
+
+# ==============================================================================
 
 
 class AddSizeIntNegDimModule(torch.nn.Module):
@@ -417,6 +443,8 @@ class AddSizeIntNegDimModule(torch.nn.Module):
 def AddSizeIntNegDimModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 3))
 
+# ==============================================================================
+
 class EmbeddingModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -438,6 +466,7 @@ class EmbeddingModule(torch.nn.Module):
 def EmbeddingModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(100, (3, 3)))
 
+# ==============================================================================
 
 class SoftmaxIntModule(torch.nn.Module):
     def __init__(self):
@@ -474,6 +503,8 @@ class _SoftmaxModule(torch.nn.Module):
 def _SoftmaxModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4))
 
+# ==============================================================================
+
 
 class SoftmaxIntNegDimModule(torch.nn.Module):
     def __init__(self):
@@ -494,6 +525,8 @@ class SoftmaxIntNegDimModule(torch.nn.Module):
 def SoftmaxIntNegDimModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4))
 
+# ==============================================================================
+
 
 class SoftmaxIntArgTypeF64Module(torch.nn.Module):
     def __init__(self):
@@ -513,6 +546,7 @@ class SoftmaxIntArgTypeF64Module(torch.nn.Module):
 def SoftmaxIntArgTypeF64Module_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4).double())
 
+# ==============================================================================
 
 class BroadcastToModule(torch.nn.Module):
     def __init__(self):
@@ -531,6 +565,8 @@ class BroadcastToModule(torch.nn.Module):
 def BroadcastToModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1, 1))
 
+# ==============================================================================
+
 class ExpandModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -548,6 +584,9 @@ class ExpandModule(torch.nn.Module):
 def ExpandModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1, 1))
 
+# ==============================================================================
+
+
 class OnesModuleInt(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -562,6 +601,8 @@ class OnesModuleInt(torch.nn.Module):
 @register_test_case(module_factory=lambda: OnesModuleInt())
 def OnesModuleInt_basic(module, tu: TestUtils):
     module.forward()
+
+# ==============================================================================
 
 class OnesModuleFloat(torch.nn.Module):
     def __init__(self):
@@ -594,6 +635,7 @@ class OnesModuleFalsePinMemory(torch.nn.Module):
 def OnesModuleFalsePinMemory_basic(module, tu: TestUtils):
     module.forward()
 
+# ==============================================================================
 
 class ContiguousModule(torch.nn.Module):
     def __init__(self):
@@ -611,7 +653,7 @@ class ContiguousModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ContiguousModule())
 def ContiguousModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1))
-
+    
 class TensorToInt(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -681,6 +723,7 @@ class NumToTensorFloatModule(torch.nn.Module):
 def NumToTensorFloatModule_basic(module, tu: TestUtils):
     module.forward()
 
+# ==============================================================================
 
 # This test can be removed once we have one real op returning 3 float32 tensors
 class ReturnThreeTensorFloat32(torch.nn.Module):

--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -42,6 +42,7 @@ from . import matmul
 from . import view
 from . import scalar
 from . import squeeze
+from . import slice_like
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend', 'tosa', 'external']

--- a/e2e_testing/torchscript/slice_like.py
+++ b/e2e_testing/torchscript/slice_like.py
@@ -1,0 +1,227 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+class SliceModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[0:5:1, 1:3:1, 2:4:1]
+
+
+@register_test_case(module_factory=lambda: SliceModule())
+def SliceModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+
+
+# ==============================================================================
+
+# This Test currently xfails due to https://github.com/llvm/torch-mlir/issues/448
+class SliceOutOfUpperBoundIndexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:8, :5, 8:]
+
+
+@register_test_case(module_factory=lambda: SliceOutOfUpperBoundIndexModule())
+def SliceOutOfUpperBoundIndexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+class SliceOutOfLowerBoundEndIndexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:-8,-7:,:]
+
+
+@register_test_case(module_factory=lambda: SliceOutOfLowerBoundEndIndexModule())
+def SliceOutOfLowerBoundEndIndexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+class SliceOutOfLowerBoundStartIndexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[-8:3:1, 1:3:1, 2:4:1]
+
+
+@register_test_case(module_factory=lambda: SliceOutOfLowerBoundStartIndexModule())
+def SliceOutOfLowerBoundStartIndexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+# This Test currently xfails due to https://github.com/llvm/torch-mlir/issues/448
+class SliceEndSleStartModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:0, 4:3, :-7]
+
+
+@register_test_case(module_factory=lambda: SliceEndSleStartModule())
+def SliceEndSleStartModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+# This Test currently xfails due to https://github.com/llvm/torch-mlir/issues/448
+class SliceStartEqEndModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[5:5, 3:3, -1:]
+
+
+@register_test_case(module_factory=lambda: SliceStartEqEndModule())
+def SliceStartEqEndModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+class SliceSizeTwoStepModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[0:5:2, 0:3:2, 0:4:2]
+
+
+@register_test_case(module_factory=lambda: SliceSizeTwoStepModule())
+def SliceSizeTwoStepModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(10,5,17))
+
+# ==============================================================================
+
+class SliceNegIdxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:-1, -2:-1]
+
+
+@register_test_case(module_factory=lambda: SliceNegIdxModule())
+def SliceNegIdxModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3,9))
+
+# ==============================================================================
+
+class SliceSingleIdxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[0]
+
+
+@register_test_case(module_factory=lambda: SliceSingleIdxModule())
+def SliceSingleIdxModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,8))
+
+# ==============================================================================
+
+class SliceWholeTensorModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:, :]
+
+
+@register_test_case(module_factory=lambda: SliceWholeTensorModule())
+def SliceWholeTensorModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,8))
+
+# ==============================================================================
+
+class SelectIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return x.select(0,0)
+
+
+@register_test_case(module_factory=lambda: SelectIntModule())
+def SelectIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (5,5)))
+
+# ==============================================================================
+

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -17,8 +17,13 @@ COMMON_TORCH_MLIR_LOWERING_XFAILS = {
     "QuantizedMLP_basic",
     "IouOfModule_basic",
 }
-
-REFBACKEND_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS
+# Fails due to https://github.com/llvm/torch-mlir/issues/448
+SIZE_ZERO_TENSOR_XFAILS = {
+    "SliceEndSleStartModule_basic",
+    "SliceStartEqEndModule_basic",
+    "SliceOutOfUpperBoundIndexModule_basic",
+}
+REFBACKEND_XFAIL_SET = set.union(COMMON_TORCH_MLIR_LOWERING_XFAILS, SIZE_ZERO_TENSOR_XFAILS)
 
 # Write the TOSA set as a "passing" set as it is very early in development
 # and very few tests work yet.

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -92,8 +92,8 @@ public:
       } else if (isa<AtenSqueezeOp, AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
                      AtenTransposeIntOp, TensorStaticInfoCastOp,
                      AtenBroadcastToOp, AtenToDtypeOp, AtenContiguousOp,
-                     AtenPermuteOp, AtenViewOp, AtenExpandOp,
-                     AtenFill_ScalarOp>(op)) {
+                     AtenPermuteOp, AtenViewOp, AtenExpandOp, AtenFill_ScalarOp,
+                     AtenSliceTensorOp, AtenSelectIntOp>(op)) {
         // AtenContiguousOp might return a view, so this is conservatively
         // correct. We could potentially be more precise and identify the cases
         // that it does not return a view and treat those as having value

--- a/test/Dialect/Torch/refine-types.mlir
+++ b/test/Dialect/Torch/refine-types.mlir
@@ -750,8 +750,8 @@ builtin.func @torch.aten.index_select$unknown_dim(%input: !torch.tensor<[2,3,4],
 // CHECK-SAME:                                        %[[INPUT:.*]]: !torch.tensor<[2,3,4],f32>,
 // CHECK-SAME:                                        %[[INDEX:.*]]: !torch.int) -> !torch.tensor {
 // CHECK:           %[[DIM:.*]] = torch.constant.int 1
-// CHECK:           %[[RET:.*]] = torch.aten.select.int %[[INPUT]], %[[DIM]], %[[INDEX]] : !torch.tensor<[2,3,4],f32>, !torch.int, !torch.int -> !torch.tensor<[2,1,4],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,1,4],f32> to !torch.tensor
+// CHECK:           %[[RET:.*]] = torch.aten.select.int %[[INPUT]], %[[DIM]], %[[INDEX]] : !torch.tensor<[2,3,4],f32>, !torch.int, !torch.int -> !torch.tensor<[2,4],f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,4],f32> to !torch.tensor
 // CHECK:           return %[[CAST]] : !torch.tensor
 
 builtin.func @torch.aten.select.int(%input: !torch.tensor<[2,3,4], f32>, %index: !torch.int) -> !torch.tensor {


### PR DESCRIPTION
Probably should have just kept dropout separate. One issue with dropout is that it has an argument called p, which is the probability an element is zero'd. This has a naming conflict the the asm printer p. I'm not sure what the best way to avoid this is, and am open to suggestion. Currently to work I just edited the generated cpp file, but that obviously isn't upstreamable.

I've tried so far to model slice in a way that it easily extends to other slice like ops. My plan is to continue to generalize things out of the `if (auto SliceTensor = dyn_cast<AtenSliceTensorOp>(op)) ` statement. 


There is currently an issue with AtenSliceTensor when there is a start and end for each dimension. For a reason I have yet to determine, the final dimension always maintains the shape of the original tensor instead of being updated to the slice size. In the IR, it actually correctly determines the final dim, but somehow loses track of the initial dim:

I'm not too familiar with how the canonicalizer works, so I'm looking into that.

[slice_mlir](https://gist.github.com/dan-garvey/4b76230adfb141a883d2df8c85b1b7e4)
