### PR TITLE
Fix setup.py backwards compatibiity

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,10 +82,20 @@ class CMakeBuild(build_py):
         python_package_dir = os.path.join(cmake_build_dir,
                                           "tools", "torch-mlir", "python_packages",
                                           "torch_mlir")
-        shutil.copytree(python_package_dir,
-                        target_dir,
-                        symlinks=False,
-                        dirs_exist_ok=True)
+
+        if sys.version_info.minor >= 8:  # python >= 3.8
+            shutil.copytree(python_package_dir,
+                            target_dir,
+                            symlinks=False,
+                            dirs_exist_ok=True)
+
+        elif os.path.exists(python_package_dir):  # python <= 3.7
+            if os.path.exists(target_dir):
+                shutil.rmtree(target_dir, ignore_errors=False, onerror=None)
+
+            shutil.copytree(python_package_dir,
+                            target_dir,
+                            symlinks=False)
 
 
 class CMakeExtension(Extension):

--- a/setup.py
+++ b/setup.py
@@ -83,19 +83,12 @@ class CMakeBuild(build_py):
                                           "tools", "torch-mlir", "python_packages",
                                           "torch_mlir")
 
-        if sys.version_info.minor >= 8:  # python >= 3.8
-            shutil.copytree(python_package_dir,
-                            target_dir,
-                            symlinks=False,
-                            dirs_exist_ok=True)
+        if os.path.exists(target_dir):
+            shutil.rmtree(target_dir, ignore_errors=False, onerror=None)
 
-        elif os.path.exists(python_package_dir):  # python <= 3.7
-            if os.path.exists(target_dir):
-                shutil.rmtree(target_dir, ignore_errors=False, onerror=None)
-
-            shutil.copytree(python_package_dir,
-                            target_dir,
-                            symlinks=False)
+        shutil.copytree(python_package_dir,
+                        target_dir,
+                        symlinks=False)
 
 
 class CMakeExtension(Extension):


### PR DESCRIPTION
According to the [PyTorch docs](https://pytorch.org/get-started/locally/#mac-python), the minimum Python version that PyTorch supports is version 3.7. However, the Torch-MLIR `setup.py` uses a feature in `shutil` that was added in version 3.8.

The change made in this PR checks the python version and uses the `dirs_exist_ok` argument if available, and uses an alternative if not available.