### PR TITLE
Make broadcasting result shape more static

### DIFF
--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -62,6 +62,28 @@ def ElementwiseBinaryModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwiseBinaryStaticShapeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([5, 4, 3, 3, 1], torch.float32, True),
+        ([4, 3, 1, 2], torch.float32, True),
+    ])
+    def forward(self, a, b):
+        return a * b
+
+@register_test_case(
+    module_factory=lambda: ElementwiseBinaryStaticShapeModule())
+def ElementwiseBinaryStaticShapeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5, 4, 3, 3, 1), tu.rand(4, 3, 1, 2))
+
+
+# ==============================================================================
+
+
 class ElementwiseTernaryModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -171,8 +193,7 @@ class ElementwiseUnsqueezeNegDimsModule(torch.nn.Module):
         return torch.unsqueeze(a, -3)
 
 
-@register_test_case(
-    module_factory=lambda: ElementwiseUnsqueezeNegDimsModule())
+@register_test_case(module_factory=lambda: ElementwiseUnsqueezeNegDimsModule())
 def ElementwiseUnsqueezeNegDimsModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(4, 3))
 
@@ -255,7 +276,7 @@ class ElementwiseGeluModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseGeluModule())
 def ElementwiseGeluModule_basic(module, tu: TestUtils):
-    module.forward(2*tu.rand(5, 3) - 0.5)
+    module.forward(2 * tu.rand(5, 3) - 0.5)
 
 
 # ==============================================================================
@@ -359,7 +380,7 @@ class ElementwiseGtIntScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseGtIntScalarModule())
 def ElementwiseGtIntScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 15, (3,4)))
+    module.forward(torch.randint(-10, 15, (3, 4)))
 
 
 class ElementwiseGtMixed2ScalarModule(torch.nn.Module):
@@ -377,7 +398,7 @@ class ElementwiseGtMixed2ScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseGtMixed2ScalarModule())
 def ElementwiseGtMixed2ScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 15, (3,4)).to(torch.int32))
+    module.forward(torch.randint(-10, 15, (3, 4)).to(torch.int32))
 
 
 class ElementwiseGtFloatTensorModule(torch.nn.Module):
@@ -415,9 +436,11 @@ class ElementwiseGtIntTensorModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseGtIntTensorModule())
 def ElementwiseGtIntTensorModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(10, (3, 5)), torch.randint(10, (5,)))
+    module.forward(torch.randint(10, (3, 5)), torch.randint(10, (5, )))
+
 
 # ==============================================================================
+
 
 class ElementwiseLtFloatScalarModule(torch.nn.Module):
     def __init__(self):
@@ -452,7 +475,7 @@ class ElementwiseLtIntScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseLtIntScalarModule())
 def ElementwiseLtIntScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 15, (3,4)))
+    module.forward(torch.randint(-10, 15, (3, 4)))
 
 
 class ElementwiseLtDiffWidthScalarModule(torch.nn.Module):
@@ -468,9 +491,10 @@ class ElementwiseLtDiffWidthScalarModule(torch.nn.Module):
         return torch.lt(x, 2)
 
 
-@register_test_case(module_factory=lambda: ElementwiseLtDiffWidthScalarModule())
+@register_test_case(
+    module_factory=lambda: ElementwiseLtDiffWidthScalarModule())
 def ElementwiseLtDiffWidthScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 15, (3,4)).to(torch.int32))
+    module.forward(torch.randint(-10, 15, (3, 4)).to(torch.int32))
 
 
 class ElementwiseLtFloatTensorModule(torch.nn.Module):
@@ -508,9 +532,11 @@ class ElementwiseLtIntTensorModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseLtIntTensorModule())
 def ElementwiseLtIntTensorModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(10, (3, 5)), torch.randint(10, (5,)))
+    module.forward(torch.randint(10, (3, 5)), torch.randint(10, (5, )))
+
 
 # ==============================================================================
+
 
 class ElementwiseEqFloatScalarModule(torch.nn.Module):
     def __init__(self):
@@ -527,8 +553,8 @@ class ElementwiseEqFloatScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseEqFloatScalarModule())
 def ElementwiseEqFloatScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.tensor([[1.0, 2.2, 6.0], [6.0, 2.0, 3.1]])
-                   .to(torch.float32))
+    module.forward(
+        torch.tensor([[1.0, 2.2, 6.0], [6.0, 2.0, 3.1]]).to(torch.float32))
 
 
 class ElementwiseEqIntScalarModule(torch.nn.Module):
@@ -546,7 +572,7 @@ class ElementwiseEqIntScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseEqIntScalarModule())
 def ElementwiseEqIntScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(2, 4, (5,8)))
+    module.forward(torch.randint(2, 4, (5, 8)))
 
 
 class ElementwiseEqDiffWidthScalarModule(torch.nn.Module):
@@ -562,9 +588,10 @@ class ElementwiseEqDiffWidthScalarModule(torch.nn.Module):
         return torch.eq(x, 2)
 
 
-@register_test_case(module_factory=lambda: ElementwiseEqDiffWidthScalarModule())
+@register_test_case(
+    module_factory=lambda: ElementwiseEqDiffWidthScalarModule())
 def ElementwiseEqDiffWidthScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(2, 4, (5,8)).to(torch.int32))
+    module.forward(torch.randint(2, 4, (5, 8)).to(torch.int32))
 
 
 class ElementwiseEqFloatTensorModule(torch.nn.Module):
@@ -583,9 +610,9 @@ class ElementwiseEqFloatTensorModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseEqFloatTensorModule())
 def ElementwiseEqFloatTensorModule_basic(module, tu: TestUtils):
-    module.forward(torch.tensor([[1.0, 2.2, 6.0], [6.0, 2.0, 3.1]])
-                   .to(torch.float32), 
-                   torch.tensor([1.0, 2.4, 6.0]).to(torch.float32))
+    module.forward(
+        torch.tensor([[1.0, 2.2, 6.0], [6.0, 2.0, 3.1]]).to(torch.float32),
+        torch.tensor([1.0, 2.4, 6.0]).to(torch.float32))
 
 
 class ElementwiseEqIntTensorModule(torch.nn.Module):
@@ -604,9 +631,11 @@ class ElementwiseEqIntTensorModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseEqIntTensorModule())
 def ElementwiseEqIntTensorModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(2, 4, (8, 5)), torch.randint(2, 4, (5,)))
+    module.forward(torch.randint(2, 4, (8, 5)), torch.randint(2, 4, (5, )))
+
 
 # ==============================================================================
+
 
 class ElementwiseClampModule(torch.nn.Module):
     def __init__(self):
@@ -666,7 +695,7 @@ class RsubModule_noalpha(torch.nn.Module):
 @register_test_case(module_factory=lambda: RsubModule_noalpha())
 def RsubModule_noalpha_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
-    
+
 # ==============================================================================
 
 class ElementwiseMulScalarIntModule(torch.nn.Module):
@@ -734,12 +763,10 @@ class ElementwiseMulTensorFloatModule(torch.nn.Module):
         return torch.mul(a, b)
 
 
-@register_test_case(
-    module_factory=lambda: ElementwiseMulTensorFloatModule())
+@register_test_case(module_factory=lambda: ElementwiseMulTensorFloatModule())
 def ElementwiseMulTensorFloatModule_basic(module, tu: TestUtils):
-    module.forward(
-        tu.rand(4),
-        tu.rand(4).type(torch.float64))
+    module.forward(tu.rand(4), tu.rand(4).type(torch.float64))
+
 
 class ElementwiseMulTensorIntModule(torch.nn.Module):
     def __init__(self):
@@ -755,12 +782,10 @@ class ElementwiseMulTensorIntModule(torch.nn.Module):
         return torch.mul(a, b)
 
 
-@register_test_case(
-    module_factory=lambda: ElementwiseMulTensorIntModule())
+@register_test_case(module_factory=lambda: ElementwiseMulTensorIntModule())
 def ElementwiseMulTensorIntModule_basic(module, tu: TestUtils):
     module.forward(
-      torch.randint(10, [4]).type(torch.int32),
-      torch.randint(10, [4]))
+        torch.randint(10, [4]).type(torch.int32), torch.randint(10, [4]))
 
 
 # ==============================================================================
@@ -783,7 +808,7 @@ def ElementwiseLogModule_basic(module, tu: TestUtils):
 
 
 class ElementwiseSqrtModule(torch.nn.Module):
-    def __init__(self): 
+    def __init__(self):
         super().__init__()
 
     @export
@@ -898,7 +923,7 @@ def ElementwiseLog2Module_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
 
 class ElementwiseRsqrtModule(torch.nn.Module):
-    def __init__(self): 
+    def __init__(self):
         super().__init__()
 
     @export
@@ -984,12 +1009,9 @@ class ElementwiseDivTensorFloatModule(torch.nn.Module):
         return torch.div(a, b)
 
 
-@register_test_case(
-    module_factory=lambda: ElementwiseDivTensorFloatModule())
+@register_test_case(module_factory=lambda: ElementwiseDivTensorFloatModule())
 def ElementwiseDivTensorFloatModule_basic(module, tu: TestUtils):
-    module.forward(
-        tu.rand(4),
-        tu.rand(4).type(torch.float64))
+    module.forward(tu.rand(4), tu.rand(4).type(torch.float64))
 
 
 # ==============================================================================
@@ -1005,15 +1027,15 @@ class ElementwiseAndIntegerModule(torch.nn.Module):
         ([-1, -1], torch.int32, True),
         ([-1, -1], torch.int64, True),
     ])
-
     def forward(self, x, y):
         return torch.bitwise_and(x, y)
 
 
 @register_test_case(module_factory=lambda: ElementwiseAndIntegerModule())
 def ElementwiseAndIntegerModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 10, (3, 4)).to(torch.int32),
-                   torch.randint(-10, 10, (3, 4)))
+    module.forward(
+        torch.randint(-10, 10, (3, 4)).to(torch.int32),
+        torch.randint(-10, 10, (3, 4)))
 
 
 class ElementwiseSubScalarIntModule(torch.nn.Module):
@@ -1026,7 +1048,8 @@ class ElementwiseSubScalarIntModule(torch.nn.Module):
         ([-1, -1], torch.int64, True),
     ])
     def forward(self, x):
-        return torch.sub(x, 2.1, alpha = 2)
+        return torch.sub(x, 2.1, alpha=2)
+
 
 @register_test_case(module_factory=lambda: ElementwiseSubScalarIntModule())
 def ElementwiseSubScalarIntModule_basic(module, tu: TestUtils):
@@ -1077,7 +1100,8 @@ class ElementwiseAddScalarFloatModule(torch.nn.Module):
         ([-1, -1], torch.float32, True),
     ])
     def forward(self, x):
-        return torch.add(x, 3.0, alpha = 2)
+        return torch.add(x, 3.0, alpha=2)
+
 
 @register_test_case(module_factory=lambda: ElementwiseAddScalarFloatModule())
 def ElementwiseAddScalarFloatModule_basic(module, tu: TestUtils):

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -28,6 +28,7 @@ TOSA_PASS_SET = {
     "ElementwiseReluModule_basic",
     "ElementwiseFloorModule_basic",
     "ElementwiseLogModule_basic",
+    "ElementwiseBinaryStaticShapeModule_basic",
     "TanhBackward_basic",
     "ElementwiseAddModule_basic",
     "ReturnThreeTensorFloat32_basic",

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -2345,7 +2345,7 @@ struct ConvertElementwiseOp : ConversionPattern {
         // undefined behavior, by doing appropriate checks against the current
         // dimension size.
         auto currentDimSize =
-            rewriter.create<tensor::DimOp>(loc, tensorOperand, size.index());
+            getDimOp(rewriter, loc, tensorOperand, size.index());
 
         // If the result size of this dimension has so far only hit the
         // statically-known-to-be-1 case above (i.e., we have not yet assigned a
@@ -2372,12 +2372,13 @@ struct ConvertElementwiseOp : ConversionPattern {
           /*dimCount=*/resultRank, /*symbolCount=*/0, exprs, getContext()));
     }
 
-    SmallVector<StringRef> iteratorTypes(resultRank, "parallel");
+    SmallVector<StringRef> iteratorTypes(resultRank,
+                                         getParallelIteratorTypeName());
     // Add the indexing map for the outs init tensor.
     indexingMaps.push_back(rewriter.getMultiDimIdentityMap(resultRank));
 
     Value initTensor = rewriter.create<linalg::InitTensorOp>(
-        loc, resultShape, resultType.getElementType());
+        loc, getAsOpFoldResult(resultShape), resultType.getElementType());
     bool hadErrorCreatingPayload = false;
     auto generic = rewriter.create<linalg::GenericOp>(
         loc, /*resultTensorTypes=*/initTensor.getType(),

--- a/test/Dialect/Torch/promote-types.mlir
+++ b/test/Dialect/Torch/promote-types.mlir
@@ -7,7 +7,7 @@
 // CHECK-SAME:                                                      %[[VAL_1:.*]]: !torch.vtensor<[1],f64>,
 // CHECK-SAME:                                                      %[[VAL_2:.*]]: !torch.float) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[?],f64>
+// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],f64>
 // CHECK:           return
 builtin.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1],f32>,
                                             %t1: !torch.vtensor<[1],f64>,
@@ -23,7 +23,7 @@ builtin.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1
 // CHECK-SAME:                                           %[[VAL_1:.*]]: !torch.vtensor<[1],f64>,
 // CHECK-SAME:                                           %[[VAL_2:.*]]: !torch.float) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:         !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[?],f64>
+// CHECK-SAME:         !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],f64>
 // CHECK:           return
 builtin.func @tensor_tensor$different_category(%t0: !torch.vtensor<[1],si32>,
                                  %t1: !torch.vtensor<[1],f64>,
@@ -39,7 +39,7 @@ builtin.func @tensor_tensor$different_category(%t0: !torch.vtensor<[1],si32>,
 // CHECK-SAME:                                                      %[[VAL_1:.*]]: !torch.vtensor<[],f64>,
 // CHECK-SAME:                                                      %[[VAL_2:.*]]: !torch.int) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[],f64>, !torch.int -> !torch.vtensor<[?],f32>
+// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[],f64>, !torch.int -> !torch.vtensor<[1],f32>
 // CHECK:           return
 builtin.func @tensor_tensor$same_category_zero_rank_wider(
                                                   %t0: !torch.vtensor<[1],f32>,
@@ -56,7 +56,7 @@ builtin.func @tensor_tensor$same_category_zero_rank_wider(
 // CHECK-SAME:                                                  %[[VAL_1:.*]]: !torch.vtensor<[],f32>,
 // CHECK-SAME:                                                  %[[VAL_2:.*]]: !torch.int) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:         !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[?],f32>
+// CHECK-SAME:         !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[1],f32>
 // CHECK:           return
 builtin.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si64>,
                                         %t1: !torch.vtensor<[],f32>,
@@ -71,7 +71,7 @@ builtin.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si
 // CHECK-SAME:                                    %[[VAL_0:.*]]: !torch.vtensor<[1],f32>, %[[VAL_1:.*]]: !torch.vtensor<[1],f32>,
 // CHECK-SAME:                                    %[[VAL_2:.*]]: !torch.float) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:        !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor<[?],f32>
+// CHECK-SAME:        !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor<[1],f32>
 // CHECK:           return
 builtin.func @tensor_tensor$alpha_wider_no_contribution(%t0: !torch.vtensor<[1],f32>,
                                %t1: !torch.vtensor<[1],f32>,


### PR DESCRIPTION
This involes the following 2 parts:
- Change refine type to propagate more static shape info.
- Get as much static shape info as possible when creating the result
tensor when converting to linalg.