### PR TITLE
[LINALG] Add E2E support for `aten.mean.dim` op

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/__init__.py
+++ b/python/torch_mlir_e2e_test/test_suite/__init__.py
@@ -52,3 +52,4 @@ def register_all_tests():
     from . import pooling
     from . import return_types
     from . import control_flow
+    from . import stats

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -759,6 +759,9 @@ def _LogSoftmaxModule_basic(module, tu: TestUtils):
     module.forward(torch.randn(3, 2, 4))
 
 
+# ==============================================================================
+
+
 class _LogSoftmaxModuleStable(torch.nn.Module):
 
     def __init__(self):
@@ -1143,50 +1146,6 @@ def DropoutTrainModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
-class MeanModule(torch.nn.Module):
-
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([3, 4], torch.float32, True),
-    ])
-    def forward(self, x):
-        return torch.mean(x)
-
-
-@register_test_case(module_factory=lambda: MeanModule())
-def MeanModule_basic(module, tu: TestUtils):
-    module.forward(torch.randn(3, 4))
-
-
-# ==============================================================================
-
-
-class MeanDynamicSizesModule(torch.nn.Module):
-
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([-1, -1], torch.float32, True),
-    ])
-    def forward(self, x):
-        return torch.mean(x)
-
-
-@register_test_case(module_factory=lambda: MeanDynamicSizesModule())
-def MeanDynamicSizesModule_basic(module, tu: TestUtils):
-    module.forward(torch.randn(3, 4))
-
-
-# ==============================================================================
-
-
 class NumelModule(torch.nn.Module):
 
     def __init__(self):
@@ -1502,94 +1461,6 @@ def SquareModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
-class VarUnbiasedModule(torch.nn.Module):
-
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([-1, -1, -1], torch.float32, True),
-    ])
-    def forward(self, x):
-        return torch.ops.aten.var(x, unbiased=True)
-
-
-@register_test_case(module_factory=lambda: VarUnbiasedModule())
-def VarUnbiasedModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(2, 3, 4))
-
-
-# ==============================================================================
-
-
-class VarBiasedModule(torch.nn.Module):
-
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([-1, -1, -1], torch.float32, True),
-    ])
-    def forward(self, x):
-        return torch.ops.aten.var(x, unbiased=False)
-
-
-@register_test_case(module_factory=lambda: VarBiasedModule())
-def VarBiasedModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(2, 3, 4))
-
-
-# ==============================================================================
-
-
-class StdUnbiasedModule(torch.nn.Module):
-
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([-1, -1, -1], torch.float32, True),
-    ])
-    def forward(self, x):
-        return torch.ops.aten.std(x, unbiased=True)
-
-
-@register_test_case(module_factory=lambda: StdUnbiasedModule())
-def StdUnbiasedModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(2, 3, 4))
-
-
-# ==============================================================================
-
-
-class StdBiasedModule(torch.nn.Module):
-
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([-1, -1, -1], torch.float32, True),
-    ])
-    def forward(self, x):
-        return torch.ops.aten.std(x, unbiased=False)
-
-
-@register_test_case(module_factory=lambda: StdBiasedModule())
-def StdBiasedModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(2, 3, 4))
-
-
-# ==============================================================================
-
-
 class HardswishModule(torch.nn.Module):
 
     def __init__(self):
@@ -1607,6 +1478,9 @@ class HardswishModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: HardswishModule())
 def HardswishModule_basic(module, tu: TestUtils):
     module.forward(torch.tensor([[4.0, -5.0, 3.0], [2.9, -1.5, -3.0]]))
+
+
+# ==============================================================================
 
 
 class HardswishRandomModule(torch.nn.Module):
@@ -1693,6 +1567,7 @@ class HardTanhIntModule(torch.nn.Module):
 def HardTanhIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(-5, 5, (100, 100)))
 
+# ==============================================================================
 
 class BincountModule(torch.nn.Module):
 
@@ -1712,6 +1587,7 @@ class BincountModule(torch.nn.Module):
 def BincountModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(10, (1000, )))
 
+# ==============================================================================
 
 class BincountStaticSizeModule(torch.nn.Module):
 
@@ -1731,6 +1607,7 @@ class BincountStaticSizeModule(torch.nn.Module):
 def BincountStaticSizeModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(100, (200, )))
 
+# ==============================================================================
 
 class BincountMinlengthModule(torch.nn.Module):
 

--- a/python/torch_mlir_e2e_test/test_suite/reduction.py
+++ b/python/torch_mlir_e2e_test/test_suite/reduction.py
@@ -220,25 +220,6 @@ def ReduceSumDimIntListKeepDimIntModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
-class ReduceMeanDtypeModule(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([-1, -1, -1], torch.float64, True),
-    ])
-    def forward(self, a):
-        return torch.mean(a, dtype=torch.float32)
-
-
-@register_test_case(module_factory=lambda: ReduceMeanDtypeModule())
-def ReduceMeanDtypeModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(3, 4, 5).to(torch.float64))
-
-# ==============================================================================
-
 class ReduceMaxAlongDim(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/python/torch_mlir_e2e_test/test_suite/stats.py
+++ b/python/torch_mlir_e2e_test/test_suite/stats.py
@@ -1,0 +1,253 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+class MeanModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, 4], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.mean(x)
+
+
+@register_test_case(module_factory=lambda: MeanModule())
+def MeanModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+
+class MeanDynamicSizesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.mean(x)
+
+
+@register_test_case(module_factory=lambda: MeanDynamicSizesModule())
+def MeanDynamicSizesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+
+class MeanDtypeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.mean(x, dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: MeanDtypeModule())
+def MeanDtypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))
+
+# ==============================================================================
+
+class MeanDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.mean(x, (0, 2))
+
+
+@register_test_case(module_factory=lambda: MeanDimModule())
+def MeanDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 7))
+
+# ==============================================================================
+
+class MeanDimDtypeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float64, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.mean(x, 0, dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: MeanDimDtypeModule())
+def MeanDimDtypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float64))
+
+# ==============================================================================
+
+class MeanDimKeepdimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.mean(x, (1, 2), keepdim=True)
+
+
+@register_test_case(module_factory=lambda: MeanDimKeepdimModule())
+def MeanDimKeepdimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class MeanDimAllReduceModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.mean(x, (0, 1, 2))
+
+
+@register_test_case(module_factory=lambda: MeanDimAllReduceModule())
+def MeanDimAllReduceModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class MeanDimAllReduceKeepdimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.mean(x, (0, 1, 2), keepdim=True)
+
+
+@register_test_case(module_factory=lambda: MeanDimAllReduceKeepdimModule())
+def MeanDimAllReduceKeepdimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class MeanDimNegativeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.mean(x, (-1, 1))
+
+
+@register_test_case(module_factory=lambda: MeanDimNegativeModule())
+def MeanDimNegativeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class VarUnbiasedModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.var(x, unbiased=True)
+
+@register_test_case(module_factory=lambda: VarUnbiasedModule())
+def VarUnbiasedModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4))
+
+# ==============================================================================
+
+class VarBiasedModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.var(x, unbiased=False)
+
+@register_test_case(module_factory=lambda: VarBiasedModule())
+def VarBiasedModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4))
+
+# ==============================================================================
+
+class StdUnbiasedModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.std(x, unbiased=True)
+
+@register_test_case(module_factory=lambda: StdUnbiasedModule())
+def StdUnbiasedModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4))
+
+# ==============================================================================
+
+class StdBiasedModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.std(x, unbiased=False)
+
+@register_test_case(module_factory=lambda: StdBiasedModule())
+def StdBiasedModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4))


### PR DESCRIPTION
- This commit adds support for `aten.mean.dim` op.
- It also adds a new test script `stats.py` for statistics related ops.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>