### PR TITLE
Add aten::nll_loss_backward op

### DIFF
--- a/e2e_testing/torchscript/nll_loss.py
+++ b/e2e_testing/torchscript/nll_loss.py
@@ -60,3 +60,61 @@ class NllLossModule_ignore_index_out_of_bounds(torch.nn.Module):
 @register_test_case(module_factory=lambda: NllLossModule_ignore_index_out_of_bounds())
 def NllLossModule_ignore_index(module, tu: TestUtils):
   module.forward(tu.rand(2, 3), torch.tensor([0, 1]))
+
+class NllLossModule_backward(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output=grad_output,
+                                           self=input,
+                                           target=target,
+                                           weight=None,
+                                           reduction=0,
+                                           ignore_index=10,
+                                           total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backward())
+def NllLossModuleBackward_basic(module, tu: TestUtils):
+  module.forward(tu.rand(3), tu.rand(3, 4), torch.tensor([2, 3, 0]),
+                 torch.tensor(3.))
+
+
+class NllLossModule_backward_ignore_index(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output=grad_output,
+                                            self=input,
+                                            target=target,
+                                            weight=None,
+                                            reduction=0,
+                                            ignore_index=1,
+                                            total_weight=total_weight)
+
+
+@register_test_case(
+    module_factory=lambda: NllLossModule_backward_ignore_index())
+def NllLossModuleBackward_ignore_index(module, tu: TestUtils):
+  module.forward(tu.rand(3), tu.rand(3, 4), torch.tensor([2, 3, 0]),
+                 torch.tensor(3.))

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1852,6 +1852,26 @@ def Torch_AtenNllLossForwardOp : Torch_Op<"aten.nll_loss_forward", [
   let assemblyFormat = "$self `,` $target `,` $weight `,` $reduction `,` $ignore_index attr-dict `:` qualified(type($self)) `,` qualified(type($target)) `,` qualified(type($weight)) `,` qualified(type($reduction)) `,` qualified(type($ignore_index)) `->` qualified(type($output)) `,` qualified(type($total_weight))";
 }
 
+def Torch_AtenNllLossBackwardOp : Torch_Op<"aten.nll_loss_backward", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::nll_loss_backward : (Tensor, Tensor, Tensor, Tensor?, int, int, Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$grad_output,
+    AnyTorchTensorType:$self,
+    AnyTorchTensorType:$target,
+    AnyTorchOptionalTensorType:$weight,
+    Torch_IntType:$reduction,
+    Torch_IntType:$ignore_index,
+    AnyTorchTensorType:$total_weight
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$grad_output `,` $self `,` $target `,` $weight `,` $reduction `,` $ignore_index `,` $total_weight attr-dict `:` qualified(type($grad_output)) `,` qualified(type($self)) `,` qualified(type($target)) `,` qualified(type($weight)) `,` qualified(type($reduction)) `,` qualified(type($ignore_index)) `,` qualified(type($total_weight)) `->` qualified(type($result))";
+}
+
 def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
@@ -70,6 +70,15 @@ struct ResultTypeState {
 ScalarType result_type(const ResultTypeState &in_state);
 ScalarType promote_skip_undefined(ScalarType a, ScalarType b);
 
+//===----------------------------------------------------------------------===//
+// These constants control the reduction behavior of the loss functions.
+// None, Mean and Sum corresponds to "do not reduce", "Mean of losses", and "sum
+// of losses" respectively.
+// Source:
+// https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/Reduction.h
+//===----------------------------------------------------------------------===//
+enum Reduction { None, Mean, Sum, END };
+
 } // namespace torch_upstream
 } // namespace torch
 } // namespace mlir

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -548,6 +548,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::std : (Tensor, bool) -> (Tensor)")
         emit("aten::var : (Tensor, bool) -> (Tensor)")
         emit("aten::nll_loss_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)")
+        emit("aten::nll_loss_backward : (Tensor, Tensor, Tensor, Tensor?, int, int, Tensor) -> (Tensor)")
 
         # Misc tensor ops.
         emit("aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)")


### PR DESCRIPTION
The lowering of aten::nll_loss_backward op has been added
from torch to linalg dialect. The changes has been made as
a part of -torch-convert-to-linalg pass.

Signed-off-by: Prashant Kumar <prashant@nod-labs.com>