### PR TITLE
[tosa] Add Torch->TOSA reduction operators

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -684,3 +684,40 @@ class ReturnThreeTensorFloat32(torch.nn.Module):
 def ReturnThreeTensorFloat32_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 3), tu.rand(2, 3), tu.rand(2, 3))
 
+class AddCMulModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,   
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, input, tensor1, tensor2):
+        return torch.addcmul(input, tensor1, tensor2, value=1.0)
+
+@register_test_case(module_factory=lambda: AddCMulModule())
+def AddCMulModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1,3), tu.rand(1,3), tu.rand(1,3))
+
+class AddCDivModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,   
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, input, tensor1, tensor2):
+        return torch.addcdiv(input, tensor1, tensor2, value=1.0)
+
+@register_test_case(module_factory=lambda: AddCDivModule())
+def AddCDivModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1,3), tu.rand(1,3), tu.rand(1,3))

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -457,6 +457,23 @@ class SoftmaxIntModule(torch.nn.Module):
 def SoftmaxIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4))
 
+class _SoftmaxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, tensor):
+        return torch.ops.aten._softmax(tensor, 0, False)
+
+
+@register_test_case(module_factory=lambda: _SoftmaxModule())
+def _SoftmaxModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 2, 4))
+
 
 class SoftmaxIntNegDimModule(torch.nn.Module):
     def __init__(self):

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -739,7 +739,6 @@ class AddCDivModule(torch.nn.Module):
 def AddCDivModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1,3), tu.rand(1,3), tu.rand(1,3))
 
-
 # ==============================================================================
 
 class DropoutModule(torch.nn.Module):
@@ -751,6 +750,7 @@ class DropoutModule(torch.nn.Module):
         None,
         ([-1, -1], torch.float32, True),
     ])
+
     def forward(self, x):
         return torch.dropout(x, 0.0, False)
 
@@ -809,3 +809,75 @@ class Fill_TensorFloat64WithInt64(torch.nn.Module):
 @register_test_case(module_factory=lambda: Fill_TensorFloat64WithInt64())
 def Fill_TensorFloat64WithInt64_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4).to(torch.float64))
+
+
+class MeanModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, 4], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.mean(x)
+
+
+@register_test_case(module_factory=lambda: MeanModule())
+def MeanModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 4))
+
+
+class MeanDynamicSizesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.mean(x)
+
+
+@register_test_case(module_factory=lambda: MeanDynamicSizesModule())
+def MeanDynamicSizesModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 4))
+
+
+class NumelModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+
+    def forward(self, input):
+        return torch.numel(input)
+
+@register_test_case(module_factory=lambda: NumelModule())
+def NumelModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 3, 5))
+
+
+class NumelZeroRankModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([], torch.int64, True),
+    ])
+
+    def forward(self, input):
+        return torch.numel(input)
+
+@register_test_case(module_factory=lambda: NumelZeroRankModule())
+def NumelZeroRankModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10,[]))

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -758,3 +758,54 @@ class DropoutModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: DropoutModule())
 def DropoutModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
+
+
+class Fill_TensorFloat64WithFloat32(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, tensor):
+        return torch.ops.aten.fill_(tensor, 3.0)
+
+@register_test_case(module_factory=lambda: Fill_TensorFloat64WithFloat32())
+def Fill_TensorFloat64WithFloat32_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 2, 4))
+
+
+class Fill_TensorFloat64WithFloat64(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, tensor):
+        return torch.ops.aten.fill_(tensor, 3.0)
+
+@register_test_case(module_factory=lambda: Fill_TensorFloat64WithFloat64())
+def Fill_TensorFloat64WithFloat64_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 2, 4).to(torch.float64))
+
+
+class Fill_TensorFloat64WithInt64(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, tensor):
+        return torch.ops.aten.fill_(tensor, 3)
+
+@register_test_case(module_factory=lambda: Fill_TensorFloat64WithInt64())
+def Fill_TensorFloat64WithInt64_basic(module, tu: TestUtils):
+    module.forward(torch.randn(3, 2, 4).to(torch.float64))

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -738,3 +738,23 @@ class AddCDivModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: AddCDivModule())
 def AddCDivModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1,3), tu.rand(1,3), tu.rand(1,3))
+
+
+# ==============================================================================
+
+class DropoutModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.dropout(x, 0.0, False)
+
+
+@register_test_case(module_factory=lambda: DropoutModule())
+def DropoutModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -100,6 +100,8 @@ class MmTanhModule(torch.nn.Module):
     def matmul(self, lhs, rhs):
         return torch.mm(lhs, rhs)
 
+# ==============================================================================
+
 
 @register_test_case(module_factory=lambda: MmTanhModule())
 def MmTanhModule_basic(module, tu: TestUtils):
@@ -192,6 +194,8 @@ class AdaptiveAvgPool2dModule(torch.nn.Module):
 def AdaptiveAvgPool2dModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(10, 3, 8, 9))
 
+# ==============================================================================
+
 
 class FlattenStaticModule(torch.nn.Module):
     def __init__(self):
@@ -210,6 +214,8 @@ class FlattenStaticModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: FlattenStaticModule())
 def FlattenStaticModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(10, 3, 8, 9, 3, 4))
+
+# ==============================================================================
 
 
 class FlattenRank0Module(torch.nn.Module):
@@ -230,6 +236,8 @@ class FlattenRank0Module(torch.nn.Module):
 def FlattenRank0Module_basic(module, tu: TestUtils):
     module.forward(torch.tensor(4.0))
 
+# ==============================================================================
+
 
 class FlattenDynamicModule(torch.nn.Module):
     def __init__(self):
@@ -249,6 +257,8 @@ class FlattenDynamicModule(torch.nn.Module):
 def FlattenDynamicModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(10, 3, 8, 9, 3, 4))
 
+# ==============================================================================
+
 
 class MaxPool2dModule(torch.nn.Module):
     def __init__(self):
@@ -265,6 +275,8 @@ class MaxPool2dModule(torch.nn.Module):
     ])
     def forward(self, x):
         return self.mp2d(x)
+
+# ==============================================================================
 
 
 @register_test_case(module_factory=lambda: MaxPool2dModule())
@@ -283,6 +295,8 @@ class TransposeIntModule(torch.nn.Module):
     ])
     def forward(self, x):
         return torch.transpose(x, 0, 1)
+
+# ==============================================================================
 
 
 @register_test_case(module_factory=lambda: TransposeIntModule())
@@ -305,6 +319,8 @@ class PermuteModule(torch.nn.Module):
 def PermuteModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 2))
 
+# ==============================================================================
+
 class TransposeIntNegDimsModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -316,6 +332,8 @@ class TransposeIntNegDimsModule(torch.nn.Module):
     ])
     def forward(self, x):
         return torch.transpose(x, -1, -2)
+
+# ==============================================================================
 
 
 @register_test_case(module_factory=lambda: TransposeIntNegDimsModule())
@@ -334,6 +352,8 @@ class PermuteNegativeIndexModule(torch.nn.Module):
     ])
     def forward(self, x):
         return x.permute(0, -1, 1)
+
+# ==============================================================================
 
 @register_test_case(module_factory=lambda: PermuteNegativeIndexModule())
 def PermuteNegativeIndexModule_basic(module, tu: TestUtils):
@@ -357,6 +377,8 @@ class TensorsConcatModule(torch.nn.Module):
 def TensorsConcatModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 2, 4), tu.rand(2, 1, 4), tu.rand(2, 3, 4))
 
+# ==============================================================================
+
 
 class GatherModule(torch.nn.Module):
     def __init__(self):
@@ -375,6 +397,8 @@ class GatherModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: GatherModule())
 def GatherModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 3, 4), torch.tensor([[[1, 2, 3], [1, 2, 3]]]))
+
+# ==============================================================================
 
 class AddSizeIntModule(torch.nn.Module):
     def __init__(self):
@@ -395,6 +419,8 @@ class AddSizeIntModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: AddSizeIntModule())
 def AddSizeIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 3))
+
+# ==============================================================================
 
 
 class AddSizeIntNegDimModule(torch.nn.Module):
@@ -417,6 +443,8 @@ class AddSizeIntNegDimModule(torch.nn.Module):
 def AddSizeIntNegDimModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 3))
 
+# ==============================================================================
+
 class EmbeddingModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -438,6 +466,7 @@ class EmbeddingModule(torch.nn.Module):
 def EmbeddingModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(100, (3, 3)))
 
+# ==============================================================================
 
 class SoftmaxIntModule(torch.nn.Module):
     def __init__(self):
@@ -474,6 +503,8 @@ class _SoftmaxModule(torch.nn.Module):
 def _SoftmaxModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4))
 
+# ==============================================================================
+
 
 class SoftmaxIntNegDimModule(torch.nn.Module):
     def __init__(self):
@@ -494,6 +525,8 @@ class SoftmaxIntNegDimModule(torch.nn.Module):
 def SoftmaxIntNegDimModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4))
 
+# ==============================================================================
+
 
 class SoftmaxIntArgTypeF64Module(torch.nn.Module):
     def __init__(self):
@@ -513,6 +546,7 @@ class SoftmaxIntArgTypeF64Module(torch.nn.Module):
 def SoftmaxIntArgTypeF64Module_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4).double())
 
+# ==============================================================================
 
 class BroadcastToModule(torch.nn.Module):
     def __init__(self):
@@ -531,6 +565,8 @@ class BroadcastToModule(torch.nn.Module):
 def BroadcastToModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1, 1))
 
+# ==============================================================================
+
 class ExpandModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -548,6 +584,9 @@ class ExpandModule(torch.nn.Module):
 def ExpandModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1, 1))
 
+# ==============================================================================
+
+
 class OnesModuleInt(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -562,6 +601,8 @@ class OnesModuleInt(torch.nn.Module):
 @register_test_case(module_factory=lambda: OnesModuleInt())
 def OnesModuleInt_basic(module, tu: TestUtils):
     module.forward()
+
+# ==============================================================================
 
 class OnesModuleFloat(torch.nn.Module):
     def __init__(self):
@@ -594,6 +635,7 @@ class OnesModuleFalsePinMemory(torch.nn.Module):
 def OnesModuleFalsePinMemory_basic(module, tu: TestUtils):
     module.forward()
 
+# ==============================================================================
 
 class ContiguousModule(torch.nn.Module):
     def __init__(self):
@@ -611,7 +653,7 @@ class ContiguousModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ContiguousModule())
 def ContiguousModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1))
-
+    
 class TensorToInt(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -681,6 +723,7 @@ class NumToTensorFloatModule(torch.nn.Module):
 def NumToTensorFloatModule_basic(module, tu: TestUtils):
     module.forward()
 
+# ==============================================================================
 
 # This test can be removed once we have one real op returning 3 float32 tensors
 class ReturnThreeTensorFloat32(torch.nn.Module):

--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -196,6 +196,24 @@ def ElementwiseReluModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(4, 2) - 0.5)
 
 # ==============================================================================
+class ElementwiseLeakyReluModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.leaky_relu(x, negative_slope=0.1)
+
+
+@register_test_case(module_factory=lambda: ElementwiseLeakyReluModule())
+def ElementwiseLeakyReluModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 2) - 0.5)
+
+# ==============================================================================
 
 
 class ElementwiseGeluModule(torch.nn.Module):

--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -479,3 +479,21 @@ class ElementwiseRsqrtModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseRsqrtModule())
 def ElementwiseRsqrtModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+class ElementwiseDivScalarModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.div(x, 10.0)
+
+
+@register_test_case(module_factory=lambda: ElementwiseDivScalarModule())
+def ElementwiseDivScalarModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))

--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -499,6 +499,43 @@ def ElementwiseRsqrtModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
 
 # ==============================================================================
+
+class ElementwiseAbsModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return torch.abs(a)
+
+@register_test_case(module_factory=lambda: ElementwiseAbsModule())
+def ElementwiseAbsModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5, low=-1.0, high=1.0))
+
+# ==============================================================================
+
+class ElementwiseReciprocalModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return torch.reciprocal(a)
+
+@register_test_case(module_factory=lambda: ElementwiseReciprocalModule())
+def ElementwiseReciprocalModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4))
+
+# ==============================================================================
+
 class ElementwiseDivScalarModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -552,3 +552,24 @@ class ElementwiseDivScalarModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseDivScalarModule())
 def ElementwiseDivScalarModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+class ElementwiseAndIntegerModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+        ([-1, -1], torch.int64, True),
+    ])
+
+    def forward(self, x, y):
+        return torch.bitwise_and(x, y)
+
+
+@register_test_case(module_factory=lambda: ElementwiseAndIntegerModule())
+def ElementwiseAndIntegerModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(-10, 10, (3, 4)).to(torch.int32),
+                   torch.randint(-10, 10, (3, 4)))

--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -42,6 +42,7 @@ from . import matmul
 from . import view
 from . import scalar
 from . import squeeze
+from . import slice_like
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend', 'tosa', 'external']

--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -41,6 +41,7 @@ from . import argmax
 from . import matmul
 from . import view
 from . import scalar
+from . import squeeze
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend', 'tosa', 'external']

--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -40,6 +40,7 @@ from . import reduction
 from . import argmax
 from . import matmul
 from . import view
+from . import scalar
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend', 'tosa', 'external']

--- a/e2e_testing/torchscript/reduction.py
+++ b/e2e_testing/torchscript/reduction.py
@@ -30,6 +30,25 @@ def ReduceSumModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class ReduceSumDtypeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: ReduceSumDtypeModule())
+def ReduceSumDtypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))
+
+# ==============================================================================
+
 class ReduceSumDimIntListModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -46,6 +65,25 @@ class ReduceSumDimIntListModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceSumDimIntListModule())
 def ReduceSumDimIntListModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceSumDimIntListDtypeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, (0, 1), dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: ReduceSumDimIntListDtypeModule())
+def ReduceSumDimIntListDtypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))
 
 # ==============================================================================
 

--- a/e2e_testing/torchscript/reduction.py
+++ b/e2e_testing/torchscript/reduction.py
@@ -103,3 +103,22 @@ class ReduceSumDimIntListKeepDimModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceSumDimIntListKeepDimModule())
 def ReduceSumDimIntListKeepDimModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceMeanDtypeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, a):
+        return torch.mean(a, dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: ReduceMeanDtypeModule())
+def ReduceMeanDtypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))

--- a/e2e_testing/torchscript/scalar.py
+++ b/e2e_testing/torchscript/scalar.py
@@ -1,0 +1,29 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+
+class AddIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([], torch.int64, True),
+        ([], torch.int64, True),
+    ])
+    def forward(self, lhs, rhs):
+        return int(lhs)+int(rhs)
+
+
+@register_test_case(module_factory=lambda: AddIntModule())
+def AddIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(-100, 100,()), torch.randint(-100, 100,()))

--- a/e2e_testing/torchscript/slice_like.py
+++ b/e2e_testing/torchscript/slice_like.py
@@ -1,0 +1,227 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+class SliceModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[0:5:1, 1:3:1, 2:4:1]
+
+
+@register_test_case(module_factory=lambda: SliceModule())
+def SliceModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+
+
+# ==============================================================================
+
+# This Test currently xfails due to https://github.com/llvm/torch-mlir/issues/448
+class SliceOutOfUpperBoundIndexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:8, :5, 8:]
+
+
+@register_test_case(module_factory=lambda: SliceOutOfUpperBoundIndexModule())
+def SliceOutOfUpperBoundIndexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+class SliceOutOfLowerBoundEndIndexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:-8,-7:,:]
+
+
+@register_test_case(module_factory=lambda: SliceOutOfLowerBoundEndIndexModule())
+def SliceOutOfLowerBoundEndIndexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+class SliceOutOfLowerBoundStartIndexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[-8:3:1, 1:3:1, 2:4:1]
+
+
+@register_test_case(module_factory=lambda: SliceOutOfLowerBoundStartIndexModule())
+def SliceOutOfLowerBoundStartIndexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+# This Test currently xfails due to https://github.com/llvm/torch-mlir/issues/448
+class SliceEndSleStartModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:0, 4:3, :-7]
+
+
+@register_test_case(module_factory=lambda: SliceEndSleStartModule())
+def SliceEndSleStartModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+# This Test currently xfails due to https://github.com/llvm/torch-mlir/issues/448
+class SliceStartEqEndModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[5:5, 3:3, -1:]
+
+
+@register_test_case(module_factory=lambda: SliceStartEqEndModule())
+def SliceStartEqEndModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,4,7))
+
+# ==============================================================================
+
+class SliceSizeTwoStepModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[0:5:2, 0:3:2, 0:4:2]
+
+
+@register_test_case(module_factory=lambda: SliceSizeTwoStepModule())
+def SliceSizeTwoStepModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(10,5,17))
+
+# ==============================================================================
+
+class SliceNegIdxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:-1, -2:-1]
+
+
+@register_test_case(module_factory=lambda: SliceNegIdxModule())
+def SliceNegIdxModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3,9))
+
+# ==============================================================================
+
+class SliceSingleIdxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[0]
+
+
+@register_test_case(module_factory=lambda: SliceSingleIdxModule())
+def SliceSingleIdxModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,8))
+
+# ==============================================================================
+
+class SliceWholeTensorModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return x[:, :]
+
+
+@register_test_case(module_factory=lambda: SliceWholeTensorModule())
+def SliceWholeTensorModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6,8))
+
+# ==============================================================================
+
+class SelectIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return x.select(0,0)
+
+
+@register_test_case(module_factory=lambda: SelectIntModule())
+def SelectIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (5,5)))
+
+# ==============================================================================
+

--- a/e2e_testing/torchscript/squeeze.py
+++ b/e2e_testing/torchscript/squeeze.py
@@ -1,0 +1,121 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+
+class SqueezeStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 7, 1, 3, 1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeStaticModule())
+def SqueezeModule_static(module, tu: TestUtils):
+    module.forward(tu.rand(1, 7, 1, 3, 1))
+
+
+# ==============================================================================
+
+
+class SqueezeDynamicModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, -1, 1, 384, -1, 1, 1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeDynamicModule())
+def SqueezeModule_dynamic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 8, 1, 384, 12, 1, 1))
+
+
+# ==============================================================================
+
+
+class SqueezeNoUnitDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([4, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeNoUnitDimModule())
+def SqueezeModule_noUnitDim(module, tu: TestUtils):
+    module.forward(tu.rand(4, 2, 3))
+
+
+# ==============================================================================
+
+
+class SqueezeAllUnitDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.squeeze(a)
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeAllUnitDimModule())
+def SqueezeModule_allUnitDim(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1))
+
+
+# ==============================================================================
+
+
+class SqueezeBroadcastModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([], torch.float32, True),
+    ])
+    def forward(self, a, b):
+        return a * b.squeeze()
+
+
+@register_test_case(
+    module_factory=lambda: SqueezeBroadcastModule())
+def SqueezeModule_broadcast(module, tu: TestUtils):
+    module.forward(tu.rand(4, 3), tu.rand())
+

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -33,4 +33,5 @@ TOSA_PASS_SET = {
     "ReturnThreeTensorFloat32_basic",
     "AddCMulModule_basic",
     "AddCDivModule_basic",
+    "SqueezeModule_broadcast",
 }

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -17,8 +17,13 @@ COMMON_TORCH_MLIR_LOWERING_XFAILS = {
     "QuantizedMLP_basic",
     "IouOfModule_basic",
 }
-
-REFBACKEND_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS
+# Fails due to https://github.com/llvm/torch-mlir/issues/448
+SIZE_ZERO_TENSOR_XFAILS = {
+    "SliceEndSleStartModule_basic",
+    "SliceStartEqEndModule_basic",
+    "SliceOutOfUpperBoundIndexModule_basic",
+}
+REFBACKEND_XFAIL_SET = set.union(COMMON_TORCH_MLIR_LOWERING_XFAILS, SIZE_ZERO_TENSOR_XFAILS)
 
 # Write the TOSA set as a "passing" set as it is very early in development
 # and very few tests work yet.

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -31,4 +31,6 @@ TOSA_PASS_SET = {
     "TanhBackward_basic",
     "ElementwiseAddModule_basic",
     "ReturnThreeTensorFloat32_basic",
+    "AddCMulModule_basic",
+    "AddCDivModule_basic",
 }

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -29,5 +29,6 @@ TOSA_PASS_SET = {
     "ElementwiseFloorModule_basic",
     "ElementwiseLogModule_basic",
     "TanhBackward_basic",
+    "ElementwiseAddModule_basic",
     "ReturnThreeTensorFloat32_basic",
 }

--- a/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h
@@ -1,0 +1,64 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZECOMMON_H
+#define TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZECOMMON_H
+
+#include "mlir/IR/PatternMatch.h" // from @llvm-project
+#include "mlir/Support/LLVM.h"    // from @llvm-project
+
+namespace mlir {
+namespace tosa {
+
+// Lowers ReduceAll to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceAllOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceAny to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceAnyOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceMin to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMinOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceMax to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMaxOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceProd to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceProdOp(PatternRewriter &rewriter, Operation *op,
+                    RankedTensorType output_type, Value input_value,
+                    ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceSum to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceSumOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceMean to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMeanOp(PatternRewriter &rewriter, Operation *op,
+                    RankedTensorType output_type, Value input_value,
+                    ElementsAttr axes_elems, bool keep_dims);
+
+} // namespace tosa
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZECOMMON_H

--- a/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h
@@ -1,0 +1,96 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZEUTILS_H
+#define TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZEUTILS_H
+
+#include "mlir/Dialect/Quant/QuantTypes.h"        // from @llvm-project
+#include "mlir/Dialect/Tosa/Utils/ShapeUtils.h"   // from @llvm-project
+#include "mlir/IR/BuiltinAttributes.h"            // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"                 // from @llvm-project
+#include "mlir/IR/PatternMatch.h"                 // from @llvm-project
+#include "mlir/Interfaces/InferTypeOpInterface.h" // from @llvm-project
+#include "mlir/Support/LLVM.h"                    // from @llvm-project
+
+namespace mlir {
+namespace tosa {
+
+// Create a TOSA rescale op from input framework scaling, zero points and
+// rounding mode
+Value buildRescale(PatternRewriter &rewriter, Operation *op,
+                   ShapedType output_type, Value input_val, double scale,
+                   int64_t input_zp, int64_t output_zp, bool double_round,
+                   bool scale32);
+
+// Creates TOSA rescale op with int32 output
+Value buildRescaleToInt32(PatternRewriter &rewriter, Operation *op,
+                          Value input_val, double input_scale,
+                          int64_t input_zp);
+
+// Create a 32-bit float constant operator from a float
+Value getTosaConstTensorSingleF32(PatternRewriter &rewriter, Operation *op,
+                                  float val);
+
+// Creates a TOSA operation and performs shape inference on the individual
+// op. This allows shape inference during the framework to TOSA lowering.
+template <typename TosaOp, typename... Args>
+TosaOp CreateOpAndInfer(PatternRewriter &rewriter, Location loc, Type result_ty,
+                        Args &&... args) {
+  auto op = rewriter.create<TosaOp>(loc, result_ty, args...);
+
+  InferShapedTypeOpInterface shapeInterface =
+      dyn_cast<InferShapedTypeOpInterface>(op.getOperation());
+  if (!shapeInterface)
+    return op;
+
+  SmallVector<ShapedTypeComponents> returnedShapes;
+  if (shapeInterface
+          .inferReturnTypeComponents(op.getContext(), op.getLoc(),
+                                     op->getOperands(), op->getAttrDictionary(),
+                                     op->getRegions(), returnedShapes)
+          .failed())
+    return op;
+
+  // We need to use the element type of the existing result type to generate
+  // the new result shaped type. This is because rescale can include a cast to
+  // different bit-width types and does not have a TypeAttr to define the
+  // target type.
+  auto result = op->getResult(0);
+  auto predictedShape = returnedShapes[0];
+  auto currentKnowledge = ValueKnowledge::getKnowledgeFromType(result_ty);
+
+  // Compute the knowledge based on the inferred type.
+  auto inferredKnowledge = ValueKnowledge::getPessimisticValueState();
+  inferredKnowledge.dtype = result_ty.cast<ShapedType>().getElementType();
+  inferredKnowledge.hasRank = predictedShape.hasRank();
+  if (predictedShape.hasRank()) {
+    for (auto dim : predictedShape.getDims()) {
+      inferredKnowledge.sizes.push_back(dim);
+    }
+  }
+
+  // Compute the new type based on the joined version.
+  auto newKnowledge = ValueKnowledge::join(currentKnowledge, inferredKnowledge);
+  auto new_ty = newKnowledge.getType();
+  result.setType(new_ty);
+  return op;
+}
+
+template <typename TosaOp, typename... Args>
+void CreateReplaceOpAndInfer(PatternRewriter &rewriter, Operation *op,
+                             Type result_ty, Args &&... args) {
+  auto result =
+      CreateOpAndInfer<TosaOp>(rewriter, op->getLoc(), result_ty, args...);
+  rewriter.replaceOp(op, result->getResults());
+}
+
+} // namespace tosa
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZEUTILS_H

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1392,6 +1392,22 @@ def Torch_AtenSqrtOp : Torch_Op<"aten.sqrt", [
   let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
 }
 
+def Torch_Aten_SoftmaxOp : Torch_Op<"aten._softmax", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::_softmax : (Tensor, int, bool) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    Torch_IntType:$dim,
+    Torch_BoolType:$half_to_float
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $dim `,` $half_to_float attr-dict `:` type($self) `,` type($dim) `,` type($half_to_float) `->` type($result)";
+}
+
 def Torch_AtenUnsqueezeOp : Torch_Op<"aten.unsqueeze", [
     AllowsTypeRefinement
   ]> {

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1508,6 +1508,20 @@ def Torch_AtenUnsqueezeOp : Torch_Op<"aten.unsqueeze", [
   let assemblyFormat = "$self `,` $dim attr-dict `:` type($self) `,` type($dim) `->` type($result)";
 }
 
+def Torch_AtenSqueezeOp : Torch_Op<"aten.squeeze", [
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::squeeze : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
+  let hasFolder = 1;
+}
+
 def Torch_AtenFlattenUsingIntsOp : Torch_Op<"aten.flatten.using_ints", [
     AllowsTypeRefinement
   ]> {

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1494,6 +1494,21 @@ def Torch_Aten_SoftmaxOp : Torch_Op<"aten._softmax", [
   let assemblyFormat = "$self `,` $dim `,` $half_to_float attr-dict `:` type($self) `,` type($dim) `,` type($half_to_float) `->` type($result)";
 }
 
+def Torch_AtenBitwiseAndTensorOp : Torch_Op<"aten.bitwise_and.Tensor", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::bitwise_and.Tensor : (Tensor, Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchTensorType:$other
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $other attr-dict `:` type($self) `,` type($other) `->` type($result)";
+}
+
 def Torch_AtenUnsqueezeOp : Torch_Op<"aten.unsqueeze", [
     AllowsTypeRefinement
   ]> {

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -72,6 +72,36 @@ def Torch_AtenRelu_Op : Torch_Op<"aten.relu_", [
   let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
 }
 
+def Torch_AtenLeakyReluOp : Torch_Op<"aten.leaky_relu", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::leaky_relu : (Tensor, Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchScalarType:$negative_slope
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $negative_slope attr-dict `:` type($self) `,` type($negative_slope) `->` type($result)";
+}
+
+def Torch_AtenLeakyRelu_Op : Torch_Op<"aten.leaky_relu_", [
+    IsTrailingUnderscoreInplaceVariant,
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::leaky_relu_ : (Tensor, Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchScalarType:$negative_slope
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $negative_slope attr-dict `:` type($self) `,` type($negative_slope) `->` type($result)";
+}
+
 def Torch_AtenLogOp : Torch_Op<"aten.log", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2197,6 +2197,7 @@ def Torch_AtenIntTensorOp : Torch_Op<"aten.Int.Tensor", [
     Torch_IntType:$result
   );
   let assemblyFormat = "$a attr-dict `:` type($a) `->` type($result)";
+  let hasFolder = 1;
 }
 
 def Torch_AtenDropoutOp : Torch_Op<"aten.dropout", [

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2895,3 +2895,37 @@ def Torch_Aten_LogSoftmaxBackwardDataOp : Torch_Op<"aten._log_softmax_backward_d
   let assemblyFormat = "$grad_output `,` $output `,` $dim `,` $input_dtype attr-dict `:` type($grad_output) `,` type($output) `,` type($dim) `,` type($input_dtype) `->` type($result)";
 }
 
+def Torch_AtenAddCMulOp : Torch_Op<"aten.addcmul", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::addcmul : (Tensor, Tensor, Tensor, Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchTensorType:$tensor1,
+    AnyTorchTensorType:$tensor2,
+    AnyTorchScalarType:$value
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $tensor1 `,` $tensor2 `,` $value attr-dict `:` type($self) `,` type($tensor1) `,` type($tensor2) `,` type($value) `->` type($result)";
+}
+
+def Torch_AtenAddCDivOp : Torch_Op<"aten.addcdiv", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::addcdiv : (Tensor, Tensor, Tensor, Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchTensorType:$tensor1,
+    AnyTorchTensorType:$tensor2,
+    AnyTorchScalarType:$value
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $tensor1 `,` $tensor2 `,` $value attr-dict `:` type($self) `,` type($tensor1) `,` type($tensor2) `,` type($value) `->` type($result)";
+}
+

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -3062,3 +3062,17 @@ def Torch_AtenAddCDivOp : Torch_Op<"aten.addcdiv", [
   let assemblyFormat = "$self `,` $tensor1 `,` $tensor2 `,` $value attr-dict `:` type($self) `,` type($tensor1) `,` type($tensor2) `,` type($value) `->` type($result)";
 }
 
+def Torch_AtenMeanOp : Torch_Op<"aten.mean", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::mean : (Tensor, int?) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    TorchOptionalIntType:$dtype
+ );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+ let assemblyFormat = "$self `,` $dtype attr-dict `:` type($self) `,` type($dtype) `->` type($result)";
+}

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -936,6 +936,62 @@ def Torch_AtenRsqrt_Op : Torch_Op<"aten.rsqrt_", [
   let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
 }
 
+def Torch_AtenAbsOp : Torch_Op<"aten.abs", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::abs : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
+}
+
+def Torch_AtenAbs_Op : Torch_Op<"aten.abs_", [
+    IsTrailingUnderscoreInplaceVariant,
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::abs_ : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
+}
+
+def Torch_AtenReciprocalOp : Torch_Op<"aten.reciprocal", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::reciprocal : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
+}
+
+def Torch_AtenReciprocal_Op : Torch_Op<"aten.reciprocal_", [
+    IsTrailingUnderscoreInplaceVariant,
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::reciprocal_ : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
+}
+
 def Torch_AtenMaximumOp : Torch_Op<"aten.maximum", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2199,6 +2199,22 @@ def Torch_AtenIntTensorOp : Torch_Op<"aten.Int.Tensor", [
   let assemblyFormat = "$a attr-dict `:` type($a) `->` type($result)";
 }
 
+def Torch_AtenDropoutOp : Torch_Op<"aten.dropout", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::dropout : (Tensor, float, bool) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$input,
+    Torch_FloatType:$p,
+    Torch_BoolType:$train
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$input `,` $p `,` $train attr-dict `:` type($input) `,` type($p) `,` type($train) `->` type($result)";
+}
+
 def Torch_Aten__Contains__StrOp : Torch_Op<"aten.__contains__.str", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -1705,10 +1705,14 @@ static Value createLinalgNeutralElementForReduceOp(OpBuilder &b, Location loc,
 
 static Value createLinalgPayloadCalculationForReduceOp(
     OpBuilder &b, Location loc, ValueRange payloadArgs, Operation *op,
-    ArrayRef<Value> operands, Type elementType) {
+    ArrayRef<Value> operands, Type resultElementType) {
   if (isa<AtenSumOp, AtenSumDimIntListOp>(op) &&
-      elementType.isa<mlir::FloatType>())
-    return b.create<arith::AddFOp>(loc, payloadArgs);
+      resultElementType.isa<mlir::FloatType>()) {
+    Value self =
+        convertScalarToDtype(b, loc, payloadArgs[0], resultElementType);
+    Value result = payloadArgs[1];
+    return b.create<arith::AddFOp>(loc, self, result);
+  }
   op->emitError("unimplemented lowering in "
                 "createLinalgPayloadCalculationForReduceOp");
   return nullptr;

--- a/lib/Conversion/TorchToStd/TorchToStd.cpp
+++ b/lib/Conversion/TorchToStd/TorchToStd.cpp
@@ -45,6 +45,19 @@ public:
 } // namespace
 
 namespace {
+class ConvertAtenAddIntOp : public OpConversionPattern<AtenAddIntOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenAddIntOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<arith::AddIOp>(op, adaptor.a(), adaptor.b());
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class ConvertAtenNeIntOp : public OpConversionPattern<AtenNeIntOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
@@ -129,6 +142,8 @@ public:
     target.addIllegalOp<Torch::ConstantIntOp>();
     patterns.add<ConvertTorchConstantOp<Torch::ConstantIntOp>>(typeConverter,
                                                                context);
+    target.addIllegalOp<AtenAddIntOp>();
+    patterns.add<ConvertAtenAddIntOp>(typeConverter, context);
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))
       return signalPassFailure();

--- a/lib/Conversion/TorchToTosa/CMakeLists.txt
+++ b/lib/Conversion/TorchToTosa/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_mlir_conversion_library(TorchMLIRTorchToTosa
   TorchToTosa.cpp
+  TosaLegalizeUtils.cpp
+  TosaLegalizeCommon.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/TorchToTosa

--- a/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
@@ -1,0 +1,314 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h"
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h"
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <numeric>
+
+#include "mlir/Dialect/Quant/QuantTypes.h" // from @llvm-project
+#include "mlir/Dialect/Tensor/IR/Tensor.h" // from @llvm-project
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"  // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"          // from @llvm-project
+#include "mlir/IR/Matchers.h"              // from @llvm-project
+#include "mlir/IR/PatternMatch.h"          // from @llvm-project
+#include "llvm/Support/FormatVariadic.h"
+
+namespace mlir {
+namespace tosa {
+
+// Common function for lowering reduce operations to TOSA ops.
+template <typename T>
+llvm::Optional<Value> convertReduceOpCommon(
+    PatternRewriter &rewriter, Operation *op, RankedTensorType output_type,
+    Value input_value, ElementsAttr axes_elems, bool keep_dims,
+    Type reduce_element_type, bool is_quantized, double input_scale,
+    int64_t input_zp, double output_scale, int64_t output_zp) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  ArrayRef<int64_t> input_shape = input_type.getShape();
+  ArrayRef<int64_t> output_shape = output_type.getShape();
+  auto input_rank = input_shape.size();
+  Value val = input_value;
+
+  if (axes_elems.getNumElements() == 0) {
+    // No axes means return the original tensor.
+    auto identity_op = CreateOpAndInfer<tosa::IdentityOp>(
+        rewriter, op->getLoc(), output_type, val);
+    val = identity_op.getResult();
+  } else {
+    // Reduce along each axis
+    SmallVector<int64_t> shape_vec(input_shape.begin(), input_shape.end());
+
+    if (is_quantized) {
+      val = buildRescaleToInt32(rewriter, op, val, input_scale, input_zp);
+    }
+
+    for (int i = 0; i < axes_elems.getNumElements(); i++) {
+      int64_t axis_val = axes_elems.getValues<IntegerAttr>()[i].getInt();
+      if (axis_val < 0)
+        axis_val += input_rank;
+      auto axis_attr = rewriter.getI64IntegerAttr(axis_val);
+
+      shape_vec[axis_val] = 1;
+      RankedTensorType reduce_type =
+          RankedTensorType::get(shape_vec, reduce_element_type);
+
+      auto reduce_op = CreateOpAndInfer<T>(rewriter, op->getLoc(), reduce_type,
+                                           val, axis_attr);
+
+      val = reduce_op.getResult();
+    }
+
+    if (is_quantized) {
+      RankedTensorType output_rescale_type =
+          RankedTensorType::get(shape_vec, output_type.getElementType());
+      val = buildRescale(rewriter, op, output_rescale_type, val, output_scale,
+                         0, output_zp, false, true);
+    }
+
+    // Optionally squeeze out the reduced axes.
+    if (!keep_dims) {
+      auto reshape_op = CreateOpAndInfer<tosa::ReshapeOp>(
+          rewriter, op->getLoc(), output_type, val,
+          rewriter.getI64ArrayAttr(output_shape));
+      val = reshape_op.getResult();
+    }
+  }
+
+  return val;
+}
+
+// Lowers ReduceAll to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceAllOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  return convertReduceOpCommon<tosa::ReduceAllOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceAny to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceAnyOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  return convertReduceOpCommon<tosa::ReduceAnyOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceMin to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMinOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  return convertReduceOpCommon<tosa::ReduceMinOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceMax to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMaxOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  return convertReduceOpCommon<tosa::ReduceMaxOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceProd to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceProdOp(PatternRewriter &rewriter, Operation *op,
+                    RankedTensorType output_type, Value input_value,
+                    ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  bool input_is_qtype =
+      input_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+  bool output_is_qtype =
+      output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+
+  if (input_is_qtype || output_is_qtype) {
+    op->emitOpError("ConvertReduceProdOp: input/output tensor should "
+                    "be all floating-point.");
+    return llvm::None;
+  }
+
+  return convertReduceOpCommon<tosa::ReduceProdOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceSum to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceSumOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  bool input_is_qtype =
+      input_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+  bool output_is_qtype =
+      output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+
+  if (input_is_qtype != output_is_qtype) {
+    op->emitOpError("ConvertReduceSumOp: input/output tensor should "
+                    "be all quantized or all floating-point.");
+    return llvm::None;
+  }
+
+  double input_scale = 1.0f;
+  double output_scale = 1.0f;
+  int64_t input_zp = 0;
+  int64_t output_zp = 0;
+  Type reduce_element_type = input_type.getElementType();
+
+  if (input_is_qtype) {
+    auto input_qtype =
+        input_type.getElementType().cast<mlir::quant::UniformQuantizedType>();
+    auto output_qtype =
+        output_type.getElementType().cast<mlir::quant::UniformQuantizedType>();
+
+    int32_t input_shift = 20;
+
+    input_scale =
+        static_cast<double>(1 << input_shift) * input_qtype.getScale();
+    output_scale =
+        1.0 / (output_qtype.getScale() * static_cast<double>(1 << input_shift));
+
+    input_zp = input_qtype.getZeroPoint();
+    output_zp = output_qtype.getZeroPoint();
+    reduce_element_type = rewriter.getI32Type();
+  }
+
+  return convertReduceOpCommon<tosa::ReduceSumOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      reduce_element_type, input_is_qtype, input_scale, input_zp, output_scale,
+      output_zp);
+}
+
+// Lowers ReduceMean to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMeanOp(PatternRewriter &rewriter, Operation *op,
+                    RankedTensorType output_type, Value input_value,
+                    ElementsAttr axes_elems, bool keep_dims) {
+  // reduce_mean is lowered as followed:
+  // op1 = reduce_sum(input)
+  // op2 = mul(op1, 1.0 / num_elements_on_reduced_axis)
+
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  bool input_is_qtype =
+      input_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+  bool output_is_qtype =
+      output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+
+  if (input_is_qtype != output_is_qtype) {
+    op->emitOpError("ConvertReduceSumOp: input/output tensor should "
+                    "be all quantized or all floating-point.");
+    return llvm::None;
+  }
+
+  // Only supports float type mean() if it's non-quantized
+  if (!input_is_qtype && !output_type.getElementType().isa<mlir::FloatType>()) {
+    op->emitWarning(
+        "Failed convertReduceMean: input unquantized type but output element "
+        "not FloatType!");
+    return llvm::None;
+  }
+
+  int64_t input_rank = input_type.getRank();
+  int64_t num_elems_on_reduced_axis = 1;
+  for (int i = 0; i < axes_elems.getNumElements(); i++) {
+    int64_t axis_val = axes_elems.getValues<IntegerAttr>()[i].getInt();
+    if (axis_val < 0)
+      axis_val += input_rank;
+    num_elems_on_reduced_axis *= input_type.getShape()[axis_val];
+  }
+  double div_scale = 1.0 / static_cast<double>(num_elems_on_reduced_axis);
+
+  double input_scale = 1.0f;
+  double output_scale = 1.0f;
+  int64_t input_zp = 0;
+  int64_t output_zp = 0;
+  Type reduce_element_type = input_type.getElementType();
+
+  if (input_is_qtype) {
+    auto input_qtype =
+        input_type.getElementType().cast<mlir::quant::UniformQuantizedType>();
+    auto output_qtype =
+        output_type.getElementType().cast<mlir::quant::UniformQuantizedType>();
+
+    // Combine 'div_scale' as part of output rescale
+    output_scale = div_scale * input_qtype.getScale() / output_qtype.getScale();
+
+    input_zp = input_qtype.getZeroPoint();
+    output_zp = output_qtype.getZeroPoint();
+    reduce_element_type = rewriter.getI32Type();
+  }
+
+  auto val = convertReduceOpCommon<tosa::ReduceSumOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      reduce_element_type, input_is_qtype, input_scale, input_zp, output_scale,
+      output_zp);
+
+  if (!val.hasValue())
+    return llvm::None;
+
+  if (!input_is_qtype) {
+    Value div_const = getTosaConstTensorSingleF32(rewriter, op, div_scale);
+    return CreateOpAndInfer<tosa::MulOp>(rewriter, op->getLoc(), output_type,
+                                         val.getValue(), div_const, 0)
+        .getResult();
+  }
+
+  return val;
+}
+
+} // namespace tosa
+} // namespace mlir

--- a/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"       // from @llvm-project
+#include "mlir/Dialect/Tosa/Utils/QuantUtils.h" // from @llvm-project
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h"
+
+namespace mlir {
+namespace tosa {
+
+// Create a TOSA rescale op from input framework tensor, zero points and
+// rounding mode
+Value buildRescale(PatternRewriter &rewriter, Operation *op,
+                   ShapedType output_type, Value input_val, double scale,
+                   int64_t input_zp, int64_t output_zp, bool double_round,
+                   bool scale32) {
+  int32_t multiplier;
+  int32_t shift;
+
+  int32_t scale_width = scale32 ? 32 : 16;
+
+  computeMultiplierAndShift(scale, multiplier, shift, scale_width);
+
+  auto rescale_op = CreateOpAndInfer<tosa::RescaleOp>(
+      rewriter, op->getLoc(), output_type, input_val,
+      rewriter.getI32IntegerAttr(static_cast<int32_t>(input_zp)),
+      rewriter.getI32IntegerAttr(static_cast<int32_t>(output_zp)),
+      rewriter.getI32ArrayAttr({multiplier}), rewriter.getI32ArrayAttr({shift}),
+      rewriter.getBoolAttr(scale32), rewriter.getBoolAttr(double_round),
+      rewriter.getBoolAttr(false));
+
+  return rescale_op.getResult();
+}
+
+// Creates TOSA rescale op with int32 output
+Value buildRescaleToInt32(PatternRewriter &rewriter, Operation *op,
+                          Value input_val, double input_scale,
+                          int64_t input_zp) {
+  // Output is always int32 type
+  auto input_type = input_val.getType().dyn_cast<mlir::ShapedType>();
+  assert(input_type);
+  auto output_type = input_type.clone(rewriter.getI32Type());
+
+  return buildRescale(rewriter, op, output_type, input_val, input_scale,
+                      input_zp, 0, false, true);
+}
+
+// Create a 32-bit float constant operator from a float
+Value getTosaConstTensorSingleF32(PatternRewriter &rewriter, Operation *op,
+                                  float val) {
+  auto const_type = RankedTensorType::get({}, rewriter.getF32Type());
+  auto const_attr = DenseElementsAttr::get(const_type, val);
+
+  auto const_op =
+      rewriter.create<tosa::ConstOp>(op->getLoc(), const_type, const_attr);
+  return const_op.getResult();
+}
+
+} // namespace tosa
+} // namespace mlir

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -1076,5 +1076,14 @@ OpFoldResult PrimDtypeOp::fold(ArrayRef<Attribute> operands) {
   }
   return nullptr;
 }
+
+OpFoldResult AtenIntTensorOp::fold(ArrayRef<Attribute> operands) {
+  // If an scalar number is converted to a 0-d tensor and passed on to
+  // aten.Int.Tensor, fold to the scalar number.
+  if (auto numToTensorScalar = a().getDefiningOp<PrimNumToTensorScalarOp>())
+    return numToTensorScalar.a();
+  return nullptr;
+}
+
 #define GET_OP_CLASSES
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.cpp.inc"

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -451,6 +451,18 @@ OpFoldResult AtenNeBoolOp::fold(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// AtenSqueezeOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenSqueezeOp::fold(ArrayRef<Attribute> operands) {
+  if (auto tensorType = getOperand().getType().dyn_cast<BaseTensorType>()) {
+    if (tensorType.hasSizes() && tensorType.getSizes().size() == 0)
+      return getOperand();
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
 // AtenDimOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -376,6 +376,26 @@ public:
 } // namespace
 
 namespace {
+template<typename OpTy, typename T1T2Op>
+class DecomposeAtenAddCLikeOp : public OpRewritePattern<OpTy> {
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+  LogicalResult matchAndRewrite(OpTy op,
+                                 PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value input = op.self();
+    Value tensor1 = op.tensor1();
+    Value tensor2 = op.tensor2();
+    Value value = op.value();
+
+    Value product = rewriter.create<T1T2Op>(loc, op.getType(), tensor1, tensor2);
+    rewriter.replaceOpWithNewOp<AtenAddTensorOp>(op, op.getType(), input, product,
+                                                  value);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class DecomposeComplexOpsPass
     : public DecomposeComplexOpsBase<DecomposeComplexOpsPass> {
   void runOnOperation() override {
@@ -408,6 +428,10 @@ class DecomposeComplexOpsPass
       // Make aten.matmul legal if the following condition is satisfied.
       return (lhsRank != 2 || rhsRank != 2) && (lhsRank != 3 || rhsRank != 3);
     });
+    patterns.add<DecomposeAtenAddCLikeOp<AtenAddCMulOp, AtenMulTensorOp>>(context);
+    target.addIllegalOp<AtenAddCMulOp>();
+    patterns.add<DecomposeAtenAddCLikeOp<AtenAddCDivOp, AtenDivTensorOp>>(context);
+    target.addIllegalOp<AtenAddCDivOp>();
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {
       return signalPassFailure();

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -419,6 +419,27 @@ public:
 };
 } // namespace
 
+// Decompose torch.mean into: sum(x)/div(numTensorElements).
+namespace {
+class DecomposeAtenMeanOp : public OpRewritePattern<AtenMeanOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AtenMeanOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value input = op.self();
+    Value output = op.result();
+    BaseTensorType inputTensorType = input.getType().cast<BaseTensorType>();
+    BaseTensorType outputTensorType = output.getType().cast<BaseTensorType>();
+    Value sum = rewriter.create<AtenSumOp>(loc, outputTensorType, input, op.dtype());
+    Value numTensorElements = rewriter.create<AtenNumelOp>(loc, input);
+    rewriter.replaceOpWithNewOp<AtenDivScalarOp>(op, outputTensorType, sum,
+                                                 numTensorElements);
+    return success();
+  }
+};
+} // namespace
+
 namespace {
 template<typename OpTy, typename T1T2Op>
 class DecomposeAtenAddCLikeOp : public OpRewritePattern<OpTy> {
@@ -464,6 +485,8 @@ class DecomposeComplexOpsPass
     target.addIllegalOp<AtenTanhBackwardOp>();
     patterns.add<DecomposeAtenAddmmOp>(context);
     target.addIllegalOp<AtenAddmmOp>();
+    patterns.add<DecomposeAtenMeanOp>(context);
+    target.addIllegalOp<AtenMeanOp>();
     patterns.add<DecomposeAtenMatmulOp>(context);
     patterns.add<DecomposeAten_LogSoftmaxBackwardDataOp>(context);
     target.addIllegalOp<Aten_LogSoftmaxBackwardDataOp>();

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -89,7 +89,7 @@ public:
       Operation *op = workList.pop_back_val();
       if (auto copyToValueTensor = dyn_cast<CopyToValueTensorOp>(op)) {
         copyToValueTensorOps.push_back(copyToValueTensor);
-      } else if (isa<AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
+      } else if (isa<AtenSqueezeOp, AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
                      AtenTransposeIntOp, TensorStaticInfoCastOp,
                      AtenBroadcastToOp, AtenToDtypeOp, AtenContiguousOp,
                      AtenPermuteOp, AtenViewOp, AtenExpandOp,

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -92,7 +92,8 @@ public:
       } else if (isa<AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
                      AtenTransposeIntOp, TensorStaticInfoCastOp,
                      AtenBroadcastToOp, AtenToDtypeOp, AtenContiguousOp,
-                     AtenPermuteOp, AtenViewOp, AtenExpandOp>(op)) {
+                     AtenPermuteOp, AtenViewOp, AtenExpandOp,
+                     AtenFill_ScalarOp>(op)) {
         // AtenContiguousOp might return a view, so this is conservatively
         // correct. We could potentially be more precise and identify the cases
         // that it does not return a view and treat those as having value

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -92,8 +92,8 @@ public:
       } else if (isa<AtenSqueezeOp, AtenUnsqueezeOp, AtenFlattenUsingIntsOp,
                      AtenTransposeIntOp, TensorStaticInfoCastOp,
                      AtenBroadcastToOp, AtenToDtypeOp, AtenContiguousOp,
-                     AtenPermuteOp, AtenViewOp, AtenExpandOp,
-                     AtenFill_ScalarOp>(op)) {
+                     AtenPermuteOp, AtenViewOp, AtenExpandOp, AtenFill_ScalarOp,
+                     AtenSliceTensorOp, AtenSelectIntOp>(op)) {
         // AtenContiguousOp might return a view, so this is conservatively
         // correct. We could potentially be more precise and identify the cases
         // that it does not return a view and treat those as having value

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -438,6 +438,11 @@ public:
       return visitAtenBmmOp(bmm, operands);
     } else if (auto matmul = dyn_cast<AtenMatmulOp>(op)) {
       return visitAtenMatmulOp(matmul, operands);
+    } else if (auto mean = dyn_cast<AtenMeanOp>(op)) {
+      Type defaultDtype = operands[0]->getValue().dtype;
+      Type dtype =
+          getDtypeOrDefault(mean.getContext(), mean.dtype(), defaultDtype);
+      return visitReductionAlongAllDimsOp(mean, dtype, operands);
     } else if (auto softmaxIntOp = dyn_cast<AtenSoftmaxIntOp>(op)) {
       return visitAtenSoftmaxLikeOp(softmaxIntOp, operands);
     } else if (auto _softmaxOp = dyn_cast<Aten_SoftmaxOp>(op)) {
@@ -563,7 +568,7 @@ private:
   ChangeResult
   visitAtenMatmulOp(AtenMatmulOp op,
                     ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  
+
   template <typename OpTy>
   ChangeResult
   visitAtenSoftmaxLikeOp(OpTy op,

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -304,7 +304,7 @@ public:
       return visitBinaryTensorScalarOp(op, operands);
     } else if (isa<AtenAddTensorOp, AtenSubTensorOp, AtenMulTensorOp,
                    AtenDivTensorOp, Aten__And__TensorOp, AtenEqTensorOp,
-                   AtenMinimumOp, AtenMaximumOp>(op)) {
+                   AtenMinimumOp, AtenMaximumOp, AtenBitwiseAndTensorOp>(op)) {
       return visitBinaryBroadcastingOp(op, operands);
     } else if (auto lerpTensor = llvm::dyn_cast<AtenLerpTensorOp>(op)) {
       return visitAtenLerpTensorOp(lerpTensor, operands);

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -232,8 +232,8 @@ public:
             AtenMaskedFill_ScalarOp, AtenCopy_Op, AtenIndexPut_Op, AtenCumsumOp,
             AtenLayerNormOp, AtenClampOp, AtenLogOp, AtenSqrtOp, AtenFloorOp,
             AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp, AtenDropoutOp,
-            AtenTanhBackwardOp, Aten_LogSoftmaxBackwardDataOp, AtenAddIntOp>(
-            op)) {
+            AtenTanhBackwardOp, Aten_LogSoftmaxBackwardDataOp, AtenAddIntOp,
+            AtenAbsOp, AtenReciprocalOp>(op)) {
       return getLatticeElement(op->getResult(0)).join(*operands[0]);
     }
 

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -67,6 +67,16 @@ static Type getTypeForDTypeInteger(MLIRContext *context, int64_t dtypeInt) {
   return getTypeForScalarType(context, (ScalarType)dtypeInt);
 }
 
+static Type getDtypeOrDefault(MLIRContext *context, Value optionalDtype,
+                              Type defaultDtype) {
+  int64_t dtypeInt;
+  if (matchPattern(optionalDtype, m_TorchConstantInt(&dtypeInt)))
+    return getTypeForDTypeInteger(context, dtypeInt);
+  else if (optionalDtype.getType().isa<Torch::NoneType>())
+    return defaultDtype;
+  return Type();
+}
+
 static Type joinElementTypes(Type lhs, Type rhs) {
   if (!lhs)
     return rhs;
@@ -309,14 +319,23 @@ public:
     } else if (auto arangeStart = dyn_cast<AtenArangeStartOp>(op)) {
       return visitAtenArangeStartOp(arangeStart);
     } else if (auto sum = dyn_cast<AtenSumOp>(op)) {
-      Type dtype = operands[0]->getValue().dtype;
+      Type defaultDtype = operands[0]->getValue().dtype;
+      Type dtype =
+          getDtypeOrDefault(sum.getContext(), sum.dtype(), defaultDtype);
       return visitReductionAlongAllDimsOp(sum, dtype, operands);
     } else if (auto sumDimIntList = dyn_cast<AtenSumDimIntListOp>(op)) {
+      Type defaultDtype = operands[0]->getValue().dtype;
+      Type dtype = getDtypeOrDefault(sumDimIntList.getContext(),
+                                     sumDimIntList.dtype(), defaultDtype);
       return visitReductionAlongDimIntListOp(sumDimIntList, sumDimIntList.dim(),
-                                             sumDimIntList.keepdim(), operands);
+                                             sumDimIntList.keepdim(), dtype,
+                                             operands);
     } else if (auto meanDim = dyn_cast<AtenMeanDimOp>(op)) {
-      return visitReductionAlongDimIntListOp(meanDim, meanDim.dim(),
-                                             meanDim.keepdim(), operands);
+      Type defaultDtype = operands[0]->getValue().dtype;
+      Type dtype = getDtypeOrDefault(meanDim.getContext(), meanDim.dtype(),
+                                     defaultDtype);
+      return visitReductionAlongDimIntListOp(
+          meanDim, meanDim.dim(), meanDim.keepdim(), dtype, operands);
     } else if (auto argmax = dyn_cast<AtenArgmaxOp>(op)) {
       Value dim = argmax.dim();
       Type dtype = IntegerType::get(op->getContext(), 64, IntegerType::Signed);
@@ -483,7 +502,7 @@ private:
       Operation *op, Type dtype,
       ArrayRef<LatticeElement<ValueKnowledge> *> operands);
   ChangeResult visitReductionAlongDimIntListOp(
-      Operation *op, Value dim, Value keepdim,
+      Operation *op, Value dim, Value keepdim, Type dtype,
       ArrayRef<LatticeElement<ValueKnowledge> *> operands);
   ChangeResult visitReductionAlongDimIntOp(
       Operation *op, Value dim, Value keepdim, Type dtype,
@@ -980,12 +999,12 @@ ChangeResult TypeAnalyzer::visitReductionAlongAllDimsOp(
 // These ops do caculation along the dims given by the integer list and reduce
 // each dim to size one. If \p keepdim is false, the dims are squeezed.
 ChangeResult TypeAnalyzer::visitReductionAlongDimIntListOp(
-    Operation *op, Value dim, Value keepdim,
+    Operation *op, Value dim, Value keepdim, Type dtype,
     ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
   auto input = operands[0]->getValue();
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.dtype = input.dtype;
+  knowledge.dtype = dtype;
   llvm::SmallVector<int64_t> dimList;
   bool keepDim;
   if (matchPattern(keepdim, m_TorchConstantBool(&keepDim))) {

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -231,7 +231,7 @@ public:
             AtenContiguousOp, AtenFill_ScalarOp, AtenDetachOp,
             AtenMaskedFill_ScalarOp, AtenCopy_Op, AtenIndexPut_Op, AtenCumsumOp,
             AtenLayerNormOp, AtenClampOp, AtenLogOp, AtenSqrtOp, AtenFloorOp,
-            AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp,
+            AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp, AtenDropoutOp,
             AtenTanhBackwardOp, Aten_LogSoftmaxBackwardDataOp, AtenAddIntOp>(
             op)) {
       return getLatticeElement(op->getResult(0)).join(*operands[0]);

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -289,7 +289,7 @@ public:
       return visitAtenAdaptiveAvgPool2dOp(avgPool2d, operands);
     } else if (isa<AtenAddScalarOp, AtenSubScalarOp, AtenMulScalarOp,
                    AtenDivScalarOp, AtenFmodScalarOp, AtenFloorDivideScalarOp,
-                   AtenPowTensorScalarOp, AtenRsubScalarOp>(op)) {
+                   AtenPowTensorScalarOp, AtenRsubScalarOp, AtenLeakyReluOp>(op)) {
       return visitBinaryTensorScalarOp(op, operands);
     } else if (isa<AtenAddTensorOp, AtenSubTensorOp, AtenMulTensorOp,
                    AtenDivTensorOp, Aten__And__TensorOp, AtenEqTensorOp,

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/StandardOps/Transforms/Passes.h"
+#include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 #include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
@@ -21,6 +22,7 @@
 
 using namespace mlir;
 using namespace mlir::torch;
+using namespace mlir::tosa;
 
 //===----------------------------------------------------------------------===//
 // Pass registration
@@ -89,6 +91,8 @@ void TorchConversion::createTorchBackendToTosaBackendPipeline(
       TorchConversion::createVerifyInvariantsBeforeBackendLoweringPass());
 
   pm.addNestedPass<FuncOp>(createConvertTorchToTosaPass());
+  // Perform rank broadcasting so TosaToLinalg pass works
+  pm.addNestedPass<FuncOp>(createTosaMakeBroadcastablePass());
 
   if (options.optimize) {
     // Clean up any non-canonical code introduced above..

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -568,7 +568,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::gather : (Tensor, int, Tensor, bool) -> (Tensor)")
         emit("aten::IntImplicit : (Tensor) -> (int)")
         emit("aten::tensor.float : (float, int?, Device?, bool) -> (Tensor)")
-        emit("aten::Int.Tensor : (Tensor) -> (int)")
+        emit("aten::Int.Tensor : (Tensor) -> (int)", has_folder=True)
         emit("aten::dropout : (Tensor, float, bool) -> (Tensor)")
 
         # Dict ops.

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -523,6 +523,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
 
         # Misc tensor ops.
         emit("aten::unsqueeze : (Tensor, int) -> (Tensor)")
+        emit("aten::squeeze : (Tensor) -> (Tensor)", has_folder=True)
         emit("aten::flatten.using_ints : (Tensor, int, int) -> (Tensor)")
         emit("aten::dim : (Tensor) -> (int)", has_folder=True)
         emit("aten::size : (Tensor) -> (int[])", has_canonicalizer=True)

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -516,6 +516,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::mean.dim : (Tensor, int[], bool, int?) -> (Tensor)")
         emit("aten::__and__.Tensor : (Tensor, Tensor) -> (Tensor)")
         emit("aten::sqrt : (Tensor) -> (Tensor)")
+        emit("aten::_softmax : (Tensor, int, bool) -> (Tensor)")
 
         # Misc tensor ops.
         emit("aten::unsqueeze : (Tensor, int) -> (Tensor)")

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -520,6 +520,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::__and__.Tensor : (Tensor, Tensor) -> (Tensor)")
         emit("aten::sqrt : (Tensor) -> (Tensor)")
         emit("aten::_softmax : (Tensor, int, bool) -> (Tensor)")
+        emit("aten::mean : (Tensor, int?) -> (Tensor)")
 
         # Misc tensor ops.
         emit("aten::unsqueeze : (Tensor, int) -> (Tensor)")

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -439,6 +439,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         for key in [
                 "aten::tanh : (Tensor) -> (Tensor)",
                 "aten::relu : (Tensor) -> (Tensor)",
+                "aten::leaky_relu : (Tensor, Scalar) -> (Tensor)",
                 "aten::log : (Tensor) -> (Tensor)",
                 "aten::sigmoid : (Tensor) -> (Tensor)",
                 "aten::sin : (Tensor) -> (Tensor)",

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -468,6 +468,8 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
                 "aten::clamp : (Tensor, Scalar?, Scalar?) -> (Tensor)",
                 "aten::log2 : (Tensor) -> (Tensor)",
                 "aten::rsqrt : (Tensor) -> (Tensor)",
+                "aten::abs : (Tensor) -> (Tensor)",
+                "aten::reciprocal : (Tensor) -> (Tensor)",
         ]:
             emit_with_mutating_variants(key)
         # Elementwise tensor compute ops that don't have the standard mutating

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -470,6 +470,8 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
                 "aten::rsqrt : (Tensor) -> (Tensor)",
                 "aten::abs : (Tensor) -> (Tensor)",
                 "aten::reciprocal : (Tensor) -> (Tensor)",
+                "aten::bitwise_and.Tensor : (Tensor, Tensor) -> (Tensor)",
+
         ]:
             emit_with_mutating_variants(key)
         # Elementwise tensor compute ops that don't have the standard mutating

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -569,6 +569,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::IntImplicit : (Tensor) -> (int)")
         emit("aten::tensor.float : (float, int?, Device?, bool) -> (Tensor)")
         emit("aten::Int.Tensor : (Tensor) -> (int)")
+        emit("aten::dropout : (Tensor, float, bool) -> (Tensor)")
 
         # Dict ops.
         emit("aten::__contains__.str : (Dict(str, t), str) -> (bool)", has_folder=True)

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -471,6 +471,8 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
             emit_with_mutating_variants(key)
         # Elementwise tensor compute ops that don't have the standard mutating
         # variants.
+        emit("aten::addcmul : (Tensor, Tensor, Tensor, Scalar) -> (Tensor)")
+        emit("aten::addcdiv : (Tensor, Tensor, Tensor, Scalar) -> (Tensor)")
         emit("aten::maximum : (Tensor, Tensor) -> (Tensor)")
         emit("aten::minimum : (Tensor, Tensor) -> (Tensor)")
         emit("aten::rsub.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)")

--- a/test/Conversion/TorchToStd/basic.mlir
+++ b/test/Conversion/TorchToStd/basic.mlir
@@ -74,3 +74,14 @@ func @torch.constant.int() -> !torch.int {
   %int1 = torch.constant.int 1
   return %int1 : !torch.int
 }
+
+// CHECK-LABEL:  func @torch.aten.add.int(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
+// CHECK:          %[[LHS_I64:.*]] = torch_c.to_i64 %[[LHS]]
+// CHECK:          %[[RHS_I64:.*]] = torch_c.to_i64 %[[RHS]]
+// CHECK:          %[[INT:.*]] = arith.addi %[[LHS_I64:.*]], [[RHS_I64:.*]] : i64
+// CHECK:          %[[INT:.*]] = torch_c.from_i64 %[[INT:.*]]
+// CHECK:          return %[[INT:.*]] : !torch.int
+func @torch.aten.add.int(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
+  %0 = torch.aten.add.int %arg0, %arg1 : !torch.int, !torch.int -> !torch.int  
+  return %0 : !torch.int
+}

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -605,3 +605,11 @@ func @torch.aten.Int.Tensor(%arg0: !torch.int) -> !torch.int {
   %scalar = torch.aten.Int.Tensor %tensor : !torch.vtensor<[],si64> -> !torch.int
   return %scalar : !torch.int
 }
+
+// CHECK-LABEL:   func @torch.aten.squeeze$zero_rank(
+// CHECK-SAME:            %[[ARG:.*]]: !torch.tensor<[],f32>) -> !torch.tensor<[],f32> {
+// CHECK-NEXT:      return %[[ARG]] : !torch.tensor<[],f32>
+func @torch.aten.squeeze$zero_rank(%arg0: !torch.tensor<[],f32>) -> !torch.tensor<[],f32> {
+  %0 = torch.aten.squeeze %arg0 : !torch.tensor<[],f32> -> !torch.tensor<[],f32>
+  return %0 : !torch.tensor<[],f32>
+}

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -594,3 +594,14 @@ func @torch.prim.TupleIndex$out_of_bound(%t0: !torch.tensor, %t1: !torch.tensor,
     %1 = torch.prim.TupleIndex %0, %int3 : !torch.tuple<!torch.tensor, !torch.tensor, !torch.tensor>, !torch.int -> !torch.tensor
     return %1 : !torch.tensor
 }
+
+
+// CHECK-LABEL:   func @torch.aten.Int.Tensor(
+// CHECK-SAME:            %[[NUM:.*]]: !torch.int) -> !torch.int {
+// CHECK:           %[[T:.*]] = torch.prim.NumToTensor.Scalar %[[NUM]] : !torch.int -> !torch.vtensor<[],si64>
+// CHECK:           return %[[NUM]] : !torch.int
+func @torch.aten.Int.Tensor(%arg0: !torch.int) -> !torch.int {
+  %tensor = torch.prim.NumToTensor.Scalar %arg0: !torch.int -> !torch.vtensor<[],si64>
+  %scalar = torch.aten.Int.Tensor %tensor : !torch.vtensor<[],si64> -> !torch.int
+  return %scalar : !torch.int
+}

--- a/test/Dialect/Torch/refine-types.mlir
+++ b/test/Dialect/Torch/refine-types.mlir
@@ -750,8 +750,8 @@ builtin.func @torch.aten.index_select$unknown_dim(%input: !torch.tensor<[2,3,4],
 // CHECK-SAME:                                        %[[INPUT:.*]]: !torch.tensor<[2,3,4],f32>,
 // CHECK-SAME:                                        %[[INDEX:.*]]: !torch.int) -> !torch.tensor {
 // CHECK:           %[[DIM:.*]] = torch.constant.int 1
-// CHECK:           %[[RET:.*]] = torch.aten.select.int %[[INPUT]], %[[DIM]], %[[INDEX]] : !torch.tensor<[2,3,4],f32>, !torch.int, !torch.int -> !torch.tensor<[2,1,4],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,1,4],f32> to !torch.tensor
+// CHECK:           %[[RET:.*]] = torch.aten.select.int %[[INPUT]], %[[DIM]], %[[INDEX]] : !torch.tensor<[2,3,4],f32>, !torch.int, !torch.int -> !torch.tensor<[2,4],f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,4],f32> to !torch.tensor
 // CHECK:           return %[[CAST]] : !torch.tensor
 
 builtin.func @torch.aten.select.int(%input: !torch.tensor<[2,3,4], f32>, %index: !torch.int) -> !torch.tensor {


### PR DESCRIPTION
Implements constructs for Torch -> TOSA reduction op lowerings. 

Currently supports variants of sum, mean, all and any; exercises variants for reduce_dims list, single reduce_dim and reduction on all dims.  