### PR TITLE
Fix bug in NumToTensor handling of float values

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -630,7 +630,7 @@ def LogSoftmaxIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4).double())
 
 
-class NumToTensorModule(torch.nn.Module):
+class NumToTensorIntModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -642,8 +642,26 @@ class NumToTensorModule(torch.nn.Module):
     def forward(self):
         return torch.ops.prim.NumToTensor(1)
 
-@register_test_case(module_factory=lambda: NumToTensorModule())
-def NumToTensorModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: NumToTensorIntModule())
+def NumToTensorIntModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class NumToTensorFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+
+    def forward(self):
+        return torch.ops.prim.NumToTensor(1.0)
+
+
+@register_test_case(module_factory=lambda: NumToTensorFloatModule())
+def NumToTensorFloatModule_basic(module, tu: TestUtils):
     module.forward()
 
 


### PR DESCRIPTION
This commit fixes a type promotion bug when NumToTensor was given a
float as an argument. In particular, the rules for type promotion of a
scalar vary depending on if the scalar is part of a tensor op or
not. NumToTensor falls under the second category, but it was being
treated as part of the first category.

This bug was encountered here https://github.com/llvm/torch-mlir/pull/430.

@cathyzhyi PTAL.