### PR TITLE
Add support for constant_pad_nd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+.cache/
 .vscode
 .env
 *.code-workspace

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -284,6 +284,47 @@ def MaxPool2dModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1, 1, 20, 20) - 0.5)
 
 
+class ConstantPad2dStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pad2d = torch.nn.ConstantPad2d((0, 1, 2, 3), -float('inf'))
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 1, 20, 20], torch.float32, True),
+    ])
+    def forward(self, x):
+        return self.pad2d(x)
+
+# ==============================================================================
+
+
+@register_test_case(module_factory=lambda: ConstantPad2dStaticModule())
+def ConstantPad2dStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1, 20, 20) - 0.5)
+
+
+class ConstantPadNdStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 1, 20, 20, 4, 4], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.constant_pad_nd(x, (0, 1), -float('inf'))
+
+# ==============================================================================
+
+
+@register_test_case(module_factory=lambda: ConstantPadNdStaticModule())
+def ConstantPadNdStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1, 20, 20, 4, 4) - 0.5)
+
+
 class TransposeIntModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1778,6 +1778,22 @@ def Torch_AtenNllLossForwardOp : Torch_Op<"aten.nll_loss_forward", [
   let assemblyFormat = "$self `,` $target `,` $weight `,` $reduction `,` $ignore_index attr-dict `:` type($self) `,` type($target) `,` type($weight) `,` type($reduction) `,` type($ignore_index) `->` type($output) `,` type($total_weight)";
 }
 
+def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    TorchIntListType:$pad,
+    AnyTorchScalarType:$value
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $pad `,` $value attr-dict `:` type($self) `,` type($pad) `,` type($value) `->` type($result)";
+}
+
 def Torch_AtenSqueezeDimOp : Torch_Op<"aten.squeeze.dim", [
     AllowsTypeRefinement
   ]> {
@@ -2915,6 +2931,22 @@ def Torch_AtenAddStrOp : Torch_Op<"aten.add.str", [
   let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
 }
 
+def Torch_AtenEqStrOp : Torch_Op<"aten.eq.str", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::eq.str : (str, str) -> (bool)`";
+  let arguments = (ins
+    Torch_StringType:$a,
+    Torch_StringType:$b
+  );
+  let results = (outs
+    Torch_BoolType:$result
+  );
+  let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
+  let hasFolder = 1;
+}
+
 def Torch_AtenStrOp : Torch_Op<"aten.str", [
     AllowsTypeRefinement,
     HasValueSemantics
@@ -3175,6 +3207,21 @@ def Torch_AtenMulIntOp : Torch_Op<"aten.mul.int", [
   let hasFolder = 1;
 }
 
+def Torch_AtenNegIntOp : Torch_Op<"aten.neg.int", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::neg.int : (int) -> (int)`";
+  let arguments = (ins
+    Torch_IntType:$a
+  );
+  let results = (outs
+    Torch_IntType:$result
+  );
+  let assemblyFormat = "$a attr-dict `:` type($a) `->` type($result)";
+  let hasFolder = 1;
+}
+
 def Torch_AtenLogIntOp : Torch_Op<"aten.log.int", [
     AllowsTypeRefinement,
     HasValueSemantics
@@ -3246,6 +3293,22 @@ def Torch_AtenLtFloatIntOp : Torch_Op<"aten.lt.float_int", [
     Torch_BoolType:$result
   );
   let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
+}
+
+def Torch_AtenEqFloatOp : Torch_Op<"aten.eq.float", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::eq.float : (float, float) -> (bool)`";
+  let arguments = (ins
+    Torch_FloatType:$a,
+    Torch_FloatType:$b
+  );
+  let results = (outs
+    Torch_BoolType:$result
+  );
+  let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
+  let hasFolder = 1;
 }
 
 def Torch_Aten__And__BoolOp : Torch_Op<"aten.__and__.bool", [

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedPrimOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedPrimOps.td
@@ -185,6 +185,7 @@ def Torch_PrimUninitializedOp : Torch_Op<"prim.Uninitialized", [
     AnyTorchType:$result
   );
   let assemblyFormat = " attr-dict `:` type($result)";
+  let hasCanonicalizer = 1;
 }
 
 def Torch_PrimUncheckedCastOp : Torch_Op<"prim.unchecked_cast", [

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
@@ -45,12 +45,33 @@ struct torch_constant_int_op_binder {
     return false;
   }
 };
+
+struct torch_constant_float_op_binder {
+  APFloat *bind_value;
+
+  /// Creates a matcher instance that binds the value to bv if match succeeds.
+  torch_constant_float_op_binder(APFloat *bv) : bind_value(bv) {}
+
+  bool match(Operation *op) {
+    if (auto constantFloat = dyn_cast<Torch::ConstantFloatOp>(op)) {
+      *bind_value = constantFloat.value();
+      return true;
+    }
+    return false;
+  }
+};
 } // namespace detail
 
 /// Matches the integer stored in a `torch.constant.bool`.
 inline detail::torch_constant_int_op_binder
 m_TorchConstantInt(int64_t *bind_value) {
   return detail::torch_constant_int_op_binder(bind_value);
+}
+
+/// Matches the integer stored in a `torch.constant.float`.
+inline detail::torch_constant_float_op_binder
+m_TorchConstantFloat(APFloat *bind_value) {
+  return detail::torch_constant_float_op_binder(bind_value);
 }
 
 namespace detail {

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -275,7 +275,24 @@ static SmallVector<Value> getTypeConvertedValues(OpBuilder &b, Location loc,
 }
 
 // Helper function to get the padding tensor given the padding int values.
-// It's assumed that the padding on the low end and high end are the same.
+static Value getPaddedTensor(Operation *op, OpBuilder &b, Value &input,
+                             SmallVectorImpl<int64_t> &lowPaddingInts,
+                             SmallVectorImpl<int64_t> &highPaddingInts,
+                             Value pad) {
+  Location loc = op->getLoc();
+  Type rankedTensorType = linalg::PadTensorOp::inferResultType(
+      input.getType().cast<RankedTensorType>(), lowPaddingInts, highPaddingInts);
+  SmallVector<OpFoldResult> lowPaddings = getAsOpFoldResult(b, loc, lowPaddingInts);
+  SmallVector<OpFoldResult> highPaddings = getAsOpFoldResult(b, loc, highPaddingInts);
+  Value paddedInput = linalg::PadTensorOp::createPadScalarOp(
+      rankedTensorType, input, pad, /*low=*/lowPaddings, /*high=*/highPaddings,
+      /*packing=*/false, loc, b);
+  return paddedInput;
+}
+
+// Helper function to get the padding tensor given the padding int values.
+// It's assumed that the padding on the low end and high end are the same,
+// and that zero padding is required.
 static Value getPaddedTensor(Operation *op, OpBuilder &b, Value &input,
                              SmallVectorImpl<int64_t> &paddingInts) {
   assert(input.getType().isa<RankedTensorType>() &&
@@ -284,13 +301,7 @@ static Value getPaddedTensor(Operation *op, OpBuilder &b, Value &input,
   Value c0 = b.create<arith::ConstantOp>(
       loc,
       b.getZeroAttr(input.getType().cast<RankedTensorType>().getElementType()));
-  SmallVector<OpFoldResult> paddings = getAsOpFoldResult(b, loc, paddingInts);
-  Type ranked4DTensorType = linalg::PadTensorOp::inferResultType(
-      input.getType().cast<RankedTensorType>(), paddingInts, paddingInts);
-  Value paddedInput = linalg::PadTensorOp::createPadScalarOp(
-      ranked4DTensorType, input, c0, /*low=*/paddings, /*high=*/paddings,
-      /*packing=*/false, loc, b);
-  return paddedInput;
+  return getPaddedTensor(op, b, input, paddingInts, paddingInts, c0);
 }
 
 static Value buildNormalCdf(OpBuilder &b, Location &loc, Value x, Value mean,
@@ -2686,6 +2697,58 @@ public:
 } // namespace
 
 namespace {
+class ConvertAtenConstantPadNdOp : public OpConversionPattern<AtenConstantPadNdOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenConstantPadNdOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+      return failure();
+    Location loc = op->getLoc();
+    Value self = adaptor.self();
+    auto type = self.getType().cast<RankedTensorType>();
+    int64_t rank = type.getRank();
+
+    Type elementType = self.getType().cast<RankedTensorType>().getElementType();
+    if (!elementType.isa<mlir::FloatType>())
+      return op.emitError("unimplemented: non-floating point type");
+
+    // Pattern match against the op's original operands, because otherwise we
+    // will get the lowered version of the operands which is harder to pattern
+    // match.
+    SmallVector<int64_t> padInts;
+    if (!matchPattern(op.pad(), m_TorchConstantIntList(padInts)))
+      return rewriter.notifyMatchFailure(op,
+                                         "only support constant int pad ranges");
+    uint64_t padRank = padInts.size() / 2;
+    if (padRank * 2 != padInts.size())
+      return rewriter.notifyMatchFailure(op, "pad range size is not even");
+    if (rank < 0 || padRank > (uint64_t)rank)
+      return rewriter.notifyMatchFailure(op, "padding exceeds tensor rank");
+
+    // low/high initialized with the dims that should not be padded
+    SmallVector<int64_t, 4> lowPadding(/*Size=*/rank - padRank, /*Value=*/0);
+    SmallVector<int64_t, 4> highPadding(/*Size=*/rank - padRank, /*Value=*/0);
+    // add requested padding - note op.pad() is higest dim first ordered pairs
+    // of low,high
+    for (uint64_t i = padRank; i > 0; --i) {
+      lowPadding.push_back(padInts[i * 2 - 2]);
+      highPadding.push_back(padInts[i * 2 - 1]);
+    }
+
+    Value castedValue =
+        rewriter.create<arith::TruncFOp>(loc, type.getElementType(), adaptor.value());
+    Value paddedInput = getPaddedTensor(op, rewriter, self, lowPadding, highPadding, castedValue);
+
+    Type newResultType = getTypeConverter()->convertType(op.getType());
+    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, paddedInput);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class ConvertAtenFlattenUsingIntsOp
     : public OpConversionPattern<AtenFlattenUsingIntsOp> {
 public:
@@ -4225,6 +4288,8 @@ public:
     patterns.add<ConvertAtenViewOp>(typeConverter, context);
     target.addIllegalOp<AtenMaxPool2dOp>();
     patterns.add<ConvertAtenMaxPool2dOp>(typeConverter, context);
+    target.addIllegalOp<AtenConstantPadNdOp>();
+    patterns.add<ConvertAtenConstantPadNdOp>(typeConverter, context);
     target.addIllegalOp<AtenSumOp>();
     patterns.add<ConvertReductionOp>(typeConverter, context);
     target.addIllegalOp<AtenTransposeIntOp>();

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -414,7 +414,7 @@ def emit_prim_ops(torch_ir_dir: str, registry: Registry):
         emit("prim::max.self_int : (int[]) -> (int)")
         emit("prim::max.int : (int, int) -> (int)")
         emit("prim::RaiseException : (str) -> ()")
-        emit("prim::Uninitialized : () -> (Any)")
+        emit("prim::Uninitialized : () -> (Any)", has_canonicalizer=True)
         emit("prim::unchecked_cast : (t) -> (t)",
              traits=["DeclareOpInterfaceMethods<CastOpInterface>"])
         emit("prim::Print : (...) -> ()")
@@ -540,6 +540,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::nll_loss_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)")
 
         # Misc tensor ops.
+        emit("aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)")
         emit("aten::squeeze.dim : (Tensor, int) -> (Tensor)", has_folder=True)
         emit("aten::unsqueeze : (Tensor, int) -> (Tensor)")
         emit("aten::squeeze : (Tensor) -> (Tensor)", has_folder=True)
@@ -619,6 +620,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
 
         # Str ops.
         emit("aten::add.str : (str, str) -> (str)")
+        emit("aten::eq.str : (str, str) -> (bool)", has_folder=True)
         emit("aten::str : (t) -> (str)")
         emit("aten::format : (...) -> (str)")
         emit("aten::join : (str, str[]) -> (str)")
@@ -640,11 +642,13 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::add.int : (int, int) -> (int)", has_folder=True)
         emit("aten::sub.int : (int, int) -> (int)", has_folder=True)
         emit("aten::mul.int : (int, int) -> (int)", has_folder=True)
+        emit("aten::neg.int : (int) -> (int)", has_folder=True)
         emit("aten::log.int : (int) -> (float)")
         emit("aten::add.float_int : (float, int) -> (float)")
         emit("aten::mul.float : (float, float) -> (float)")
         emit("aten::neg.float : (float) -> (float)")
         emit("aten::lt.float_int : (float, int) -> (bool)")
+        emit("aten::eq.float : (float, float) -> (bool)", has_folder=True)
         emit("aten::__and__.bool : (bool, bool) -> (bool)")
         emit("aten::ne.bool : (bool, bool) -> (bool)", has_folder=True)
         emit("aten::__is__ : (t1, t2) -> (bool)", has_folder=True)


### PR DESCRIPTION
Note that to enable folding of the code coming from an example
like the ConstantPad2dStaticModule e2e test, support for other
operations had to be added/improved:
- aten::neg.int
- aten::eq.float
- aten::eq.str
- prim::Uninitialized