### PR TITLE
[MLIR][TORCH] Add E2E support for [`aten.mul.Scalar`|`aten.addmm`]

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -105,6 +105,74 @@ class MmTanhModule(torch.nn.Module):
 def MmTanhModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(4, 2), tu.rand(2, 4))
 
+# ==============================================================================
+
+
+class AddmmModuleFloat(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, M, mat1, mat2):
+        return torch.addmm(M, mat1, mat2, beta=3.0, alpha=7.0)
+
+
+@register_test_case(module_factory=lambda: AddmmModuleFloat())
+def AddmmModuleFloat_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 4), tu.rand(4, 2), tu.rand(2, 4))
+
+#  ==============================================================================
+
+
+class AddmmModuleBroadcastable(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, M, mat1, mat2):
+        return torch.addmm(M, mat1, mat2, beta=2.0, alpha=7.0)
+
+
+@register_test_case(module_factory=lambda: AddmmModuleBroadcastable())
+def AddmmModule_broadcastable(module, tu: TestUtils):
+    module.forward(tu.rand(1, 2), tu.rand(3, 2), tu.rand(2, 2))
+
+#  ==============================================================================
+
+
+class AddmmModuleDifferentRankBroadcastable(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, M, mat1, mat2):
+        return torch.addmm(M, mat1, mat2, beta=11.0, alpha=7.0)
+
+
+@register_test_case(module_factory=lambda: AddmmModuleDifferentRankBroadcastable())
+def AddmmModule_differentRankBroadcastable(module, tu: TestUtils):
+    module.forward(tu.rand(3), tu.rand(3, 2), tu.rand(2, 3))
+
+#  ==============================================================================
+
 
 class AdaptiveAvgPool2dModule(torch.nn.Module):
     def __init__(self):

--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -345,6 +345,23 @@ def RsubModule_noalpha_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
     
 # ==============================================================================
+class ElementwiseMulScalarModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.mul(x, 100.0)
+
+@register_test_case(module_factory=lambda: ElementwiseMulScalarModule())
+def ElementwiseMulScalarModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+    
+# ==============================================================================
 class ElementwiseLogModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1076,6 +1076,24 @@ def Torch_AtenMmOp : Torch_Op<"aten.mm", [
   let assemblyFormat = "$self `,` $mat2 attr-dict `:` type($self) `,` type($mat2) `->` type($result)";
 }
 
+def Torch_AtenAddmmOp : Torch_Op<"aten.addmm", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::addmm : (Tensor, Tensor, Tensor, Scalar, Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchTensorType:$mat1,
+    AnyTorchTensorType:$mat2,
+    AnyTorchScalarType:$beta,
+    AnyTorchScalarType:$alpha
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $mat1 `,` $mat2 `,` $beta `,` $alpha attr-dict `:` type($self) `,` type($mat1) `,` type($mat2) `,` type($beta) `,` type($alpha) `->` type($result)";
+}
+
 def Torch_AtenMatmulOp : Torch_Op<"aten.matmul", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -483,6 +483,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         # Non-elementwise tensor compute ops
         emit("aten::linear : (Tensor, Tensor, Tensor?) -> (Tensor)")
         emit("aten::mm : (Tensor, Tensor) -> (Tensor)")
+        emit("aten::addmm : (Tensor, Tensor, Tensor, Scalar, Scalar) -> (Tensor)")
         emit("aten::matmul : (Tensor, Tensor) -> (Tensor)")
         emit(
             "aten::conv2d : (Tensor, Tensor, Tensor?, int[], int[], int[], int) -> (Tensor)"


### PR DESCRIPTION
This commit adds lowering of `aten.mul.Scalar` and also adds
decomposition of `aten.addmm` to `aten.mul.Scalar`, `aten.add.Tensor`
and `aten.mm` ops.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>