### PR TITLE
[TORCH][MLIR] Add E2E support for `aten.gelu_backward` operation.

### DIFF
--- a/e2e_testing/torchscript/backprop.py
+++ b/e2e_testing/torchscript/backprop.py
@@ -53,3 +53,26 @@ class TanhBackwardModule(torch.nn.Module):
 def TanhBackward_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 3), torch.randn(3, 3))
 
+
+# ==============================================================================
+
+class GeluBackwardModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gelu = torch.nn.GELU()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, grad, input):
+        return torch.ops.aten.gelu_backward(grad, input)
+
+
+@register_test_case(module_factory=lambda: GeluBackwardModule())
+def GeluBackwardModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5, 3), tu.rand(5, 3))
+
+

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2845,3 +2845,18 @@ def Torch_AtenTanhBackwardOp : Torch_Op<"aten.tanh_backward", [
   let assemblyFormat = "$grad_output `,` $output attr-dict `:` type($grad_output) `,` type($output) `->` type($result)";
 }
 
+def Torch_AtenGeluBackwardOp : Torch_Op<"aten.gelu_backward", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::gelu_backward : (Tensor, Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$grad,
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$grad `,` $self attr-dict `:` type($grad) `,` type($self) `->` type($result)";
+}
+

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -224,13 +224,14 @@ public:
   visitOperation(Operation *op,
                  ArrayRef<LatticeElement<ValueKnowledge> *> operands) final {
     if (isa<TensorStaticInfoCastOp, CopyToValueTensorOp, CopyToNonValueTensorOp,
-            AtenTanhOp, AtenBatchNormOp, AtenReluOp, AtenGeluOp, AtenEqScalarOp,
-            AtenGeScalarOp, AtenGtScalarOp, AtenNeScalarOp, AtenBitwiseNotOp,
-            AtenExpOp, AtenSinOp, AtenCosOp, AtenSigmoidOp, DerefineOp,
-            AtenToPrimDeviceOp, AtenCpuOp, AtenContiguousOp, AtenFill_ScalarOp,
-            AtenDetachOp, AtenMaskedFill_ScalarOp, AtenCopy_Op, AtenIndexPut_Op,
-            AtenCumsumOp, AtenLayerNormOp, AtenClampOp, AtenLogOp, AtenSqrtOp,
-            AtenFloorOp, AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp,
+            AtenTanhOp, AtenBatchNormOp, AtenReluOp, AtenGeluOp,
+            AtenGeluBackwardOp, AtenEqScalarOp, AtenGeScalarOp, AtenGtScalarOp,
+            AtenNeScalarOp, AtenBitwiseNotOp, AtenExpOp, AtenSinOp, AtenCosOp,
+            AtenSigmoidOp, DerefineOp, AtenToPrimDeviceOp, AtenCpuOp,
+            AtenContiguousOp, AtenFill_ScalarOp, AtenDetachOp,
+            AtenMaskedFill_ScalarOp, AtenCopy_Op, AtenIndexPut_Op, AtenCumsumOp,
+            AtenLayerNormOp, AtenClampOp, AtenLogOp, AtenSqrtOp, AtenFloorOp,
+            AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp,
             AtenTanhBackwardOp>(op)) {
       return getLatticeElement(op->getResult(0)).join(*operands[0]);
     }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -625,6 +625,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         # backprop ops
         emit("aten::_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)")
         emit("aten::tanh_backward : (Tensor, Tensor) -> (Tensor)")
+        emit("aten::gelu_backward : (Tensor, Tensor) -> (Tensor)")
 
 
 def emit_quantized_ops(torch_ir_dir: str, registry: Registry):


### PR DESCRIPTION
This commit adds new operation `aten.gelu_backward` in the aten
dialect and adds lowering of this operation from aten to linalg.

Signed-Off-By: Prateek Gupta <prateek@nod-labs.com>