### PR TITLE
[tosa] Add Torch reduction operators

### DIFF
--- a/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h
@@ -1,0 +1,64 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZECOMMON_H
+#define TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZECOMMON_H
+
+#include "mlir/IR/PatternMatch.h" // from @llvm-project
+#include "mlir/Support/LLVM.h"    // from @llvm-project
+
+namespace mlir {
+namespace tosa {
+
+// Lowers ReduceAll to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceAllOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceAny to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceAnyOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceMin to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMinOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceMax to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMaxOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceProd to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceProdOp(PatternRewriter &rewriter, Operation *op,
+                    RankedTensorType output_type, Value input_value,
+                    ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceSum to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceSumOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims);
+
+// Lowers ReduceMean to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMeanOp(PatternRewriter &rewriter, Operation *op,
+                    RankedTensorType output_type, Value input_value,
+                    ElementsAttr axes_elems, bool keep_dims);
+
+} // namespace tosa
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZECOMMON_H

--- a/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h
@@ -1,0 +1,96 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZEUTILS_H
+#define TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZEUTILS_H
+
+#include "mlir/Dialect/Quant/QuantTypes.h"        // from @llvm-project
+#include "mlir/Dialect/Tosa/Utils/ShapeUtils.h"   // from @llvm-project
+#include "mlir/IR/BuiltinAttributes.h"            // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"                 // from @llvm-project
+#include "mlir/IR/PatternMatch.h"                 // from @llvm-project
+#include "mlir/Interfaces/InferTypeOpInterface.h" // from @llvm-project
+#include "mlir/Support/LLVM.h"                    // from @llvm-project
+
+namespace mlir {
+namespace tosa {
+
+// Create a TOSA rescale op from input framework scaling, zero points and
+// rounding mode
+Value buildRescale(PatternRewriter &rewriter, Operation *op,
+                   ShapedType output_type, Value input_val, double scale,
+                   int64_t input_zp, int64_t output_zp, bool double_round,
+                   bool scale32);
+
+// Creates TOSA rescale op with int32 output
+Value buildRescaleToInt32(PatternRewriter &rewriter, Operation *op,
+                          Value input_val, double input_scale,
+                          int64_t input_zp);
+
+// Create a 32-bit float constant operator from a float
+Value getTosaConstTensorSingleF32(PatternRewriter &rewriter, Operation *op,
+                                  float val);
+
+// Creates a TOSA operation and performs shape inference on the individual
+// op. This allows shape inference during the framework to TOSA lowering.
+template <typename TosaOp, typename... Args>
+TosaOp CreateOpAndInfer(PatternRewriter &rewriter, Location loc, Type result_ty,
+                        Args &&... args) {
+  auto op = rewriter.create<TosaOp>(loc, result_ty, args...);
+
+  InferShapedTypeOpInterface shapeInterface =
+      dyn_cast<InferShapedTypeOpInterface>(op.getOperation());
+  if (!shapeInterface)
+    return op;
+
+  SmallVector<ShapedTypeComponents> returnedShapes;
+  if (shapeInterface
+          .inferReturnTypeComponents(op.getContext(), op.getLoc(),
+                                     op->getOperands(), op->getAttrDictionary(),
+                                     op->getRegions(), returnedShapes)
+          .failed())
+    return op;
+
+  // We need to use the element type of the existing result type to generate
+  // the new result shaped type. This is because rescale can include a cast to
+  // different bit-width types and does not have a TypeAttr to define the
+  // target type.
+  auto result = op->getResult(0);
+  auto predictedShape = returnedShapes[0];
+  auto currentKnowledge = ValueKnowledge::getKnowledgeFromType(result_ty);
+
+  // Compute the knowledge based on the inferred type.
+  auto inferredKnowledge = ValueKnowledge::getPessimisticValueState();
+  inferredKnowledge.dtype = result_ty.cast<ShapedType>().getElementType();
+  inferredKnowledge.hasRank = predictedShape.hasRank();
+  if (predictedShape.hasRank()) {
+    for (auto dim : predictedShape.getDims()) {
+      inferredKnowledge.sizes.push_back(dim);
+    }
+  }
+
+  // Compute the new type based on the joined version.
+  auto newKnowledge = ValueKnowledge::join(currentKnowledge, inferredKnowledge);
+  auto new_ty = newKnowledge.getType();
+  result.setType(new_ty);
+  return op;
+}
+
+template <typename TosaOp, typename... Args>
+void CreateReplaceOpAndInfer(PatternRewriter &rewriter, Operation *op,
+                             Type result_ty, Args &&... args) {
+  auto result =
+      CreateOpAndInfer<TosaOp>(rewriter, op->getLoc(), result_ty, args...);
+  rewriter.replaceOp(op, result->getResults());
+}
+
+} // namespace tosa
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_TORCHTOTOSA_TOSALEGALIZEUTILS_H

--- a/lib/Conversion/TorchToTosa/CMakeLists.txt
+++ b/lib/Conversion/TorchToTosa/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_mlir_conversion_library(TorchMLIRTorchToTosa
   TorchToTosa.cpp
+  TosaLegalizeUtils.cpp
+  TosaLegalizeCommon.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/TorchToTosa

--- a/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
@@ -1,0 +1,314 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h"
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h"
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <numeric>
+
+#include "mlir/Dialect/Quant/QuantTypes.h" // from @llvm-project
+#include "mlir/Dialect/Tensor/IR/Tensor.h" // from @llvm-project
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"  // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"          // from @llvm-project
+#include "mlir/IR/Matchers.h"              // from @llvm-project
+#include "mlir/IR/PatternMatch.h"          // from @llvm-project
+#include "llvm/Support/FormatVariadic.h"
+
+namespace mlir {
+namespace tosa {
+
+// Common function for lowering reduce operations to TOSA ops.
+template <typename T>
+llvm::Optional<Value> convertReduceOpCommon(
+    PatternRewriter &rewriter, Operation *op, RankedTensorType output_type,
+    Value input_value, ElementsAttr axes_elems, bool keep_dims,
+    Type reduce_element_type, bool is_quantized, double input_scale,
+    int64_t input_zp, double output_scale, int64_t output_zp) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  ArrayRef<int64_t> input_shape = input_type.getShape();
+  ArrayRef<int64_t> output_shape = output_type.getShape();
+  auto input_rank = input_shape.size();
+  Value val = input_value;
+
+  if (axes_elems.getNumElements() == 0) {
+    // No axes means return the original tensor.
+    auto identity_op = CreateOpAndInfer<tosa::IdentityOp>(
+        rewriter, op->getLoc(), output_type, val);
+    val = identity_op.getResult();
+  } else {
+    // Reduce along each axis
+    SmallVector<int64_t> shape_vec(input_shape.begin(), input_shape.end());
+
+    if (is_quantized) {
+      val = buildRescaleToInt32(rewriter, op, val, input_scale, input_zp);
+    }
+
+    for (int i = 0; i < axes_elems.getNumElements(); i++) {
+      int64_t axis_val = axes_elems.getValues<IntegerAttr>()[i].getInt();
+      if (axis_val < 0)
+        axis_val += input_rank;
+      auto axis_attr = rewriter.getI64IntegerAttr(axis_val);
+
+      shape_vec[axis_val] = 1;
+      RankedTensorType reduce_type =
+          RankedTensorType::get(shape_vec, reduce_element_type);
+
+      auto reduce_op = CreateOpAndInfer<T>(rewriter, op->getLoc(), reduce_type,
+                                           val, axis_attr);
+
+      val = reduce_op.getResult();
+    }
+
+    if (is_quantized) {
+      RankedTensorType output_rescale_type =
+          RankedTensorType::get(shape_vec, output_type.getElementType());
+      val = buildRescale(rewriter, op, output_rescale_type, val, output_scale,
+                         0, output_zp, false, true);
+    }
+
+    // Optionally squeeze out the reduced axes.
+    if (!keep_dims) {
+      auto reshape_op = CreateOpAndInfer<tosa::ReshapeOp>(
+          rewriter, op->getLoc(), output_type, val,
+          rewriter.getI64ArrayAttr(output_shape));
+      val = reshape_op.getResult();
+    }
+  }
+
+  return val;
+}
+
+// Lowers ReduceAll to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceAllOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  return convertReduceOpCommon<tosa::ReduceAllOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceAny to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceAnyOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  return convertReduceOpCommon<tosa::ReduceAnyOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceMin to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMinOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  return convertReduceOpCommon<tosa::ReduceMinOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceMax to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMaxOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  return convertReduceOpCommon<tosa::ReduceMaxOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceProd to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceProdOp(PatternRewriter &rewriter, Operation *op,
+                    RankedTensorType output_type, Value input_value,
+                    ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  bool input_is_qtype =
+      input_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+  bool output_is_qtype =
+      output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+
+  if (input_is_qtype || output_is_qtype) {
+    op->emitOpError("ConvertReduceProdOp: input/output tensor should "
+                    "be all floating-point.");
+    return llvm::None;
+  }
+
+  return convertReduceOpCommon<tosa::ReduceProdOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      output_type.getElementType(), false, 1.0f, 0, 1.0f, 0);
+}
+
+// Lowers ReduceSum to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceSumOp(PatternRewriter &rewriter, Operation *op,
+                   RankedTensorType output_type, Value input_value,
+                   ElementsAttr axes_elems, bool keep_dims) {
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  bool input_is_qtype =
+      input_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+  bool output_is_qtype =
+      output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+
+  if (input_is_qtype != output_is_qtype) {
+    op->emitOpError("ConvertReduceSumOp: input/output tensor should "
+                    "be all quantized or all floating-point.");
+    return llvm::None;
+  }
+
+  double input_scale = 1.0f;
+  double output_scale = 1.0f;
+  int64_t input_zp = 0;
+  int64_t output_zp = 0;
+  Type reduce_element_type = input_type.getElementType();
+
+  if (input_is_qtype) {
+    auto input_qtype =
+        input_type.getElementType().cast<mlir::quant::UniformQuantizedType>();
+    auto output_qtype =
+        output_type.getElementType().cast<mlir::quant::UniformQuantizedType>();
+
+    int32_t input_shift = 20;
+
+    input_scale =
+        static_cast<double>(1 << input_shift) * input_qtype.getScale();
+    output_scale =
+        1.0 / (output_qtype.getScale() * static_cast<double>(1 << input_shift));
+
+    input_zp = input_qtype.getZeroPoint();
+    output_zp = output_qtype.getZeroPoint();
+    reduce_element_type = rewriter.getI32Type();
+  }
+
+  return convertReduceOpCommon<tosa::ReduceSumOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      reduce_element_type, input_is_qtype, input_scale, input_zp, output_scale,
+      output_zp);
+}
+
+// Lowers ReduceMean to a sequence of TOSA ops.
+llvm::Optional<Value>
+convertReduceMeanOp(PatternRewriter &rewriter, Operation *op,
+                    RankedTensorType output_type, Value input_value,
+                    ElementsAttr axes_elems, bool keep_dims) {
+  // reduce_mean is lowered as followed:
+  // op1 = reduce_sum(input)
+  // op2 = mul(op1, 1.0 / num_elements_on_reduced_axis)
+
+  RankedTensorType input_type =
+      input_value.getType().dyn_cast<RankedTensorType>();
+  if (!input_type)
+    return llvm::None;
+
+  bool input_is_qtype =
+      input_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+  bool output_is_qtype =
+      output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
+
+  if (input_is_qtype != output_is_qtype) {
+    op->emitOpError("ConvertReduceSumOp: input/output tensor should "
+                    "be all quantized or all floating-point.");
+    return llvm::None;
+  }
+
+  // Only supports float type mean() if it's non-quantized
+  if (!input_is_qtype && !output_type.getElementType().isa<mlir::FloatType>()) {
+    op->emitWarning(
+        "Failed convertReduceMean: input unquantized type but output element "
+        "not FloatType!");
+    return llvm::None;
+  }
+
+  int64_t input_rank = input_type.getRank();
+  int64_t num_elems_on_reduced_axis = 1;
+  for (int i = 0; i < axes_elems.getNumElements(); i++) {
+    int64_t axis_val = axes_elems.getValues<IntegerAttr>()[i].getInt();
+    if (axis_val < 0)
+      axis_val += input_rank;
+    num_elems_on_reduced_axis *= input_type.getShape()[axis_val];
+  }
+  double div_scale = 1.0 / static_cast<double>(num_elems_on_reduced_axis);
+
+  double input_scale = 1.0f;
+  double output_scale = 1.0f;
+  int64_t input_zp = 0;
+  int64_t output_zp = 0;
+  Type reduce_element_type = input_type.getElementType();
+
+  if (input_is_qtype) {
+    auto input_qtype =
+        input_type.getElementType().cast<mlir::quant::UniformQuantizedType>();
+    auto output_qtype =
+        output_type.getElementType().cast<mlir::quant::UniformQuantizedType>();
+
+    // Combine 'div_scale' as part of output rescale
+    output_scale = div_scale * input_qtype.getScale() / output_qtype.getScale();
+
+    input_zp = input_qtype.getZeroPoint();
+    output_zp = output_qtype.getZeroPoint();
+    reduce_element_type = rewriter.getI32Type();
+  }
+
+  auto val = convertReduceOpCommon<tosa::ReduceSumOp>(
+      rewriter, op, output_type, input_value, axes_elems, keep_dims,
+      reduce_element_type, input_is_qtype, input_scale, input_zp, output_scale,
+      output_zp);
+
+  if (!val.hasValue())
+    return llvm::None;
+
+  if (!input_is_qtype) {
+    Value div_const = getTosaConstTensorSingleF32(rewriter, op, div_scale);
+    return CreateOpAndInfer<tosa::MulOp>(rewriter, op->getLoc(), output_type,
+                                         val.getValue(), div_const, 0)
+        .getResult();
+  }
+
+  return val;
+}
+
+} // namespace tosa
+} // namespace mlir

--- a/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"       // from @llvm-project
+#include "mlir/Dialect/Tosa/Utils/QuantUtils.h" // from @llvm-project
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h"
+
+namespace mlir {
+namespace tosa {
+
+// Create a TOSA rescale op from input framework tensor, zero points and
+// rounding mode
+Value buildRescale(PatternRewriter &rewriter, Operation *op,
+                   ShapedType output_type, Value input_val, double scale,
+                   int64_t input_zp, int64_t output_zp, bool double_round,
+                   bool scale32) {
+  int32_t multiplier;
+  int32_t shift;
+
+  int32_t scale_width = scale32 ? 32 : 16;
+
+  computeMultiplierAndShift(scale, multiplier, shift, scale_width);
+
+  auto rescale_op = CreateOpAndInfer<tosa::RescaleOp>(
+      rewriter, op->getLoc(), output_type, input_val,
+      rewriter.getI32IntegerAttr(static_cast<int32_t>(input_zp)),
+      rewriter.getI32IntegerAttr(static_cast<int32_t>(output_zp)),
+      rewriter.getI32ArrayAttr({multiplier}), rewriter.getI32ArrayAttr({shift}),
+      rewriter.getBoolAttr(scale32), rewriter.getBoolAttr(double_round),
+      rewriter.getBoolAttr(false));
+
+  return rescale_op.getResult();
+}
+
+// Creates TOSA rescale op with int32 output
+Value buildRescaleToInt32(PatternRewriter &rewriter, Operation *op,
+                          Value input_val, double input_scale,
+                          int64_t input_zp) {
+  // Output is always int32 type
+  auto input_type = input_val.getType().dyn_cast<mlir::ShapedType>();
+  assert(input_type);
+  auto output_type = input_type.clone(rewriter.getI32Type());
+
+  return buildRescale(rewriter, op, output_type, input_val, input_scale,
+                      input_zp, 0, false, true);
+}
+
+// Create a 32-bit float constant operator from a float
+Value getTosaConstTensorSingleF32(PatternRewriter &rewriter, Operation *op,
+                                  float val) {
+  auto const_type = RankedTensorType::get({}, rewriter.getF32Type());
+  auto const_attr = DenseElementsAttr::get(const_type, val);
+
+  auto const_op =
+      rewriter.create<tosa::ConstOp>(op->getLoc(), const_type, const_attr);
+  return const_op.getResult();
+}
+
+} // namespace tosa
+} // namespace mlir


### PR DESCRIPTION
- Supports variants with multiple dims, one dim, all dime
- Leverages legalize_common and legalize_utils code from
TensorFlow-TOSA work

Signed-off-by: Suraj Sudhir <suraj.sudhir@arm.com>