### PR TITLE
[TORCH][MLIR] Add E2E support for `aten.reshape` op

### DIFF
--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -39,7 +39,7 @@ from . import backprop
 from . import reduction
 from . import argmax
 from . import matmul
-from . import view
+from . import reshape_like
 from . import scalar
 from . import squeeze
 from . import slice_like

--- a/e2e_testing/torchscript/reshape_like.py
+++ b/e2e_testing/torchscript/reshape_like.py
@@ -123,3 +123,41 @@ class View1DFoldModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: View1DFoldModule())
 def View1DFoldModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(32))
+
+# ==============================================================================
+
+class ReshapeExpandModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.reshape(12, 32)
+
+@register_test_case(module_factory=lambda: ReshapeExpandModule())
+def ReshapeExpandModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(384))
+
+# ==============================================================================
+
+class ReshapeCollapseModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return torch.reshape(a, (-1,))
+
+@register_test_case(module_factory=lambda: ReshapeCollapseModule())
+def ReshapeCollapseModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 4))

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -90,7 +90,7 @@ public:
       if (auto copyToValueTensor = dyn_cast<CopyToValueTensorOp>(op)) {
         copyToValueTensorOps.push_back(copyToValueTensor);
       } else if (isa<AtenSqueezeOp, AtenSqueezeDimOp, AtenUnsqueezeOp,
-                     AtenFlattenUsingIntsOp, AtenTransposeIntOp,
+                     AtenFlattenUsingIntsOp, AtenTransposeIntOp, AtenReshapeOp,
                      TensorStaticInfoCastOp, AtenBroadcastToOp, AtenToDtypeOp,
                      AtenContiguousOp, AtenPermuteOp, AtenViewOp, AtenExpandOp,
                      AtenFill_ScalarOp, AtenSliceTensorOp, AtenSelectIntOp,


### PR DESCRIPTION
This commit decomposes `aten.reshape` into `aten.view` op in the case of
value tensor type operand.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>