### PR TITLE
[TORCH][MLIR] Templatize lowering of [`aten.zeros|aten.ones|aten.empty`] ops

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -637,6 +637,57 @@ def OnesModuleFalsePinMemory_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class EmptyIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return 0 * torch.empty((3, 4), dtype=torch.int64)
+
+@register_test_case(module_factory=lambda: EmptyIntModule())
+def EmptyModule_int(module, tu: TestUtils):
+    module.forward()
+
+# ==============================================================================
+
+class EmptyFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return torch.abs(torch.empty((3, 4), dtype=torch.float32)) > -1.0
+
+@register_test_case(module_factory=lambda: EmptyFloatModule())
+def EmptyModule_float(module, tu: TestUtils):
+    module.forward()
+
+
+class EmptyFalsePinMemoryModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return torch.abs(torch.empty((3, 4), dtype=torch.float32, 
+                                     pin_memory=False)) > -1.0 
+
+@register_test_case(module_factory=lambda: EmptyFalsePinMemoryModule())
+def EmptyModule_falsePinMemory(module, tu: TestUtils):
+    module.forward()
+
+# ==============================================================================
+
 class ContiguousModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -443,8 +443,24 @@ def RsubModule_noalpha_basic(module, tu: TestUtils):
     
 # ==============================================================================
 
+class ElementwiseMulScalarIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
 
-class ElementwiseMulScalarModule(torch.nn.Module):
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return torch.mul(x, 4)
+
+@register_test_case(module_factory=lambda: ElementwiseMulScalarIntModule())
+def ElementwiseMulScalarModule_int(module, tu: TestUtils):
+    module.forward(torch.randint(10, (3, 4)))
+
+
+class ElementwiseMulScalarFloatModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -456,10 +472,26 @@ class ElementwiseMulScalarModule(torch.nn.Module):
     def forward(self, x):
         return torch.mul(x, 100.0)
 
-@register_test_case(module_factory=lambda: ElementwiseMulScalarModule())
-def ElementwiseMulScalarModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: ElementwiseMulScalarFloatModule())
+def ElementwiseMulScalarModule_float(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
 
+
+class ElementwiseMulScalarModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return torch.mul(x, 8.0)
+
+@register_test_case(module_factory=lambda: ElementwiseMulScalarModule())
+def ElementwiseMulScalarModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (3, 4)))
 
 
 class ElementwiseMulTensorFloatModule(torch.nn.Module):


### PR DESCRIPTION
- Templatize `aten.zeros` and `aten.ones` ops lowering.
- Add E2E support for `aten.empty` op.
- Add Integer type support in `aten.mul.Scalar` op lowering.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>