### PR TITLE
Adding support for returning elemental types.

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -518,16 +518,13 @@ class TensorToInt(torch.nn.Module):
     @annotate_args([
         None,
         ([], torch.int64, True),
-        ([], torch.float32, True),
     ])
-    def forward(self, x, y):
-        # This is a workaround for not returning scalar value.
-        a =  int(x)
-        return y.add(y, alpha=a)
+    def forward(self, x):
+        return int(x)
 
 @register_test_case(module_factory=lambda: TensorToInt())
 def TensorToInt_basic(module, tu: TestUtils):
-    module.forward(torch.randint(10,[]), tu.rand())
+    module.forward(torch.randint(10,[]))
     
 class LogSoftmaxIntModule(torch.nn.Module):
     def __init__(self):

--- a/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -33,16 +33,37 @@ class RefBackendInvoker:
         self.result = None
 
         @ctypes.CFUNCTYPE(None, ctypes.POINTER(UnrankedMemRefDescriptor))
-        def consume_i64_return(a):
+        def consume_memref_i64_return(a):
             self.result = unranked_memref_to_numpy(a, np.int64)
 
         @ctypes.CFUNCTYPE(None, ctypes.POINTER(UnrankedMemRefDescriptor))
-        def consume_f32_return(a):
+        def consume_memref_f32_return(a):
             self.result = unranked_memref_to_numpy(a, np.float32)
 
         @ctypes.CFUNCTYPE(None, ctypes.POINTER(UnrankedMemRefDescriptor))
-        def consume_f64_return(a):
+        def consume_memref_f64_return(a):
             self.result = unranked_memref_to_numpy(a, np.float64)
+
+        @ctypes.CFUNCTYPE(None, ctypes.c_int)
+        def consume_i64_return(a):
+            self.result = a
+
+        @ctypes.CFUNCTYPE(None, ctypes.c_float)
+        def consume_f32_return(a):
+            self.result = a
+
+        @ctypes.CFUNCTYPE(None, ctypes.c_double)
+        def consume_f64_return(a):
+            self.result = a
+
+        self.ee.register_runtime("refbackend_consume_memref_int64_func_return",
+                                 consume_memref_i64_return)
+
+        self.ee.register_runtime("refbackend_consume_memref_float32_func_return",
+                                 consume_memref_f32_return)
+
+        self.ee.register_runtime("refbackend_consume_memref_float64_func_return",
+                                 consume_memref_f64_return)
 
         self.ee.register_runtime("refbackend_consume_int64_func_return",
                                  consume_i64_return)

--- a/test/RefBackend/munge-calling-conventions.mlir
+++ b/test/RefBackend/munge-calling-conventions.mlir
@@ -4,7 +4,7 @@
 // CHECK-SAME:            %[[ARG0:.*]]: memref<*xf32>) attributes {llvm.emit_c_interface} {
 // CHECK:           %[[VAL:.*]] = memref.cast %[[ARG0]] : memref<*xf32> to memref<?xf32>
 // CHECK:           %[[RESULT:.*]] = memref.cast %[[VAL]] : memref<?xf32> to memref<*xf32>
-// CHECK:           call @refbackend_consume_float32_func_return(%[[RESULT]]) : (memref<*xf32>) -> ()
+// CHECK:           call @refbackend_consume_memref_float32_func_return(%[[RESULT]]) : (memref<*xf32>) -> ()
 // CHECK:           return
 func @f(%arg0: memref<?xf32>) -> memref<?xf32> {
   return %arg0 : memref<?xf32>
@@ -16,8 +16,21 @@ func @f(%arg0: memref<?xf32>) -> memref<?xf32> {
 // CHECK-SAME:            %[[ARG0:.*]]: memref<*xi64>) attributes {llvm.emit_c_interface} {
 // CHECK:           %[[VAL:.*]] = memref.cast %[[ARG0]] : memref<*xi64> to memref<?xi64>
 // CHECK:           %[[RESULT:.*]] = memref.cast %[[VAL]] : memref<?xi64> to memref<*xi64>
-// CHECK:           call @refbackend_consume_int64_func_return(%[[RESULT]]) : (memref<*xi64>) -> ()
+// CHECK:           call @refbackend_consume_memref_int64_func_return(%[[RESULT]]) : (memref<*xi64>) -> ()
 // CHECK:           return
 func @i(%arg0: memref<?xi64>) -> memref<?xi64> {
   return %arg0 : memref<?xi64>
+}
+
+// -----
+
+// CHECK-LABEL:   func @elemental_type(
+// CHECK-SAME:             %[[ARG0:.*]]: memref<*xi64>) attributes {llvm.emit_c_interface} {
+// CHECK:           %[[VAL:.*]] = memref.cast %[[ARG0]] : memref<*xi64> to memref<i64>
+// CHECK:           %[[RESULT:.*]] = memref.load %[[VAL]][] : memref<i64>
+// CHECK:           call @refbackend_consume_int64_func_return(%[[RESULT]]) : (i64) -> ()
+// CHECK:           return
+func @elemental_type(%arg0: memref<i64>) -> i64 {
+  %0 = memref.load %arg0[] : memref<i64>
+  return %0 : i64
 }


### PR DESCRIPTION
Support for returning elemental types. Previously, only
memref types as returning types was supported. All the hacky ways
to write tests which return elemental types should be taken care of.

Signed-off-by: Prashant Kumar <prashant@nod-labs.com>