### PR TITLE
[MLIR][TORCH] Add E2E support for `aten.squeeze` op

### DIFF
--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -41,6 +41,7 @@ from . import argmax
 from . import matmul
 from . import view
 from . import scalar
+from . import squeeze
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend', 'tosa', 'external']

--- a/e2e_testing/torchscript/squeeze.py
+++ b/e2e_testing/torchscript/squeeze.py
@@ -1,0 +1,121 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+
+class SqueezeStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 7, 1, 3, 1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeStaticModule())
+def SqueezeModule_static(module, tu: TestUtils):
+    module.forward(tu.rand(1, 7, 1, 3, 1))
+
+
+# ==============================================================================
+
+
+class SqueezeDynamicModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, -1, 1, 384, -1, 1, 1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeDynamicModule())
+def SqueezeModule_dynamic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 8, 1, 384, 12, 1, 1))
+
+
+# ==============================================================================
+
+
+class SqueezeNoUnitDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([4, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeNoUnitDimModule())
+def SqueezeModule_noUnitDim(module, tu: TestUtils):
+    module.forward(tu.rand(4, 2, 3))
+
+
+# ==============================================================================
+
+
+class SqueezeAllUnitDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeAllUnitDimModule())
+def SqueezeModule_allUnitDim(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1))
+
+
+# ==============================================================================
+
+
+class SqueezeBroadcastModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([], torch.float32, True),
+    ])
+    def forward(self, a, b):
+        return a * b.squeeze()
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeBroadcastModule())
+def SqueezeModule_broadcast(module, tu: TestUtils):
+    module.forward(tu.rand(4, 3), tu.rand())
+

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1508,6 +1508,20 @@ def Torch_AtenUnsqueezeOp : Torch_Op<"aten.unsqueeze", [
   let assemblyFormat = "$self `,` $dim attr-dict `:` type($self) `,` type($dim) `->` type($result)";
 }
 
+def Torch_AtenSqueezeOp : Torch_Op<"aten.squeeze", [
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::squeeze : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
+  let hasFolder = 1;
+}
+
 def Torch_AtenFlattenUsingIntsOp : Torch_Op<"aten.flatten.using_ints", [
     AllowsTypeRefinement
   ]> {

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -451,6 +451,18 @@ OpFoldResult AtenNeBoolOp::fold(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// AtenSqueezeOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenSqueezeOp::fold(ArrayRef<Attribute> operands) {
+  if (auto tensorType = getOperand().getType().dyn_cast<BaseTensorType>()) {
+    if (tensorType.hasSizes() && tensorType.getSizes().size() == 0)
+      return getOperand();
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
 // AtenDimOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -89,7 +89,7 @@ public:
       Operation *op = workList.pop_back_val();
       if (auto copyToValueTensor = dyn_cast<CopyToValueTensorOp>(op)) {
         copyToValueTensorOps.push_back(copyToValueTensor);
-      } else if (isa<AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
+      } else if (isa<AtenSqueezeOp, AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
                      AtenTransposeIntOp, TensorStaticInfoCastOp,
                      AtenBroadcastToOp, AtenToDtypeOp, AtenContiguousOp,
                      AtenPermuteOp, AtenViewOp, AtenExpandOp,

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -523,6 +523,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
 
         # Misc tensor ops.
         emit("aten::unsqueeze : (Tensor, int) -> (Tensor)")
+        emit("aten::squeeze : (Tensor) -> (Tensor)", has_folder=True)
         emit("aten::flatten.using_ints : (Tensor, int, int) -> (Tensor)")
         emit("aten::dim : (Tensor) -> (int)", has_folder=True)
         emit("aten::size : (Tensor) -> (int[])", has_canonicalizer=True)

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -605,3 +605,11 @@ func @torch.aten.Int.Tensor(%arg0: !torch.int) -> !torch.int {
   %scalar = torch.aten.Int.Tensor %tensor : !torch.vtensor<[],si64> -> !torch.int
   return %scalar : !torch.int
 }
+
+// CHECK-LABEL:   func @torch.aten.squeeze$zero_rank(
+// CHECK-SAME:            %[[ARG:.*]]: !torch.tensor<[],f32>) -> !torch.tensor<[],f32> {
+// CHECK-NEXT:      return %[[ARG]] : !torch.tensor<[],f32>
+func @torch.aten.squeeze$zero_rank(%arg0: !torch.tensor<[],f32>) -> !torch.tensor<[],f32> {
+  %0 = torch.aten.squeeze %arg0 : !torch.tensor<[],f32> -> !torch.tensor<[],f32>
+  return %0 : !torch.tensor<[],f32>
+}


### PR DESCRIPTION
This commit adds lowering of `aten.Squeeze` op into
`linalg.TensorCollapseShape` op. The size 1 dynamic dimensions are not
handled as a part of this commit.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>