### PR TITLE
Add decomposition/lowering of `aten.max.dim` op.

### DIFF
--- a/e2e_testing/torchscript/reduction.py
+++ b/e2e_testing/torchscript/reduction.py
@@ -122,3 +122,97 @@ class ReduceMeanDtypeModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceMeanDtypeModule())
 def ReduceMeanDtypeModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5).to(torch.float64))
+
+# ==============================================================================
+
+class ReduceMaxAlongDim(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.max(a, 1)[0]
+
+
+@register_test_case(module_factory=lambda: ReduceMaxAlongDim())
+def ReduceMaxAlongDim_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))
+
+# ==============================================================================
+
+class ReduceMaxAlongDimNegative(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.max(a, 1)[0]
+
+
+@register_test_case(module_factory=lambda: ReduceMaxAlongDimNegative())
+def ReduceMaxAlongDimNegative_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5, low=-10, high=10).to(torch.float64))
+
+# ==============================================================================
+
+class ReduceMaxKeepDim(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.max(a, 1, keepdim=True)[1]
+
+
+@register_test_case(module_factory=lambda: ReduceMaxKeepDim())
+def ReduceMaxKeepDim_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))
+
+# ==============================================================================
+
+class ReduceMaxKeepDimReturnBoth(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.max(a, 1, keepdim=True)
+
+@register_test_case(module_factory=lambda: ReduceMaxKeepDimReturnBoth())
+def ReduceMaxKeepDimReturnBoth_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5, low=-10, high=-5))
+
+# ==============================================================================
+
+class ReduceMaxAllDims(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.float32, True),
+  ])
+  def forward(self, a):
+    return torch.ops.aten.max(a)
+
+@register_test_case(module_factory=lambda: ReduceMaxAllDims())
+def ReduceMaxAllDims_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5, low=-10, high=-5))

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2506,6 +2506,37 @@ def Torch_AtenSumDimIntListOp : Torch_Op<"aten.sum.dim_IntList", [
   let assemblyFormat = "$self `,` $dim `,` $keepdim `,` $dtype attr-dict `:` qualified(type($self)) `,` qualified(type($dim)) `,` qualified(type($keepdim)) `,` qualified(type($dtype)) `->` qualified(type($result))";
 }
 
+def Torch_AtenMaxOp : Torch_Op<"aten.max", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::max : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self attr-dict `:` qualified(type($self)) `->` qualified(type($result))";
+}
+
+def Torch_AtenMaxDimOp : Torch_Op<"aten.max.dim", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::max.dim : (Tensor, int, bool) -> (Tensor, Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    Torch_IntType:$dim,
+    Torch_BoolType:$keepdim
+  );
+  let results = (outs
+    AnyTorchTensorType:$values,
+    AnyTorchTensorType:$indices
+  );
+  let assemblyFormat = "$self `,` $dim `,` $keepdim attr-dict `:` qualified(type($self)) `,` qualified(type($dim)) `,` qualified(type($keepdim)) `->` qualified(type($values)) `,` qualified(type($indices))";
+}
+
 def Torch_AtenToDtypeOp : Torch_Op<"aten.to.dtype", [
     AllowsTypeRefinement
   ]> {

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -587,6 +587,8 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::stack : (Tensor[], int) -> (Tensor)")
         emit("aten::sum : (Tensor, int?) -> (Tensor)")
         emit("aten::sum.dim_IntList : (Tensor, int[], bool, int?) -> (Tensor)")
+        emit("aten::max : (Tensor) -> (Tensor)")
+        emit("aten::max.dim : (Tensor, int, bool) -> (Tensor, Tensor)")
         emit("aten::to.dtype : (Tensor, int, bool, bool, int?) -> (Tensor)", has_folder=True)
         emit("aten::to.other : (Tensor, Tensor, bool, bool, int?) -> (Tensor)")
         emit("aten::to.prim_Device : (Tensor, Device?, int?, bool, bool) -> (Tensor)")

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -154,3 +154,34 @@ func @torch.aten.arange.start() -> !torch.vtensor<[?],si64> {
   %0 = torch.aten.arange.start %int0, %int10, %none, %none, %none, %none : !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[?],si64>
   return %0 : !torch.vtensor<[?],si64>
 }
+
+// ----
+// CHECK-LABEL: func @torch.aten.argmax(
+// CHECK-SAME:  %[[INP:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[1,?],si64> {
+// CHECK:       %[[CST0:.*]] = torch.constant.int 0
+// CHECK:       %[[TRUE:.*]] = torch.constant.bool true
+// CHECK:       %[[VAL:.*]], %[[IND:.*]] = torch.aten.max.dim %[[INP]], %[[CST0]], %[[TRUE]] : !torch.vtensor<[?,?],f32>, !torch.int, !torch.bool -> !torch.vtensor<[1,?],f32>, !torch.vtensor<[1,?],si64>
+// CHECK:       return %[[IND]] : !torch.vtensor<[1,?],si64>
+func @torch.aten.argmax(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[1,?],si64> {
+  %int0 = torch.constant.int 0
+  %true = torch.constant.bool true
+  %0 = torch.aten.argmax %arg0, %int0, %true : !torch.vtensor<[?,?],f32>, !torch.int, !torch.bool -> !torch.vtensor<[1,?],si64>
+  return %0 : !torch.vtensor<[1,?],si64>
+}
+
+// ----
+// CHECK-LABEL: func @torch.aten.argmax$reduceall(
+// CHECK-SAME:   %[[INP:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[],si64> {
+// CHECK:        %[[NONE:.*]] = torch.constant.none
+// CHECK:        %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:        %[[CST0:.*]] = torch.constant.int 0
+// CHECK:        %[[CST1:.*]] = torch.constant.int 1
+// CHECK:        %[[FLATTEN:.*]] = torch.aten.flatten.using_ints %[[INP]], %[[CST0]], %[[CST1]] : !torch.vtensor<[?,?],f32>, !torch.int, !torch.int -> !torch.vtensor<[?],f32>
+// CHECK:        %[[VAL:.*]], %[[IND:.*]] = torch.aten.max.dim %[[FLATTEN]], %[[CST0]], %[[FALSE]] : !torch.vtensor<[?],f32>, !torch.int, !torch.bool -> !torch.vtensor<[],f32>, !torch.vtensor<[],si64>
+// CHECK:        return %[[IND]] : !torch.vtensor<[],si64>
+func @torch.aten.argmax$reduceall(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[],si64> {
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %0 = torch.aten.argmax %arg0, %none, %false : !torch.vtensor<[?,?],f32>, !torch.none, !torch.bool -> !torch.vtensor<[],si64>
+  return %0 : !torch.vtensor<[],si64>
+}


### PR DESCRIPTION
In order to facilitate lowering of `aten.max.dim` op, a custom op i.e.,
`cutom.aten.max.dim` is introduced which makes the decomposition easy.