### PR TITLE
[LINALG] Support for contiguous memory format in `clone` and `empty`

### DIFF
--- a/e2e_testing/torchscript/constant_alloc.py
+++ b/e2e_testing/torchscript/constant_alloc.py
@@ -173,6 +173,23 @@ def OnesModuleFalsePinMemory_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class EmptyContiguousModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return torch.empty((3, 4),
+                           memory_format=torch.contiguous_format).fill_(0)
+
+@register_test_case(module_factory=lambda: EmptyContiguousModule())
+def EmptyModule_contiguous(module, tu: TestUtils):
+    module.forward()
+
+
 class EmptyDefaultDtypeModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -871,3 +871,22 @@ class ElementwiseCloneModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseCloneModule())
 def ElementwiseCloneModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 3, 4))
+
+# ==============================================================================
+
+class ElementwiseCloneContiguousModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.clone(x, memory_format=torch.contiguous_format)
+
+
+@register_test_case(module_factory=lambda: ElementwiseCloneContiguousModule())
+def ElementwiseCloneContiguousModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4))

--- a/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
@@ -81,6 +81,18 @@ ScalarType promote_skip_undefined(ScalarType a, ScalarType b);
 //===----------------------------------------------------------------------===//
 enum Reduction { None, Mean, Sum, END };
 
+//===----------------------------------------------------------------------===//
+// Possible values for `memory_format` argument in PyTorch ops that support it.
+// Source:
+// https://github.com/pytorch/pytorch/blob/master/c10/core/MemoryFormat.h
+//===----------------------------------------------------------------------===//
+enum MemoryFormat {
+  Contiguous,
+  Preserve,
+  ChannelsLast,
+  ChannelsLast3d
+};
+
 } // namespace torch_upstream
 } // namespace torch
 } // namespace mlir


### PR DESCRIPTION
This commit adds support for the contiguous memory format for the ops
`AtenCloneOp` and `AtenEmptyMemoryFormatOp`.