### PR TITLE
Added support for importing node prim::Constant with list type

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.cpp
@@ -559,11 +559,11 @@ void IValueImporter::importCompilationUnit(torch::jit::CompilationUnit *cu) {
   }
 }
 
-void torch_mlir::importIValue(c10::IValue ivalue, MlirBlock block,
+MlirValue torch_mlir::importIValue(c10::IValue ivalue, MlirBlock block,
                               MlirContext context, ClassAnnotator &annotator) {
   // When debugging module importing, it can be useful to dump as so:
   // if (ivalue.isModule())
   //   ivalue.toModule().dump(true, false, false);
   IValueImporter importer(block, context, annotator);
-  importer.importIValue(ivalue);
+  return importer.importIValue(ivalue);
 }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.h
@@ -25,8 +25,8 @@ namespace torch_mlir {
 
 /// Main entry-point for importing torch IValue's .
 /// Recursively imports `ivalue`, inserting operations at the end of `block`.
-void importIValue(c10::IValue ivalue, MlirBlock block, MlirContext context,
-                  ClassAnnotator &annotator);
+MlirValue importIValue(c10::IValue ivalue, MlirBlock block, MlirContext context,
+                       ClassAnnotator &annotator);
 
 } // namespace torch_mlir
 


### PR DESCRIPTION
Prior to this commit, importing a `prim::Constant` node with list type would result in an error since it was not supported. `ivalue_importer::importIValue` was modified to return the MlirValue corresponding to the root so its parent operation could be extracted.

Issue https://github.com/llvm/torch-mlir/issues/555

(cc: @cathyzhyi)