### PR TITLE
[TORCH][MLIR] Add E2E support for `aten.native_batch_norm` op

### DIFF
--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -30,7 +30,7 @@ from . import basic
 from . import vision_models
 from . import mlp
 from . import conv
-from . import batchnorm
+from . import norm_like
 from . import quantized_models
 from . import elementwise
 from . import type_promotion

--- a/e2e_testing/torchscript/norm_like.py
+++ b/e2e_testing/torchscript/norm_like.py
@@ -9,8 +9,8 @@ from torch_mlir_e2e_test.torchscript.framework import TestUtils
 from torch_mlir_e2e_test.torchscript.registry import register_test_case
 from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
 
-
 # ==============================================================================
+
 class BatchNorm1DModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -35,8 +35,8 @@ class BatchNorm1DModule(torch.nn.Module):
 def BatchNorm1DModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(10, 4, 3))
 
-
 # ==============================================================================
+
 class BatchNorm2DModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -60,8 +60,8 @@ class BatchNorm2DModule(torch.nn.Module):
 def BatchNorm2DModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(10, 2, 3, 3))
 
-
 # ==============================================================================
+
 class BatchNorm3DModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -89,6 +89,107 @@ def BatchNorm3DModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class NativeBatchNorm1DModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, x, weight, bias, running_mean, running_var):
+        return torch.ops.aten.native_batch_norm(
+            x, weight, bias, running_mean, running_var, training=False, 
+            momentum=0.1, eps=0.00001)
+
+
+@register_test_case(module_factory=lambda: NativeBatchNorm1DModule())
+def NativeBatchNorm1DModule_basic(module, tu: TestUtils):
+    module.forward(
+        tu.rand(2, 5, 3), tu.rand(5), tu.rand(5), tu.rand(5), tu.rand(5))
+
+# ==============================================================================
+
+class NativeBatchNorm2DModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, x, weight, bias, running_mean, running_var):
+        return torch.ops.aten.native_batch_norm(
+            x, weight, bias, running_mean, running_var, training=False, 
+            momentum=0.1, eps=0.00001)
+
+
+@register_test_case(module_factory=lambda: NativeBatchNorm2DModule())
+def NativeBatchNorm2DModule_basic(module, tu: TestUtils):
+    module.forward(
+        tu.rand(2, 5, 2, 3), tu.rand(5), tu.rand(5), tu.rand(5), tu.rand(5))
+
+# ==============================================================================
+
+class NativeBatchNorm3DModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1, -1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, x, weight, bias, running_mean, running_var):
+        return torch.ops.aten.native_batch_norm(
+            x, weight, bias, running_mean, running_var, training=False, 
+            momentum=0.1, eps=0.00001)
+
+
+@register_test_case(module_factory=lambda: NativeBatchNorm3DModule())
+def NativeBatchNorm3DModule_basic(module, tu: TestUtils):
+    module.forward(
+        tu.rand(2, 5, 2, 2, 3), tu.rand(5), tu.rand(5), tu.rand(5), tu.rand(5))
+
+# ==============================================================================
+
+class NativeBatchNormNoneWeightModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1, -1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, x, bias, running_mean, running_var):
+        return torch.ops.aten.native_batch_norm(
+            x, None, bias, running_mean, running_var, training=False, 
+            momentum=0.1, eps=0.00001)
+
+
+@register_test_case(module_factory=lambda: NativeBatchNormNoneWeightModule())
+def NativeBatchNormNoneWeightModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 5, 2, 2, 3), tu.rand(5), tu.rand(5), tu.rand(5))
+
+# ==============================================================================
 
 class NativeLayerNormModule(torch.nn.Module):
     def __init__(self):
@@ -113,7 +214,6 @@ def NativeLayerNormModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
-
 class NativeLayerNormModule4D(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -135,9 +235,7 @@ class NativeLayerNormModule4D(torch.nn.Module):
 def NativeLayerNormModule4D_basic(module, tu: TestUtils):
     module.forward(tu.rand(5, 2, 2, 3), tu.rand(2, 2, 3), tu.rand(2, 2, 3))
 
-
 # ==============================================================================
-
 
 class LayerNormModule(torch.nn.Module):
     def __init__(self):
@@ -164,8 +262,8 @@ class LayerNormModule(torch.nn.Module):
 def LayerNormModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 5, 2, 2, 3))
 
-
 # ==============================================================================
+
 class LayerNormLastDimModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -188,7 +286,6 @@ def LayerNormLastDimModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 5, 2, 2, 3))
 
 # ==============================================================================
-
 
 class LayerNormNormalizeOverAllDimsModule(torch.nn.Module):
     def __init__(self):

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1489,6 +1489,29 @@ def Torch_AtenConv2dOp : Torch_Op<"aten.conv2d", [
   let assemblyFormat = "$input `,` $weight `,` $bias `,` $stride `,` $padding `,` $dilation `,` $groups attr-dict `:` qualified(type($input)) `,` qualified(type($weight)) `,` qualified(type($bias)) `,` qualified(type($stride)) `,` qualified(type($padding)) `,` qualified(type($dilation)) `,` qualified(type($groups)) `->` qualified(type($result))";
 }
 
+def Torch_AtenNativeBatchNormOp : Torch_Op<"aten.native_batch_norm", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::native_batch_norm : (Tensor, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, float) -> (Tensor, Tensor, Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$input,
+    AnyTorchOptionalTensorType:$weight,
+    AnyTorchOptionalTensorType:$bias,
+    AnyTorchOptionalTensorType:$running_mean,
+    AnyTorchOptionalTensorType:$running_var,
+    Torch_BoolType:$training,
+    Torch_FloatType:$momentum,
+    Torch_FloatType:$eps
+  );
+  let results = (outs
+    AnyTorchTensorType:$result0,
+    AnyTorchTensorType:$result1,
+    AnyTorchTensorType:$result2
+  );
+  let assemblyFormat = "$input `,` $weight `,` $bias `,` $running_mean `,` $running_var `,` $training `,` $momentum `,` $eps attr-dict `:` qualified(type($input)) `,` qualified(type($weight)) `,` qualified(type($bias)) `,` qualified(type($running_mean)) `,` qualified(type($running_var)) `,` qualified(type($training)) `,` qualified(type($momentum)) `,` qualified(type($eps)) `->` qualified(type($result0)) `,` qualified(type($result1)) `,` qualified(type($result2))";
+}
+
 def Torch_AtenBatchNormOp : Torch_Op<"aten.batch_norm", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -515,6 +515,9 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
             "aten::conv2d : (Tensor, Tensor, Tensor?, int[], int[], int[], int) -> (Tensor)"
         )
         emit(
+            "aten::native_batch_norm : (Tensor, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, float) -> (Tensor, Tensor, Tensor)"
+        )
+        emit(
             "aten::batch_norm : (Tensor, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, float, bool) -> (Tensor)"
         )
         emit(


### PR DESCRIPTION
- This commit adds support for `aten.native_batch_norm` operation.
- The current implementation only supports inference mode of
  `aten.native_batch_norm` op.

Signed-Off-By: Gaurav Shukla <gaurav@nod-labs.com>