### PR TITLE
[MLIR][TORCH] Add E2E support for aten.div.Scalar

### DIFF
--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -479,3 +479,21 @@ class ElementwiseRsqrtModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseRsqrtModule())
 def ElementwiseRsqrtModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+class ElementwiseDivScalarModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.div(x, 10.0)
+
+
+@register_test_case(module_factory=lambda: ElementwiseDivScalarModule())
+def ElementwiseDivScalarModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))


### PR DESCRIPTION
This commit adds lowering of `aten.div.Scalar`.

Signed-Off By: Vivek Khandelwal <vivek@nod-labs.com>