### PR TITLE
[WIP][TORCH][MLIR] Add E2E support for `aten.segment_reduce` op

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -1069,3 +1069,26 @@ class ReturnTwoTensorF32I64(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReturnTwoTensorF32I64())
 def ReturnTwoTensorF32I64_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 3), torch.randint(5, (2, 3)))
+
+# ==============================================================================
+
+class EmbeddingBagModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, bag_weight, indices, lengths):
+        index_select_val = torch.index_select(bag_weight, 0, indices)
+        return torch.segment_reduce(index_select_val, 'sum', lengths=lengths)
+
+@register_test_case(module_factory=lambda: EmbeddingBagModule())
+def EmbeddingBagModule_basic(module, tu: TestUtils):
+    indices = torch.tensor([1,2,4,4,4,3,2,4], dtype=torch.long)
+    lengths = torch.tensor([3,5], dtype=torch.long)
+    module.forward(tu.rand(10, 3), indices, lengths)

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2621,6 +2621,26 @@ def Torch_AtenSliceTensorOp : Torch_Op<"aten.slice.Tensor", [
   let assemblyFormat = "$self `,` $dim `,` $start `,` $end `,` $step attr-dict `:` type($self) `,` type($dim) `,` type($start) `,` type($end) `,` type($step) `->` type($result)";
 }
 
+def Torch_AtenSegmentReduceOp : Torch_Op<"aten.segment_reduce", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::segment_reduce : (Tensor, str, Tensor?, Tensor?, int, bool, Scalar?) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$data,
+    Torch_StringType:$reduce,
+    AnyTorchOptionalTensorType:$lengths,
+    AnyTorchOptionalTensorType:$indices,
+    Torch_IntType:$axis,
+    Torch_BoolType:$unsafe,
+    AnyTorchOptionalScalarType:$initial
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$data `,` $reduce `,` $lengths `,` $indices `,` $axis `,` $unsafe `,` $initial attr-dict `:` type($data) `,` type($reduce) `,` type($lengths) `,` type($indices) `,` type($axis) `,` type($unsafe) `,` type($initial) `->` type($result)";
+}
+
 def Torch_AtenLenTensorOp : Torch_Op<"aten.len.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -593,6 +593,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::view : (Tensor, int[]) -> (Tensor)", has_folder=True)
         emit("aten::where.self : (Tensor, Tensor, Tensor) -> (Tensor)")
         emit("aten::slice.Tensor : (Tensor, int, int?, int?, int) -> (Tensor)")
+        emit("aten::segment_reduce : (Tensor, str, Tensor?, Tensor?, int, bool, Scalar?) -> (Tensor)")
         emit("aten::len.Tensor : (Tensor) -> (int)")
         emit("aten::cpu : (Tensor) -> (Tensor)")
         emit("aten::gather : (Tensor, int, Tensor, bool) -> (Tensor)")


### PR DESCRIPTION
This commit adds lowering of `aten.segment_reduce` op.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>