### PR TITLE
Add aten::max_pool2d_with_indices_backward

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -1151,7 +1151,8 @@ class ConvolutionOverrideableModule(torch.nn.Module):
     @export
     @annotate_args([
         None,
-        ([], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
     ])
     def forward(self, x, y):
         return torch.ops.aten.convolution_overrideable(x, y, None, [1], [0], [1], False, [0], 1)

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -1153,7 +1153,7 @@ class MaxPool2dWithIndicesBackwardsModule(torch.nn.Module):
         None,
         ([-1, -1, -1], torch.float32, True),
         ([-1, -1, -1], torch.float32, True),
-        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.int, True),
     ])
     def forward(self, x, y, z):
         return torch.ops.aten.max_pool2d_with_indices_backward(x, y, [2, 2], [1, 1], [0, 0], [1, 1], False, z)

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -1144,22 +1144,23 @@ def TModuleRank0_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
-class ConvolutionOverrideableModule(torch.nn.Module):
+class MaxPool2dWithIndicesBackwardsModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
     @export
     @annotate_args([
         None,
-        ([-1, -1], torch.float32, True),
-        ([-1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
     ])
-    def forward(self, x, y):
-        return torch.ops.aten.convolution_overrideable(x, y, None, [1], [0], [1], False, [0], 1)
+    def forward(self, x, y, z):
+        return torch.ops.aten.max_pool2d_with_indices_backward(x, y, [2, 2], [1, 1], [0, 0], [1, 1], False, z)
 
-@register_test_case(module_factory=lambda: ConvolutionOverrideableModule())
-def ConvolutionOverrideableModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(2, 3), tu.rand(2, 3))
+@register_test_case(module_factory=lambda: MaxPool2dWithIndicesBackwardsModule())
+def MaxPool2dWithIndicesBackwardsModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 1), tu.rand(2, 4, 2), torch.ones(2, 3, 1, dtype=torch.long))
 
 # ==============================================================================
 

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -1144,6 +1144,24 @@ def TModuleRank0_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class ConvolutionOverrideableModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([], torch.float32, True),
+    ])
+    def forward(self, x, y):
+        return torch.ops.aten.convolution_overrideable(x, y, None, [1], [0], [1], False, [0], 1)
+
+@register_test_case(module_factory=lambda: ConvolutionOverrideableModule())
+def ConvolutionOverrideableModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3), tu.rand(2, 3))
+
+# ==============================================================================
+
 class TensorLiteralModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2931,6 +2931,28 @@ def Torch_AtenCpuOp : Torch_Op<"aten.cpu", [
   let assemblyFormat = "$self attr-dict `:` qualified(type($self)) `->` qualified(type($result))";
 }
 
+def Torch_AtenConvolutionOverrideableOp : Torch_Op<"aten.convolution_overrideable", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::convolution_overrideable : (Tensor, Tensor, Tensor?, int[], int[], int[], bool, int[], int) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$input,
+    AnyTorchTensorType:$weight,
+    AnyTorchOptionalTensorType:$bias,
+    TorchIntListType:$stride,
+    TorchIntListType:$padding,
+    TorchIntListType:$dilation,
+    Torch_BoolType:$transposed,
+    TorchIntListType:$output_padding,
+    Torch_IntType:$groups
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$input `,` $weight `,` $bias `,` $stride `,` $padding `,` $dilation `,` $transposed `,` $output_padding `,` $groups attr-dict `:` qualified(type($input)) `,` qualified(type($weight)) `,` qualified(type($bias)) `,` qualified(type($stride)) `,` qualified(type($padding)) `,` qualified(type($dilation)) `,` qualified(type($transposed)) `,` qualified(type($output_padding)) `,` qualified(type($groups)) `->` qualified(type($result))";
+}
+
 def Torch_AtenGatherOp : Torch_Op<"aten.gather", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -3047,6 +3047,27 @@ def Torch_AtenDropoutOp : Torch_Op<"aten.dropout", [
   let assemblyFormat = "$input `,` $p `,` $train attr-dict `:` qualified(type($input)) `,` qualified(type($p)) `,` qualified(type($train)) `->` qualified(type($result))";
 }
 
+def Torch_AtenMaxPool2dWithIndicesBackwardOp : Torch_Op<"aten.max_pool2d_with_indices_backward", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::max_pool2d_with_indices_backward : (Tensor, Tensor, int[], int[], int[], int[], bool, Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$grad_output,
+    AnyTorchTensorType:$self,
+    TorchIntListType:$kernel_size,
+    TorchIntListType:$stride,
+    TorchIntListType:$padding,
+    TorchIntListType:$dilation,
+    Torch_BoolType:$ceil_mode,
+    AnyTorchTensorType:$indices
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$grad_output `,` $self `,` $kernel_size `,` $stride `,` $padding `,` $dilation `,` $ceil_mode `,` $indices attr-dict `:` qualified(type($grad_output)) `,` qualified(type($self)) `,` qualified(type($kernel_size)) `,` qualified(type($stride)) `,` qualified(type($padding)) `,` qualified(type($dilation)) `,` qualified(type($ceil_mode)) `,` qualified(type($indices)) `->` qualified(type($result))";
+}
+
 def Torch_AtenTOp : Torch_Op<"aten.t", [
     AllowsTypeRefinement
   ]> {

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -3118,13 +3118,43 @@ public:
 } // namespace
 
 namespace {
-class ConvertAtenConvolutionOverrideableOp : public OpConversionPattern<AtenConvolutionOverrideableOp> {
+class ConvertAtenMaxPool2dWithIndicesBackwardOp : public OpConversionPattern<AtenMaxPool2dWithIndicesBackwardOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
-  matchAndRewrite(AtenConvolutionOverrideableOp op, OpAdaptor adaptor,
+  matchAndRewrite(AtenMaxPool2dWithIndicesBackwardOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // TODO:
+    // Verify types
+    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+      return failure();
+    Location loc = op.getLoc();
+    Value grad = adaptor.grad_output();
+    Value self = adaptor.self();
+    // auto inputType = input.getType().cast<RankedTensorType>();
+    // ArrayRef<int64_t> inputShape = inputType.getShape();
+    // int64_t inputRank = inputType.getRank();
+    // TypeConverter *typeConverter = getTypeConverter();
+    // auto resultType =
+    //     typeConverter->convertType(op.getType()).cast<RankedTensorType>();
+    // int64_t resultRank = resultType.getRank();
+
+    // Get values
+    SmallVector<Value> kernelSize;
+    if (!getListConstructElements(op.kernel_size(), kernelSize))
+      return rewriter.notifyMatchFailure(op, "kernel size not constructed from ListConstruct");
+    SmallVector<Value> stride;
+    if (!getListConstructElements(op.stride(), stride))
+      return rewriter.notifyMatchFailure(op, "stride not constructed from ListConstruct");
+    SmallVector<Value> padding;
+    if (!getListConstructElements(op.padding(), padding))
+      return rewriter.notifyMatchFailure(op, "padding not constructed from ListConstruct");
+    SmallVector<Value> dilation;
+    if (!getListConstructElements(op.dilation(), dilation))
+      return rewriter.notifyMatchFailure(op, "dilation not constructed from ListConstruct");
+
+    // Create output
+    // Fill output with zero
+    // Add in indices
     return success();
   }
 };
@@ -4570,8 +4600,8 @@ public:
     patterns.add<ConvertAtenFlattenUsingIntsOp>(typeConverter, context);
     target.addIllegalOp<AtenViewOp>();
     patterns.add<ConvertAtenViewOp>(typeConverter, context);
-    target.addIllegalOp<AtenConvolutionOverrideableOp>();
-    patterns.add<ConvertAtenConvolutionOverrideableOp>(typeConverter, context);
+    target.addIllegalOp<AtenMaxPool2dWithIndicesBackwardOp>();
+    patterns.add<ConvertAtenMaxPool2dWithIndicesBackwardOp>(typeConverter, context);
     target.addIllegalOp<AtenMaxPool2dOp>();
     patterns.add<ConvertAtenMaxPool2dOp>(typeConverter, context);
     target.addIllegalOp<AtenConstantPadNdOp>();

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -3130,6 +3130,9 @@ public:
     Location loc = op.getLoc();
     Value grad = adaptor.grad_output();
     Value self = adaptor.self();
+    auto selfType = self.getType().cast<RankedTensorType>();
+    SmallVector<Value> selfShape = getTensorSizes(rewriter, loc, self);
+    Type selfEType = selfType.getElementType();
     // auto inputType = input.getType().cast<RankedTensorType>();
     // ArrayRef<int64_t> inputShape = inputType.getShape();
     // int64_t inputRank = inputType.getRank();
@@ -3152,9 +3155,56 @@ public:
     if (!getListConstructElements(op.dilation(), dilation))
       return rewriter.notifyMatchFailure(op, "dilation not constructed from ListConstruct");
 
-    // Create output
-    // Fill output with zero
+    // Add asserts/compile-time checks for values
+    // TODO
+
+    // Create empty output tensor
+    Value output = createZeroInitTensor(rewriter, loc, selfShape, selfEType);
+    // Value output = rewriter.create<linalg::InitTensorOp>(loc, selfShape, selfEType);
+
     // Add in indices
+    Attribute attrs[2];
+    if (selfEType.isa<mlir::FloatType>()) {
+      attrs[0] = rewriter.getFloatAttr(selfEType, 0);
+      attrs[1] = rewriter.getFloatAttr(selfEType, 1);
+    } else if (selfEType.isa<mlir::IntegerType>()) {
+      attrs[0] = rewriter.getIntegerAttr(selfEType, 0);
+      attrs[1] = rewriter.getIntegerAttr(selfEType, 1);
+    } else {
+      return rewriter.notifyMatchFailure(op, "unsupported dtype");
+    }
+    Value zero = rewriter.create<arith::ConstantOp>(loc, attrs[0]);
+    Value one = rewriter.create<arith::ConstantOp>(loc, attrs[1]); 
+
+    // Collapse input to 1d
+    SmallVector<ReassociationIndices> reassociation(1);
+    for(auto i = 0; i < selfType.getRank(); i++)
+      reassociation[0].push_back(i);
+    Value flattened = rewriter.create<tensor::CollapseShapeOp>(loc, RankedTensorType::get({-1}, selfEType), self, reassociation);
+    // Fill with 0
+    Value zeroed = rewriter.create<linalg::FillOp>(loc, zero, flattened).getResult(0);
+    // Put 1 at each index in indices
+    SmallVector<ReassociationIndices> association{{1}};
+    //Value filled = rewriter.create<tensor::InsertOp>(loc);
+    // Expand back
+    // Return
+
+    //Value outputFilled = rewriter.create<linalg::GenericOp>(loc, selfType, self, output,
+    //  indexingMaps, iteratorTypes,
+    //  [&](OpBuilder &b, Location loc, ValueRange args) {
+    //    // Copy the stuff here
+    //    Value cmp;
+    //    if(selfEType.isa<mlir::FloatType>()) {
+    //      cmp = b.create<arith::CmpFOp>(loc, arith::CmpFPredicate::UNE, args[0], zero);
+    //    } else {
+    //      cmp = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, args[0], zero);
+    //    }
+    //    b.create<linalg::YieldOp>(loc, b.create<SelectOp>(loc, cmp, zero, args[1]).getResult());
+    //  }).getResult(0);
+
+    // Replace op
+    //rewriter.replaceOpWithNewOp<tensor::CastOp>(op, selfType, outputFilled);
+
     return success();
   }
 };

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -3118,6 +3118,19 @@ public:
 } // namespace
 
 namespace {
+class ConvertAtenConvolutionOverrideableOp : public OpConversionPattern<AtenConvolutionOverrideableOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenConvolutionOverrideableOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // TODO:
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class ConvertAtenSqueezeOp : public OpConversionPattern<AtenSqueezeOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
@@ -4557,6 +4570,8 @@ public:
     patterns.add<ConvertAtenFlattenUsingIntsOp>(typeConverter, context);
     target.addIllegalOp<AtenViewOp>();
     patterns.add<ConvertAtenViewOp>(typeConverter, context);
+    target.addIllegalOp<AtenConvolutionOverrideableOp>();
+    patterns.add<ConvertAtenConvolutionOverrideableOp>(typeConverter, context);
     target.addIllegalOp<AtenMaxPool2dOp>();
     patterns.add<ConvertAtenMaxPool2dOp>(typeConverter, context);
     target.addIllegalOp<AtenConstantPadNdOp>();

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -620,6 +620,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::slice.Tensor : (Tensor, int, int?, int?, int) -> (Tensor)")
         emit("aten::len.Tensor : (Tensor) -> (int)")
         emit("aten::cpu : (Tensor) -> (Tensor)")
+        emit("aten::convolution_overrideable : (Tensor, Tensor, Tensor?, int[], int[], int[], bool, int[], int) -> (Tensor)")
         emit("aten::gather : (Tensor, int, Tensor, bool) -> (Tensor)")
         emit("aten::IntImplicit : (Tensor) -> (int)")
         emit("aten::tensor.float : (float, int?, Device?, bool) -> (Tensor)")

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -627,6 +627,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::Int.Tensor : (Tensor) -> (int)", has_folder=True)
         emit("aten::Float.Tensor : (Tensor) -> (float)", has_folder=True)
         emit("aten::dropout : (Tensor, float, bool) -> (Tensor)")
+        emit("aten::max_pool2d_with_indices_backward : (Tensor, Tensor, int[], int[], int[], int[], bool, Tensor) -> (Tensor)")
         emit("aten::t : (Tensor) -> (Tensor)")
 
         # Dict ops.


### PR DESCRIPTION
Making a WIP here to get some feedback on how I'm approaching this. Should I be decomposing this as opposed to implementing it directly in linalg? The logic I'm currently working with is:

1. Flatten gradient output to a 1d tensor

2. Fill with zeroes

3. Loop through the indices, inserting 1 into the zeroed-out tensor at each point

4. Expand to the original size and return

That'd need TiledLoop, which I don't think is implemented. When I suggested doing something similar for Nonzero, Sean recommended I decompose the op for performance reasons - should I be doing the same here?

Also, an oddity that I can't place: the indices tensor is apparently has dtype f32 - shouldn't it be index? Am I missing something in ReefineTypes?