### PR TITLE
Add e2e lowering for aten.index.put op.

### DIFF
--- a/e2e_testing/torchscript/index_put.py
+++ b/e2e_testing/torchscript/index_put.py
@@ -1,0 +1,87 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+
+# Updating a 2d tensor from 0d indices and value.
+class IndexPutZeroModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1], torch.float32, True),
+      ([], torch.int64, True),
+      ([], torch.int64, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, input, index1, index2, value):
+    return torch.ops.aten.index_put(input, (index1, index2), value)
+
+
+@register_test_case(module_factory=lambda: IndexPutZeroModule())
+def IndexPutZeroModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(2, 2), torch.tensor(1, dtype=torch.int64),
+                 torch.tensor(1, dtype=torch.int64), tu.rand())
+
+
+# Updating a 3d tensor from 2d indices and value.
+class IndexPut3dModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.float32, True),
+      ([-1, -1], torch.int64, True),
+      ([-1, -1], torch.int64, True),
+      ([-1, -1], torch.int64, True),
+      ([-1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index1, index2, index3, value):
+    return torch.ops.aten.index_put(input, (index1, index2, index3), value)
+
+
+@register_test_case(module_factory=lambda: IndexPut3dModule())
+def IndexPut3dModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(5, 5, 5), torch.randint(5, (2, 2)),
+                 torch.randint(1, 4, (2, 2)), torch.randint(0, 4, (2, 2)),
+                 tu.rand(2, 2))
+
+# Updating a 3d tensor from arbitrary equivalent indices and value.
+class IndexPutEquivalentIndicesModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.float32, True),
+      ([-1, -1], torch.int64, True),
+      ([-1], torch.int64, True),
+      ([-1, -1, -1], torch.int64, True),
+      ([-1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index1, index2, index3, value):
+    return torch.ops.aten.index_put(input, (index1, index2, index3), value)
+
+
+@register_test_case(module_factory=lambda: IndexPutEquivalentIndicesModule())
+def IndexPutEquivalentIndicesModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(5, 5, 5), torch.randint(5, (1, 2)),
+                 torch.randint(1, 4, (2,)), torch.randint(0, 4, (1, 1, 2)),
+                 tu.rand(1, 2))

--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -46,6 +46,7 @@ from . import slice_like
 from . import nll_loss
 from . import index_select
 from . import arange
+from . import index_put
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend', 'tosa', 'external']

--- a/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
+++ b/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
@@ -39,68 +39,81 @@ public:
         opOperand.set(rewriter.create<CopyToValueTensorOp>(op->getLoc(),
                                                            opOperand.get()));
       } else if (auto listType = operandType.dyn_cast<ListType>()) {
-        if (!listType.getContainedType().isa<NonValueTensorType>())
-          continue;
+        if (!(listType.getContainedType().isa<NonValueTensorType>() ||
+              listType.getContainedType().isa<OptionalType>()))
+            continue;
 
-        // Construct a new list whose elements are value tensors copied from
-        // the none value tensors of the original list.
-        auto listConstruct =
-            opOperand.get().getDefiningOp<PrimListConstructOp>();
-        if (!listConstruct) {
-          rewriter.cancelRootUpdate(op);
-          return rewriter.notifyMatchFailure(op, 
-              "unimplemented: list of non vtensor type not constructed "
-              "from list construct");
+          // Construct a new list whose elements are value tensors copied from
+          // the non-value tensors of the original list.
+          auto listConstruct =
+              opOperand.get().getDefiningOp<PrimListConstructOp>();
+          if (!listConstruct) {
+            rewriter.cancelRootUpdate(op);
+            return rewriter.notifyMatchFailure(
+                op, "unimplemented: list of non vtensor type not constructed "
+                    "from list construct");
+          }
+
+          if (listConstruct.elements().empty())
+            continue;
+
+          // TODO: Handle optional type in list type.
+          if (listType.getContainedType().isa<OptionalType>())
+            if (!llvm::all_of(listConstruct.elements(), [](Value val) {
+                  return val.getType().isa<NonValueTensorType>();
+                }))
+              return rewriter.notifyMatchFailure(
+                  op, "unimplemented: list containing optional type is not "
+                      "handled.");
+
+          auto newListElements = llvm::to_vector<4>(llvm::map_range(
+              listConstruct.elements(), [&](Value tensor) -> Value {
+                return rewriter.create<CopyToValueTensorOp>(op->getLoc(),
+                                                            tensor);
+              }));
+          opOperand.set(rewriter.create<PrimListConstructOp>(
+              op->getLoc(),
+              Torch::ListType::get(newListElements.front().getType()),
+              newListElements));
+        } else if (auto optionalType = operandType.dyn_cast<OptionalType>()) {
+          // TODO: A more general way to handle the optional type is to
+          // introduce a `copy.to_optional_vtensor` op.
+          if (!optionalType.getContainedType().isa<NonValueTensorType>())
+            continue;
+
+          // Create a new optional value whose input is a value tensor copied
+          // from the non value tensor of the original optional value.
+          auto derefine = opOperand.get().getDefiningOp<DerefineOp>();
+          if (!derefine) {
+            rewriter.cancelRootUpdate(op);
+            return rewriter.notifyMatchFailure(
+                op, "unimplemented: optional of non vtensor type not from "
+                    "derefine");
+          }
+
+          if (!derefine.operand().getType().isa<NonValueTensorType>())
+            continue;
+          auto newOperand = rewriter.create<CopyToValueTensorOp>(
+              op->getLoc(), derefine.operand());
+          opOperand.set(rewriter.create<DerefineOp>(
+              op->getLoc(), Torch::OptionalType::get(newOperand.getType()),
+              newOperand));
         }
-
-        if (listConstruct.elements().empty())
-          continue;
-        auto newListElements = llvm::to_vector<4>(llvm::map_range(
-            listConstruct.elements(), [&](Value tensor) -> Value {
-              return rewriter.create<CopyToValueTensorOp>(op->getLoc(), tensor);
-            }));
-        opOperand.set(rewriter.create<PrimListConstructOp>(
-            op->getLoc(),
-            Torch::ListType::get(newListElements.front().getType()),
-            newListElements));
-      } else if (auto optionalType = operandType.dyn_cast<OptionalType>()) {
-        // TODO: A more general way to handle the optional type is to
-        // introduce a `copy.to_optional_vtensor` op.
-        if (!optionalType.getContainedType().isa<NonValueTensorType>())
-          continue;
-
-        // Create a new optional value whose input is a value tensor copied
-        // from the non value tensor of the original optional value.
-        auto derefine = opOperand.get().getDefiningOp<DerefineOp>();
-        if (!derefine) {
-          rewriter.cancelRootUpdate(op);
-          return rewriter.notifyMatchFailure(op, 
-              "unimplemented: optional of non vtensor type not from derefine");
-        }
-
-        if (!derefine.operand().getType().isa<NonValueTensorType>())
-          continue;
-        auto newOperand = rewriter.create<CopyToValueTensorOp>(
-            op->getLoc(), derefine.operand());
-        opOperand.set(rewriter.create<DerefineOp>(
-            op->getLoc(), Torch::OptionalType::get(newOperand.getType()),
-            newOperand));
       }
+      // Convert all results.
+      rewriter.setInsertionPointAfter(op);
+      for (Value result : op->getResults()) {
+        auto tensorType = result.getType().dyn_cast<NonValueTensorType>();
+        if (!tensorType)
+          continue;
+        result.setType(tensorType.getWithValueSemantics());
+        auto nonValueTensor =
+            rewriter.create<CopyToNonValueTensorOp>(op->getLoc(), result);
+        result.replaceAllUsesExcept(nonValueTensor, nonValueTensor);
+      }
+      rewriter.finalizeRootUpdate(op);
+      return success();
     }
-    // Convert all results.
-    rewriter.setInsertionPointAfter(op);
-    for (Value result : op->getResults()) {
-      auto tensorType = result.getType().dyn_cast<NonValueTensorType>();
-      if (!tensorType)
-        continue;
-      result.setType(tensorType.getWithValueSemantics());
-      auto nonValueTensor =
-          rewriter.create<CopyToNonValueTensorOp>(op->getLoc(), result);
-      result.replaceAllUsesExcept(nonValueTensor, nonValueTensor);
-    }
-    rewriter.finalizeRootUpdate(op);
-    return success();
-  }
 };
 } // namespace
 

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -242,7 +242,7 @@ public:
             AtenClampOp, AtenLogOp, AtenNegOp, AtenSqrtOp, AtenFloorOp,
             AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp, AtenDropoutOp,
             AtenTanhBackwardOp, Aten_LogSoftmaxBackwardDataOp, AtenAddIntOp,
-            AtenAbsOp, AtenReciprocalOp, AtenCeilOp>(op)) {
+            AtenAbsOp, AtenReciprocalOp, AtenCeilOp, AtenIndexPutOp>(op)) {
       return getLatticeElement(op->getResult(0)).join(*operands[0]);
     }
 


### PR DESCRIPTION
This commit adds e2e lowering for `aten.index.put` op.
Also, fixes a bug in reduce_op_variant to check for optional types
which may contain non-value type tensors.