### PR TITLE
[LINALG] Add decomposition of `aten.dropout` op

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -939,7 +939,27 @@ def TensorFloatModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
-class DropoutModule(torch.nn.Module):
+class DropoutEvalIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+
+    def forward(self, x):
+        return torch.dropout(x, 0.2, train=False)
+
+
+@register_test_case(module_factory=lambda: DropoutEvalIntModule())
+def DropoutEvalIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(5, 10, (3, 4)))
+
+# ==============================================================================
+
+class DropoutEvalFloatModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -950,12 +970,33 @@ class DropoutModule(torch.nn.Module):
     ])
 
     def forward(self, x):
-        return torch.dropout(x, 0.0, False)
+        return torch.dropout(x, 0.1, train=False)
 
 
-@register_test_case(module_factory=lambda: DropoutModule())
-def DropoutModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: DropoutEvalFloatModule())
+def DropoutEvalFloatModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+
+class DropoutTrainModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, x):
+        res = torch.dropout(x, 0.3, train=True)
+        return torch.mean(res), torch.std(res)
+
+
+@register_test_case(module_factory=lambda: DropoutTrainModule())
+def DropoutTrainModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(256, 256))
 
 # ==============================================================================
 

--- a/e2e_testing/torchscript/scalar.py
+++ b/e2e_testing/torchscript/scalar.py
@@ -9,6 +9,7 @@ from torch_mlir_e2e_test.torchscript.framework import TestUtils
 from torch_mlir_e2e_test.torchscript.registry import register_test_case
 from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
 
+# ==============================================================================
 
 class AddIntModule(torch.nn.Module):
     def __init__(self):
@@ -23,6 +24,13 @@ class AddIntModule(torch.nn.Module):
     def forward(self, lhs, rhs):
         return int(lhs)+int(rhs)
 
+
+@register_test_case(module_factory=lambda: AddIntModule())
+def AddIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(-100, 100,()), torch.randint(-100, 100,()))
+
+# ==============================================================================
+
 class SubIntModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -35,6 +43,33 @@ class SubIntModule(torch.nn.Module):
     ])
     def forward(self, lhs, rhs):
         return int(lhs)-int(rhs)
+
+
+@register_test_case(module_factory=lambda: SubIntModule())
+def SubIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(-100, 100,()), torch.randint(-100, 100,()))
+
+# ==============================================================================
+
+class SubFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([], torch.float64, True),
+        ([], torch.float64, True),
+    ])
+    def forward(self, lhs, rhs):
+        return float(lhs)-float(rhs)
+
+
+@register_test_case(module_factory=lambda: SubFloatModule())
+def SubFloatModule_basic(module, tu: TestUtils):
+    module.forward(torch.rand(()).double(), torch.rand(()).double())
+
+# ==============================================================================
 
 class MulIntModule(torch.nn.Module):
     def __init__(self):
@@ -50,14 +85,8 @@ class MulIntModule(torch.nn.Module):
         return int(lhs)*int(rhs)
 
 
-@register_test_case(module_factory=lambda: AddIntModule())
-def AddIntModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-100, 100,()), torch.randint(-100, 100,()))
-
-@register_test_case(module_factory=lambda: SubIntModule())
-def SubIntModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-100, 100,()), torch.randint(-100, 100,()))
-
 @register_test_case(module_factory=lambda: MulIntModule())
 def MulIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(-100, 100,()), torch.randint(-100, 100,()))
+
+# ==============================================================================

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -134,4 +134,6 @@ TOSA_PASS_SET = {
     "NewOnesModuleFloat3D_basic",
     "NewOnesModuleFalsePinMemory_basic",
     "SiluModule_basic",
+    "DropoutEvalIntModule_basic",
+    "DropoutEvalFloatModule_basic",
 }

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -6103,6 +6103,30 @@ def Torch_AtenAddFloatIntOp : Torch_Op<"aten.add.float_int", [
   }];
 }
 
+def Torch_AtenSubFloatOp : Torch_Op<"aten.sub.float", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::sub.float : (float, float) -> (float)`";
+  let arguments = (ins
+    Torch_FloatType:$a,
+    Torch_FloatType:$b
+  );
+  let results = (outs
+    Torch_FloatType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenSubFloatOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 2, 1);
+    }
+    void AtenSubFloatOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 2, 1);
+    }
+  }];
+}
+
 def Torch_AtenMulFloatOp : Torch_Op<"aten.mul.float", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/lib/Conversion/TorchToStd/TorchToStd.cpp
+++ b/lib/Conversion/TorchToStd/TorchToStd.cpp
@@ -210,6 +210,9 @@ public:
         typeConverter, context);
     patterns.add<ConvertAtenBinaryOp<AtenMulIntOp, arith::MulIOp>>(
         typeConverter, context);
+    target.addIllegalOp<AtenSubFloatOp>();
+    patterns.add<ConvertAtenBinaryOp<AtenSubFloatOp, arith::SubFOp>>(
+        typeConverter, context);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -471,6 +471,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::neg.int : (int) -> (int)", has_folder=True)
     emit("aten::log.int : (int) -> (float)")
     emit("aten::add.float_int : (float, int) -> (float)")
+    emit("aten::sub.float : (float, float) -> (float)")
     emit("aten::mul.float : (float, float) -> (float)")
     emit("aten::neg.float : (float) -> (float)")
     emit("aten::eq.float : (float, float) -> (bool)", has_folder=True)

--- a/test/Conversion/TorchToStd/basic.mlir
+++ b/test/Conversion/TorchToStd/basic.mlir
@@ -102,34 +102,53 @@ func @torch.constant.int() -> !torch.int {
   return %int1 : !torch.int
 }
 
-// CHECK-LABEL:  func @torch.aten.add.int(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
+// CHECK-LABEL:  func @torch.aten.add.int(
+// CHECK-SAME:                            %[[LHS:.*]]: !torch.int,
+// CHECK-SAME:                            %[[RHS:.*]]: !torch.int) -> !torch.int {
 // CHECK:          %[[LHS_I64:.*]] = torch_c.to_i64 %[[LHS]]
 // CHECK:          %[[RHS_I64:.*]] = torch_c.to_i64 %[[RHS]]
-// CHECK:          %[[INT:.*]] = arith.addi %[[LHS_I64:.*]], [[RHS_I64:.*]] : i64
-// CHECK:          %[[INT:.*]] = torch_c.from_i64 %[[INT:.*]]
-// CHECK:          return %[[INT:.*]] : !torch.int
+// CHECK:          %[[ADD:.*]] = arith.addi %[[LHS_I64:.*]], [[RHS_I64:.*]] : i64
+// CHECK:          %[[OUT:.*]] = torch_c.from_i64 %[[INT:.*]]
+// CHECK:          return %[[OUT:.*]] : !torch.int
 func @torch.aten.add.int(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
   %0 = torch.aten.add.int %arg0, %arg1 : !torch.int, !torch.int -> !torch.int
   return %0 : !torch.int
 }
 
-// CHECK-LABEL:  func @torch.aten.sub.int(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
+// CHECK-LABEL:  func @torch.aten.sub.int(
+// CHECK-SAME:                            %[[LHS:.*]]: !torch.int,
+// CHECK-SAME:                            %[[RHS:.*]]: !torch.int) -> !torch.int {
 // CHECK:          %[[LHS_I64:.*]] = torch_c.to_i64 %[[LHS]]
 // CHECK:          %[[RHS_I64:.*]] = torch_c.to_i64 %[[RHS]]
-// CHECK:          %[[INT:.*]] = arith.subi %[[LHS_I64:.*]], [[RHS_I64:.*]] : i64
-// CHECK:          %[[INT:.*]] = torch_c.from_i64 %[[INT:.*]]
-// CHECK:          return %[[INT:.*]] : !torch.int
+// CHECK:          %[[SUB:.*]] = arith.subi %[[LHS_I64:.*]], [[RHS_I64:.*]] : i64
+// CHECK:          %[[OUT:.*]] = torch_c.from_i64 %[[INT:.*]]
+// CHECK:          return %[[OUT:.*]] : !torch.int
 func @torch.aten.sub.int(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
   %0 = torch.aten.sub.int %arg0, %arg1 : !torch.int, !torch.int -> !torch.int
   return %0 : !torch.int
 }
 
-// CHECK-LABEL:  func @torch.aten.mul.int(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
+// CHECK-LABEL:  func @torch.aten.sub.float(
+// CHECK-SAME:                            %[[LHS:.*]]: !torch.float,
+// CHECK-SAME:                            %[[RHS:.*]]: !torch.float) -> !torch.float {
+// CHECK:          %[[LHS_F64:.*]] = torch_c.to_f64 %[[LHS]]
+// CHECK:          %[[RHS_F64:.*]] = torch_c.to_f64 %[[RHS]]
+// CHECK:          %[[SUB:.*]] = arith.subf %[[LHS_F64:.*]], [[RHS_F64:.*]] : f64
+// CHECK:          %[[OUT:.*]] = torch_c.from_f64 %[[SUB:.*]]
+// CHECK:          return %[[OUT:.*]] : !torch.float
+func @torch.aten.sub.float(%arg0: !torch.float, %arg1: !torch.float) -> !torch.float {
+  %0 = torch.aten.sub.float %arg0, %arg1 : !torch.float, !torch.float -> !torch.float
+  return %0 : !torch.float
+}
+
+// CHECK-LABEL:  func @torch.aten.mul.int(
+// CHECK-SAME:                            %[[LHS:.*]]: !torch.int,
+// CHECK-SAME:                            %[[RHS:.*]]: !torch.int) -> !torch.int {
 // CHECK:          %[[LHS_I64:.*]] = torch_c.to_i64 %[[LHS]]
 // CHECK:          %[[RHS_I64:.*]] = torch_c.to_i64 %[[RHS]]
-// CHECK:          %[[INT:.*]] = arith.muli %[[LHS_I64:.*]], [[RHS_I64:.*]] : i64
-// CHECK:          %[[INT:.*]] = torch_c.from_i64 %[[INT:.*]]
-// CHECK:          return %[[INT:.*]] : !torch.int
+// CHECK:          %[[MUL:.*]] = arith.muli %[[LHS_I64:.*]], [[RHS_I64:.*]] : i64
+// CHECK:          %[[OUT:.*]] = torch_c.from_i64 %[[MUL:.*]]
+// CHECK:          return %[[OUT:.*]] : !torch.int
 func @torch.aten.mul.int(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
   %0 = torch.aten.mul.int %arg0, %arg1 : !torch.int, !torch.int -> !torch.int
   return %0 : !torch.int

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -701,3 +701,51 @@ func @torch.aten._to_copy(%arg0: !torch.vtensor<[?,?,?],f32>) -> !torch.vtensor<
   %0 = torch.aten._to_copy %arg0, %none, %none, %none, %none, %false, %none : !torch.vtensor<[?,?,?],f32>, !torch.none, !torch.none, !torch.none, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?],f32>
   return %0 : !torch.vtensor<[?,?,?],f32>
 }
+
+// -----
+// CHECK-LABEL:   func @torch.aten.dropout$eval(
+// CHECK-SAME:                  %[[INP:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK:           %[[PROB:.*]] = torch.constant.float 1.000000e-01
+// CHECK:           %[[TRAIN:.*]] = torch.constant.bool false
+// CHECK:           return %[[INP:.*]] : !torch.vtensor<[?,?],f32>
+func @torch.aten.dropout$eval(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %float1.000000e-01 = torch.constant.float 1.000000e-01
+  %false = torch.constant.bool false
+  %0 = torch.aten.dropout %arg0, %float1.000000e-01, %false : !torch.vtensor<[?,?],f32>, !torch.float, !torch.bool -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.dropout$train(
+// CHECK-SAME:                  %[[INP:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK:           %[[PROB:.*]] = torch.constant.float 3.000000e-01
+// CHECK:           %[[TRAIN:.*]] = torch.constant.bool true
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[CST1:.*]] = torch.constant.float 1.000000e+00
+// CHECK:           %[[ONEMINUSP:.*]] = torch.aten.sub.float %[[CST1]], %[[PROB]] : !torch.float, !torch.float -> !torch.float
+// CHECK:           %[[PROB_TENSOR:.*]] = torch.prim.NumToTensor.Scalar %[[ONEMINUSP]] : !torch.float -> !torch.vtensor<[],f64>
+// CHECK:           %[[INT7:.*]] = torch.constant.int 7
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[NONE_0:.*]] = torch.constant.none
+// CHECK:           %[[CON2FLOAT:.*]] = torch.aten.to.dtype %[[INP]], %[[INT7]], %[[FALSE]], %[[FALSE]], %[[NONE_0]] :
+// CHECK-SAME:          !torch.vtensor<[?,?],f32>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,?],f64>
+// CHECK:           %[[NONE_1:.*]] = torch.constant.none
+// CHECK:           %[[NONE_2:.*]] = torch.constant.none
+// CHECK:           %[[FLOAT0:.*]] = torch.constant.float 0.000000e+00
+// CHECK:           %[[FLOAT1:.*]] = torch.constant.float 1.000000e+00
+// CHECK:           %[[UNF:.*]] = torch.valsem.aten.uniform %[[CON2FLOAT]], %[[FLOAT0]], %[[FLOAT1]], %[[NONE_2]] : !torch.vtensor<[?,?],f64>, !torch.float, !torch.float, !torch.none -> !torch.vtensor<[?,?],f64>
+// CHECK:           %[[CMP:.*]] = torch.aten.lt.Tensor %[[UNF]], %[[PROB_TENSOR]] : !torch.vtensor<[?,?],f64>, !torch.vtensor<[],f64> -> !torch.vtensor<[?,?],i1>
+// CHECK:           %[[INT6:.*]] = torch.constant.int 6
+// CHECK:           %[[FALSE_2:.*]] = torch.constant.bool false
+// CHECK:           %[[NONE_3:.*]] = torch.constant.none
+// CHECK:           %[[BOOL_MASK:.*]] = torch.aten.to.dtype %[[CMP]], %[[INT6]], %[[FALSE_2]], %[[FALSE_2]], %[[NONE_3]] :
+// CHECK-SAME:        !torch.vtensor<[?,?],i1>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,?],f32>
+// CHECK:           %[[MASK_INP:.*]] = torch.aten.mul.Tensor %[[BOOL_MASK]], %[[INP]] : !torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+// CHECK:           %[[OUT:.*]] = torch.aten.div.Scalar %[[MASK_INP]], %[[ONEMINUSP]] : !torch.vtensor<[?,?],f32>, !torch.float -> !torch.vtensor<[?,?],f32>
+// CHECK:           return %[[OUT]] : !torch.vtensor<[?,?],f32>
+func @torch.aten.dropout$train(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %float3.000000e-01 = torch.constant.float 3.000000e-01
+  %true = torch.constant.bool true
+  %0 = torch.aten.dropout %arg0, %float3.000000e-01, %true : !torch.vtensor<[?,?],f32>, !torch.float, !torch.bool -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}


### PR DESCRIPTION
- This commit adds decomposition of `aten.dropout` op. It also covers the
  training mode of the same op.
- It also adds lowering of `aten.sub.float` op.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>