### PR TITLE
[LINALG] Add handling of inferred dimension in size list of `view` op

### DIFF
--- a/e2e_testing/torchscript/reshape_like.py
+++ b/e2e_testing/torchscript/reshape_like.py
@@ -126,6 +126,44 @@ def View1DFoldModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class ViewCollapseInferredDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([2, 3, 4], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(-1, 4)
+
+@register_test_case(module_factory=lambda: ViewCollapseInferredDimModule())
+def ViewCollapseInferredDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4))
+
+# ==============================================================================
+
+class ViewExpandInferredDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([2, 6], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(2, -1, 2)
+
+@register_test_case(module_factory=lambda: ViewExpandInferredDimModule())
+def ViewExpandInferredDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 6))
+
+# ==============================================================================
+
 class UnsafeViewExpandModule(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
The view op allows for the new shape argument to have a -1 value for
one of the dimensions, and the op is expected to deduce the size of
that dimension by looking at the sizes of the other dimensions and
comparing it to the total number of elements in the original
tensor. This commit adds this functionality.

Note: this only works when there is enough static information to deduce the dimension