### PR TITLE
[MLIR][TORCH] Add TorchToTMTensor pass

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -1402,3 +1402,53 @@ class HardTanhIntModule(torch.nn.Module):
 def HardTanhIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(-5, 5, (100, 100)))
 
+
+class BincountModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.bincount(x)
+
+@register_test_case(module_factory=lambda: BincountModule())
+def BincountModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(100, (10,)))
+
+
+class BincountStaticSizeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([20], torch.int64, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.bincount(x)
+
+@register_test_case(module_factory=lambda: BincountStaticSizeModule())
+def BincountStaticSizeModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1000, (20,)))
+
+
+class BincountMinlengthModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.bincount(x, minlength=600)
+
+@register_test_case(module_factory=lambda: BincountMinlengthModule())
+def BincountMinlengthModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(500, (20,)))

--- a/e2e_testing/torchscript/reduction.py
+++ b/e2e_testing/torchscript/reduction.py
@@ -11,7 +11,7 @@ from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
 
 # ==============================================================================
 
-class ReduceSumModule(torch.nn.Module):
+class ReduceSumFloatModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -24,13 +24,13 @@ class ReduceSumModule(torch.nn.Module):
         return torch.sum(a)
 
 
-@register_test_case(module_factory=lambda: ReduceSumModule())
-def ReduceSumModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: ReduceSumFloatModule())
+def ReduceSumFloatModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
 
 # ==============================================================================
 
-class ReduceSumDtypeModule(torch.nn.Module):
+class ReduceSumDtypeFloatModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -43,13 +43,13 @@ class ReduceSumDtypeModule(torch.nn.Module):
         return torch.sum(a, dtype=torch.float32)
 
 
-@register_test_case(module_factory=lambda: ReduceSumDtypeModule())
-def ReduceSumDtypeModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: ReduceSumDtypeFloatModule())
+def ReduceSumDtypeFloatModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5).to(torch.float64))
 
 # ==============================================================================
 
-class ReduceSumDimIntListModule(torch.nn.Module):
+class ReduceSumDimIntListFloatModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -62,13 +62,13 @@ class ReduceSumDimIntListModule(torch.nn.Module):
         return torch.sum(a, (0, 1))
 
 
-@register_test_case(module_factory=lambda: ReduceSumDimIntListModule())
-def ReduceSumDimIntListModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: ReduceSumDimIntListFloatModule())
+def ReduceSumDimIntListFloatModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
 
 # ==============================================================================
 
-class ReduceSumDimIntListDtypeModule(torch.nn.Module):
+class ReduceSumDimIntListDtypeFloatModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -81,13 +81,13 @@ class ReduceSumDimIntListDtypeModule(torch.nn.Module):
         return torch.sum(a, (0, 1), dtype=torch.float32)
 
 
-@register_test_case(module_factory=lambda: ReduceSumDimIntListDtypeModule())
-def ReduceSumDimIntListDtypeModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: ReduceSumDimIntListDtypeFloatModule())
+def ReduceSumDimIntListDtypeFloatModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5).to(torch.float64))
 
 # ==============================================================================
 
-class ReduceSumDimIntListKeepDimModule(torch.nn.Module):
+class ReduceSumDimIntListKeepDimFloatModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -100,9 +100,123 @@ class ReduceSumDimIntListKeepDimModule(torch.nn.Module):
         return torch.sum(a, (1, 2), keepdim=True)
 
 
-@register_test_case(module_factory=lambda: ReduceSumDimIntListKeepDimModule())
-def ReduceSumDimIntListKeepDimModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: ReduceSumDimIntListKeepDimFloatModule())
+def ReduceSumDimIntListKeepDimFloatModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceSumUnsignedIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a)
+
+
+@register_test_case(module_factory=lambda: ReduceSumUnsignedIntModule())
+def ReduceSumUnsignedIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(0, 100, (3, 4, 5)))
+
+# ==============================================================================
+
+class ReduceSumSignedIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a)
+
+
+@register_test_case(module_factory=lambda: ReduceSumSignedIntModule())
+def ReduceSumSignedIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(-100, 100, (3, 4, 5)))
+
+# ==============================================================================
+
+class ReduceSumDtypeIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int32, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, dtype=torch.int64)
+
+
+@register_test_case(module_factory=lambda: ReduceSumDtypeIntModule())
+def ReduceSumDtypeIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(100, (3, 4, 5)).to(torch.int32))
+
+# ==============================================================================
+
+class ReduceSumDimIntListIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, (0, 1))
+
+
+@register_test_case(module_factory=lambda: ReduceSumDimIntListIntModule())
+def ReduceSumDimIntListIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(100, (3, 4, 5)))
+
+# ==============================================================================
+
+class ReduceSumDimIntListDtypeIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int32, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, (0, 1), dtype=torch.int64)
+
+
+@register_test_case(module_factory=lambda: ReduceSumDimIntListDtypeIntModule())
+def ReduceSumDimIntListDtypeIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(100, (3, 4, 5)).to(torch.int32))
+
+# ==============================================================================
+
+class ReduceSumDimIntListKeepDimIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, (1, 2), keepdim=True)
+
+
+@register_test_case(module_factory=lambda: ReduceSumDimIntListKeepDimIntModule())
+def ReduceSumDimIntListKeepDimIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(100, (3, 4, 5)))
 
 # ==============================================================================
 
@@ -234,3 +348,57 @@ class ReduceMaxNegativeDim(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceMaxNegativeDim())
 def ReduceMaxNegativeDim_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceMaxFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.max(a)
+
+@register_test_case(module_factory=lambda: ReduceMaxFloatModule())
+def ReduceMaxFloatModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceMaxSignedIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.max(a)
+
+@register_test_case(module_factory=lambda: ReduceMaxSignedIntModule())
+def ReduceMaxSignedIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(-100, 100, (3, 4, 5)))
+
+# ==============================================================================
+
+class ReduceMaxUnsignedIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.max(a)
+
+@register_test_case(module_factory=lambda: ReduceMaxUnsignedIntModule())
+def ReduceMaxUnsignedIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(100, (3, 4, 5)))

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -114,4 +114,15 @@ def ConvertTorchToTosa : Pass<"convert-torch-to-tosa", "FuncOp"> {
   let constructor = "mlir::torch::createConvertTorchToTosaPass()";
 }
 
+def ConvertTorchToTMTensor : Pass<"convert-torch-to-tmtensor", "FuncOp"> {
+  let summary = "Convert recognized Torch ops to TMTensor/Linalg ops";
+  let description = [{
+    Convert ATen ops to tmtensor/linalg ops.
+
+    This pass is similar to the TorchToLinalg pass; the difference is that this
+    pass also makes use of TMTensor Dialect, which the former one doesn't.
+  }];
+  let constructor = "mlir::torch::createConvertTorchToTMTensorPass()";
+}
+
 #endif // TORCHMLIR_CONVERSION_PASSES

--- a/include/torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h
+++ b/include/torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h
@@ -1,0 +1,21 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_TORCHTOTMTENSOR_TORCHTOTMTENSOR_H
+#define TORCHMLIR_CONVERSION_TORCHTOTMTENSOR_TORCHTOTMTENSOR_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace torch {
+std::unique_ptr<OperationPass<FuncOp>> createConvertTorchToTMTensorPass();
+}
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_TORCHTOTMTENSOR_TORCHTOTMTENSOR_H

--- a/include/torch-mlir/Conversion/Utils/Utils.h
+++ b/include/torch-mlir/Conversion/Utils/Utils.h
@@ -1,0 +1,84 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_UTILS_H
+#define TORCHMLIR_CONVERSION_UTILS_H
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace torch {
+namespace Torch {
+
+LogicalResult verifyLinalgCompatibleTypes(Operation *op,
+                                          PatternRewriter &rewriter);
+
+LogicalResult checkNotNone(PatternRewriter &rewriter, Operation *op, Value v);
+
+Value toPositiveDimDynamic(OpBuilder &b, Location loc, Value dim,
+                           Value inputRank);
+
+void assertIsValidDim(OpBuilder &b, Location loc, Value dim, Value inputRank);
+
+bool isConstantIntListMatching(Value value, SmallVectorImpl<int64_t> &expects);
+
+void checkDimEqualHelper(OpBuilder &b, Location loc, Value lhsDim,
+                         Value rhsDim);
+
+// Creates a tensor with required `sizes` and `elemTy` and fills it with
+// initElem.
+Value createInitTensor(OpBuilder &b, Location loc, ValueRange sizes,
+                       Type elemTy, Value initElem);
+
+Value castIntToIndex(OpBuilder &b, Location loc, Value v);
+
+Value castIndexToInt(OpBuilder &b, Location loc, Value idx);
+
+Value getDimOp(OpBuilder &b, Location loc, Value v, int dim);
+
+SmallVector<Value> getTensorSizesUntilDim(OpBuilder &b, Location loc,
+                                          Value tensor, int dim);
+
+SmallVector<Value> getTensorSizes(OpBuilder &b, Location loc, Value tensor);
+
+Value getTensorSize(OpBuilder &b, Location loc, Value tensor);
+
+Value createZeroInitTensor(OpBuilder &b, Location loc, ValueRange sizes,
+                           Type elemTy);
+
+// Creates a constant of type `elemType` with value `val`.
+Value getConstant(OpBuilder &b, Location loc, int64_t val, Type elemType);
+
+SmallVector<Value> getAsConstantIntValues(OpBuilder &b, Location loc,
+                                          SmallVectorImpl<int64_t> &ints);
+
+SmallVector<Value> getAsConstantIndexValues(OpBuilder &b, Location loc,
+                                            SmallVectorImpl<int64_t> &ints);
+
+// This is a temporary solution to deal with types that are not fully supported
+// like list, dict. For those container tyes, this helper can be used to
+// convert their elements to valid target type.
+// TODO: remove this when list gets full support.
+SmallVector<Value> getTypeConvertedValues(OpBuilder &b, Location loc,
+                                          TypeConverter *converter,
+                                          SmallVectorImpl<Value> &vs);
+
+// Convert a scalar value to the target type. The scalar value can be an element
+// from a tensor or a scalar in the pytorch dialect. Both the scalar and dtype
+// should be converted builtin types.
+Value convertScalarToDtype(OpBuilder &b, Location loc, Value scalar,
+                           Type dtype);
+
+} // namespace Torch
+} // namespace torch
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_UTILS_H

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2136,6 +2136,22 @@ def Torch_AtenNllLossBackwardOp : Torch_Op<"aten.nll_loss_backward", [
   let assemblyFormat = "$grad_output `,` $self `,` $target `,` $weight `,` $reduction `,` $ignore_index `,` $total_weight attr-dict `:` qualified(type($grad_output)) `,` qualified(type($self)) `,` qualified(type($target)) `,` qualified(type($weight)) `,` qualified(type($reduction)) `,` qualified(type($ignore_index)) `,` qualified(type($total_weight)) `->` qualified(type($result))";
 }
 
+def Torch_AtenBincountOp : Torch_Op<"aten.bincount", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::bincount : (Tensor, Tensor?, int) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchOptionalTensorType:$weights,
+    Torch_IntType:$minlength
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $weights `,` $minlength attr-dict `:` qualified(type($self)) `,` qualified(type($weights)) `,` qualified(type($minlength)) `->` qualified(type($result))";
+}
+
 def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -9,10 +9,10 @@
 #ifndef TORCHMLIR_DIALECT_TORCH_UTILS_H
 #define TORCHMLIR_DIALECT_TORCH_UTILS_H
 
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LLVM.h"
 #include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
-
 
 namespace mlir {
 namespace torch {
@@ -22,6 +22,9 @@ int64_t toPositiveDim(int64_t dim, int64_t inputRank);
 bool isValidDim(int64_t dim, int64_t inputRank);
 bool getListConstructElements(Value v, SmallVectorImpl<Value> &elems);
 torch_upstream::ScalarType getScalarTypeForType(Type type);
+// Helper to convert a tensor to a specific scalar type.
+Value convertTensorToDtype(PatternRewriter &rewriter, Location loc, Value input,
+                           Type dtype);
 
 } // namespace Torch
 } // namespace torch

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToStd)
 add_subdirectory(TorchToTosa)
+add_subdirectory(Utils)
 
 # TODO: Automate this with add_torch_mlir_conversion_library.
 #get_property(torch_mlir_conversion_libs GLOBAL PROPERTY TORCH_MLIR_CONVERSION_LIBS)
@@ -20,5 +21,6 @@ add_mlir_library(TorchMLIRConversionPasses
   TorchMLIRTorchToSCF
   TorchMLIRTorchToStd
   TorchMLIRTorchToTosa
+  TorchMLIRConversionUtils
   #${torch_mlir_conversion_libs}
 )

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToStd)
 add_subdirectory(TorchToTosa)
+add_subdirectory(TorchToTMTensor)
 add_subdirectory(Utils)
 
 # TODO: Automate this with add_torch_mlir_conversion_library.
@@ -21,6 +22,7 @@ add_mlir_library(TorchMLIRConversionPasses
   TorchMLIRTorchToSCF
   TorchMLIRTorchToStd
   TorchMLIRTorchToTosa
+  TorchMLIRTorchToTMTensor
   TorchMLIRConversionUtils
   #${torch_mlir_conversion_libs}
 )

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -13,6 +13,7 @@
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToStd/TorchToStd.h"
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
+#include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 
 //===----------------------------------------------------------------------===//
 // Pass registration

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -25,7 +25,6 @@
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
-#include "torch-mlir/Conversion/Utils/Utils.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
 #include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
@@ -2254,12 +2253,8 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
 static Value createLinalgNeutralElementForReduceOp(OpBuilder &b, Location loc,
                                                    Operation *op,
                                                    Type elementType) {
-  if (isa<AtenSumOp, AtenSumDimIntListOp>(op)) {
-    if (elementType.isa<mlir::FloatType>())
-      return b.create<arith::ConstantOp>(loc, b.getZeroAttr(elementType));
-    else if (elementType.isa<mlir::IntegerType>())
-      return b.create<arith::ConstantOp>(loc, b.getZeroAttr(elementType));
-  }
+  if (isa<AtenSumOp, AtenSumDimIntListOp>(op))
+    return b.create<arith::ConstantOp>(loc, b.getZeroAttr(elementType));
 
   if (isa<AtenMaxOp>(op)) {
     if (elementType.isa<mlir::FloatType>())

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -25,6 +25,7 @@
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "torch-mlir/Conversion/Utils/Utils.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
 #include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
@@ -57,117 +58,6 @@ using namespace mlir::torch::torch_upstream; // For ScalarType and type
 // that these patterns become mostly mechanical associations of
 // "aten.foo -> linalg.foo".
 
-static LogicalResult verifyLinalgCompatibleTypes(Operation *op,
-                                                 PatternRewriter &rewriter) {
-  // Check the value tensor is ranked as expected by Linalg.
-  // TODO: Remove this check but use a separate verification pass to verify the
-  // invariants expected by later passes.
-  auto isValidLinalgType = [](Type type) {
-    auto tensor = type.dyn_cast<ValueTensorType>();
-    return !tensor ||
-           tensor.toBuiltinTensor().dyn_cast_or_null<RankedTensorType>();
-  };
-
-  bool valid = llvm::all_of(op->getOperandTypes(), isValidLinalgType) &&
-               llvm::all_of(op->getResultTypes(), isValidLinalgType);
-  if (!valid)
-    return rewriter.notifyMatchFailure(op, "type cannot be lowered to linalg");
-  return success();
-}
-
-static LogicalResult checkNotNone(PatternRewriter &rewriter, Operation *op,
-                                  Value v) {
-  Type type = v.getType();
-  if (type.isa<OptionalType>() || type.isa<Torch::NoneType>() ||
-      type.isa<mlir::NoneType>())
-    return rewriter.notifyMatchFailure(op, "unimplemented None type arg");
-  return success();
-}
-
-// Generate IR: dim = dim >= 0 ? dim : dim + inputRank
-static Value toPositiveDimDynamic(OpBuilder &b, Location loc, Value dim,
-                                  Value inputRank) {
-  assert(dim.getType().isa<IntegerType>() &&
-         "dim arg of toPositiveDim must be integer type");
-  Value dimAddInputRank = b.create<arith::AddIOp>(loc, dim, inputRank);
-  Value cst0 =
-      b.create<arith::ConstantOp>(loc, b.getZeroAttr(inputRank.getType()));
-  Value predDimGEZero =
-      b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge, dim, cst0);
-  Value dimInt =
-      b.create<arith::SelectOp>(loc, predDimGEZero, dim, dimAddInputRank);
-  return dimInt;
-}
-
-// Generate IR: assert(dim >= 0 && dim < inputRank)
-static void assertIsValidDim(OpBuilder &b, Location loc, Value dim,
-                             Value inputRank) {
-  assert(dim.getType().isa<IntegerType>() &&
-         "dim arg of assertIsValidDim must be integer type");
-  Value cst0 =
-      b.create<arith::ConstantOp>(loc, b.getZeroAttr(inputRank.getType()));
-  Value predGEZero =
-      b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge, dim, cst0);
-  b.create<cf::AssertOp>(
-      loc, predGEZero, b.getStringAttr("dim must be greater or equal to zero"));
-  Value predLTInputRank =
-      b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, dim, inputRank);
-  b.create<cf::AssertOp>(loc, predLTInputRank,
-                         b.getStringAttr("dim must be smaller than inputRank"));
-}
-
-// Hack to deal with the Torch list type arguments which is not supported end
-// to end. Constant values can be be extracted directly and non constant
-// list values are not supported.
-// TODO: loose this constraint when properly support list type
-static bool isConstantIntListMatching(Value value,
-                                      SmallVectorImpl<int64_t> &expects) {
-  SmallVector<int64_t> intValues;
-  if (!matchPattern(value, m_TorchConstantIntList(intValues)))
-    return false;
-
-  if (intValues.size() != expects.size())
-    return false;
-
-  for (auto it : llvm::zip(intValues, expects)) {
-    if (std::get<0>(it) != std::get<1>(it))
-      return false;
-  }
-  return true;
-}
-
-static Value castIntToIndex(OpBuilder &b, Location loc, Value v) {
-  assert(v.getType().isa<IntegerType>() && "must be called with integer type");
-  return b.create<arith::IndexCastOp>(loc, b.getIndexType(), v);
-}
-
-static Value castIndexToInt(OpBuilder &b, Location loc, Value idx) {
-  assert(idx.getType().isa<IndexType>() && "must be called with integer type");
-  return b.create<arith::IndexCastOp>(loc, b.getI64Type(), idx);
-}
-
-static Value getDimOp(OpBuilder &b, Location loc, Value v, int dim) {
-  return b.createOrFold<tensor::DimOp>(loc, v, dim);
-}
-
-static void checkDimEqualHelper(OpBuilder &b, Location loc, Value lhsDim,
-                                Value rhsDim) {
-  Type lhsType = lhsDim.getType();
-  Type rhsType = rhsDim.getType();
-  auto checkIntOrIndex = [](Type type) {
-    assert(type.isa<IntegerType>() ||
-           type.isa<IndexType>() && "must be either integer or index type");
-  };
-  checkIntOrIndex(lhsType);
-  checkIntOrIndex(rhsType);
-  Value lhsDimInt = lhsType.isIndex() ? castIndexToInt(b, loc, lhsDim) : lhsDim;
-  Value rhsDimInt = rhsType.isIndex() ? castIndexToInt(b, loc, rhsDim) : rhsDim;
-  Value contractingDimEqual = b.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::eq, lhsDimInt, rhsDimInt);
-  b.create<cf::AssertOp>(loc, contractingDimEqual,
-                         b.getStringAttr("mismatching contracting dimension"));
-}
-
 template <arith::CmpFPredicate fpred, arith::CmpIPredicate iupred,
           arith::CmpIPredicate ispred>
 static Value createComparisonTemplate(OpBuilder &b, Location loc, Type type,
@@ -199,64 +89,6 @@ static Value createLessThan(OpBuilder &b, Location loc, Type elementalType,
       b, loc, elementalType, lhs, rhs);
 }
 
-static SmallVector<Value> getTensorSizesUntilDim(OpBuilder &b, Location loc,
-                                                 Value tensor, int dim) {
-  RankedTensorType type = tensor.getType().cast<RankedTensorType>();
-  assert(dim < type.getRank() &&
-         "The given dim must be smaller than tensor rank");
-  (void)type;
-  SmallVector<Value> sizes;
-  for (int i = 0; i <= dim; i++)
-    sizes.push_back(getDimOp(b, loc, tensor, i));
-  return sizes;
-}
-
-static SmallVector<Value> getTensorSizes(OpBuilder &b, Location loc,
-                                         Value tensor) {
-  RankedTensorType type = tensor.getType().cast<RankedTensorType>();
-  return getTensorSizesUntilDim(b, loc, tensor, type.getRank() - 1);
-}
-
-static Value getTensorSize(OpBuilder &b, Location loc, Value tensor) {
-  SmallVector<Value> sizes(getTensorSizes(b, loc, tensor));
-  Value productResult = b.create<arith::ConstantOp>(loc, b.getIndexAttr(1));
-  for (Value size : sizes)
-    productResult = b.create<arith::MulIOp>(loc, productResult, size);
-  return castIndexToInt(b, loc, productResult);
-}
-
-static Value createZeroInitTensor(OpBuilder &b, Location loc, ValueRange sizes,
-                                  Type elemTy) {
-  Value initTensor = b.create<linalg::InitTensorOp>(loc, sizes, elemTy);
-  RankedTensorType type = initTensor.getType().cast<RankedTensorType>();
-  Value c0 =
-      b.create<arith::ConstantOp>(loc, b.getZeroAttr(type.getElementType()));
-  return b.create<linalg::FillOp>(loc, c0, initTensor).getResult(0);
-}
-
-// Creates a tensor with required `sizes` and `elemTy` and fills it with
-// initElem.
-static Value createInitTensor(OpBuilder &b, Location loc, ValueRange sizes,
-                              Type elemTy, Value initElem) {
-  Value initTensor = b.create<linalg::InitTensorOp>(loc, sizes, elemTy);
-  return b.create<linalg::FillOp>(loc, initElem, initTensor).getResult(0);
-}
-// Creates a constant of type `elemType` with value `val`.
-static Value getConstant(OpBuilder &b, Location loc, int64_t val,
-                         Type elemType) {
-  Attribute attr = {};
-  if (elemType.isa<mlir::FloatType>())
-    attr = b.getFloatAttr(elemType, val);
-  if (elemType.isa<mlir::IndexType>())
-    attr = b.getIndexAttr(val);
-  if (elemType.isa<mlir::IntegerType>())
-    attr = b.getIntegerAttr(
-        elemType, APInt(elemType.cast<IntegerType>().getWidth(), val));
-  if (!attr)
-    return nullptr;
-  return b.create<arith::ConstantOp>(loc, elemType, attr);
-}
-
 // Helper function to caculate the output tensor dims for convolution-like ops.
 // Along each dim:
 // dim_out =
@@ -285,40 +117,10 @@ static Value getOutputDimForConvOps(OpBuilder &b, Location loc, Value in,
   return castIntToIndex(b, loc, out);
 }
 
-static SmallVector<Value>
-getAsConstantIntValues(OpBuilder &b, Location loc,
-                       SmallVectorImpl<int64_t> &ints) {
-  return llvm::to_vector<4>(llvm::map_range(ints, [&](int64_t val) -> Value {
-    return b.create<arith::ConstantOp>(loc,
-                                       b.getIntegerAttr(b.getI64Type(), val));
-  }));
-}
-
-static SmallVector<Value>
-getAsConstantIndexValues(OpBuilder &b, Location loc,
-                         SmallVectorImpl<int64_t> &ints) {
-  return llvm::to_vector<4>(llvm::map_range(ints, [&](int64_t val) -> Value {
-    return b.create<arith::ConstantOp>(loc, b.getIndexAttr(val));
-  }));
-}
-
 static SmallVector<OpFoldResult>
 getAsOpFoldResult(OpBuilder &b, Location loc, SmallVectorImpl<int64_t> &ints) {
   return llvm::to_vector<4>(llvm::map_range(
       ints, [&](int64_t val) -> OpFoldResult { return b.getIndexAttr(val); }));
-}
-
-// This is a temporary solution to deal with types that are not fully supported
-// like list, dict. For those container tyes, this helper can be used to
-// convert their elements to valid target type.
-// TODO: remove this when list gets full support.
-static SmallVector<Value> getTypeConvertedValues(OpBuilder &b, Location loc,
-                                                 TypeConverter *converter,
-                                                 SmallVectorImpl<Value> &vs) {
-  return llvm::to_vector<4>(llvm::map_range(vs, [&](Value v) {
-    return converter->materializeTargetConversion(
-        b, loc, converter->convertType(v.getType()), v);
-  }));
 }
 
 // Helper function to get the padding tensor given the padding int values.
@@ -375,66 +177,6 @@ static Value buildUnitNormalCdf(OpBuilder &b, Location &loc, Value x) {
   Value zero = b.create<arith::ConstantOp>(loc, FloatAttr::get(elementType, 0));
   Value one = b.create<arith::ConstantOp>(loc, FloatAttr::get(elementType, 1));
   return buildNormalCdf(b, loc, x, zero, one);
-}
-
-// Convert a scalar value to the target type. The scalar value can be an element
-// from a tensor or a scalar in the pytorch dialect. Both the scalar and dtype
-// should be converted builtin types.
-static Value convertScalarToDtype(OpBuilder &b, Location loc, Value scalar,
-                                  Type dtype) {
-  Type scalarType = scalar.getType();
-  if (scalarType == dtype)
-    return scalar;
-
-  // TODO: For the byte(ui8) or char(i8) case, we need the unconverted dtype to
-  // be able to know if we need signed or unsigned conversion.
-  auto isByteOrChar = [](Type type) {
-    if (auto integerTy = type.dyn_cast<mlir::IntegerType>()) {
-      return integerTy.getWidth() == 8;
-    }
-    return false;
-  };
-
-  if (isByteOrChar(scalarType) || isByteOrChar(dtype) ||
-      dtype.isSignlessInteger(1)) {
-    // TODO: Handle to-boolean conversion(from-boolean conversion is handled).
-    mlir::emitError(loc)
-        << "unsupported byte, char or bool type for convertScalarToDtype "
-        << scalarType << "(scalar type) -> " << dtype << "(dtype)";
-    return nullptr;
-  }
-
-  if (auto dtypeFloat = dtype.dyn_cast<mlir::FloatType>()) {
-    if (auto scalarFloat = scalarType.dyn_cast<mlir::FloatType>()) {
-      if (scalarFloat.getWidth() > dtypeFloat.getWidth())
-        return b.create<arith::TruncFOp>(loc, dtype, scalar);
-      // Only scalarFloat width < dtypeFloat width can reach here.
-      return b.create<arith::ExtFOp>(loc, dtype, scalar);
-    }
-    assert(scalarType.isa<mlir::IntegerType>());
-    if (scalarType.isSignlessInteger(1))
-      return b.create<arith::UIToFPOp>(loc, dtype, scalar);
-    // It's safe to use SIToFPOp because ui8/si8 are the only ones where
-    // unsigned handling is needed, and we checked for that case above.
-    return b.create<arith::SIToFPOp>(loc, dtype, scalar);
-  }
-
-  if (auto dtypeInteger = dtype.dyn_cast<mlir::IntegerType>()) {
-    if (auto scalarFloat = scalarType.dyn_cast<mlir::FloatType>())
-      return b.create<arith::FPToSIOp>(loc, dtype, scalar);
-    assert(scalarType.isa<mlir::IntegerType>());
-    auto scalarInteger = scalarType.cast<mlir::IntegerType>();
-    if (scalarInteger.getWidth() > dtypeInteger.getWidth())
-      return b.create<arith::TruncIOp>(loc, dtype, scalar);
-    if (scalarType.isSignlessInteger(1))
-      return b.create<arith::ExtUIOp>(loc, dtype, scalar);
-    // Only scalarInteger width < dtypeInteger width can reach here.
-    // It's safe to use ExtSIOp here because ui8/si8 are the only ones where
-    // unsigned handling is needed, and we checked for that case above.
-    return b.create<arith::ExtSIOp>(loc, dtype, scalar);
-  }
-
-  llvm_unreachable("convertScalarToDtype should handle all the types");
 }
 
 // Create a reduction of `tensorOperand`, reducing along the dimensions

--- a/lib/Conversion/TorchToTMTensor/CMakeLists.txt
+++ b/lib/Conversion/TorchToTMTensor/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_mlir_conversion_library(TorchMLIRTorchToTMTensor
+TorchToTMTensor.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/TorchToTMTensor
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRLinalg
+  MLIRMath
+  TorchMLIRTorchDialect
+  TorchMLIRTMTensorDialect
+)
+
+torch_mlir_target_includes(TorchMLIRTorchToTMTensor)

--- a/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
+++ b/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
@@ -1,0 +1,221 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/MLIRContext.h"
+#include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"
+#include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.h"
+#include "torch-mlir/Conversion/Utils/Utils.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
+#include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+using namespace mlir::torch::TorchConversion;
+using namespace mlir::torch::TMTensor;
+
+// -----------------------------------------------------------------------------
+// Patterns (as this grows, it should be organized into multiple files)
+// -----------------------------------------------------------------------------
+// This is going to eventually be O(#aten ops), which is in the 100s.
+//
+// Most of these patterns consist of:
+// 1. Checking that the operand/result types and other static properties are
+//    good-enough to create a valid linalg op (such as operands being of
+//    ranks/dtypes acceptable to the linalg op).
+// 2. Creating dynamic error guards, usually checking a predicate on the
+//    compatibility of operand shapes.
+// 3. Creating init tensors for the computation op. Usually this involves
+//    reifying IR for a shape transfer function based on the operand shapes.
+// 4. Creating a named linalg op to replace the original op.
+//
+// TODO: Use linalg OpDSL to autogenerate at least 1)/2)/3) such
+// that these patterns become mostly mechanical associations of
+// "aten.foo -> linalg.foo".
+
+namespace {
+// aten::bincount op counts the frequency of each value in a 1-d input tensor of
+// non-negative ints.
+class ConvertAtenBincountOp : public OpConversionPattern<AtenBincountOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenBincountOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+      return failure();
+    Location loc = op.getLoc();
+    MLIRContext *context = op->getContext();
+    TypeConverter *typeConverter = getTypeConverter();
+    Value input = adaptor.self();
+    Value torchTypeInput = op.self();
+    Value minlength = adaptor.minlength();
+    Value weights = adaptor.weights();
+
+    // TODO: Add a check to verify that the input tensor elements are all
+    // non-negative.
+    // Check whether the input is a 1-d tensor of integer type or not.
+    RankedTensorType inputType = input.getType().cast<RankedTensorType>();
+    if (inputType.getRank() != 1 ||
+        !inputType.getElementType().isa<mlir::IntegerType>())
+      return rewriter.notifyMatchFailure(
+          op,
+          "Input tensor has to be a one-dimensional tensor of integer type.");
+
+    // Check whether the input tensor element type is i64 or not.
+    IntegerType inputIntegerType =
+        inputType.getElementType().cast<IntegerType>();
+    if (inputIntegerType.getWidth() != 64)
+      return rewriter.notifyMatchFailure(
+          op,
+          "Unimplemented: Integer width not equal to 64 are not supported.");
+
+    // TODO: Incorporate the weight argument.
+    if (!weights.getType().isa<mlir::torch::Torch::NoneType>())
+      return rewriter.notifyMatchFailure(
+          op, "Unimplemented, the weights operand is not incorporated.");
+
+    // Finding the maximum value in the input tensor.
+    SmallVector<int64_t> maxTensorSizes;
+    ValueTensorType maxTensorType = ValueTensorType::get(
+        context, llvm::makeArrayRef(maxTensorSizes),
+        torchTypeInput.getType().cast<ValueTensorType>().getDtype());
+    Value maxTensor =
+        rewriter.create<AtenMaxOp>(loc, maxTensorType, torchTypeInput);
+    maxTensor = typeConverter->materializeTargetConversion(
+        rewriter, loc, typeConverter->convertType(maxTensor.getType()),
+        maxTensor);
+
+    // `maxTensor` is a 0-d tensor, extracting its only element and
+    // storing it in `maxInput`.
+    Value maxInput = rewriter.create<tensor::ExtractOp>(loc, maxTensor);
+
+    // Creating a tm_tensor.scatter op with the following mapping:
+    // 1.) `input` tensor maps to the indices in scatter op. `input` is
+    // expanded from 1-d to 2-d, and its element type is set to i32 as required
+    // for the scatter op.
+    // 2.) `updates` is a 1-d dummy tensor with the size equivalent to the
+    // `input`.
+    // 3.) `bincount` a 1-d tensor maps to the original in scatter op
+    // with size equal to the max(max(input) + 1, minlength).
+    SmallVector<int64_t> expandedInputSizes{inputType.getShape()[0], 1};
+    ValueTensorType expandInputType = ValueTensorType::get(
+        context, llvm::makeArrayRef(expandedInputSizes),
+        torchTypeInput.getType().cast<ValueTensorType>().getDtype());
+    Value torchCstOne = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(1));
+    Value expandedInputTensor = rewriter.create<AtenUnsqueezeOp>(
+        loc, expandInputType, torchTypeInput, torchCstOne);
+
+    // Converting the input element type to i32.
+    Value indices = convertTensorToDtype(
+        rewriter, loc, expandedInputTensor,
+        mlir::IntegerType::get(context, 32, mlir::IntegerType::Signed));
+    indices = typeConverter->materializeTargetConversion(
+        rewriter, loc, typeConverter->convertType(indices.getType()), indices);
+
+    Type resultElemType = typeConverter->convertType(op->getResult(0).getType())
+                              .cast<RankedTensorType>()
+                              .getElementType();
+
+    SmallVector<Value, 1> inputSizeDynamic =
+        getTensorSizesUntilDim(rewriter, loc, input, 0);
+    Value updatesTensor = rewriter.create<linalg::InitTensorOp>(
+        loc, getAsOpFoldResult(inputSizeDynamic), resultElemType);
+
+    Value constantZero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getZeroAttr(resultElemType));
+    Value constantOne = rewriter.create<arith::ConstantIntOp>(
+        loc, 1, resultElemType.getIntOrFloatBitWidth());
+
+    // Bincount size = max(max(input) + 1, minlength)
+    Value maxInputPlusOne =
+        rewriter.create<arith::AddIOp>(loc, maxInput, constantOne);
+    Value bincountSize =
+        rewriter.create<arith::MaxSIOp>(loc, maxInputPlusOne, minlength);
+    bincountSize = castIntToIndex(rewriter, loc, bincountSize);
+    Value bincountTensor = createInitTensor(rewriter, loc, {bincountSize},
+                                            resultElemType, constantZero);
+
+    auto scatterOp = rewriter.create<TMTensor::ScatterOp>(
+        loc, bincountTensor.getType(), ValueRange{updatesTensor, indices},
+        ValueRange{bincountTensor},
+        /*unique_indices=*/false);
+
+    Region &scatterOpRegion = scatterOp.region();
+    auto &scatterOpBlock = scatterOpRegion.emplaceBlock();
+    scatterOpBlock.addArguments(TypeRange{resultElemType, resultElemType},
+                                {loc, loc});
+    auto blockArgs = scatterOpBlock.getArguments();
+
+    // Creating an add instruction inside the scatter op region to increment the
+    // frequency counter with one.
+    OpBuilder regionBuilder(scatterOpRegion);
+    Value add = regionBuilder.create<arith::AddIOp>(loc,
+                                                    /*bincount=*/blockArgs[1],
+                                                    constantOne);
+    regionBuilder.create<TMTensor::YieldOp>(loc, add);
+    rewriter.replaceOp(op, scatterOp->getResult(0));
+    return success();
+  }
+};
+} // namespace
+
+// -----------------------------------------------------------------------------
+// The pass
+// -----------------------------------------------------------------------------
+
+namespace {
+class ConvertTorchToTMTensor
+    : public ConvertTorchToTMTensorBase<ConvertTorchToTMTensor> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+    registry.insert<StandardOpsDialect>();
+    registry.insert<tensor::TensorDialect>();
+    registry.insert<arith::ArithmeticDialect>();
+    registry.insert<TMTensorDialect>();
+    TorchConversion::getBackendTypeConversionDependentDialects(registry);
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ConversionTarget target(*context);
+    target.addLegalDialect<linalg::LinalgDialect, StandardOpsDialect,
+                           tensor::TensorDialect, arith::ArithmeticDialect,
+                           Torch::TorchDialect, TMTensorDialect>();
+
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    TorchConversion::setupBackendTypeConversion(target, typeConverter);
+
+    RewritePatternSet patterns(context);
+    target.addIllegalOp<AtenBincountOp>();
+    patterns.add<ConvertAtenBincountOp>(typeConverter, context);
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::torch::createConvertTorchToTMTensorPass() {
+  return std::make_unique<ConvertTorchToTMTensor>();
+}

--- a/lib/Conversion/Utils/CMakeLists.txt
+++ b/lib/Conversion/Utils/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_mlir_conversion_library(TorchMLIRConversionUtils
+  Utils.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/Utils
+)

--- a/lib/Conversion/Utils/Utils.cpp
+++ b/lib/Conversion/Utils/Utils.cpp
@@ -1,0 +1,277 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/Utils/Utils.h"
+
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+
+namespace mlir {
+namespace torch {
+namespace Torch {
+
+LogicalResult verifyLinalgCompatibleTypes(Operation *op,
+                                          PatternRewriter &rewriter) {
+  // Check the value tensor is ranked as expected by Linalg.
+  // TODO: Remove this check but use a separate verification pass to verify the
+  // invariants expected by later passes.
+  auto isValidLinalgType = [](Type type) {
+    auto tensor = type.dyn_cast<ValueTensorType>();
+    return !tensor ||
+           tensor.toBuiltinTensor().dyn_cast_or_null<RankedTensorType>();
+  };
+
+  bool valid = llvm::all_of(op->getOperandTypes(), isValidLinalgType) &&
+               llvm::all_of(op->getResultTypes(), isValidLinalgType);
+  if (!valid)
+    return rewriter.notifyMatchFailure(op, "type cannot be lowered to linalg");
+  return success();
+}
+
+LogicalResult checkNotNone(PatternRewriter &rewriter, Operation *op, Value v) {
+  Type type = v.getType();
+  if (type.isa<OptionalType>() || type.isa<Torch::NoneType>() ||
+      type.isa<mlir::NoneType>())
+    return rewriter.notifyMatchFailure(op, "unimplemented None type arg");
+  return success();
+}
+
+// Generate IR: dim = dim >= 0 ? dim : dim + inputRank
+Value toPositiveDimDynamic(OpBuilder &b, Location loc, Value dim,
+                           Value inputRank) {
+  assert(dim.getType().isa<IntegerType>() &&
+         "dim arg of toPositiveDim must be integer type");
+  Value dimAddInputRank = b.create<arith::AddIOp>(loc, dim, inputRank);
+  Value cst0 =
+      b.create<arith::ConstantOp>(loc, b.getZeroAttr(inputRank.getType()));
+  Value predDimGEZero =
+      b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge, dim, cst0);
+  Value dimInt =
+      b.create<arith::SelectOp>(loc, predDimGEZero, dim, dimAddInputRank);
+  return dimInt;
+}
+
+// Generate IR: assert(dim >= 0 && dim < inputRank)
+void assertIsValidDim(OpBuilder &b, Location loc, Value dim, Value inputRank) {
+  assert(dim.getType().isa<IntegerType>() &&
+         "dim arg of assertIsValidDim must be integer type");
+  Value cst0 =
+      b.create<arith::ConstantOp>(loc, b.getZeroAttr(inputRank.getType()));
+  Value predGEZero =
+      b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge, dim, cst0);
+  b.create<cf::AssertOp>(
+      loc, predGEZero, b.getStringAttr("dim must be greater or equal to zero"));
+  Value predLTInputRank =
+      b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, dim, inputRank);
+  b.create<cf::AssertOp>(loc, predLTInputRank,
+                         b.getStringAttr("dim must be smaller than inputRank"));
+}
+
+// Hack to deal with the Torch list type arguments which is not supported end
+// to end. Constant values can be be extracted directly and non constant
+// list values are not supported.
+// TODO: loose this constraint when properly support list type
+bool isConstantIntListMatching(Value value, SmallVectorImpl<int64_t> &expects) {
+  SmallVector<int64_t> intValues;
+  if (!matchPattern(value, m_TorchConstantIntList(intValues)))
+    return false;
+
+  if (intValues.size() != expects.size())
+    return false;
+
+  for (auto it : llvm::zip(intValues, expects)) {
+    if (std::get<0>(it) != std::get<1>(it))
+      return false;
+  }
+  return true;
+}
+
+void checkDimEqualHelper(OpBuilder &b, Location loc, Value lhsDim,
+                         Value rhsDim) {
+  Type lhsType = lhsDim.getType();
+  Type rhsType = rhsDim.getType();
+  auto checkIntOrIndex = [](Type type) {
+    assert(type.isa<IntegerType>() ||
+           type.isa<IndexType>() && "must be either integer or index type");
+  };
+  checkIntOrIndex(lhsType);
+  checkIntOrIndex(rhsType);
+  Value lhsDimInt = lhsType.isIndex() ? castIndexToInt(b, loc, lhsDim) : lhsDim;
+  Value rhsDimInt = rhsType.isIndex() ? castIndexToInt(b, loc, rhsDim) : rhsDim;
+  Value contractingDimEqual = b.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::eq, lhsDimInt, rhsDimInt);
+  b.create<cf::AssertOp>(loc, contractingDimEqual,
+                         b.getStringAttr("mismatching contracting dimension"));
+}
+
+// Creates a tensor with required `sizes` and `elemTy` and fills it with
+// initElem.
+Value createInitTensor(OpBuilder &b, Location loc, ValueRange sizes,
+                       Type elemTy, Value initElem) {
+  Value initTensor = b.create<linalg::InitTensorOp>(loc, sizes, elemTy);
+  return b.create<linalg::FillOp>(loc, initElem, initTensor).getResult(0);
+}
+
+Value castIntToIndex(OpBuilder &b, Location loc, Value v) {
+  assert(v.getType().isa<IntegerType>() && "must be called with integer type");
+  return b.create<arith::IndexCastOp>(loc, b.getIndexType(), v);
+}
+
+Value castIndexToInt(OpBuilder &b, Location loc, Value idx) {
+  assert(idx.getType().isa<IndexType>() && "must be called with integer type");
+  return b.create<arith::IndexCastOp>(loc, b.getI64Type(), idx);
+}
+
+Value getDimOp(OpBuilder &b, Location loc, Value v, int dim) {
+  return b.createOrFold<tensor::DimOp>(loc, v, dim);
+}
+
+SmallVector<Value> getTensorSizesUntilDim(OpBuilder &b, Location loc,
+                                          Value tensor, int dim) {
+  RankedTensorType type = tensor.getType().cast<RankedTensorType>();
+  assert(dim < type.getRank() &&
+         "The given dim must be smaller than tensor rank");
+  (void)type;
+  SmallVector<Value> sizes;
+  for (int i = 0; i <= dim; i++)
+    sizes.push_back(getDimOp(b, loc, tensor, i));
+  return sizes;
+}
+
+SmallVector<Value> getTensorSizes(OpBuilder &b, Location loc, Value tensor) {
+  RankedTensorType type = tensor.getType().cast<RankedTensorType>();
+  return getTensorSizesUntilDim(b, loc, tensor, type.getRank() - 1);
+}
+
+Value getTensorSize(OpBuilder &b, Location loc, Value tensor) {
+  SmallVector<Value> sizes(getTensorSizes(b, loc, tensor));
+  Value productResult = b.create<arith::ConstantOp>(loc, b.getIndexAttr(1));
+  for (Value size : sizes)
+    productResult = b.create<arith::MulIOp>(loc, productResult, size);
+  return castIndexToInt(b, loc, productResult);
+}
+
+Value createZeroInitTensor(OpBuilder &b, Location loc, ValueRange sizes,
+                           Type elemTy) {
+  Value initTensor = b.create<linalg::InitTensorOp>(loc, sizes, elemTy);
+  RankedTensorType type = initTensor.getType().cast<RankedTensorType>();
+  Value c0 =
+      b.create<arith::ConstantOp>(loc, b.getZeroAttr(type.getElementType()));
+  return b.create<linalg::FillOp>(loc, c0, initTensor).getResult(0);
+}
+
+// Creates a constant of type `elemType` with value `val`.
+Value getConstant(OpBuilder &b, Location loc, int64_t val, Type elemType) {
+  Attribute attr = {};
+  if (elemType.isa<mlir::FloatType>())
+    attr = b.getFloatAttr(elemType, val);
+  if (elemType.isa<mlir::IndexType>())
+    attr = b.getIndexAttr(val);
+  if (elemType.isa<mlir::IntegerType>())
+    attr = b.getIntegerAttr(
+        elemType, APInt(elemType.cast<IntegerType>().getWidth(), val));
+  if (!attr)
+    return nullptr;
+  return b.create<arith::ConstantOp>(loc, elemType, attr);
+}
+
+SmallVector<Value> getAsConstantIntValues(OpBuilder &b, Location loc,
+                                          SmallVectorImpl<int64_t> &ints) {
+  return llvm::to_vector<4>(llvm::map_range(ints, [&](int64_t val) -> Value {
+    return b.create<arith::ConstantOp>(loc,
+                                       b.getIntegerAttr(b.getI64Type(), val));
+  }));
+}
+
+SmallVector<Value> getAsConstantIndexValues(OpBuilder &b, Location loc,
+                                            SmallVectorImpl<int64_t> &ints) {
+  return llvm::to_vector<4>(llvm::map_range(ints, [&](int64_t val) -> Value {
+    return b.create<arith::ConstantOp>(loc, b.getIndexAttr(val));
+  }));
+}
+
+// This is a temporary solution to deal with types that are not fully supported
+// like list, dict. For those container tyes, this helper can be used to
+// convert their elements to valid target type.
+// TODO: remove this when list gets full support.
+SmallVector<Value> getTypeConvertedValues(OpBuilder &b, Location loc,
+                                          TypeConverter *converter,
+                                          SmallVectorImpl<Value> &vs) {
+  return llvm::to_vector<4>(llvm::map_range(vs, [&](Value v) {
+    return converter->materializeTargetConversion(
+        b, loc, converter->convertType(v.getType()), v);
+  }));
+}
+
+// Convert a scalar value to the target type. The scalar value can be an element
+// from a tensor or a scalar in the pytorch dialect. Both the scalar and dtype
+// should be converted builtin types.
+Value convertScalarToDtype(OpBuilder &b, Location loc, Value scalar,
+                           Type dtype) {
+  Type scalarType = scalar.getType();
+  if (scalarType == dtype)
+    return scalar;
+
+  // TODO: For the byte(ui8) or char(i8) case, we need the unconverted dtype to
+  // be able to know if we need signed or unsigned conversion.
+  auto isByteOrChar = [](Type type) {
+    if (auto integerTy = type.dyn_cast<mlir::IntegerType>()) {
+      return integerTy.getWidth() == 8;
+    }
+    return false;
+  };
+
+  if (isByteOrChar(scalarType) || isByteOrChar(dtype) ||
+      dtype.isSignlessInteger(1)) {
+    // TODO: Handle to-boolean conversion(from-boolean conversion is handled).
+    mlir::emitError(loc)
+        << "unsupported byte, char or bool type for convertScalarToDtype "
+        << scalarType << "(scalar type) -> " << dtype << "(dtype)";
+    return nullptr;
+  }
+
+  if (auto dtypeFloat = dtype.dyn_cast<mlir::FloatType>()) {
+    if (auto scalarFloat = scalarType.dyn_cast<mlir::FloatType>()) {
+      if (scalarFloat.getWidth() > dtypeFloat.getWidth())
+        return b.create<arith::TruncFOp>(loc, dtype, scalar);
+      // Only scalarFloat width < dtypeFloat width can reach here.
+      return b.create<arith::ExtFOp>(loc, dtype, scalar);
+    }
+    assert(scalarType.isa<mlir::IntegerType>());
+    if (scalarType.isSignlessInteger(1))
+      return b.create<arith::UIToFPOp>(loc, dtype, scalar);
+    // It's safe to use SIToFPOp because ui8/si8 are the only ones where
+    // unsigned handling is needed, and we checked for that case above.
+    return b.create<arith::SIToFPOp>(loc, dtype, scalar);
+  }
+
+  if (auto dtypeInteger = dtype.dyn_cast<mlir::IntegerType>()) {
+    if (auto scalarFloat = scalarType.dyn_cast<mlir::FloatType>())
+      return b.create<arith::FPToSIOp>(loc, dtype, scalar);
+    assert(scalarType.isa<mlir::IntegerType>());
+    auto scalarInteger = scalarType.cast<mlir::IntegerType>();
+    if (scalarInteger.getWidth() > dtypeInteger.getWidth())
+      return b.create<arith::TruncIOp>(loc, dtype, scalar);
+    if (scalarType.isSignlessInteger(1))
+      return b.create<arith::ExtUIOp>(loc, dtype, scalar);
+    // Only scalarInteger width < dtypeInteger width can reach here.
+    // It's safe to use ExtSIOp here because ui8/si8 are the only ones where
+    // unsigned handling is needed, and we checked for that case above.
+    return b.create<arith::ExtSIOp>(loc, dtype, scalar);
+  }
+
+  llvm_unreachable("convertScalarToDtype should handle all the types");
+}
+
+} // namespace Torch
+} // namespace torch
+} // namespace mlir

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -119,30 +119,8 @@ static Value createTensorSub(PatternRewriter &rewriter, Location loc,
   return sub;
 }
 
-static Value getDtypeIntValueForType(PatternRewriter &rewriter, Location loc,
-                                     Type dtype) {
-  int intType = (int)getScalarTypeForType(dtype);
-  return rewriter.create<ConstantIntOp>(loc,
-                                        rewriter.getI64IntegerAttr(intType));
-}
-
-// Helper to convert a tensor to a specific scalar type.
-static Value convertTensorToDtype(PatternRewriter &rewriter, Location loc,
-                                  Value input, Type dtype) {
-  BaseTensorType origType = input.getType().cast<BaseTensorType>();
-  Type newType = origType.getWithSizesAndDtype(origType.getSizes(), dtype);
-  // `convertIntVal` contains the corresponding integer for the dtype which is
-  // used by the aten.to.dtype op.
-  Value convertIntVal = getDtypeIntValueForType(rewriter, loc, dtype);
-  Value falseVal = rewriter.create<ConstantBoolOp>(loc, false);
-  Value noneVal = rewriter.create<ConstantNoneOp>(loc);
-  Value converted = rewriter.create<AtenToDtypeOp>(
-      loc, newType, input, convertIntVal, falseVal, falseVal, noneVal);
-  return converted;
-}
-
-// Helper to create a tensor filled with the given `scalar`. `scalar` would be
-// converted to the element type of the given `resultType`.
+// Helper to create a tensor filled with the given scalar. Scalar would be
+// converted the to the element type of the given tensor type.
 static Value createInitTensor(PatternRewriter &rewriter, Location loc,
                               Type resultType, Value scalar, Value sizeList) {
   BaseTensorType tensorType = resultType.cast<BaseTensorType>();

--- a/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
@@ -23,6 +23,7 @@ add_mlir_library(TorchMLIRTorchConversionPasses
   TorchMLIRTorchDialect
   TorchMLIRTorchPasses
   TorchMLIRTorchToLinalg
+  TorchMLIRTorchToTMTensor
   TorchMLIRTorchToStd
   TorchMLIRTorchToSCF
   MLIRMemRefTransforms

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -19,6 +19,7 @@
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToStd/TorchToStd.h"
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
+#include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
 
 using namespace mlir;
@@ -58,6 +59,7 @@ void TorchConversion::createTorchBackendToLinalgOnTensorsBackendPipeline(
   // We do this first as it tends to involve pattern-matching against constants,
   // (e.g. dimensions which must be constant in a ranked programming model)
   // and those constants get somewhat obscured by TorchToStd.
+  pm.addNestedPass<FuncOp>(createConvertTorchToTMTensorPass());
   pm.addNestedPass<FuncOp>(createConvertTorchToLinalgPass());
   pm.addNestedPass<FuncOp>(createConvertTorchToStdPass());
   pm.addNestedPass<FuncOp>(createConvertTorchToSCFPass());

--- a/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
@@ -16,6 +16,8 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"
+#include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
 #include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h"
 
@@ -24,6 +26,8 @@
 using namespace mlir;
 using namespace mlir::torch;
 using namespace mlir::torch::TorchConversion;
+using namespace TMTensor;
+
 
 namespace {
 class VerifyLinalgOnTensorsBackendContractPass
@@ -71,6 +75,7 @@ class VerifyLinalgOnTensorsBackendContractPass
     target.addDynamicallyLegalDialect<tensor::TensorDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<AffineDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<cf::ControlFlowDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<TMTensorDialect>(opHasLegalTypes);
 
     // ConstantOp is used for tensors and for scalars.
     target.addDynamicallyLegalOp<arith::ConstantOp>(opHasLegalTypes);

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -565,6 +565,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::var : (Tensor, bool) -> (Tensor)")
         emit("aten::nll_loss_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)")
         emit("aten::nll_loss_backward : (Tensor, Tensor, Tensor, Tensor?, int, int, Tensor) -> (Tensor)")
+        emit ("aten::bincount : (Tensor, Tensor?, int) -> (Tensor)")
 
         # Misc tensor ops.
         emit("aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)")


### PR DESCRIPTION
This pass is added to lower ops, which can not be lowered
via the TorchToLinalg pass, such as `embedding_dense_backward`
op. This pass also uses torch-mlir's TMTensor Dialect to lower the
complex ops.

Also add torch.bincount op lowering with the help of TMTensor dialect