### PR TITLE
[MLIR][TORCH] Add E2E support for aten.mean op

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -739,7 +739,6 @@ class AddCDivModule(torch.nn.Module):
 def AddCDivModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1,3), tu.rand(1,3), tu.rand(1,3))
 
-
 # ==============================================================================
 
 class DropoutModule(torch.nn.Module):
@@ -751,6 +750,7 @@ class DropoutModule(torch.nn.Module):
         None,
         ([-1, -1], torch.float32, True),
     ])
+
     def forward(self, x):
         return torch.dropout(x, 0.0, False)
 
@@ -809,3 +809,75 @@ class Fill_TensorFloat64WithInt64(torch.nn.Module):
 @register_test_case(module_factory=lambda: Fill_TensorFloat64WithInt64())
 def Fill_TensorFloat64WithInt64_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4).to(torch.float64))
+
+
+class MeanModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, 4], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.mean(x)
+
+
+@register_test_case(module_factory=lambda: MeanModule())
+def MeanModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 4))
+
+
+class MeanDynamicSizesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.mean(x)
+
+
+@register_test_case(module_factory=lambda: MeanDynamicSizesModule())
+def MeanDynamicSizesModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 4))
+
+
+class NumelModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+
+    def forward(self, input):
+        return torch.numel(input)
+
+@register_test_case(module_factory=lambda: NumelModule())
+def NumelModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 3, 5))
+
+
+class NumelZeroRankModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([], torch.int64, True),
+    ])
+
+    def forward(self, input):
+        return torch.numel(input)
+
+@register_test_case(module_factory=lambda: NumelZeroRankModule())
+def NumelZeroRankModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10,[]))

--- a/e2e_testing/torchscript/reduction.py
+++ b/e2e_testing/torchscript/reduction.py
@@ -103,3 +103,22 @@ class ReduceSumDimIntListKeepDimModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceSumDimIntListKeepDimModule())
 def ReduceSumDimIntListKeepDimModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceMeanDtypeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, a):
+        return torch.mean(a, dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: ReduceMeanDtypeModule())
+def ReduceMeanDtypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -3062,3 +3062,17 @@ def Torch_AtenAddCDivOp : Torch_Op<"aten.addcdiv", [
   let assemblyFormat = "$self `,` $tensor1 `,` $tensor2 `,` $value attr-dict `:` type($self) `,` type($tensor1) `,` type($tensor2) `,` type($value) `->` type($result)";
 }
 
+def Torch_AtenMeanOp : Torch_Op<"aten.mean", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::mean : (Tensor, int?) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    TorchOptionalIntType:$dtype
+ );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+ let assemblyFormat = "$self `,` $dtype attr-dict `:` type($self) `,` type($dtype) `->` type($result)";
+}

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -419,6 +419,27 @@ public:
 };
 } // namespace
 
+// Decompose torch.mean into: sum(x)/div(numTensorElements).
+namespace {
+class DecomposeAtenMeanOp : public OpRewritePattern<AtenMeanOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AtenMeanOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value input = op.self();
+    Value output = op.result();
+    BaseTensorType inputTensorType = input.getType().cast<BaseTensorType>();
+    BaseTensorType outputTensorType = output.getType().cast<BaseTensorType>();
+    Value sum = rewriter.create<AtenSumOp>(loc, outputTensorType, input, op.dtype());
+    Value numTensorElements = rewriter.create<AtenNumelOp>(loc, input);
+    rewriter.replaceOpWithNewOp<AtenDivScalarOp>(op, outputTensorType, sum,
+                                                 numTensorElements);
+    return success();
+  }
+};
+} // namespace
+
 namespace {
 template<typename OpTy, typename T1T2Op>
 class DecomposeAtenAddCLikeOp : public OpRewritePattern<OpTy> {
@@ -464,6 +485,8 @@ class DecomposeComplexOpsPass
     target.addIllegalOp<AtenTanhBackwardOp>();
     patterns.add<DecomposeAtenAddmmOp>(context);
     target.addIllegalOp<AtenAddmmOp>();
+    patterns.add<DecomposeAtenMeanOp>(context);
+    target.addIllegalOp<AtenMeanOp>();
     patterns.add<DecomposeAtenMatmulOp>(context);
     patterns.add<DecomposeAten_LogSoftmaxBackwardDataOp>(context);
     target.addIllegalOp<Aten_LogSoftmaxBackwardDataOp>();

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -438,6 +438,11 @@ public:
       return visitAtenBmmOp(bmm, operands);
     } else if (auto matmul = dyn_cast<AtenMatmulOp>(op)) {
       return visitAtenMatmulOp(matmul, operands);
+    } else if (auto mean = dyn_cast<AtenMeanOp>(op)) {
+      Type defaultDtype = operands[0]->getValue().dtype;
+      Type dtype =
+          getDtypeOrDefault(mean.getContext(), mean.dtype(), defaultDtype);
+      return visitReductionAlongAllDimsOp(mean, dtype, operands);
     } else if (auto softmaxIntOp = dyn_cast<AtenSoftmaxIntOp>(op)) {
       return visitAtenSoftmaxLikeOp(softmaxIntOp, operands);
     } else if (auto _softmaxOp = dyn_cast<Aten_SoftmaxOp>(op)) {
@@ -563,7 +568,7 @@ private:
   ChangeResult
   visitAtenMatmulOp(AtenMatmulOp op,
                     ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  
+
   template <typename OpTy>
   ChangeResult
   visitAtenSoftmaxLikeOp(OpTy op,

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -520,6 +520,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::__and__.Tensor : (Tensor, Tensor) -> (Tensor)")
         emit("aten::sqrt : (Tensor) -> (Tensor)")
         emit("aten::_softmax : (Tensor, int, bool) -> (Tensor)")
+        emit("aten::mean : (Tensor, int?) -> (Tensor)")
 
         # Misc tensor ops.
         emit("aten::unsqueeze : (Tensor, int) -> (Tensor)")


### PR DESCRIPTION
The lowering of `aten.mean` op has been added.
Signed-Off By: Vivek Khandelwal <vivek@nod-labs.com>