### PR TITLE
[TORCH][MLIR] Add E2E support for `aten.squeeze.dim` op

### DIFF
--- a/e2e_testing/torchscript/squeeze.py
+++ b/e2e_testing/torchscript/squeeze.py
@@ -119,3 +119,113 @@ class SqueezeBroadcastModule(torch.nn.Module):
 def SqueezeModule_broadcast(module, tu: TestUtils):
     module.forward(tu.rand(4, 3), tu.rand())
 
+
+# ==============================================================================
+
+
+class SqueezeDimStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 7], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a, 0)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeDimStaticModule())
+def SqueezeDimModule_static(module, tu: TestUtils):
+    module.forward(tu.rand(1, 7))
+    
+
+# ==============================================================================
+
+
+class SqueezeDimDynamicModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, 1, 384, -1, 1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a, 4)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeDimDynamicModule())
+def SqueezeDimModule_dynamic(module, tu: TestUtils):
+    module.forward(tu.rand(8, 1, 384, 12, 1))
+
+
+# ==============================================================================
+
+
+class SqueezeDimNegDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, -1, 1, 384, -1, 1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a, -6)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeDimNegDimModule())
+def SqueezeDimModule_negDim(module, tu: TestUtils):
+    module.forward(tu.rand(1, 8, 1, 384, 12, 1))
+
+
+# ==============================================================================
+
+
+class SqueezeDimIdentityModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([4, 1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a, 0)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeDimIdentityModule())
+def SqueezeDimModule_identity(module, tu: TestUtils):
+    module.forward(tu.rand(4, 1, 3))
+
+
+# ==============================================================================
+
+
+class SqueezeDimUnitDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a, 0)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeDimUnitDimModule())
+def SqueezeDimModule_unitDim(module, tu: TestUtils):
+    module.forward(tu.rand(1))
+

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1608,6 +1608,21 @@ def Torch_AtenNllLossForwardOp : Torch_Op<"aten.nll_loss_forward", [
   let assemblyFormat = "$self `,` $target `,` $weight `,` $reduction `,` $ignore_index attr-dict `:` type($self) `,` type($target) `,` type($weight) `,` type($reduction) `,` type($ignore_index) `->` type($output) `,` type($total_weight)";
 }
 
+def Torch_AtenSqueezeDimOp : Torch_Op<"aten.squeeze.dim", [
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::squeeze.dim : (Tensor, int) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    Torch_IntType:$dim
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $dim attr-dict `:` type($self) `,` type($dim) `->` type($result)";
+  let hasFolder = 1;
+}
+
 def Torch_AtenUnsqueezeOp : Torch_Op<"aten.unsqueeze", [
     AllowsTypeRefinement
   ]> {

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -463,6 +463,18 @@ OpFoldResult AtenSqueezeOp::fold(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// AtenSqueezeDimOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenSqueezeDimOp::fold(ArrayRef<Attribute> operands) {
+  if (auto tensorType = getOperand(0).getType().dyn_cast<BaseTensorType>()) {
+    if (tensorType.hasSizes() && tensorType.getSizes().size() == 0)
+      return getOperand(0);
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
 // AtenDimOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -89,11 +89,12 @@ public:
       Operation *op = workList.pop_back_val();
       if (auto copyToValueTensor = dyn_cast<CopyToValueTensorOp>(op)) {
         copyToValueTensorOps.push_back(copyToValueTensor);
-      } else if (isa<AtenSqueezeOp, AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
-                     AtenTransposeIntOp, TensorStaticInfoCastOp,
-                     AtenBroadcastToOp, AtenToDtypeOp, AtenContiguousOp,
-                     AtenPermuteOp, AtenViewOp, AtenExpandOp, AtenFill_ScalarOp,
-                     AtenSliceTensorOp, AtenSelectIntOp>(op)) {
+      } else if (isa<AtenSqueezeOp, AtenSqueezeDimOp, AtenUnsqueezeOp,
+                     AtenFlattenUsingIntsOp, AtenTransposeIntOp,
+                     TensorStaticInfoCastOp, AtenBroadcastToOp, AtenToDtypeOp,
+                     AtenContiguousOp, AtenPermuteOp, AtenViewOp, AtenExpandOp,
+                     AtenFill_ScalarOp, AtenSliceTensorOp, AtenSelectIntOp>(
+                     op)) {
         // AtenContiguousOp might return a view, so this is conservatively
         // correct. We could potentially be more precise and identify the cases
         // that it does not return a view and treat those as having value

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -527,6 +527,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::nll_loss_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)")
 
         # Misc tensor ops.
+        emit("aten::squeeze.dim : (Tensor, int) -> (Tensor)", has_folder=True)
         emit("aten::unsqueeze : (Tensor, int) -> (Tensor)")
         emit("aten::squeeze : (Tensor) -> (Tensor)", has_folder=True)
         emit("aten::flatten.using_ints : (Tensor, int, int) -> (Tensor)")

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -613,3 +613,12 @@ func @torch.aten.squeeze$zero_rank(%arg0: !torch.tensor<[],f32>) -> !torch.tenso
   %0 = torch.aten.squeeze %arg0 : !torch.tensor<[],f32> -> !torch.tensor<[],f32>
   return %0 : !torch.tensor<[],f32>
 }
+
+// CHECK-LABEL:   func @torch.aten.squeeze.dim$zero_rank(
+// CHECK-SAME:            %[[ARG:.*]]: !torch.tensor<[],f32>) -> !torch.tensor<[],f32> {
+// CHECK-NEXT:      return %[[ARG]] : !torch.tensor<[],f32>
+func @torch.aten.squeeze.dim$zero_rank(%arg0: !torch.tensor<[],f32>) -> !torch.tensor<[],f32> {
+  %int0 = torch.constant.int 0
+  %0 = torch.aten.squeeze.dim %arg0, %int0 : !torch.tensor<[],f32>, !torch.int -> !torch.tensor<[],f32>
+  return %0 : !torch.tensor<[],f32>
+}


### PR DESCRIPTION
This commit adds lowering of `aten.Squeeze.dim` op into
`linalg.TensorCollapseShape` op. The size 1 dynamic dimension is not
handled as a part of this commit.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>