### PR TITLE
Fix bug in handling of pin_memory in AtenOnesOp conversion

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -493,6 +493,23 @@ class OnesModuleFloat(torch.nn.Module):
 def OnesModuleFloat_basic(module, tu: TestUtils):
     module.forward()
 
+
+class OnesModuleFalsePinMemory(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return torch.ones(3, 4, dtype=torch.float32, pin_memory=False)
+
+@register_test_case(module_factory=lambda: OnesModuleFalsePinMemory())
+def OnesModuleFalsePinMemory_basic(module, tu: TestUtils):
+    module.forward()
+
+
 class ContiguousModule(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
This commit fixes a bug with the way `ConvertAtenOnesOp` was matching on
the `pin_memory` bool argument, adds an error message for when the 
`pin_memory` is not false, and adds a unit test.

The reason the match was failing was because `matchPattern` was being given the
element from the `operands` list corresponding to `pin_memory`, which has been
casted to type `i1` by an `unrealized_conversion_cast`, instead of the operand from
`AtenOnesOp`. Since the `matchPattern` expected a `!torch.bool` the match
would always fail regardless of the value of `pin_memory`.