### PR TITLE
Support aten::linear with rank 3 inputs

### DIFF
--- a/e2e_testing/torchscript/mlp.py
+++ b/e2e_testing/torchscript/mlp.py
@@ -56,3 +56,22 @@ class Mlp2LayerModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: Mlp2LayerModule())
 def Mlp2LayerModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(5, 3))
+
+class BatchMlpLayerModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Reset seed to make model deterministic.
+        torch.manual_seed(0)
+        self.fc0 = nn.Linear(3, 5)
+        self.tanh0 = nn.Tanh()
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return self.tanh0(self.fc0(x))
+
+@register_test_case(module_factory=lambda: BatchMlpLayerModule())
+def BatchMlpLayerModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(7, 5, 3))


### PR DESCRIPTION
Now, aten::linear supports rank 3 inputs. This is a fix
for upcoming bert-inference task. The correct way should be
to support broadcasting in `aten.matmul` op and decompose
`aten.linear` into right ops.