### PR TITLE
Add Add and Sub scalar op conversions.

### DIFF
--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -1000,3 +1000,69 @@ def ElementwiseAndIntegerModule_basic(module, tu: TestUtils):
                    torch.randint(-10, 10, (3, 4)))
 
 
+class ElementwiseSubScalarIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return torch.sub(x, 2.1, alpha = 2)
+
+@register_test_case(module_factory=lambda: ElementwiseSubScalarIntModule())
+def ElementwiseSubScalarIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (3, 4)))
+
+
+class ElementwiseSubScalarFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.sub(x, 2.1)
+
+@register_test_case(module_factory=lambda: ElementwiseSubScalarFloatModule())
+def ElementwiseSubScalarFloatModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+
+
+class ElementwiseAddScalarIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return torch.add(x, 3.0)
+
+@register_test_case(module_factory=lambda: ElementwiseAddScalarIntModule())
+def ElementwiseAddScalarIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (3, 4)))
+
+
+class ElementwiseAddScalarFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.add(x, 3.0, alpha = 2)
+
+@register_test_case(module_factory=lambda: ElementwiseAddScalarFloatModule())
+def ElementwiseAddScalarFloatModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))


### PR DESCRIPTION
`aten.add.Scalar` and `aten.sub.Scalar` op conversions have been added.
The changes have been made as a part of `-convert-torch-to-linalg` pass.