### PR TITLE
Fix build error regarding missing types in torch::jit

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/class_annotator.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/class_annotator.h
@@ -23,6 +23,8 @@
 #ifndef TORCHMLIRJITIRIMPORTER_CSRC_CLASS_ANNOTATOR_H
 #define TORCHMLIRJITIRIMPORTER_CSRC_CLASS_ANNOTATOR_H
 
+#include <torch/csrc/jit/ir/ir.h>
+
 #include "pybind.h"
 
 namespace torch_mlir {

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/get_registered_ops.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/get_registered_ops.cpp
@@ -9,6 +9,8 @@
 
 #include "get_registered_ops.h"
 
+#include <torch/csrc/jit/ir/ir.h>
+
 namespace py = pybind11;
 
 static const char kGetRegisteredOpsDocstring[] =


### PR DESCRIPTION
This commit adds include statements of the file
`torch/csrc/jit/ir/ir.h` for files that use types from torch::jit.

Fixes https://github.com/llvm/torch-mlir/issues/506