### PR TITLE
Add e2e suport for aten._softmax_backward_data

### DIFF
--- a/e2e_testing/torchscript/backprop.py
+++ b/e2e_testing/torchscript/backprop.py
@@ -1,0 +1,35 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+class SoftmaxBackwardModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, grad_output, output):
+        return torch.ops.aten._softmax_backward_data(grad_output,
+                                                     output,
+                                                     dim=1,
+                                                     input_dtype=6)
+
+
+@register_test_case(module_factory=lambda: SoftmaxBackwardModule())
+def SoftmaxBackwardModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 2, 4), torch.randn(3, 2, 4))
+

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -224,7 +224,7 @@ def TransposeIntModule_basic(module, tu: TestUtils):
 class PermuteModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
-    
+
     @export
     @annotate_args([
         None,
@@ -258,7 +258,7 @@ def TransposeIntNegDimsModule_basic(module, tu: TestUtils):
 class PermuteNegativeIndexModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
-    
+
     @export
     @annotate_args([
         None,
@@ -374,7 +374,6 @@ def EmbeddingModule_basic(module, tu: TestUtils):
 class SoftmaxIntModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        torch.manual_seed(0)
         self.softmax = torch.nn.Softmax(2)
 
     @export
@@ -428,6 +427,7 @@ class SoftmaxIntArgTypeF64Module(torch.nn.Module):
 @register_test_case(module_factory=lambda: SoftmaxIntArgTypeF64Module())
 def SoftmaxIntArgTypeF64Module_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4).double())
+
 
 class BroadcastToModule(torch.nn.Module):
     def __init__(self):
@@ -509,7 +509,7 @@ class ContiguousModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ContiguousModule())
 def ContiguousModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1))
-    
+
 class TensorToInt(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -521,6 +521,7 @@ class TensorToInt(torch.nn.Module):
     ])
     def forward(self, x):
         return int(x)
+
 
 @register_test_case(module_factory=lambda: TensorToInt())
 def TensorToInt_basic(module, tu: TestUtils):
@@ -542,6 +543,7 @@ class LogSoftmaxIntModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: LogSoftmaxIntModule())
 def LogSoftmaxIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4).double())
+
 
 class NumToTensorModule(torch.nn.Module):
     def __init__(self):

--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -35,6 +35,7 @@ from . import quantized_models
 from . import elementwise
 from . import type_promotion
 from . import type_conversion
+from . import backprop
 from . import reduction
 from . import argmax
 from . import matmul

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2785,3 +2785,20 @@ def Torch_AtenEqDeviceOp : Torch_Op<"aten.eq.device", [
   let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
 }
 
+def Torch_Aten_SoftmaxBackwardDataOp : Torch_Op<"aten._softmax_backward_data", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$grad_output,
+    AnyTorchTensorType:$output,
+    Torch_IntType:$dim,
+    Torch_IntType:$input_dtype
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$grad_output `,` $output `,` $dim `,` $input_dtype attr-dict `:` type($grad_output) `,` type($output) `,` type($dim) `,` type($input_dtype) `->` type($result)";
+}
+

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -230,7 +230,7 @@ public:
             AtenToPrimDeviceOp, AtenCpuOp, AtenContiguousOp, AtenFill_ScalarOp,
             AtenDetachOp, AtenMaskedFill_ScalarOp, AtenCopy_Op, AtenIndexPut_Op,
             AtenCumsumOp, AtenLayerNormOp, AtenClampOp, AtenLogOp, AtenSqrtOp,
-            AtenFloorOp, AtenLog2Op>(op)) {
+            AtenFloorOp, AtenLog2Op, Aten_SoftmaxBackwardDataOp>(op)) {
       return getLatticeElement(op->getResult(0)).join(*operands[0]);
     }
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -621,6 +621,9 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::div : (Scalar, Scalar) -> (float)")
         emit("aten::eq.device : (Device, Device) -> (bool)")
 
+        # backprop ops
+        emit("aten::_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)")
+
 
 def emit_quantized_ops(torch_ir_dir: str, registry: Registry):
     td_file = os.path.join(torch_ir_dir, "GeneratedQuantizedOps.td")

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -107,3 +107,17 @@ func @torch.aten.softmax.int$unknown_shape(%t: !torch.tensor<*,f32>) -> !torch.t
   %ret = torch.aten.softmax.int %t, %dim, %none : !torch.tensor<*,f32>, !torch.int, !torch.none -> !torch.tensor<*,f32>
   return %ret : !torch.tensor<*,f32>
 }
+
+// ----
+// CHECK-LABEL:   func @torch.aten.size(
+// CHECK-SAME:                         %[[T:.*]]: !torch.vtensor<[?,3],f32>) -> !torch.list<!torch.int> {
+// CHECK:           %[[CST0:.*]] = torch.constant.int 0
+// CHECK:           %[[DIM0:.*]] = torch.aten.size.int %[[T]], %[[CST0]] : !torch.vtensor<[?,3],f32>, !torch.int -> !torch.int
+// CHECK:           %[[CST1:.*]] = torch.constant.int 1
+// CHECK:           %[[DIM1:.*]] = torch.aten.size.int %[[T]], %[[CST1]] : !torch.vtensor<[?,3],f32>, !torch.int -> !torch.int
+// CHECK:           %[[SIZE:.*]] = torch.prim.ListConstruct %[[DIM0]], %[[DIM1]] : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+// CHECK:           return %[[SIZE]] : !torch.list<!torch.int>
+func @torch.aten.size(%arg0: !torch.vtensor<[?,3],f32>) -> !torch.list<!torch.int> {
+  %0 = torch.aten.size %arg0 : !torch.vtensor<[?,3],f32> -> !torch.list<!torch.int>
+  return %0 : !torch.list<!torch.int>
+}


### PR DESCRIPTION
This PR also added a helper for scalar type conversion in the
TorchToLinalg file. Will need https://github.com/llvm/torch-mlir/pull/392 to add more complete testing for the helper.