### PR TITLE
Add support for dtype argument in reduction ops

### DIFF
--- a/e2e_testing/torchscript/reduction.py
+++ b/e2e_testing/torchscript/reduction.py
@@ -30,6 +30,25 @@ def ReduceSumModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class ReduceSumDtypeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: ReduceSumDtypeModule())
+def ReduceSumDtypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))
+
+# ==============================================================================
+
 class ReduceSumDimIntListModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -46,6 +65,25 @@ class ReduceSumDimIntListModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceSumDimIntListModule())
 def ReduceSumDimIntListModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceSumDimIntListDtypeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, (0, 1), dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: ReduceSumDimIntListDtypeModule())
+def ReduceSumDimIntListDtypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))
 
 # ==============================================================================
 

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -1673,10 +1673,14 @@ static Value createLinalgNeutralElementForReduceOp(OpBuilder &b, Location loc,
 
 static Value createLinalgPayloadCalculationForReduceOp(
     OpBuilder &b, Location loc, ValueRange payloadArgs, Operation *op,
-    ArrayRef<Value> operands, Type elementType) {
+    ArrayRef<Value> operands, Type resultElementType) {
   if (isa<AtenSumOp, AtenSumDimIntListOp>(op) &&
-      elementType.isa<mlir::FloatType>())
-    return b.create<arith::AddFOp>(loc, payloadArgs);
+      resultElementType.isa<mlir::FloatType>()) {
+    Value self =
+        convertScalarToDtype(b, loc, payloadArgs[0], resultElementType);
+    Value result = payloadArgs[1];
+    return b.create<arith::AddFOp>(loc, self, result);
+  }
   op->emitError("unimplemented lowering in "
                 "createLinalgPayloadCalculationForReduceOp");
   return nullptr;


### PR DESCRIPTION
Many reduction ops take as an argument an optional output dtype that
can change the type of the input tensor before the reduction is
performed. This commit adds support for the optional dtype flag that
had been previously ignored.

Test:
/tools/torchscript_e2e_test.sh -f 'ReduceSumDtype'
/tools/torchscript_e2e_test.sh -f 'ReduceSumDImIntListDtype'