### PR TITLE
Install torch-mlir binaries

### DIFF
--- a/tools/torch-mlir-lsp-server/CMakeLists.txt
+++ b/tools/torch-mlir-lsp-server/CMakeLists.txt
@@ -1,6 +1,11 @@
 # torch-mlir-lsp-server is always linked dynamically as we want to distribute the
 # binaries with the python packages for hacking/debugging.
-add_executable(torch-mlir-lsp-server torch-mlir-lsp-server.cpp)
+add_llvm_executable(torch-mlir-lsp-server torch-mlir-lsp-server.cpp)
+
+install(TARGETS torch-mlir-lsp-server
+EXPORT TorchMLIRTargets
+RUNTIME DESTINATION ${LLVM_TOOLS_INSTALL_DIR}
+COMPONENT torch-mlir-lsp-server)
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)

--- a/tools/torch-mlir-opt/CMakeLists.txt
+++ b/tools/torch-mlir-opt/CMakeLists.txt
@@ -1,4 +1,9 @@
-add_executable(torch-mlir-opt torch-mlir-opt.cpp)
+add_llvm_executable(torch-mlir-opt torch-mlir-opt.cpp)
+
+install(TARGETS torch-mlir-opt
+EXPORT TorchMLIRTargets
+RUNTIME DESTINATION ${LLVM_TOOLS_INSTALL_DIR}
+COMPONENT torch-mlir-opt)
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)


### PR DESCRIPTION
In addition, use add_llvm_executable so that the relative rpath of
the installed binaries is set properly.