### PR TITLE
[LINALG] Add value tensor variant to `fill_.Scalar`

### DIFF
--- a/e2e_testing/torchscript/constant_alloc.py
+++ b/e2e_testing/torchscript/constant_alloc.py
@@ -182,7 +182,7 @@ class EmptyDefaultDtypeModule(torch.nn.Module):
         None,
     ])
     def forward(self):
-        return torch.pow(torch.empty((3, 4)), 0)
+        return torch.empty((3, 4)).fill_(0)
 
 @register_test_case(module_factory=lambda: EmptyDefaultDtypeModule())
 def EmptyModule_defaultDtype(module, tu: TestUtils):
@@ -198,7 +198,7 @@ class EmptyIntModule(torch.nn.Module):
         None,
     ])
     def forward(self):
-        return 0 * torch.empty((3, 4), dtype=torch.int64)
+        return torch.empty((3, 4), dtype=torch.int64).fill_(0)
 
 @register_test_case(module_factory=lambda: EmptyIntModule())
 def EmptyModule_int(module, tu: TestUtils):
@@ -214,7 +214,7 @@ class EmptyFloatModule(torch.nn.Module):
         None,
     ])
     def forward(self):
-        return torch.pow(torch.empty((3, 4), dtype=torch.float32), 0)
+        return torch.empty((3, 4), dtype=torch.float32).fill_(0)
 
 @register_test_case(module_factory=lambda: EmptyFloatModule())
 def EmptyModule_float(module, tu: TestUtils):
@@ -230,8 +230,8 @@ class EmptyFalsePinMemoryModule(torch.nn.Module):
         None,
     ])
     def forward(self):
-        return torch.pow(torch.empty((3, 4), dtype=torch.float32, 
-                                     pin_memory=False), 0)
+        return torch.empty((3, 4), dtype=torch.float32, 
+                           pin_memory=False).fill_(0)
 
 @register_test_case(module_factory=lambda: EmptyFalsePinMemoryModule())
 def EmptyModule_falsePinMemory(module, tu: TestUtils):
@@ -249,7 +249,7 @@ class EmptyLikeDefaultDtypeModule(torch.nn.Module):
         ([-1, -1], torch.float32, True),
     ])
     def forward(self, a):
-        return torch.pow(torch.empty_like(a), 0.0)
+        return torch.empty_like(a).fill_(0)
 
 @register_test_case(module_factory=lambda: EmptyLikeDefaultDtypeModule())
 def EmptyLikeModule_defaultDtype(module, tu: TestUtils):
@@ -266,7 +266,7 @@ class EmptyLikeIntModule(torch.nn.Module):
         ([-1, -1], torch.int64, True),
     ])
     def forward(self, a):
-        return 0 * torch.empty_like(a, dtype=torch.int32)
+        return torch.empty_like(a, dtype=torch.int32).fill_(0)
 
 @register_test_case(module_factory=lambda: EmptyLikeIntModule())
 def EmptyLikeModule_int(module, tu: TestUtils):
@@ -283,7 +283,7 @@ class EmptyLikeFloatModule(torch.nn.Module):
         ([-1, -1], torch.float32, True),
     ])
     def forward(self, a):
-        return torch.pow(torch.empty_like(a, dtype=torch.float32), 0)
+        return torch.empty_like(a, dtype=torch.float32).fill_(0)
 
 @register_test_case(module_factory=lambda: EmptyLikeFloatModule())
 def EmptyLikeModule_float(module, tu: TestUtils):
@@ -300,8 +300,8 @@ class EmptyLikeFalsePinMemoryModule(torch.nn.Module):
         ([-1, -1, -1], torch.float32, True),
     ])
     def forward(self, a):
-        return torch.pow(torch.empty_like(a, dtype=torch.float64, 
-                                     pin_memory=False), 0)
+        return torch.empty_like(a, dtype=torch.float64,
+                                pin_memory=False).fill_(0)
 
 @register_test_case(module_factory=lambda: EmptyLikeFalsePinMemoryModule())
 def EmptyLikeModule_falsePinMemory(module, tu: TestUtils):

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -949,6 +949,23 @@ def Torch_PseudoAtenBernoulliFloatOp: Torch_Op<"pseudo.aten.bernoulli.float", [
   let assemblyFormat = "$self `,` $p `,` $generator attr-dict `:` type($self) `,` type($p) `,` type($generator) `->` type($result)";
 }
 
+// The corresponding without underscore variant for `torch.aten.fill_.Scalar`
+// doesn't exist in the pytorch ops registry. Add it here.
+def Torch_PseudoAtenFillScalarOp: Torch_Op<"pseudo.aten.fill.Scalar", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+  ]> {
+  let summary = "`fill.Scalar op : (Tensor, Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchScalarType:$value
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $value attr-dict `:` qualified(type($self)) `,` qualified(type($value)) `->` qualified(type($result))";
+}
+
 // To handle runtime assertions, torchscript provides us `torch._assert` operation. 
 // But TS compiler introduces control flow for `torch._assert` operation. The 
 // `torch._assert` would introduce control flow like: 

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -925,8 +925,8 @@ class DecomposeConstantTensorAllocLikeOp : public OpRewritePattern<OpTy> {
     Value constVal = rewriter.create<Torch::ConstantIntOp>(
         loc, rewriter.getI64IntegerAttr(fillVal));
     // Initialize the allocated memory block with `fillVal`.
-    rewriter.replaceOpWithNewOp<AtenFill_ScalarOp>(op, initTensor.getType(),
-                                                   initTensor, constVal);
+    rewriter.replaceOpWithNewOp<PseudoAtenFillScalarOp>(
+        op, initTensor.getType(), initTensor, constVal);
     return success();
   }
 };

--- a/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
+++ b/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
@@ -134,6 +134,9 @@ public:
     } else if (isa<AtenBernoulli_FloatOp>(op)) {
       newOp = rewriter.create<PseudoAtenBernoulliFloatOp>(
           loc, op->getResultTypes(), op->getOperands());
+    } else if (isa<AtenFill_ScalarOp>(op)) {
+      newOp = rewriter.create<PseudoAtenFillScalarOp>(loc, op->getResultTypes(),
+                                                      op->getOperands());
     } else {
       return failure();
     }
@@ -210,6 +213,7 @@ class ReduceOpVariantsPass : public ReduceOpVariantsBase<ReduceOpVariantsPass> {
     target.addIllegalOp<NonValueTensorLiteralOp>();
     target.addIllegalOp<AtenUniform_Op>();
     target.addIllegalOp<AtenBernoulli_FloatOp>();
+    target.addIllegalOp<AtenFill_ScalarOp>();
     target.markUnknownOpDynamicallyLegal([](Operation *op) {
       if (op->hasTrait<Torch::OpTrait::HasValueSemantics>()) {
         auto hasValueSemantics = [](Type t) {

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -229,7 +229,7 @@ public:
             AtenTanhBackwardOp, Aten_LogSoftmaxBackwardDataOp, AtenAddIntOp,
             AtenAbsOp, AtenThresholdOp, AtenSquareOp, PseudoAtenUniformOp,
             AtenCloneOp, AtenBernoulliOp, AtenBernoulli_FloatOp,
-            PseudoAtenBernoulliFloatOp>(op)) {
+            PseudoAtenBernoulliFloatOp, PseudoAtenFillScalarOp>(op)) {
       return getLatticeElement(op->getResult(0)).join(*operands[0]);
     }
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -502,6 +502,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
 
         # Ops without value semantics but the corresponding without trailing
         # underscore variant doesn't exist.
+        emit("aten::fill_.Scalar : (Tensor, Scalar) -> (Tensor)")
         emit("aten::uniform_ : (Tensor, float, float, Generator?) -> (Tensor)")
         emit("aten::bernoulli : (Tensor, Generator?) -> (Tensor)")
         emit("aten::bernoulli_.float : (Tensor, float, Generator?) -> (Tensor)")
@@ -567,7 +568,6 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::flatten.using_ints : (Tensor, int, int) -> (Tensor)")
         emit("aten::dim : (Tensor) -> (int)", has_folder=True)
         emit("aten::size : (Tensor) -> (int[])", has_canonicalizer=True)
-        emit("aten::fill_.Scalar : (Tensor, Scalar) -> (Tensor)")
         emit("aten::Bool.Tensor : (Tensor) -> (bool)")
         emit("aten::ones : (int[], int?, int?, Device?, bool?) -> (Tensor)")
         emit("aten::zeros : (int[], int?, int?, Device?, bool?) -> (Tensor)")

--- a/test/Dialect/Torch/reduce-op-variants.mlir
+++ b/test/Dialect/Torch/reduce-op-variants.mlir
@@ -161,3 +161,18 @@ func @torch.aten.bernoulli_.float(%t: !torch.tensor) -> !torch.tensor {
   %ret = torch.aten.bernoulli_.float %t, %p, %generator : !torch.tensor, !torch.float, !torch.none -> !torch.tensor
   return %ret : !torch.tensor
 }
+
+// CHECK-LABEL:   func @torch.aten.fill_.Scalar(
+// CHECK-SAME:                                  %[[T:.*]]: !torch.tensor) -> !torch.tensor {
+// CHECK:           %[[VALUE:.*]] = torch.constant.int 1
+// CHECK:           %[[T_VTENSOR:.*]] = torch.copy.to_vtensor %[[T]] : !torch.vtensor
+// CHECK:           %[[VRET:.*]] = torch.pseudo.aten.fill.Scalar %[[T_VTENSOR]], %[[VALUE]] : !torch.vtensor, !torch.int -> !torch.vtensor
+// CHECK:           %[[RET:.*]] = torch.copy.to_tensor %[[VRET]] : !torch.tensor
+// CHECK:           %[[COPY_VTENSOR:.*]] = torch.copy.to_vtensor %[[RET]] : !torch.vtensor
+// CHECK:           torch.overwrite.tensor %[[COPY_VTENSOR]] overwrites %[[T]] : !torch.vtensor, !torch.tensor
+// CHECK:           return %[[T]] : !torch.tensor
+func @torch.aten.fill_.Scalar(%t: !torch.tensor) -> !torch.tensor {
+  %value = torch.constant.int 1
+  %ret = torch.aten.fill_.Scalar %t, %value : !torch.tensor, !torch.int -> !torch.tensor
+  return %ret : !torch.tensor
+}


### PR DESCRIPTION
This commit adds the op `PseudoAtenFillScalarOp` that represents
`AtenFill_ScalarOp` without the underscore. The approach is the same
as in commit dd998fa4d4163af14519fed436f29e82e72673ae.

Adding this op allows for a simpler and more consistent version of the 
`empty` and `empty_like` op e2e tests.