### PR TITLE
Add e2e test for `aten.log_softmax_back_data` op

### DIFF
--- a/e2e_testing/torchscript/backprop.py
+++ b/e2e_testing/torchscript/backprop.py
@@ -73,3 +73,23 @@ class GeluBackwardModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: GeluBackwardModule())
 def GeluBackwardModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(5, 3), tu.rand(5, 3))
+
+class LogSoftmaxBackwardModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, grad_output, output):
+        return torch.ops.aten._log_softmax_backward_data(grad_output,
+                                                         output,
+                                                         dim=1,
+                                                         input_dtype=6)
+
+@register_test_case(module_factory=lambda: LogSoftmaxBackwardModule())
+def LogSoftmaxBackwardModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 2, 4), torch.randn(3, 2, 4))

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2878,3 +2878,20 @@ def Torch_AtenGeluBackwardOp : Torch_Op<"aten.gelu_backward", [
   let assemblyFormat = "$grad `,` $self attr-dict `:` type($grad) `,` type($self) `->` type($result)";
 }
 
+def Torch_Aten_LogSoftmaxBackwardDataOp : Torch_Op<"aten._log_softmax_backward_data", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::_log_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$grad_output,
+    AnyTorchTensorType:$output,
+    Torch_IntType:$dim,
+    Torch_IntType:$input_dtype
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$grad_output `,` $output `,` $dim `,` $input_dtype attr-dict `:` type($grad_output) `,` type($output) `,` type($dim) `,` type($input_dtype) `->` type($result)";
+}
+

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -232,7 +232,7 @@ public:
             AtenMaskedFill_ScalarOp, AtenCopy_Op, AtenIndexPut_Op, AtenCumsumOp,
             AtenLayerNormOp, AtenClampOp, AtenLogOp, AtenSqrtOp, AtenFloorOp,
             AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp,
-            AtenTanhBackwardOp>(op)) {
+            AtenTanhBackwardOp, Aten_LogSoftmaxBackwardDataOp>(op)) {
       return getLatticeElement(op->getResult(0)).join(*operands[0]);
     }
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -627,6 +627,8 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)")
         emit("aten::tanh_backward : (Tensor, Tensor) -> (Tensor)")
         emit("aten::gelu_backward : (Tensor, Tensor) -> (Tensor)")
+        emit("aten::_log_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)")
+
 
 
 def emit_quantized_ops(torch_ir_dir: str, registry: Registry):


### PR DESCRIPTION
`aten.log_softmax_back_data` op lowering and required
tests has been added.

Signed-off-by: Prashant Kumar <prashant@nod-labs.com>