### PR TITLE
Modify aten._log_softmax op decomposition for numerical stability.

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -665,6 +665,26 @@ class _LogSoftmaxModule(torch.nn.Module):
 def _LogSoftmaxModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4))
 
+class _LogSoftmaxModuleStable(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, tensor):
+        return torch.ops.aten._log_softmax(tensor, dim=0, half_to_float=False)
+
+
+@register_test_case(module_factory=lambda: _LogSoftmaxModuleStable())
+def _LogSoftmaxModuleStable_basic(module, tu: TestUtils):
+    # testing for numerical stability.
+    # Should result in  tensor([-1e9, 0.00]) rather than tensor([-inf, 0.]).
+    a = torch.tensor([0, 1e9])
+    module.forward(a)
+
 # ==============================================================================
 class BroadcastToModule(torch.nn.Module):
     def __init__(self):

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -363,10 +363,11 @@ func @torch.aten._unsafe_view$dynamic(%arg0: !torch.vtensor<[?,?,?],f32>) -> !to
 // CHECK:           %[[NONE:.*]] = torch.constant.none
 // CHECK:           %[[SUM_DIM:.*]] = torch.aten.sum.dim_IntList %[[EXP]], %[[PRIM]], %[[TRU]], %[[NONE]] :
 // CHECK-SAME:      !torch.vtensor<[?,?,?],f32>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.vtensor<[1,?,?],f32>
-// CHECK:           %[[SOFTMAX:.*]] = torch.aten.div.Tensor %[[EXP]], %[[SUM_DIM]] : !torch.vtensor<[?,?,?],f32>, !torch.vtensor<[1,?,?],f32> -> !torch.vtensor<[?,?,?],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.vtensor<[?,?,?],f32> to !torch.vtensor<[?,?,?],f32>
-// CHECK:           %[[LOG:.*]] = torch.aten.log %[[CAST]] : !torch.vtensor<[?,?,?],f32> -> !torch.vtensor<[?,?,?],f32>
-// CHECK:           return %[[LOG]] : !torch.vtensor<[?,?,?],f32>
+// CHECK:           %[[LOG:.*]] = torch.aten.log %[[SUM_DIM]] : !torch.vtensor<[1,?,?],f32> -> !torch.vtensor<[1,?,?],f32>
+// CHECK:           %[[FLOAT_1:.*]] = torch.constant.float 1.000000e+00
+// CHECK:           %[[SUB1:.*]] = torch.aten.sub.Tensor %[[SUB]], %[[LOG]], %[[FLOAT_1]] : !torch.vtensor<[?,?,?],f32>, 
+// CHECK-SAME:      !torch.vtensor<[1,?,?],f32>, !torch.float -> !torch.vtensor<[?,?,?],f32>
+// CHECK:           return %[[SUB1]] : !torch.vtensor<[?,?,?],f32>
 func @torch.aten._log_softmax(%arg0: !torch.vtensor<[?,?,?],f32> loc(unknown)) -> !torch.vtensor<[?,?,?],f32> {
   %int0 = torch.constant.int 0
   %false = torch.constant.bool false


### PR DESCRIPTION
`aten.log_softmax` is decomposed to be more numerically stable.