### PR TITLE
Lower aten::view with linalg.collapse and linalg.expand

### DIFF
--- a/e2e_testing/torchscript/view.py
+++ b/e2e_testing/torchscript/view.py
@@ -9,7 +9,6 @@ from torch_mlir_e2e_test.torchscript.registry import register_test_case
 from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
 
 # ==============================================================================
-
 class ViewExpandModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -46,3 +45,60 @@ class ViewDynamicExpandModule(torch.nn.Module):
 def ViewDynamicExpandModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 4, 30, 384))
 
+
+# ==============================================================================
+class ViewDynamicExpandWithAtenSizeIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(a.size(0), a.size(1), 12, 32)
+
+@register_test_case(module_factory=lambda: ViewDynamicExpandWithAtenSizeIntModule())
+def ViewDynamicExpandWithAtenSizeIntModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 4, 384))
+
+# ==============================================================================
+class ViewCollapseModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(8)
+
+@register_test_case(module_factory=lambda: ViewCollapseModule())
+def ViewCollapseModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 4))
+
+
+# ==============================================================================
+class ViewCollapseDynamicWithAtenSizeIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1, -1, -1], torch.float32, True),
+        ([], torch.int64, True),
+        ([], torch.int64, True),
+    ])
+
+    def forward(self, a, b, c):
+        return a.view(a.size(0), int(b), int(c), a.size(3), 384)
+
+@register_test_case(module_factory=lambda: ViewCollapseDynamicWithAtenSizeIntModule())
+def ViewCollapseDynamicWithAtenSizeIntModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 5, 4, 12, 32), torch.tensor(3), torch.tensor(5))

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
@@ -108,6 +108,34 @@ m_TorchConstantIntList(SmallVectorImpl<int64_t> &bind_values) {
   return detail::torch_list_construct_op_binder(bind_values);
 }
 
+namespace detail {
+/// Matches the expected tensor and dim from `torch.aten.size.int`.
+struct torch_tensor_size_int_op_binder {
+  int64_t *dim;
+  Value tensor;
+
+  /// Creates a matcher instance that binds the value to dim if match succeeds.
+  torch_tensor_size_int_op_binder(Value tensor, int64_t *dim)
+      : dim(dim), tensor(tensor) {}
+
+  bool match(Operation *op) {
+    if (auto atenSizeIntOp = dyn_cast<Torch::AtenSizeIntOp>(op)) {
+      if (atenSizeIntOp.self() == tensor) {
+        if (matchPattern(atenSizeIntOp.dim(), m_TorchConstantInt(dim)))
+          return true;
+      }
+    }
+    return false;
+  }
+};
+} // namespace detail
+
+/// Matches the tensor and dim of `torch.size.int`.
+inline detail::torch_tensor_size_int_op_binder
+m_TorchTensorSizeInt(Value tensor, int64_t *dim) {
+  return detail::torch_tensor_size_int_op_binder(tensor, dim);
+}
+
 /// Create code to copy `tensor` to type `newType`.
 ///
 /// This involves two independent steps, which we keep orthogonal in our


### PR DESCRIPTION
We only handle the expanding OR collapsing cases, we do not handle
expanding And collapsing happening at the same time or cases where
it's neither collapsing nor expanding like view of [2,3] for
3x2 tensor.

It's assumed that if a shape list element is got from
`aten.size(tensor, dim)` the corresponding dim is not splitted or
collapsed. This assumption makes it easier to deal with dynamic shapes.