### PR TITLE
Introduce new shape library design.

### DIFF
--- a/build_tools/update_shape_lib.sh
+++ b/build_tools/update_shape_lib.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Updates auto-generated shape library files for the `torch` dialect.
+set -e
+
+src_dir="$(realpath $(dirname $0)/..)"
+build_dir="$(realpath "${TORCH_MLIR_BUILD_DIR:-$src_dir/build}")"
+torch_transforms_cpp_dir="${src_dir}/lib/Dialect/Torch/Transforms"
+python_packages_dir="${build_dir}/tools/torch-mlir/python_packages"
+
+#ninja -C "${build_dir}"
+PYTHONPATH="${python_packages_dir}/torch_mlir" python \
+  -m torch_mlir.dialects.torch.importer.jit_ir.build_tools.shape_lib_gen \
+  --torch_transforms_cpp_dir="${torch_transforms_cpp_dir}"

--- a/docs/adding_a_shape_function.md
+++ b/docs/adding_a_shape_function.md
@@ -1,0 +1,71 @@
+# Adding a Shape Function
+
+## Overview
+
+As part of adding support for a Torch operator in Torch-MLIR, it is usually
+necessary to define a shape function so that the compiler can infer the shapes
+of result tensors for the operator. We use the [shape library](shape_lib.md) for this process.
+
+## Step-by-step guide
+
+We will use the example of adding support for the `torch.aten.tanh` op.
+
+1. First, you need to find the shape function signature for the operator you are
+   implementing a shape function for. This can be found in
+   `include/torch-mlir/Dialect/Torch/IR/JITOperatorRegistryDump.txt` generated
+   by the `build_tools/update_torch_ods.sh` script. That file is the "rosetta
+   stone" that allows translating between e.g. `torch.aten.tanh`, `AtenTanhOp`,
+   and the shape function signature
+   `def aten〇tanh(self: List[int]) -> List[int]:`. Note the use of `〇` as a
+   separator since `.` or `::` aren't legal in a Python identifier.
+
+2. Paste the shape function signature into `shape_lib_gen.py` in an appropriate
+   place (ideally near other functions with a similar shape function). Note that
+   `shape_lib_gen.py` will check that this signature is verbatim identical with
+   the one given in `JITOperatorRegistryDump.txt` -- this ensures that the shape
+   functions don't get outdated if Torch changes an operator signature.
+
+3. Fill in the body of the shape function. Ideally this will just be a call into
+   a helper function from `upstream_shape_helpers.py`. But in general, you will
+   need to write the shape function and test it (see the comments about "Shape
+   function testing infrastructure" in `shape_lib_gen.py`).
+
+4. Re-run the `build_tools/update_shape_lib.sh` script to update the shape
+   library. After this step happens, ideally everything "just works" and the
+   shape is now correctly inferred for the operator.
+
+## When things go wrong
+
+It is possible that the shape refinement pipeline (see
+[Shape Refinement Pipeline Architecture](shape_lib.md#shape-refinement-pipeline-architecture))
+is not able to infer the shape of a tensor with a given shape function. This
+usually means that there is something about the shape function which the
+optimizations in `torch-simplify-shape-functions`
+(`lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp`) cannot handle.
+
+To debug this, the overall goal is to pinpoint the IR construct that is not
+being simplified. This is usually accomplished by a combination of looking at
+the Python code for the shape function and the IR dumps. The best IR dump to
+look at varies, but frequently the IR dump right before `DropShapeCalculations`
+is the most useful, because it has already been simplified as much as possible,
+making it is easy to see what is blocking further simplification. Examples of
+issues you might see:
+
+- You might find that there is a loop with a non-constant trip count, but based
+  on your understanding of the shape function, you would expect it to be
+  simplified to a constant trip count -- you can then look at the trip count
+  calculation and see if there is a missing fold or canonicalization.
+
+- You might find that there is a list operation that is not currently understood
+  by the optimizations. You can then teach the optimizations about that
+  operation.
+
+- You might find that there is an `Optional` value that you would expect to be
+  resolved to either a concrete value or `None`. You can then look at the calculation that produces the optional value and see what folds or canonicalizations are missing.
+
+See [this video](https://www.youtube.com/watch?v=E5epCJOtrf8) for general
+guidance on debugging Torch-MLIR.
+
+As a last resort, you can rewrite the shape function using constructs that
+`torch-simplify-shape-functions` can handle (look at other shape functions for
+examples, sometimes it requires writing things a little awkwardly).

--- a/docs/shape_lib.md
+++ b/docs/shape_lib.md
@@ -1,0 +1,128 @@
+# Torch-MLIR Shape Library Infrastructure
+
+## Overview
+
+The Torch-MLIR project has an infrastructure for maintaining a library of shape
+functions for different Torch operators. These shape functions are fully
+executable specifications of the shape functions for each operator and can be
+authored and tested from Python for convenience. These are then brought into the
+compiler and can be manipulated / transformed for various purposes.
+Additionally, this effort is synergistic with upstream PyTorch efforts to
+maintain a library of shape functions.
+
+The two main use cases are:
+
+- Shape refinement / shape inference. The `torch-shape-refinement-pipeline` pass
+  pipeline orchestrates a series of passes that use the available shape information in the program to further refine the types in the program.
+
+- Error guard insertion for backends (Not Yet Implemented). The executable shape
+  functions can include error guards / assertions that abort the program in case
+  of invalid input (such as a matmul with a mismatching contracting dimension).
+
+## Architecture
+
+Shape functions are defined as TorchScript-able Python functions in
+`python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py`.
+The signatures of the shape functions are systematically derived from Torch JIT
+operator registry (mainly by replacing `Tensor` with `List[int]` in the operator
+signatures). Most shape functions are expected to reuse the upstream helper
+functions in
+`python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/upstream_shape_helpers.py`.
+
+The `build_tools/update_shape_lib.sh` script invokes `shape_lib_gen.py` to
+generate an MLIR module containing the shape functions, which is currently
+embedded as a string literal in `lib/Dialect/Torch/Transforms/ShapeLibrary.cpp`.
+
+The function `StringRef mlir::torch::Torch::getShapeLibrary()` is available for
+use inside the compiler any time that the shape library is needed.
+
+## Shape Refinement Pipeline Architecture
+
+One of the main services that Torch-MLIR provides for backends is to normalize
+all Torch frontends into a common form which includes tensor shapes that are as
+precise as possible. This alleviates the need for backends to solve this problem
+themselves. This process of shape refinement is accomplished in Torch-MLIR
+through a pipeline of passes which uses the shape library combined with abstract
+interpretation of the shape functions to calculate shapes that are as precise as
+possible.
+
+The pipeline works as follows:
+
+1. Shape calculations are reified. The `torch-reify-shape-calculations` reifies
+   (i.e., materializes into the IR) the shape functions for each op with a shape
+   function in the shape library. To do this, it wraps those ops in a
+   `torch.shape.calculate` op, which has two regions: 1) a body with the op
+   itself, and 2) the shape calculation, which calculates the shapes of the
+   tensors yielded by the body.
+
+2. Simplifying the shape functions and propagating the shapes. After the shape
+   functions are reified, we then attempt to "optimize hard enough" until the
+   shapes yielded by the shape calculation regions become obvious in the IR.
+   Those shapes are propagated through the IR, which usually reveals more
+   opportunities for simplification.
+
+   a. After reification, the shape functions are just a loose collection of
+   functions, which are difficult to analyze. The first step is to inline them.
+
+   b. After inlining, the `torch-simplify-shape-calculations` pass is used to
+   simplify the shape calculations. This pass brings in a number of targeted
+   canonicalization patterns and folds, along with a few specific patterns such
+   as unrolling fixed-trip-count loops and abstractly interpreting list
+   operations (an example is turning a series of "append" operations into a list
+   literal). This pass also looks at the values yielded by the shape calculation
+   regions, and if the resulting shape can be deduced by looking at the IR (for
+   example, the shape is the list literal `[1, 2, 3]`), it will refine the types
+   of the `torch.shape.calculate` op. This usually yields more opportunities for
+   simplification. This process runs to a fixed-point.
+
+3. Dropping the shape calculations. Once all the types in the program have been
+   refined as much as possible, the ops that were originally wrapped in
+   `torch.shape.calculate` are unwrapped by the `torch-drop-shape-calculations`
+   pass which drops the reified shape calculations, leaving behind the shape-refined program.
+
+Inferring precise shape often is needed for correctness by backends. That said,
+requiring "optimizing hard enough" for correctness is usually considered quite
+brittle in a compiler flow. In this case, the saving grace is that we are only
+optimizing the shape functions, which are authored by compiler developers (not
+users), and thus there is some give-and-take in terms of understanding the
+optimizable constructs while authoring the shape functions, or improving the
+optimizations to enable easier authoring. Some brittleness is likely to escape
+to users, unfortunately, since there will always be situations where, for
+example, a statically shaped program allows the shape functions to be simplified
+to a greater extent than in a dynamically shaped program (for example, if the
+shape function checks "is this dimension of size 1"). We hope that this is
+minimal.
+
+## Adding to the shape library
+
+See [Adding a Shape Function](adding_a_shape_function.md) for details on how to
+add a shpae function for an operator.
+
+## Rationale
+
+### Use of full operator signatures
+
+The use of the full operator signature such as
+`def aten〇add〇Tensor(self: List[int], other: List[int], alpha: float = 1) -> List[int]:`
+for defining shape functions is somewhat verbose and repetitive, especially when
+there are multiple identical shape functions. Upstream uses a map with key-value
+pairs like `"aten.add.Tensor": upstream_shape_helpers.broadcast`, which is more
+compact and less repetitive in some ways (upstream also allows trailing
+arguments beyond those accepted by the shape function to be ignored, allowing
+further deduplication). The decision to do it the more verbose way in Torch-MLIR
+was based on the following goals:
+
+- To make the system very easy to debug and test.
+
+- To make the system maximally consistent between shape functions that are
+  implemented with the upstream shape helpers and the ones that are manually
+  written, which are still a fairly large and non-trivial set.
+
+- To make it as mechanical as possible to add a new shape function.
+
+## TODO
+
+We should develop a workflow with upstream to push our manually-authored shape
+functions to live and be tested there. We should also find a way to share with
+upstream the mapping between operators and their shape functions. We will be
+able to simplify this infrastructure quite a bit once that happens.

--- a/e2e_testing/torchscript/norm_like.py
+++ b/e2e_testing/torchscript/norm_like.py
@@ -204,6 +204,7 @@ class NativeLayerNormModule(torch.nn.Module):
     ])
     def forward(self, x, weight, bias):
         list = [2, 2, 3]
+        # TODO: Fix the case of the other return values.
         return torch.ops.aten.native_layer_norm(
             x, list, weight, bias, eps=0.5)[0]
 

--- a/e2e_testing/torchscript/slice_like.py
+++ b/e2e_testing/torchscript/slice_like.py
@@ -232,4 +232,3 @@ def SelectIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(10, (5,5)))
 
 # ==============================================================================
-

--- a/e2e_testing/torchscript/squeeze.py
+++ b/e2e_testing/torchscript/squeeze.py
@@ -34,50 +34,6 @@ def SqueezeModule_static(module, tu: TestUtils):
 # ==============================================================================
 
 
-class SqueezeDynamicModule(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([1, -1, 1, 384, -1, 1, 1], torch.float32, True),
-    ])
-    def forward(self, a):
-        return torch.squeeze(a)
-
-
-@register_test_case(
-    module_factory=lambda: SqueezeDynamicModule())
-def SqueezeModule_dynamic(module, tu: TestUtils):
-    module.forward(tu.rand(1, 8, 1, 384, 12, 1, 1))
-
-
-# ==============================================================================
-
-
-class SqueezeNoUnitDimModule(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([4, -1, -1], torch.float32, True),
-    ])
-    def forward(self, a):
-        return torch.squeeze(a)
-
-
-@register_test_case(
-    module_factory=lambda: SqueezeNoUnitDimModule())
-def SqueezeModule_noUnitDim(module, tu: TestUtils):
-    module.forward(tu.rand(4, 2, 3))
-
-
-# ==============================================================================
-
-
 class SqueezeAllUnitDimModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -228,4 +184,3 @@ class SqueezeDimUnitDimModule(torch.nn.Module):
     module_factory=lambda: SqueezeDimUnitDimModule())
 def SqueezeDimModule_unitDim(module, tu: TestUtils):
     module.forward(tu.rand(1))
-

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -18,7 +18,8 @@
 
 def Torch_AtenTanhOp : Torch_Op<"aten.tanh", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::tanh : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -46,7 +47,8 @@ def Torch_AtenTanh_Op : Torch_Op<"aten.tanh_", [
 
 def Torch_AtenHardtanhOp : Torch_Op<"aten.hardtanh", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::hardtanh : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -78,7 +80,8 @@ def Torch_AtenHardtanh_Op : Torch_Op<"aten.hardtanh_", [
 
 def Torch_AtenReluOp : Torch_Op<"aten.relu", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::relu : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -106,7 +109,8 @@ def Torch_AtenRelu_Op : Torch_Op<"aten.relu_", [
 
 def Torch_AtenLeakyReluOp : Torch_Op<"aten.leaky_relu", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::leaky_relu : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -136,7 +140,8 @@ def Torch_AtenLeakyRelu_Op : Torch_Op<"aten.leaky_relu_", [
 
 def Torch_AtenLogOp : Torch_Op<"aten.log", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::log : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -164,7 +169,8 @@ def Torch_AtenLog_Op : Torch_Op<"aten.log_", [
 
 def Torch_AtenSigmoidOp : Torch_Op<"aten.sigmoid", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::sigmoid : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -192,7 +198,8 @@ def Torch_AtenSigmoid_Op : Torch_Op<"aten.sigmoid_", [
 
 def Torch_AtenHardsigmoidOp : Torch_Op<"aten.hardsigmoid", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::hardsigmoid : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -220,7 +227,8 @@ def Torch_AtenHardsigmoid_Op : Torch_Op<"aten.hardsigmoid_", [
 
 def Torch_AtenHardswishOp : Torch_Op<"aten.hardswish", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::hardswish : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -248,7 +256,8 @@ def Torch_AtenHardswish_Op : Torch_Op<"aten.hardswish_", [
 
 def Torch_AtenErfOp : Torch_Op<"aten.erf", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::erf : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -276,7 +285,8 @@ def Torch_AtenErf_Op : Torch_Op<"aten.erf_", [
 
 def Torch_AtenSiluOp : Torch_Op<"aten.silu", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::silu : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -304,7 +314,8 @@ def Torch_AtenSilu_Op : Torch_Op<"aten.silu_", [
 
 def Torch_AtenSinOp : Torch_Op<"aten.sin", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::sin : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -332,7 +343,8 @@ def Torch_AtenSin_Op : Torch_Op<"aten.sin_", [
 
 def Torch_AtenExpOp : Torch_Op<"aten.exp", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::exp : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -360,7 +372,8 @@ def Torch_AtenExp_Op : Torch_Op<"aten.exp_", [
 
 def Torch_AtenCosOp : Torch_Op<"aten.cos", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::cos : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -388,7 +401,8 @@ def Torch_AtenCos_Op : Torch_Op<"aten.cos_", [
 
 def Torch_AtenNegOp : Torch_Op<"aten.neg", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::neg : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -416,7 +430,8 @@ def Torch_AtenNeg_Op : Torch_Op<"aten.neg_", [
 
 def Torch_AtenFloorOp : Torch_Op<"aten.floor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::floor : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -444,7 +459,8 @@ def Torch_AtenFloor_Op : Torch_Op<"aten.floor_", [
 
 def Torch_AtenCeilOp : Torch_Op<"aten.ceil", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::ceil : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -472,7 +488,8 @@ def Torch_AtenCeil_Op : Torch_Op<"aten.ceil_", [
 
 def Torch_AtenBitwiseNotOp : Torch_Op<"aten.bitwise_not", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::bitwise_not : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -500,7 +517,8 @@ def Torch_AtenBitwiseNot_Op : Torch_Op<"aten.bitwise_not_", [
 
 def Torch_AtenAddTensorOp : Torch_Op<"aten.add.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::add.Tensor : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -532,7 +550,8 @@ def Torch_AtenAdd_TensorOp : Torch_Op<"aten.add_.Tensor", [
 
 def Torch_AtenSubTensorOp : Torch_Op<"aten.sub.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::sub.Tensor : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -564,7 +583,8 @@ def Torch_AtenSub_TensorOp : Torch_Op<"aten.sub_.Tensor", [
 
 def Torch_AtenMulTensorOp : Torch_Op<"aten.mul.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::mul.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -594,7 +614,8 @@ def Torch_AtenMul_TensorOp : Torch_Op<"aten.mul_.Tensor", [
 
 def Torch_AtenDivTensorOp : Torch_Op<"aten.div.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::div.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -624,7 +645,8 @@ def Torch_AtenDiv_TensorOp : Torch_Op<"aten.div_.Tensor", [
 
 def Torch_AtenLerpTensorOp : Torch_Op<"aten.lerp.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::lerp.Tensor : (Tensor, Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -656,7 +678,8 @@ def Torch_AtenLerp_TensorOp : Torch_Op<"aten.lerp_.Tensor", [
 
 def Torch_AtenEqTensorOp : Torch_Op<"aten.eq.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::eq.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -686,7 +709,8 @@ def Torch_AtenEq_TensorOp : Torch_Op<"aten.eq_.Tensor", [
 
 def Torch_AtenGtTensorOp : Torch_Op<"aten.gt.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::gt.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -716,7 +740,8 @@ def Torch_AtenGt_TensorOp : Torch_Op<"aten.gt_.Tensor", [
 
 def Torch_AtenLtTensorOp : Torch_Op<"aten.lt.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::lt.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -746,7 +771,8 @@ def Torch_AtenLt_TensorOp : Torch_Op<"aten.lt_.Tensor", [
 
 def Torch_AtenNeTensorOp : Torch_Op<"aten.ne.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::ne.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -776,7 +802,8 @@ def Torch_AtenNe_TensorOp : Torch_Op<"aten.ne_.Tensor", [
 
 def Torch_AtenAddScalarOp : Torch_Op<"aten.add.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::add.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -808,7 +835,8 @@ def Torch_AtenAdd_ScalarOp : Torch_Op<"aten.add_.Scalar", [
 
 def Torch_AtenSubScalarOp : Torch_Op<"aten.sub.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::sub.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -840,7 +868,8 @@ def Torch_AtenSub_ScalarOp : Torch_Op<"aten.sub_.Scalar", [
 
 def Torch_AtenMulScalarOp : Torch_Op<"aten.mul.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::mul.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -870,7 +899,8 @@ def Torch_AtenMul_ScalarOp : Torch_Op<"aten.mul_.Scalar", [
 
 def Torch_AtenDivScalarOp : Torch_Op<"aten.div.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::div.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -900,7 +930,8 @@ def Torch_AtenDiv_ScalarOp : Torch_Op<"aten.div_.Scalar", [
 
 def Torch_AtenNeScalarOp : Torch_Op<"aten.ne.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::ne.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -930,7 +961,8 @@ def Torch_AtenNe_ScalarOp : Torch_Op<"aten.ne_.Scalar", [
 
 def Torch_AtenEqScalarOp : Torch_Op<"aten.eq.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::eq.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -960,7 +992,8 @@ def Torch_AtenEq_ScalarOp : Torch_Op<"aten.eq_.Scalar", [
 
 def Torch_AtenGtScalarOp : Torch_Op<"aten.gt.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::gt.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -990,7 +1023,8 @@ def Torch_AtenGt_ScalarOp : Torch_Op<"aten.gt_.Scalar", [
 
 def Torch_AtenGeScalarOp : Torch_Op<"aten.ge.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::ge.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1020,7 +1054,8 @@ def Torch_AtenGe_ScalarOp : Torch_Op<"aten.ge_.Scalar", [
 
 def Torch_AtenLtScalarOp : Torch_Op<"aten.lt.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::lt.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1050,7 +1085,8 @@ def Torch_AtenLt_ScalarOp : Torch_Op<"aten.lt_.Scalar", [
 
 def Torch_AtenLeScalarOp : Torch_Op<"aten.le.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::le.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1080,7 +1116,8 @@ def Torch_AtenLe_ScalarOp : Torch_Op<"aten.le_.Scalar", [
 
 def Torch_AtenFmodScalarOp : Torch_Op<"aten.fmod.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::fmod.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1110,7 +1147,8 @@ def Torch_AtenFmod_ScalarOp : Torch_Op<"aten.fmod_.Scalar", [
 
 def Torch_AtenMaskedFillScalarOp : Torch_Op<"aten.masked_fill.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::masked_fill.Scalar : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1142,7 +1180,8 @@ def Torch_AtenMaskedFill_ScalarOp : Torch_Op<"aten.masked_fill_.Scalar", [
 
 def Torch_AtenClampOp : Torch_Op<"aten.clamp", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::clamp : (Tensor, Scalar?, Scalar?) -> (Tensor)`";
   let arguments = (ins
@@ -1174,7 +1213,8 @@ def Torch_AtenClamp_Op : Torch_Op<"aten.clamp_", [
 
 def Torch_AtenLog2Op : Torch_Op<"aten.log2", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::log2 : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1202,7 +1242,8 @@ def Torch_AtenLog2_Op : Torch_Op<"aten.log2_", [
 
 def Torch_AtenRsqrtOp : Torch_Op<"aten.rsqrt", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::rsqrt : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1230,7 +1271,8 @@ def Torch_AtenRsqrt_Op : Torch_Op<"aten.rsqrt_", [
 
 def Torch_AtenAbsOp : Torch_Op<"aten.abs", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::abs : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1258,7 +1300,8 @@ def Torch_AtenAbs_Op : Torch_Op<"aten.abs_", [
 
 def Torch_AtenReciprocalOp : Torch_Op<"aten.reciprocal", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::reciprocal : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1286,7 +1329,8 @@ def Torch_AtenReciprocal_Op : Torch_Op<"aten.reciprocal_", [
 
 def Torch_AtenBitwiseAndTensorOp : Torch_Op<"aten.bitwise_and.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::bitwise_and.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1316,7 +1360,8 @@ def Torch_AtenBitwiseAnd_TensorOp : Torch_Op<"aten.bitwise_and_.Tensor", [
 
 def Torch_AtenThresholdOp : Torch_Op<"aten.threshold", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::threshold : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1348,7 +1393,8 @@ def Torch_AtenThreshold_Op : Torch_Op<"aten.threshold_", [
 
 def Torch_AtenSquareOp : Torch_Op<"aten.square", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::square : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1376,7 +1422,8 @@ def Torch_AtenSquare_Op : Torch_Op<"aten.square_", [
 
 def Torch_AtenAddcmulOp : Torch_Op<"aten.addcmul", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::addcmul : (Tensor, Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1393,7 +1440,8 @@ def Torch_AtenAddcmulOp : Torch_Op<"aten.addcmul", [
 
 def Torch_AtenAddcdivOp : Torch_Op<"aten.addcdiv", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::addcdiv : (Tensor, Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1410,7 +1458,8 @@ def Torch_AtenAddcdivOp : Torch_Op<"aten.addcdiv", [
 
 def Torch_AtenMaximumOp : Torch_Op<"aten.maximum", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::maximum : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1425,7 +1474,8 @@ def Torch_AtenMaximumOp : Torch_Op<"aten.maximum", [
 
 def Torch_AtenMinimumOp : Torch_Op<"aten.minimum", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::minimum : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1440,7 +1490,8 @@ def Torch_AtenMinimumOp : Torch_Op<"aten.minimum", [
 
 def Torch_AtenRsubScalarOp : Torch_Op<"aten.rsub.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::rsub.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1456,7 +1507,8 @@ def Torch_AtenRsubScalarOp : Torch_Op<"aten.rsub.Scalar", [
 
 def Torch_AtenGeluOp : Torch_Op<"aten.gelu", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::gelu : (Tensor, str) -> (Tensor)`";
   let arguments = (ins
@@ -1471,7 +1523,8 @@ def Torch_AtenGeluOp : Torch_Op<"aten.gelu", [
 
 def Torch_AtenPowTensorScalarOp : Torch_Op<"aten.pow.Tensor_Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::pow.Tensor_Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1486,7 +1539,8 @@ def Torch_AtenPowTensorScalarOp : Torch_Op<"aten.pow.Tensor_Scalar", [
 
 def Torch_AtenThresholdBackwardOp : Torch_Op<"aten.threshold_backward", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::threshold_backward : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1532,7 +1586,8 @@ def Torch_AtenUniform_Op : Torch_Op<"aten.uniform_", [
 
 def Torch_AtenRandLikeOp : Torch_Op<"aten.rand_like", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::rand_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -1551,7 +1606,8 @@ def Torch_AtenRandLikeOp : Torch_Op<"aten.rand_like", [
 
 def Torch_AtenBernoulliOp : Torch_Op<"aten.bernoulli", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::bernoulli : (Tensor, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -1596,7 +1652,8 @@ def Torch_AtenBernoulli_TensorOp : Torch_Op<"aten.bernoulli_.Tensor", [
 
 def Torch_AtenTriuOp : Torch_Op<"aten.triu", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::triu : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -1626,7 +1683,8 @@ def Torch_AtenTriu_Op : Torch_Op<"aten.triu_", [
 
 def Torch_AtenIndexPutOp : Torch_Op<"aten.index_put", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::index_put : (Tensor, Tensor?[], Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -1660,7 +1718,8 @@ def Torch_AtenIndexPut_Op : Torch_Op<"aten.index_put_", [
 
 def Torch_AtenLinearOp : Torch_Op<"aten.linear", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::linear : (Tensor, Tensor, Tensor?) -> (Tensor)`";
   let arguments = (ins
@@ -1676,7 +1735,8 @@ def Torch_AtenLinearOp : Torch_Op<"aten.linear", [
 
 def Torch_AtenMmOp : Torch_Op<"aten.mm", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::mm : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1691,7 +1751,8 @@ def Torch_AtenMmOp : Torch_Op<"aten.mm", [
 
 def Torch_AtenAddmmOp : Torch_Op<"aten.addmm", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::addmm : (Tensor, Tensor, Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1709,7 +1770,8 @@ def Torch_AtenAddmmOp : Torch_Op<"aten.addmm", [
 
 def Torch_AtenMatmulOp : Torch_Op<"aten.matmul", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::matmul : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1724,7 +1786,8 @@ def Torch_AtenMatmulOp : Torch_Op<"aten.matmul", [
 
 def Torch_AtenConv2dOp : Torch_Op<"aten.conv2d", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::conv2d : (Tensor, Tensor, Tensor?, int[], int[], int[], int) -> (Tensor)`";
   let arguments = (ins
@@ -1744,7 +1807,8 @@ def Torch_AtenConv2dOp : Torch_Op<"aten.conv2d", [
 
 def Torch_AtenNativeBatchNormOp : Torch_Op<"aten.native_batch_norm", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::native_batch_norm : (Tensor, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, float) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -1767,7 +1831,8 @@ def Torch_AtenNativeBatchNormOp : Torch_Op<"aten.native_batch_norm", [
 
 def Torch_AtenBatchNormOp : Torch_Op<"aten.batch_norm", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::batch_norm : (Tensor, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, float, bool) -> (Tensor)`";
   let arguments = (ins
@@ -1789,7 +1854,8 @@ def Torch_AtenBatchNormOp : Torch_Op<"aten.batch_norm", [
 
 def Torch_AtenLayerNormOp : Torch_Op<"aten.layer_norm", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::layer_norm : (Tensor, int[], Tensor?, Tensor?, float, bool) -> (Tensor)`";
   let arguments = (ins
@@ -1808,7 +1874,8 @@ def Torch_AtenLayerNormOp : Torch_Op<"aten.layer_norm", [
 
 def Torch_AtenNativeLayerNormOp : Torch_Op<"aten.native_layer_norm", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::native_layer_norm : (Tensor, int[], Tensor?, Tensor?, float) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -1828,7 +1895,8 @@ def Torch_AtenNativeLayerNormOp : Torch_Op<"aten.native_layer_norm", [
 
 def Torch_AtenMaxPool2dOp : Torch_Op<"aten.max_pool2d", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::max_pool2d : (Tensor, int[], int[], int[], int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -1847,7 +1915,8 @@ def Torch_AtenMaxPool2dOp : Torch_Op<"aten.max_pool2d", [
 
 def Torch_AtenSoftmaxIntOp : Torch_Op<"aten.softmax.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::softmax.int : (Tensor, int, int?) -> (Tensor)`";
   let arguments = (ins
@@ -1863,7 +1932,8 @@ def Torch_AtenSoftmaxIntOp : Torch_Op<"aten.softmax.int", [
 
 def Torch_AtenLogSoftmaxIntOp : Torch_Op<"aten.log_softmax.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::log_softmax.int : (Tensor, int, int?) -> (Tensor)`";
   let arguments = (ins
@@ -1879,7 +1949,8 @@ def Torch_AtenLogSoftmaxIntOp : Torch_Op<"aten.log_softmax.int", [
 
 def Torch_Aten_LogSoftmaxOp : Torch_Op<"aten._log_softmax", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::_log_softmax : (Tensor, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -1895,7 +1966,8 @@ def Torch_Aten_LogSoftmaxOp : Torch_Op<"aten._log_softmax", [
 
 def Torch_AtenAdaptiveAvgPool2dOp : Torch_Op<"aten.adaptive_avg_pool2d", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::adaptive_avg_pool2d : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -1910,7 +1982,8 @@ def Torch_AtenAdaptiveAvgPool2dOp : Torch_Op<"aten.adaptive_avg_pool2d", [
 
 def Torch_AtenTopkOp : Torch_Op<"aten.topk", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::topk : (Tensor, int, int, bool, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -1928,7 +2001,8 @@ def Torch_AtenTopkOp : Torch_Op<"aten.topk", [
 }
 
 def Torch_AtenTransposeIntOp : Torch_Op<"aten.transpose.int", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::transpose.int : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -1943,7 +2017,8 @@ def Torch_AtenTransposeIntOp : Torch_Op<"aten.transpose.int", [
 }
 
 def Torch_AtenPermuteOp : Torch_Op<"aten.permute", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::permute : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -1958,7 +2033,8 @@ def Torch_AtenPermuteOp : Torch_Op<"aten.permute", [
 
 def Torch_AtenBmmOp : Torch_Op<"aten.bmm", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::bmm : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1973,7 +2049,8 @@ def Torch_AtenBmmOp : Torch_Op<"aten.bmm", [
 
 def Torch_AtenCumsumOp : Torch_Op<"aten.cumsum", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::cumsum : (Tensor, int, int?) -> (Tensor)`";
   let arguments = (ins
@@ -1989,7 +2066,8 @@ def Torch_AtenCumsumOp : Torch_Op<"aten.cumsum", [
 
 def Torch_AtenFloorDivideScalarOp : Torch_Op<"aten.floor_divide.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::floor_divide.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -2004,7 +2082,8 @@ def Torch_AtenFloorDivideScalarOp : Torch_Op<"aten.floor_divide.Scalar", [
 
 def Torch_AtenLogsumexpOp : Torch_Op<"aten.logsumexp", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::logsumexp : (Tensor, int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -2020,7 +2099,8 @@ def Torch_AtenLogsumexpOp : Torch_Op<"aten.logsumexp", [
 
 def Torch_AtenMeanDimOp : Torch_Op<"aten.mean.dim", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::mean.dim : (Tensor, int[], bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2037,7 +2117,8 @@ def Torch_AtenMeanDimOp : Torch_Op<"aten.mean.dim", [
 
 def Torch_Aten__And__TensorOp : Torch_Op<"aten.__and__.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::__and__.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2052,7 +2133,8 @@ def Torch_Aten__And__TensorOp : Torch_Op<"aten.__and__.Tensor", [
 
 def Torch_AtenSqrtOp : Torch_Op<"aten.sqrt", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::sqrt : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2066,7 +2148,8 @@ def Torch_AtenSqrtOp : Torch_Op<"aten.sqrt", [
 
 def Torch_Aten_SoftmaxOp : Torch_Op<"aten._softmax", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::_softmax : (Tensor, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2082,7 +2165,8 @@ def Torch_Aten_SoftmaxOp : Torch_Op<"aten._softmax", [
 
 def Torch_AtenMeanOp : Torch_Op<"aten.mean", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::mean : (Tensor, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2097,7 +2181,8 @@ def Torch_AtenMeanOp : Torch_Op<"aten.mean", [
 
 def Torch_AtenStdOp : Torch_Op<"aten.std", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::std : (Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2112,7 +2197,8 @@ def Torch_AtenStdOp : Torch_Op<"aten.std", [
 
 def Torch_AtenVarOp : Torch_Op<"aten.var", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::var : (Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2127,7 +2213,8 @@ def Torch_AtenVarOp : Torch_Op<"aten.var", [
 
 def Torch_AtenNllLossForwardOp : Torch_Op<"aten.nll_loss_forward", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::nll_loss_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -2146,7 +2233,8 @@ def Torch_AtenNllLossForwardOp : Torch_Op<"aten.nll_loss_forward", [
 
 def Torch_AtenNllLossBackwardOp : Torch_Op<"aten.nll_loss_backward", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::nll_loss_backward : (Tensor, Tensor, Tensor, Tensor?, int, int, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2166,7 +2254,8 @@ def Torch_AtenNllLossBackwardOp : Torch_Op<"aten.nll_loss_backward", [
 
 def Torch_AtenBincountOp : Torch_Op<"aten.bincount", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::bincount : (Tensor, Tensor?, int) -> (Tensor)`";
   let arguments = (ins
@@ -2182,7 +2271,8 @@ def Torch_AtenBincountOp : Torch_Op<"aten.bincount", [
 
 def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -2197,7 +2287,8 @@ def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
 }
 
 def Torch_AtenSqueezeDimOp : Torch_Op<"aten.squeeze.dim", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::squeeze.dim : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -2212,7 +2303,8 @@ def Torch_AtenSqueezeDimOp : Torch_Op<"aten.squeeze.dim", [
 }
 
 def Torch_AtenUnsqueezeOp : Torch_Op<"aten.unsqueeze", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::unsqueeze : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -2226,7 +2318,8 @@ def Torch_AtenUnsqueezeOp : Torch_Op<"aten.unsqueeze", [
 }
 
 def Torch_AtenSqueezeOp : Torch_Op<"aten.squeeze", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::squeeze : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2240,7 +2333,8 @@ def Torch_AtenSqueezeOp : Torch_Op<"aten.squeeze", [
 }
 
 def Torch_AtenFlattenUsingIntsOp : Torch_Op<"aten.flatten.using_ints", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::flatten.using_ints : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -2256,7 +2350,8 @@ def Torch_AtenFlattenUsingIntsOp : Torch_Op<"aten.flatten.using_ints", [
 
 def Torch_AtenDimOp : Torch_Op<"aten.dim", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::dim : (Tensor) -> (int)`";
   let arguments = (ins
@@ -2271,7 +2366,8 @@ def Torch_AtenDimOp : Torch_Op<"aten.dim", [
 
 def Torch_AtenSizeOp : Torch_Op<"aten.size", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::size : (Tensor) -> (int[])`";
   let arguments = (ins
@@ -2286,7 +2382,8 @@ def Torch_AtenSizeOp : Torch_Op<"aten.size", [
 
 def Torch_AtenBoolTensorOp : Torch_Op<"aten.Bool.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::Bool.Tensor : (Tensor) -> (bool)`";
   let arguments = (ins
@@ -2300,7 +2397,8 @@ def Torch_AtenBoolTensorOp : Torch_Op<"aten.Bool.Tensor", [
 
 def Torch_AtenOnesOp : Torch_Op<"aten.ones", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::ones : (int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -2318,7 +2416,8 @@ def Torch_AtenOnesOp : Torch_Op<"aten.ones", [
 
 def Torch_AtenNewOnesOp : Torch_Op<"aten.new_ones", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::new_ones : (Tensor, int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -2337,7 +2436,8 @@ def Torch_AtenNewOnesOp : Torch_Op<"aten.new_ones", [
 
 def Torch_AtenZerosOp : Torch_Op<"aten.zeros", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::zeros : (int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -2355,7 +2455,8 @@ def Torch_AtenZerosOp : Torch_Op<"aten.zeros", [
 
 def Torch_AtenNewZerosOp : Torch_Op<"aten.new_zeros", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::new_zeros : (Tensor, int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -2374,7 +2475,8 @@ def Torch_AtenNewZerosOp : Torch_Op<"aten.new_zeros", [
 
 def Torch_AtenTensorOp : Torch_Op<"aten.tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::tensor : (t[], int?, Device?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2391,7 +2493,8 @@ def Torch_AtenTensorOp : Torch_Op<"aten.tensor", [
 
 def Torch_AtenTensorBoolOp : Torch_Op<"aten.tensor.bool", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::tensor.bool : (bool, int?, Device?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2408,7 +2511,8 @@ def Torch_AtenTensorBoolOp : Torch_Op<"aten.tensor.bool", [
 
 def Torch_AtenTensorIntOp : Torch_Op<"aten.tensor.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::tensor.int : (int, int?, Device?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2425,7 +2529,8 @@ def Torch_AtenTensorIntOp : Torch_Op<"aten.tensor.int", [
 
 def Torch_Aten_ShapeAsTensorOp : Torch_Op<"aten._shape_as_tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::_shape_as_tensor : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2439,7 +2544,8 @@ def Torch_Aten_ShapeAsTensorOp : Torch_Op<"aten._shape_as_tensor", [
 
 def Torch_AtenAllOp : Torch_Op<"aten.all", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::all : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2453,7 +2559,8 @@ def Torch_AtenAllOp : Torch_Op<"aten.all", [
 
 def Torch_AtenAnyOp : Torch_Op<"aten.any", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::any : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2467,7 +2574,8 @@ def Torch_AtenAnyOp : Torch_Op<"aten.any", [
 
 def Torch_AtenAnyDimOp : Torch_Op<"aten.any.dim", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::any.dim : (Tensor, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2483,7 +2591,8 @@ def Torch_AtenAnyDimOp : Torch_Op<"aten.any.dim", [
 
 def Torch_AtenArangeOp : Torch_Op<"aten.arange", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::arange : (Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -2501,7 +2610,8 @@ def Torch_AtenArangeOp : Torch_Op<"aten.arange", [
 
 def Torch_AtenArangeStartOp : Torch_Op<"aten.arange.start", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::arange.start : (Scalar, Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -2520,7 +2630,8 @@ def Torch_AtenArangeStartOp : Torch_Op<"aten.arange.start", [
 
 def Torch_AtenArangeStartStepOp : Torch_Op<"aten.arange.start_step", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::arange.start_step : (Scalar, Scalar, Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -2540,7 +2651,8 @@ def Torch_AtenArangeStartStepOp : Torch_Op<"aten.arange.start_step", [
 
 def Torch_AtenArgmaxOp : Torch_Op<"aten.argmax", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::argmax : (Tensor, int?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2556,7 +2668,8 @@ def Torch_AtenArgmaxOp : Torch_Op<"aten.argmax", [
 
 def Torch_AtenBucketizeTensorOp : Torch_Op<"aten.bucketize.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::bucketize.Tensor : (Tensor, Tensor, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2573,7 +2686,8 @@ def Torch_AtenBucketizeTensorOp : Torch_Op<"aten.bucketize.Tensor", [
 
 def Torch_AtenCloneOp : Torch_Op<"aten.clone", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::clone : (Tensor, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2587,7 +2701,8 @@ def Torch_AtenCloneOp : Torch_Op<"aten.clone", [
 }
 
 def Torch_AtenContiguousOp : Torch_Op<"aten.contiguous", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::contiguous : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -2616,7 +2731,8 @@ def Torch_AtenCopy_Op : Torch_Op<"aten.copy_", [
 }
 
 def Torch_AtenDetachOp : Torch_Op<"aten.detach", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::detach : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2630,7 +2746,8 @@ def Torch_AtenDetachOp : Torch_Op<"aten.detach", [
 
 def Torch_AtenEmbeddingOp : Torch_Op<"aten.embedding", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::embedding : (Tensor, Tensor, int, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -2648,7 +2765,8 @@ def Torch_AtenEmbeddingOp : Torch_Op<"aten.embedding", [
 
 def Torch_AtenEmptyLikeOp : Torch_Op<"aten.empty_like", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::empty_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2667,7 +2785,8 @@ def Torch_AtenEmptyLikeOp : Torch_Op<"aten.empty_like", [
 
 def Torch_AtenZerosLikeOp : Torch_Op<"aten.zeros_like", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::zeros_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2686,7 +2805,8 @@ def Torch_AtenZerosLikeOp : Torch_Op<"aten.zeros_like", [
 
 def Torch_AtenOnesLikeOp : Torch_Op<"aten.ones_like", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::ones_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2705,7 +2825,8 @@ def Torch_AtenOnesLikeOp : Torch_Op<"aten.ones_like", [
 
 def Torch_AtenEmptyMemoryFormatOp : Torch_Op<"aten.empty.memory_format", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::empty.memory_format : (int[], int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2723,7 +2844,8 @@ def Torch_AtenEmptyMemoryFormatOp : Torch_Op<"aten.empty.memory_format", [
 }
 
 def Torch_AtenExpandOp : Torch_Op<"aten.expand", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::expand : (Tensor, int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -2738,7 +2860,8 @@ def Torch_AtenExpandOp : Torch_Op<"aten.expand", [
 }
 
 def Torch_AtenBroadcastToOp : Torch_Op<"aten.broadcast_to", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::broadcast_to : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -2753,7 +2876,8 @@ def Torch_AtenBroadcastToOp : Torch_Op<"aten.broadcast_to", [
 
 def Torch_AtenIndexTensorOp : Torch_Op<"aten.index.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::index.Tensor : (Tensor, Tensor?[]) -> (Tensor)`";
   let arguments = (ins
@@ -2768,7 +2892,8 @@ def Torch_AtenIndexTensorOp : Torch_Op<"aten.index.Tensor", [
 
 def Torch_AtenIndexSelectOp : Torch_Op<"aten.index_select", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::index_select : (Tensor, int, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2784,7 +2909,8 @@ def Torch_AtenIndexSelectOp : Torch_Op<"aten.index_select", [
 
 def Torch_AtenItemOp : Torch_Op<"aten.item", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::item : (Tensor) -> (Scalar)`";
   let arguments = (ins
@@ -2798,7 +2924,8 @@ def Torch_AtenItemOp : Torch_Op<"aten.item", [
 
 def Torch_AtenMaskedSelectOp : Torch_Op<"aten.masked_select", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::masked_select : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2813,7 +2940,8 @@ def Torch_AtenMaskedSelectOp : Torch_Op<"aten.masked_select", [
 
 def Torch_AtenNumelOp : Torch_Op<"aten.numel", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::numel : (Tensor) -> (int)`";
   let arguments = (ins
@@ -2827,7 +2955,8 @@ def Torch_AtenNumelOp : Torch_Op<"aten.numel", [
 
 def Torch_AtenRepeatOp : Torch_Op<"aten.repeat", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::repeat : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -2841,7 +2970,8 @@ def Torch_AtenRepeatOp : Torch_Op<"aten.repeat", [
 }
 
 def Torch_AtenReshapeOp : Torch_Op<"aten.reshape", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::reshape : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -2870,7 +3000,8 @@ def Torch_AtenResize_Op : Torch_Op<"aten.resize_", [
 }
 
 def Torch_AtenSelectIntOp : Torch_Op<"aten.select.int", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::select.int : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -2886,7 +3017,8 @@ def Torch_AtenSelectIntOp : Torch_Op<"aten.select.int", [
 
 def Torch_AtenSizeIntOp : Torch_Op<"aten.size.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::size.int : (Tensor, int) -> (int)`";
   let arguments = (ins
@@ -2902,7 +3034,8 @@ def Torch_AtenSizeIntOp : Torch_Op<"aten.size.int", [
 
 def Torch_AtenStackOp : Torch_Op<"aten.stack", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::stack : (Tensor[], int) -> (Tensor)`";
   let arguments = (ins
@@ -2917,7 +3050,8 @@ def Torch_AtenStackOp : Torch_Op<"aten.stack", [
 
 def Torch_AtenSumOp : Torch_Op<"aten.sum", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::sum : (Tensor, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2932,7 +3066,8 @@ def Torch_AtenSumOp : Torch_Op<"aten.sum", [
 
 def Torch_AtenSumDimIntListOp : Torch_Op<"aten.sum.dim_IntList", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::sum.dim_IntList : (Tensor, int[], bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2949,7 +3084,8 @@ def Torch_AtenSumDimIntListOp : Torch_Op<"aten.sum.dim_IntList", [
 
 def Torch_AtenMaxOp : Torch_Op<"aten.max", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::max : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2963,7 +3099,8 @@ def Torch_AtenMaxOp : Torch_Op<"aten.max", [
 
 def Torch_AtenMaxDimOp : Torch_Op<"aten.max.dim", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::max.dim : (Tensor, int, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -2979,7 +3116,8 @@ def Torch_AtenMaxDimOp : Torch_Op<"aten.max.dim", [
 }
 
 def Torch_AtenToDtypeOp : Torch_Op<"aten.to.dtype", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::to.dtype : (Tensor, int, bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -2997,7 +3135,8 @@ def Torch_AtenToDtypeOp : Torch_Op<"aten.to.dtype", [
 }
 
 def Torch_AtenToOtherOp : Torch_Op<"aten.to.other", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::to.other : (Tensor, Tensor, bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -3014,7 +3153,8 @@ def Torch_AtenToOtherOp : Torch_Op<"aten.to.other", [
 }
 
 def Torch_AtenToPrimDeviceOp : Torch_Op<"aten.to.prim_Device", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::to.prim_Device : (Tensor, Device?, int?, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -3032,7 +3172,8 @@ def Torch_AtenToPrimDeviceOp : Torch_Op<"aten.to.prim_Device", [
 
 def Torch_AtenTypeAsOp : Torch_Op<"aten.type_as", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::type_as : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3046,7 +3187,8 @@ def Torch_AtenTypeAsOp : Torch_Op<"aten.type_as", [
 }
 
 def Torch_AtenViewOp : Torch_Op<"aten.view", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::view : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -3062,7 +3204,8 @@ def Torch_AtenViewOp : Torch_Op<"aten.view", [
 
 def Torch_Aten_UnsafeViewOp : Torch_Op<"aten._unsafe_view", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::_unsafe_view : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -3077,7 +3220,8 @@ def Torch_Aten_UnsafeViewOp : Torch_Op<"aten._unsafe_view", [
 
 def Torch_AtenWhereSelfOp : Torch_Op<"aten.where.self", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::where.self : (Tensor, Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3092,7 +3236,8 @@ def Torch_AtenWhereSelfOp : Torch_Op<"aten.where.self", [
 }
 
 def Torch_AtenSliceTensorOp : Torch_Op<"aten.slice.Tensor", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::slice.Tensor : (Tensor, int, int?, int?, int) -> (Tensor)`";
   let arguments = (ins
@@ -3110,7 +3255,8 @@ def Torch_AtenSliceTensorOp : Torch_Op<"aten.slice.Tensor", [
 
 def Torch_AtenLenTensorOp : Torch_Op<"aten.len.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::len.Tensor : (Tensor) -> (int)`";
   let arguments = (ins
@@ -3123,7 +3269,8 @@ def Torch_AtenLenTensorOp : Torch_Op<"aten.len.Tensor", [
 }
 
 def Torch_AtenCpuOp : Torch_Op<"aten.cpu", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::cpu : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3137,7 +3284,8 @@ def Torch_AtenCpuOp : Torch_Op<"aten.cpu", [
 
 def Torch_AtenGatherOp : Torch_Op<"aten.gather", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::gather : (Tensor, int, Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -3154,7 +3302,8 @@ def Torch_AtenGatherOp : Torch_Op<"aten.gather", [
 
 def Torch_AtenIntImplicitOp : Torch_Op<"aten.IntImplicit", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::IntImplicit : (Tensor) -> (int)`";
   let arguments = (ins
@@ -3168,7 +3317,8 @@ def Torch_AtenIntImplicitOp : Torch_Op<"aten.IntImplicit", [
 
 def Torch_AtenTensorFloatOp : Torch_Op<"aten.tensor.float", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::tensor.float : (float, int?, Device?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -3185,7 +3335,8 @@ def Torch_AtenTensorFloatOp : Torch_Op<"aten.tensor.float", [
 
 def Torch_AtenIntTensorOp : Torch_Op<"aten.Int.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::Int.Tensor : (Tensor) -> (int)`";
   let arguments = (ins
@@ -3200,7 +3351,8 @@ def Torch_AtenIntTensorOp : Torch_Op<"aten.Int.Tensor", [
 
 def Torch_AtenFloatTensorOp : Torch_Op<"aten.Float.Tensor", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::Float.Tensor : (Tensor) -> (float)`";
   let arguments = (ins
@@ -3215,7 +3367,8 @@ def Torch_AtenFloatTensorOp : Torch_Op<"aten.Float.Tensor", [
 
 def Torch_AtenDropoutOp : Torch_Op<"aten.dropout", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::dropout : (Tensor, float, bool) -> (Tensor)`";
   let arguments = (ins
@@ -3230,7 +3383,8 @@ def Torch_AtenDropoutOp : Torch_Op<"aten.dropout", [
 }
 
 def Torch_AtenTOp : Torch_Op<"aten.t", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::t : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3244,7 +3398,8 @@ def Torch_AtenTOp : Torch_Op<"aten.t", [
 
 def Torch_AtenFullOp : Torch_Op<"aten.full", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::full : (int[], Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -3263,7 +3418,8 @@ def Torch_AtenFullOp : Torch_Op<"aten.full", [
 
 def Torch_AtenFullLikeOp : Torch_Op<"aten.full_like", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::full_like : (Tensor, Scalar, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -3283,7 +3439,8 @@ def Torch_AtenFullLikeOp : Torch_Op<"aten.full_like", [
 
 def Torch_Aten__Contains__StrOp : Torch_Op<"aten.__contains__.str", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::__contains__.str : (Dict(str, t), str) -> (bool)`";
   let arguments = (ins
@@ -3298,7 +3455,8 @@ def Torch_Aten__Contains__StrOp : Torch_Op<"aten.__contains__.str", [
 }
 
 def Torch_Aten__Getitem__DictStrOp : Torch_Op<"aten.__getitem__.Dict_str", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::__getitem__.Dict_str : (Dict(str, t), str) -> (t)`";
   let arguments = (ins
@@ -3327,7 +3485,8 @@ def Torch_Aten_SetItemStrOp : Torch_Op<"aten._set_item.str", [
 }
 
 def Torch_AtenKeysStrOp : Torch_Op<"aten.keys.str", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::keys.str : (Dict(str, t)) -> (str[])`";
   let arguments = (ins
@@ -3340,7 +3499,8 @@ def Torch_AtenKeysStrOp : Torch_Op<"aten.keys.str", [
 }
 
 def Torch_AtenGetDefaultStrOp : Torch_Op<"aten.get.default_str", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::get.default_str : (Dict(str, t), str, t) -> (t)`";
   let arguments = (ins
@@ -3369,7 +3529,8 @@ def Torch_AtenDeleteDictStrOp : Torch_Op<"aten.Delete.Dict_str", [
 
 def Torch_AtenCatOp : Torch_Op<"aten.cat", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::cat : (Tensor[], int) -> (Tensor)`";
   let arguments = (ins
@@ -3398,7 +3559,8 @@ def Torch_AtenAppendTOp : Torch_Op<"aten.append.t", [
 
 def Torch_AtenAddTOp : Torch_Op<"aten.add.t", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::add.t : (t[], t[]) -> (t[])`";
   let arguments = (ins
@@ -3413,7 +3575,8 @@ def Torch_AtenAddTOp : Torch_Op<"aten.add.t", [
 
 def Torch_AtenEqIntListOp : Torch_Op<"aten.eq.int_list", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::eq.int_list : (int[], int[]) -> (bool)`";
   let arguments = (ins
@@ -3424,11 +3587,13 @@ def Torch_AtenEqIntListOp : Torch_Op<"aten.eq.int_list", [
     Torch_BoolType:$result
   );
   let assemblyFormat = "$a `,` $b attr-dict `:` qualified(type($a)) `,` qualified(type($b)) `->` qualified(type($result))";
+  let hasFolder = 1;
 }
 
 def Torch_AtenListTOp : Torch_Op<"aten.list.t", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::list.t : (t[]) -> (t[])`";
   let arguments = (ins
@@ -3442,7 +3607,8 @@ def Torch_AtenListTOp : Torch_Op<"aten.list.t", [
 
 def Torch_AtenSliceTOp : Torch_Op<"aten.slice.t", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::slice.t : (t[], int?, int?, int) -> (t[])`";
   let arguments = (ins
@@ -3457,9 +3623,40 @@ def Torch_AtenSliceTOp : Torch_Op<"aten.slice.t", [
   let assemblyFormat = "$l `,` $start `,` $end `,` $step attr-dict `:` qualified(type($l)) `,` qualified(type($start)) `,` qualified(type($end)) `,` qualified(type($step)) `->` qualified(type($result))";
 }
 
+def Torch_AtenInsertTOp : Torch_Op<"aten.insert.t", [
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::insert.t : (t[], int, t) -> ()`";
+  let arguments = (ins
+    AnyTorchListType:$self,
+    Torch_IntType:$idx,
+    AnyTorchType:$el
+  );
+  let results = (outs
+  );
+  let assemblyFormat = "$self `,` $idx `,` $el attr-dict `:` qualified(type($self)) `,` qualified(type($idx)) `,` qualified(type($el))";
+}
+
+def Torch_AtenNeIntListOp : Torch_Op<"aten.ne.int_list", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::ne.int_list : (int[], int[]) -> (bool)`";
+  let arguments = (ins
+    TorchIntListType:$a,
+    TorchIntListType:$b
+  );
+  let results = (outs
+    Torch_BoolType:$result
+  );
+  let assemblyFormat = "$a `,` $b attr-dict `:` qualified(type($a)) `,` qualified(type($b)) `->` qualified(type($result))";
+}
+
 def Torch_AtenAddStrOp : Torch_Op<"aten.add.str", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::add.str : (str, str) -> (str)`";
   let arguments = (ins
@@ -3474,7 +3671,8 @@ def Torch_AtenAddStrOp : Torch_Op<"aten.add.str", [
 
 def Torch_AtenEqStrOp : Torch_Op<"aten.eq.str", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::eq.str : (str, str) -> (bool)`";
   let arguments = (ins
@@ -3490,7 +3688,8 @@ def Torch_AtenEqStrOp : Torch_Op<"aten.eq.str", [
 
 def Torch_AtenStrOp : Torch_Op<"aten.str", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::str : (t) -> (str)`";
   let arguments = (ins
@@ -3503,7 +3702,8 @@ def Torch_AtenStrOp : Torch_Op<"aten.str", [
 }
 
 def Torch_AtenFormatOp : Torch_Op<"aten.format", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::format : (...) -> (str)`";
   let arguments = (ins
@@ -3517,7 +3717,8 @@ def Torch_AtenFormatOp : Torch_Op<"aten.format", [
 
 def Torch_AtenJoinOp : Torch_Op<"aten.join", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::join : (str, str[]) -> (str)`";
   let arguments = (ins
@@ -3532,7 +3733,8 @@ def Torch_AtenJoinOp : Torch_Op<"aten.join", [
 
 def Torch_AtenFloatScalarOp : Torch_Op<"aten.Float.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::Float.Scalar : (Scalar) -> (float)`";
   let arguments = (ins
@@ -3542,11 +3744,13 @@ def Torch_AtenFloatScalarOp : Torch_Op<"aten.Float.Scalar", [
     Torch_FloatType:$result
   );
   let assemblyFormat = "$a attr-dict `:` qualified(type($a)) `->` qualified(type($result))";
+  let hasFolder = 1;
 }
 
 def Torch_AtenFloatStrOp : Torch_Op<"aten.Float.str", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::Float.str : (str) -> (float)`";
   let arguments = (ins
@@ -3560,7 +3764,8 @@ def Torch_AtenFloatStrOp : Torch_Op<"aten.Float.str", [
 
 def Torch_AtenIntFloatOp : Torch_Op<"aten.Int.float", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::Int.float : (float) -> (int)`";
   let arguments = (ins
@@ -3572,9 +3777,46 @@ def Torch_AtenIntFloatOp : Torch_Op<"aten.Int.float", [
   let assemblyFormat = "$a attr-dict `:` qualified(type($a)) `->` qualified(type($result))";
 }
 
+def Torch_Aten__RangeLengthOp : Torch_Op<"aten.__range_length", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::__range_length : (int, int, int) -> (int)`";
+  let arguments = (ins
+    Torch_IntType:$lo,
+    Torch_IntType:$hi,
+    Torch_IntType:$step
+  );
+  let results = (outs
+    Torch_IntType:$result
+  );
+  let assemblyFormat = "$lo `,` $hi `,` $step attr-dict `:` qualified(type($lo)) `,` qualified(type($hi)) `,` qualified(type($step)) `->` qualified(type($result))";
+  let hasFolder = 1;
+}
+
+def Torch_Aten__DeriveIndexOp : Torch_Op<"aten.__derive_index", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::__derive_index : (int, int, int) -> (int)`";
+  let arguments = (ins
+    Torch_IntType:$index,
+    Torch_IntType:$start,
+    Torch_IntType:$step
+  );
+  let results = (outs
+    Torch_IntType:$result
+  );
+  let assemblyFormat = "$index `,` $start `,` $step attr-dict `:` qualified(type($index)) `,` qualified(type($start)) `,` qualified(type($step)) `->` qualified(type($result))";
+  let hasFolder = 1;
+}
+
 def Torch_AtenGtIntOp : Torch_Op<"aten.gt.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::gt.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -3590,7 +3832,8 @@ def Torch_AtenGtIntOp : Torch_Op<"aten.gt.int", [
 
 def Torch_AtenGeIntOp : Torch_Op<"aten.ge.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::ge.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -3606,7 +3849,8 @@ def Torch_AtenGeIntOp : Torch_Op<"aten.ge.int", [
 
 def Torch_AtenLtIntOp : Torch_Op<"aten.lt.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::lt.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -3622,7 +3866,8 @@ def Torch_AtenLtIntOp : Torch_Op<"aten.lt.int", [
 
 def Torch_AtenLeIntOp : Torch_Op<"aten.le.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::le.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -3638,7 +3883,8 @@ def Torch_AtenLeIntOp : Torch_Op<"aten.le.int", [
 
 def Torch_AtenNeIntOp : Torch_Op<"aten.ne.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::ne.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -3654,7 +3900,8 @@ def Torch_AtenNeIntOp : Torch_Op<"aten.ne.int", [
 
 def Torch_AtenEqIntOp : Torch_Op<"aten.eq.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::eq.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -3670,7 +3917,8 @@ def Torch_AtenEqIntOp : Torch_Op<"aten.eq.int", [
 
 def Torch_AtenFloordivIntOp : Torch_Op<"aten.floordiv.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::floordiv.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -3686,7 +3934,8 @@ def Torch_AtenFloordivIntOp : Torch_Op<"aten.floordiv.int", [
 
 def Torch_AtenRemainderIntOp : Torch_Op<"aten.remainder.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::remainder.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -3702,7 +3951,8 @@ def Torch_AtenRemainderIntOp : Torch_Op<"aten.remainder.int", [
 
 def Torch_AtenAddIntOp : Torch_Op<"aten.add.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::add.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -3718,7 +3968,8 @@ def Torch_AtenAddIntOp : Torch_Op<"aten.add.int", [
 
 def Torch_AtenSubIntOp : Torch_Op<"aten.sub.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::sub.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -3734,7 +3985,8 @@ def Torch_AtenSubIntOp : Torch_Op<"aten.sub.int", [
 
 def Torch_AtenMulIntOp : Torch_Op<"aten.mul.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::mul.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -3750,7 +4002,8 @@ def Torch_AtenMulIntOp : Torch_Op<"aten.mul.int", [
 
 def Torch_AtenNegIntOp : Torch_Op<"aten.neg.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::neg.int : (int) -> (int)`";
   let arguments = (ins
@@ -3765,7 +4018,8 @@ def Torch_AtenNegIntOp : Torch_Op<"aten.neg.int", [
 
 def Torch_AtenLogIntOp : Torch_Op<"aten.log.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::log.int : (int) -> (float)`";
   let arguments = (ins
@@ -3779,7 +4033,8 @@ def Torch_AtenLogIntOp : Torch_Op<"aten.log.int", [
 
 def Torch_AtenAddFloatIntOp : Torch_Op<"aten.add.float_int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::add.float_int : (float, int) -> (float)`";
   let arguments = (ins
@@ -3794,7 +4049,8 @@ def Torch_AtenAddFloatIntOp : Torch_Op<"aten.add.float_int", [
 
 def Torch_AtenMulFloatOp : Torch_Op<"aten.mul.float", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::mul.float : (float, float) -> (float)`";
   let arguments = (ins
@@ -3809,7 +4065,8 @@ def Torch_AtenMulFloatOp : Torch_Op<"aten.mul.float", [
 
 def Torch_AtenNegFloatOp : Torch_Op<"aten.neg.float", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::neg.float : (float) -> (float)`";
   let arguments = (ins
@@ -3823,7 +4080,8 @@ def Torch_AtenNegFloatOp : Torch_Op<"aten.neg.float", [
 
 def Torch_AtenEqFloatOp : Torch_Op<"aten.eq.float", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::eq.float : (float, float) -> (bool)`";
   let arguments = (ins
@@ -3839,7 +4097,8 @@ def Torch_AtenEqFloatOp : Torch_Op<"aten.eq.float", [
 
 def Torch_AtenGtFloatOp : Torch_Op<"aten.gt.float", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::gt.float : (float, float) -> (bool)`";
   let arguments = (ins
@@ -3855,7 +4114,8 @@ def Torch_AtenGtFloatOp : Torch_Op<"aten.gt.float", [
 
 def Torch_AtenLtFloatOp : Torch_Op<"aten.lt.float", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::lt.float : (float, float) -> (bool)`";
   let arguments = (ins
@@ -3871,7 +4131,8 @@ def Torch_AtenLtFloatOp : Torch_Op<"aten.lt.float", [
 
 def Torch_AtenLtFloatIntOp : Torch_Op<"aten.lt.float_int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::lt.float_int : (float, int) -> (bool)`";
   let arguments = (ins
@@ -3886,7 +4147,8 @@ def Torch_AtenLtFloatIntOp : Torch_Op<"aten.lt.float_int", [
 
 def Torch_Aten__And__BoolOp : Torch_Op<"aten.__and__.bool", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::__and__.bool : (bool, bool) -> (bool)`";
   let arguments = (ins
@@ -3901,7 +4163,8 @@ def Torch_Aten__And__BoolOp : Torch_Op<"aten.__and__.bool", [
 
 def Torch_AtenNeBoolOp : Torch_Op<"aten.ne.bool", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::ne.bool : (bool, bool) -> (bool)`";
   let arguments = (ins
@@ -3917,7 +4180,8 @@ def Torch_AtenNeBoolOp : Torch_Op<"aten.ne.bool", [
 
 def Torch_Aten__Is__Op : Torch_Op<"aten.__is__", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::__is__ : (t1, t2) -> (bool)`";
   let arguments = (ins
@@ -3933,7 +4197,8 @@ def Torch_Aten__Is__Op : Torch_Op<"aten.__is__", [
 
 def Torch_Aten__Isnot__Op : Torch_Op<"aten.__isnot__", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::__isnot__ : (t1, t2) -> (bool)`";
   let arguments = (ins
@@ -3949,7 +4214,8 @@ def Torch_Aten__Isnot__Op : Torch_Op<"aten.__isnot__", [
 
 def Torch_Aten__Not__Op : Torch_Op<"aten.__not__", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::__not__ : (bool) -> (bool)`";
   let arguments = (ins
@@ -3964,7 +4230,8 @@ def Torch_Aten__Not__Op : Torch_Op<"aten.__not__", [
 
 def Torch_AtenLenTOp : Torch_Op<"aten.len.t", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::len.t : (t[]) -> (int)`";
   let arguments = (ins
@@ -3979,7 +4246,8 @@ def Torch_AtenLenTOp : Torch_Op<"aten.len.t", [
 }
 
 def Torch_Aten__Getitem__TOp : Torch_Op<"aten.__getitem__.t", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::__getitem__.t : (t[], int) -> (t)`";
   let arguments = (ins
@@ -4010,7 +4278,8 @@ def Torch_Aten_SetItemTOp : Torch_Op<"aten._set_item.t", [
 
 def Torch_AtenDivOp : Torch_Op<"aten.div", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::div : (Scalar, Scalar) -> (float)`";
   let arguments = (ins
@@ -4025,7 +4294,8 @@ def Torch_AtenDivOp : Torch_Op<"aten.div", [
 
 def Torch_AtenEqDeviceOp : Torch_Op<"aten.eq.device", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::eq.device : (Device, Device) -> (bool)`";
   let arguments = (ins
@@ -4040,7 +4310,8 @@ def Torch_AtenEqDeviceOp : Torch_Op<"aten.eq.device", [
 
 def Torch_Aten_SoftmaxBackwardDataOp : Torch_Op<"aten._softmax_backward_data", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -4057,7 +4328,8 @@ def Torch_Aten_SoftmaxBackwardDataOp : Torch_Op<"aten._softmax_backward_data", [
 
 def Torch_AtenTanhBackwardOp : Torch_Op<"aten.tanh_backward", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::tanh_backward : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4072,7 +4344,8 @@ def Torch_AtenTanhBackwardOp : Torch_Op<"aten.tanh_backward", [
 
 def Torch_AtenGeluBackwardOp : Torch_Op<"aten.gelu_backward", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::gelu_backward : (Tensor, Tensor, str) -> (Tensor)`";
   let arguments = (ins
@@ -4088,7 +4361,8 @@ def Torch_AtenGeluBackwardOp : Torch_Op<"aten.gelu_backward", [
 
 def Torch_Aten_LogSoftmaxBackwardDataOp : Torch_Op<"aten._log_softmax_backward_data", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::_log_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)`";
   let arguments = (ins

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedPrimOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedPrimOps.td
@@ -18,7 +18,8 @@
 
 def Torch_PrimLayoutOp : Torch_Op<"prim.layout", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::layout : (Tensor) -> (int)`";
   let arguments = (ins
@@ -32,7 +33,8 @@ def Torch_PrimLayoutOp : Torch_Op<"prim.layout", [
 
 def Torch_PrimTupleIndexOp : Torch_Op<"prim.TupleIndex", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::TupleIndex : (Any, int) -> (Any)`";
   let arguments = (ins
@@ -48,7 +50,8 @@ def Torch_PrimTupleIndexOp : Torch_Op<"prim.TupleIndex", [
 
 def Torch_PrimDeviceOp : Torch_Op<"prim.device", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::device : (Tensor) -> (Device)`";
   let arguments = (ins
@@ -62,7 +65,8 @@ def Torch_PrimDeviceOp : Torch_Op<"prim.device", [
 
 def Torch_PrimDtypeOp : Torch_Op<"prim.dtype", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::dtype : (Tensor) -> (int)`";
   let arguments = (ins
@@ -76,7 +80,8 @@ def Torch_PrimDtypeOp : Torch_Op<"prim.dtype", [
 }
 
 def Torch_PrimTupleUnpackOp : Torch_Op<"prim.TupleUnpack", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::TupleUnpack : (Any) -> (...)`";
   let arguments = (ins
@@ -91,7 +96,8 @@ def Torch_PrimTupleUnpackOp : Torch_Op<"prim.TupleUnpack", [
 
 def Torch_PrimNumToTensorScalarOp : Torch_Op<"prim.NumToTensor.Scalar", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::NumToTensor.Scalar : (Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -105,7 +111,8 @@ def Torch_PrimNumToTensorScalarOp : Torch_Op<"prim.NumToTensor.Scalar", [
 
 def Torch_PrimMinSelfIntOp : Torch_Op<"prim.min.self_int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::min.self_int : (int[]) -> (int)`";
   let arguments = (ins
@@ -115,11 +122,13 @@ def Torch_PrimMinSelfIntOp : Torch_Op<"prim.min.self_int", [
     Torch_IntType:$result
   );
   let assemblyFormat = "$self attr-dict `:` qualified(type($self)) `->` qualified(type($result))";
+  let hasFolder = 1;
 }
 
 def Torch_PrimMinIntOp : Torch_Op<"prim.min.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::min.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -134,7 +143,8 @@ def Torch_PrimMinIntOp : Torch_Op<"prim.min.int", [
 
 def Torch_PrimMaxSelfIntOp : Torch_Op<"prim.max.self_int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::max.self_int : (int[]) -> (int)`";
   let arguments = (ins
@@ -148,7 +158,8 @@ def Torch_PrimMaxSelfIntOp : Torch_Op<"prim.max.self_int", [
 
 def Torch_PrimMaxIntOp : Torch_Op<"prim.max.int", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::max.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -159,11 +170,13 @@ def Torch_PrimMaxIntOp : Torch_Op<"prim.max.int", [
     Torch_IntType:$result
   );
   let assemblyFormat = "$a `,` $b attr-dict `:` qualified(type($a)) `,` qualified(type($b)) `->` qualified(type($result))";
+  let hasFolder = 1;
 }
 
 def Torch_PrimRaiseExceptionOp : Torch_Op<"prim.RaiseException", [
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::RaiseException : (str, str?) -> ()`";
   let arguments = (ins
@@ -178,7 +191,8 @@ def Torch_PrimRaiseExceptionOp : Torch_Op<"prim.RaiseException", [
 def Torch_PrimUninitializedOp : Torch_Op<"prim.Uninitialized", [
     NoSideEffect,
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::Uninitialized : () -> (Any)`";
   let arguments = (ins
@@ -187,11 +201,13 @@ def Torch_PrimUninitializedOp : Torch_Op<"prim.Uninitialized", [
     AnyTorchType:$result
   );
   let assemblyFormat = " attr-dict `:` qualified(type($result))";
+  let hasCanonicalizer = 1;
 }
 
 def Torch_PrimUncheckedCastOp : Torch_Op<"prim.unchecked_cast", [
     DeclareOpInterfaceMethods<CastOpInterface>,
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::unchecked_cast : (t) -> (t)`";
   let arguments = (ins
@@ -205,7 +221,8 @@ def Torch_PrimUncheckedCastOp : Torch_Op<"prim.unchecked_cast", [
 }
 
 def Torch_PrimPrintOp : Torch_Op<"prim.Print", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::Print : (...) -> ()`";
   let arguments = (ins
@@ -217,7 +234,8 @@ def Torch_PrimPrintOp : Torch_Op<"prim.Print", [
 }
 
 def Torch_PrimTolistOp : Torch_Op<"prim.tolist", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    ReadOnly
   ]> {
   let summary = "Generated op for `prim::tolist : (...) -> (...)`";
   let arguments = (ins

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedQuantizedOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedQuantizedOps.td
@@ -19,7 +19,8 @@
 def Torch_QuantizedLinearOp : Torch_Op<"quantized.linear", [
     HasValueSemantics,
     AllowsTypeRefinement,
-    HasValueSemantics
+    HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `quantized::linear : (Tensor, __torch__.torch.classes.quantized.LinearPackedParamsBase, float, int) -> (Tensor)`";
   let arguments = (ins

--- a/include/torch-mlir/Dialect/Torch/IR/TorchBase.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchBase.td
@@ -44,6 +44,7 @@ class TorchOpTrait<string name> : NativeOpTrait<""> {
 }
 
 def HasValueSemantics : TorchOpTrait<"HasValueSemantics">;
+def ReadOnly : TorchOpTrait<"ReadOnly">;
 def IsTrailingUnderscoreInplaceVariant
   : TorchOpTrait<"IsTrailingUnderscoreInplaceVariant">;
 def AllowsTypeRefinement : TorchOpTrait<"AllowsTypeRefinement">;

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
@@ -186,6 +186,16 @@ m_TorchTensorSizeInt(Value tensor, int64_t *dim) {
 /// 2. Performing the copy, which allows us to add/remove value semantics.
 Value copyTensorToType(OpBuilder &builder, Location loc, BaseTensorType newType,
                        Value tensor);
+
+/// Returns true if `list` is potentially mutated.
+bool isListPotentiallyMutated(Value list);
+
+/// Returns true if `op` might mutate any lists that it has as operands.
+///
+/// A return value of true does not guarantee that the operation mutates
+/// the list.
+bool potentiallyMutatesListOperands(Operation *op);
+
 } // namespace Torch
 } // namespace torch
 } // namespace mlir

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -394,6 +394,23 @@ def Torch_PrimDictConstructOp: Torch_Op<"prim.DictConstruct", [
   }];
 }
 
+def Torch_PrimCreateObjectOp: Torch_Op<"prim.CreateObject", [
+    NoSideEffect,
+    AllowsTypeRefinement,
+    ]> {
+  let summary = "TorchScript prim::CreateObject op";
+
+  let arguments = (ins
+  );
+  let results = (outs
+    Torch_NnModuleType:$result
+  );
+
+  let assemblyFormat = [{
+    attr-dict qualified(type($result))
+  }];
+}
+
 def Torch_PrimGetAttrOp : Torch_Op<"prim.GetAttr", []> {
   let summary = "TorchScript prim::GetAttr op";
 
@@ -458,6 +475,12 @@ def Torch_PrimLoopOp : Torch_Op<"prim.Loop", [
     attr-dict `:` functional-type(operands, results)
   }];
   let verifier = [{ return RegionBranchOpInterface::verifyTypes(*this); }];
+  let extraClassDeclaration = [{
+    /// Returns true if this loop is "for-like". Otherwise it is "while-like"
+    /// and this function returns false.
+    /// See https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/OVERVIEW.md#loops
+    bool isForLike();
+  }];
 }
 
 def Torch_PrimLoopConditionOp : Torch_Op<"prim.Loop.condition", [
@@ -512,6 +535,7 @@ def Torch_PrimIfOp : Torch_Op<"prim.If", [
 def Torch_PrimIfYieldOp : Torch_Op<"prim.If.yield", [
     Terminator,
     ReturnLike,
+    NoSideEffect,
     HasParent<"::mlir::torch::Torch::PrimIfOp">]> {
   let summary = "yield-like terminator for torch.prim.If";
   let description = [{
@@ -664,6 +688,8 @@ def Torch_DerefineOp : Torch_Op<"derefine", [
   let assemblyFormat = [{
     $operand attr-dict `:` qualified(type($operand)) `to` qualified(type($result))
   }];
+
+  let hasFolder = 1;
 }
 
 def Torch_OperatorOp : Torch_Op<"operator", [
@@ -921,6 +947,7 @@ def Torch_OverwriteTensorContentsOp : Torch_Op<"overwrite.tensor.contents", [
 def Torch_PseudoAtenUniformOp: Torch_Op<"pseudo.aten.uniform", [
     AllowsTypeRefinement,
     HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "`uniform op : (Tensor, float, float, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -940,6 +967,7 @@ def Torch_PseudoAtenUniformOp: Torch_Op<"pseudo.aten.uniform", [
 def Torch_PseudoAtenBernoulliFloatOp: Torch_Op<"pseudo.aten.bernoulli.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "`bernoulli.float op : (Tensor, float, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -958,6 +986,7 @@ def Torch_PseudoAtenBernoulliFloatOp: Torch_Op<"pseudo.aten.bernoulli.float", [
 def Torch_PseudoAtenBernoulliTensorOp: Torch_Op<"pseudo.aten.bernoulli.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Generated op for `aten::bernoulli_.Tensor : (Tensor, Tensor, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -976,6 +1005,7 @@ def Torch_PseudoAtenBernoulliTensorOp: Torch_Op<"pseudo.aten.bernoulli.Tensor", 
 def Torch_PseudoAtenFillScalarOp: Torch_Op<"pseudo.aten.fill.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "`fill.Scalar op : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1006,6 +1036,7 @@ def Torch_PseudoAtenFillScalarOp: Torch_Op<"pseudo.aten.fill.Scalar", [
 def Torch_RuntimeAssertOp: Torch_Op<"runtime.assert", [
     AllowsTypeRefinement,
     HasValueSemantics,
+    ReadOnly
   ]> {
   let summary = "Runtime Assertion";
   let arguments = (ins
@@ -1015,6 +1046,87 @@ def Torch_RuntimeAssertOp: Torch_Op<"runtime.assert", [
   let results = (outs
   );
   let assemblyFormat = "$condition `,` $message attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// Shape modeling ops.
+//===----------------------------------------------------------------------===//
+
+def Torch_ShapeCalculateOp : Torch_Op<"shape.calculate", [
+  DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
+  let summary = "Shape calculation encapsulation op";
+  let description = [{
+    The `torch.shape.calculate` op captures a shape calculation
+    (in the region `shapeCalculation`) which calculates the shapes for
+    the set of values yielded by the `body` region.
+
+    The `shapeCalculation` region yields a `!torch.list<!torch.int>` for each
+    value yielded by the `body` region.
+
+    Conceptually, the `shapeCalculation` region executes first, then `body`
+    region. So the `shapeCalculation` region can also contain arbitrary
+    assertions or side-effecting code which guard the validity of the execution
+    of the body (typically by terminating the program with a
+    torch.prim.RaiseException op).
+
+    The program has undefined behavior if the values yielded by the `body`
+    region do not have the shapes yielded by the `shapeCalculation` region.
+  }];
+
+  let arguments = (ins);
+  let results = (outs Variadic<AnyTorchType>:$results);
+  let regions = (region
+    SizedRegion<1>:$body,
+    SizedRegion<1>:$shapeCalculation
+  );
+
+  let assemblyFormat = [{
+    $body `shapes` $shapeCalculation attr-dict `:` type($results)
+  }];
+  let verifier = [{ return RegionBranchOpInterface::verifyTypes(*this); }];
+}
+
+def Torch_ShapeCalculateYieldOp : Torch_Op<"shape.calculate.yield", [
+    Terminator,
+    ReturnLike,
+    HasParent<"::mlir::torch::Torch::ShapeCalculateOp">]> {
+  let summary = "yield-like terminator for torch.shape.calculate";
+  let description = [{
+    This op terminates the `body` region of a `torch.shape.calculate` op.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyTorchType>:$results
+  );
+  let results = (outs);
+
+  let assemblyFormat = [{
+    attr-dict ($results^ `:` type($results))?
+  }];
+}
+
+def Torch_ShapeCalculateYieldShapesOp : Torch_Op<"shape.calculate.yield.shapes", [
+    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>,
+    Terminator,
+    HasValueSemantics,
+    ReadOnly,
+    HasParent<"::mlir::torch::Torch::ShapeCalculateOp">]> {
+  let summary = "yield-like terminator for torch.shape.calculate shape region";
+  let description = [{
+    This op terminates the `shapeCalculation` region of a
+    `torch.shape.calculate` op.
+  }];
+
+  let arguments = (ins
+    Variadic<TorchIntListType>:$results
+  );
+  let results = (outs);
+
+  let assemblyFormat = [{
+    attr-dict ($results^ `:` type($results))?
+  }];
+
+  let verifier = "return ::verify(*this);";
 }
 
 #endif // TORCH_OPS

--- a/include/torch-mlir/Dialect/Torch/IR/TorchTraits.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchTraits.h
@@ -23,11 +23,21 @@ namespace Torch {
 namespace OpTrait {
 
 // If a Torch op has this trait, it means that the op does not exploit the
-// mutability / aliasing properties of torch tensors. This enables a
-// transformation which locally replaces mutable arrays with immutable tensors.
+// mutability / aliasing properties of torch tensors, lists, or dictionaries.
+// This enables transformations to locally reason about immutability for those
+// types.
 template <typename ConcreteType>
 class HasValueSemantics
     : public ::mlir::OpTrait::TraitBase<ConcreteType, HasValueSemantics> {};
+
+// If a Torch op has this trait, it means that the op does not mutate any
+// operands.
+//
+// This is a weaker form of HasValueSemantics, since that trait also requires no
+// aliasing. That is, HasValueSemantics implies this trait.
+template <typename ConcreteType>
+class ReadOnly
+    : public ::mlir::OpTrait::TraitBase<ConcreteType, ReadOnly> {};
 
 // If a Torch op has this trait, it means that the op is a "trailing underscore"
 // op variant that performs an in-place operation on its first argument. These

--- a/include/torch-mlir/Dialect/Torch/IR/TorchTypes.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchTypes.h
@@ -87,6 +87,21 @@ public:
   /// value semantics.
   ValueTensorType getWithValueSemantics() const;
 };
+
+/// Return the tensor type which assumes the static information from both types.
+///
+/// For example, if `lhs = !torch.vtensor<[100],unk>` and
+/// `rhs = !torch.vtensor<*,f32>` then this function would return
+/// `!torch.vtensor<[100],f32>`.
+///
+/// Returns null if the types have conflicting static information.
+///
+/// This function requires both `lhs` and `rhs` to either both be
+/// ValueTensorType or both be NonValueTensorType, since the sense of
+/// "meet" between value tensors and non-value tensors is useful in different
+/// ways in different situations.
+Type meetTensorTypes(BaseTensorType lhs, BaseTensorType rhs);
+
 } // namespace Torch
 } // namespace torch
 } // namespace mlir

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
@@ -42,6 +42,10 @@ void createTorchScriptModuleToTorchBackendPipeline(
 void createTorchFunctionToTorchBackendPipeline(
     OpPassManager &pm, const TorchLoweringPipelineOptions &options);
 
+/// Creates a pipeline that refines shapes of tensor operations in the program.
+void createTorchShapeRefinementPipeline(
+    OpPassManager &pm, const TorchLoweringPipelineOptions &options);
+
 std::unique_ptr<OperationPass<ModuleOp>> createAdjustCallingConventionsPass();
 
 std::unique_ptr<OperationPass<FuncOp>> createRefineTypesPass();
@@ -55,6 +59,16 @@ std::unique_ptr<OperationPass<FuncOp>> createMaximizeValueSemanticsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createRefinePublicReturnPass();
 
 std::unique_ptr<OperationPass<FuncOp>> createDecomposeComplexOpsPass();
+
+std::unique_ptr<OperationPass<ModuleOp>> createPreprocessShapeLibraryPass();
+
+std::unique_ptr<OperationPass<ModuleOp>> createReifyShapeCalculationsPass();
+
+std::unique_ptr<OperationPass<FuncOp>> createSimplifyShapeCalculationsPass();
+
+std::unique_ptr<OperationPass<FuncOp>> createDropShapeCalculationsPass();
+
+StringRef getShapeLibrary();
 
 } // namespace Torch
 

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -231,4 +231,26 @@ def DecomposeComplexOps : Pass<"torch-decompose-complex-ops", "FuncOp"> {
   }];
 }
 
+def ReifyShapeCalculations : Pass<"torch-reify-shape-calculations", "ModuleOp"> {
+  let summary = "Decompose complicated torch operations";
+  let constructor = "mlir::torch::Torch::createReifyShapeCalculationsPass()";
+  let description = [{
+  }];
+}
+
+def SimplifyShapeCalculations : Pass<"torch-simplify-shape-calculations", "FuncOp"> {
+  let summary = "Simplify reified shape calculations.";
+  let constructor = "mlir::torch::Torch::createSimplifyShapeCalculationsPass()";
+  let description = [{
+    Mainly for getting rank specialization.
+  }];
+}
+
+def DropShapeCalculations : Pass<"torch-drop-shape-calculations", "FuncOp"> {
+  let summary = "Drop reified shape calculations.";
+  let constructor = "mlir::torch::Torch::createDropShapeCalculationsPass()";
+  let description = [{
+  }];
+}
+
 #endif // TORCHMLIR_TORCH_PASSES

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -15,6 +15,7 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Support/LLVM.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Casting.h"
 
@@ -61,6 +62,31 @@ Value mlir::torch::Torch::copyTensorToType(OpBuilder &builder, Location loc,
     tensor = builder.create<CopyToNonValueTensorOp>(loc, tensor);
 
   return tensor;
+}
+
+bool mlir::torch::Torch::isListPotentiallyMutated(Value list) {
+  assert(list.getType().isa<Torch::ListType>());
+  return llvm::any_of(list.getUsers(), potentiallyMutatesListOperands);
+}
+
+bool mlir::torch::Torch::potentiallyMutatesListOperands(Operation *op) {
+  // TODO: Find a better place to put this assertion.
+  assert((!op->hasTrait<Torch::OpTrait::HasValueSemantics>() ||
+          op->hasTrait<OpTrait::ReadOnly>()) &&
+         "HasValueSemantics should imply ReadOnly!");
+  // ReadOnly ops trivially do not mutate any list operands.
+  if (op->hasTrait<Torch::OpTrait::ReadOnly>())
+    return false;
+
+  // Ops with no MemoryEffectOpInterface effects also do not mutate any list
+  // operands.
+  if (auto effects = dyn_cast<MemoryEffectOpInterface>(op)) {
+    if (effects.hasNoEffect())
+      return false;
+  }
+
+  // Conservatively assume that an op might mutate any list operands.
+  return true;
 }
 
 static IntegerAttr getI64IntegerAttr(MLIRContext *context, int64_t value) {
@@ -275,6 +301,11 @@ void PrimLoopOp::getSuccessorRegions(
   regions.emplace_back(getResults());
 }
 
+bool PrimLoopOp::isForLike() {
+  bool b;
+  return matchPattern(initialCondition(), m_TorchConstantBool(&b)) && b;
+}
+
 //===----------------------------------------------------------------------===//
 // PrimLoopConditionOp
 //===----------------------------------------------------------------------===//
@@ -377,6 +408,80 @@ void PrimIfOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
         rewriter, op, constantBool.value() ? op.thenRegion() : op.elseRegion());
     return success();
   });
+  // If the thenRegion and elseRegion yield the same Value's, then use those
+  // directly.
+  patterns.add(+[](PrimIfOp op, PatternRewriter &rewriter) {
+    auto trueTerminator = op.thenRegion().front().getTerminator();
+    auto falseTerminator = op.elseRegion().front().getTerminator();
+    bool madeChange = false;
+    SmallVector<int> resultsToErase;
+    for (auto t : llvm::zip(trueTerminator->getOperands(),
+                            falseTerminator->getOperands(), op->getResults())) {
+      auto trueVal = std::get<0>(t);
+      auto falseVal = std::get<1>(t);
+      auto resultToBeReplaced = std::get<2>(t);
+      if (trueVal == falseVal) {
+        madeChange |= !resultToBeReplaced.use_empty();
+        resultToBeReplaced.replaceAllUsesWith(trueVal);
+      }
+    }
+    // We leave it up to a separate pattern (not yet implemented) to erase the
+    // results that are now dead. That transformation is independently useful,
+    // and also pretty tricky to implement because it changes the number of
+    // results.
+    return success(madeChange);
+  });
+  // Erase any dead results.
+  patterns.add(+[](PrimIfOp op, PatternRewriter &rewriter) {
+    llvm::BitVector resultsToErase(op.getNumResults());
+    for (auto result : llvm::enumerate(op->getResults())) {
+      if (result.value().use_empty())
+        resultsToErase.set(result.index());
+    }
+
+    // If no results have uses and there are no side effects, just erase the op.
+    // Approximate the body having no side effects by checking if it is just a
+    // terminator.
+    // Note: We don't want to make this logic too fancy, because in general,
+    // checking for recursive side effects can result in a quadratic amount of
+    // work (N nested If's each resulting in O(N) work). It should probably be
+    // split into its own pattern if we want to make it fancier.
+    if (resultsToErase.all() &&
+        llvm::hasSingleElement(op.thenRegion().front()) &&
+        llvm::hasSingleElement(op.elseRegion().front())) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    // If there are no results to erase, we're done.
+    if (!resultsToErase.any())
+      return failure();
+
+    SmallVector<Type> newResultTypes;
+    for (int i = 0, e = op->getNumResults(); i < e; ++i) {
+      if (resultsToErase[i])
+        continue;
+      newResultTypes.push_back(op->getResult(i).getType());
+    }
+    auto newIf =
+        rewriter.create<PrimIfOp>(op->getLoc(), newResultTypes, op.condition());
+    rewriter.inlineRegionBefore(op.thenRegion(), newIf.thenRegion(),
+                                newIf.thenRegion().end());
+    rewriter.inlineRegionBefore(op.elseRegion(), newIf.elseRegion(),
+                                newIf.elseRegion().end());
+    newIf.thenRegion().front().getTerminator()->eraseOperands(resultsToErase);
+    newIf.elseRegion().front().getTerminator()->eraseOperands(resultsToErase);
+    SmallVector<Value> replacementValues;
+    for (int i = 0, e = op->getNumResults(), nextNewValue = 0; i < e; ++i) {
+      if (resultsToErase[i])
+        replacementValues.push_back(nullptr);
+      else
+        replacementValues.push_back(newIf->getResult(nextNewValue++));
+    }
+    rewriter.replaceOp(op, replacementValues);
+
+    return success();
+  });
 }
 
 //===----------------------------------------------------------------------===//
@@ -388,32 +493,90 @@ bool DerefineOp::areCastCompatible(mlir::TypeRange inputs,
   return isValidSubtype(inputs[0], outputs[0]);
 }
 
-template <typename OpTy>
-static OpFoldResult atenIsOrIsNotFoldHelper(OpTy op, bool equalIsTrue) {
-  Value lhs = op.self();
-  Value rhs = op.obj();
+OpFoldResult DerefineOp::fold(ArrayRef<Attribute> operands) {
+  auto uncheckedCast = getOperand().getDefiningOp<PrimUncheckedCastOp>();
+  if (!uncheckedCast)
+    return nullptr;
+  if (uncheckedCast.getOperand().getType() == getType())
+    return uncheckedCast.getOperand();
+  return nullptr;
+}
 
-  // If either value is typed NoneType, make it be the lhs.
-  if (rhs.getType().template isa<Torch::NoneType>())
-    std::swap(lhs, rhs);
-
-  if (rhs.getType().template isa<Torch::OptionalType>())
-    if (auto derefine = rhs.getDefiningOp<Torch::DerefineOp>())
-      rhs = derefine.operand();
-
+static OpFoldResult atenIsOrIsNotFoldHelper(Operation *op, bool equalIsTrue) {
+  Value lhs = op->getOperand(0);
+  Value rhs = op->getOperand(1);
+  // Look through DerefineOp's to get more refined static information.
+  if (auto derefine = lhs.getDefiningOp<DerefineOp>())
+    lhs = derefine.getOperand();
+  if (auto derefine = rhs.getDefiningOp<DerefineOp>())
+    rhs = derefine.getOperand();
   Type lhsType = lhs.getType();
   Type rhsType = rhs.getType();
-  // TODO: Implement and use subtype infra for this.
-  // If neither type is a subtype of the other, then the result is false.
-  if (lhsType.template isa<Torch::NoneType>() &&
-      rhsType.template isa<Torch::NoneType>())
-    return IntegerAttr::get(IntegerType::get(op.getContext(), 1), equalIsTrue);
 
-  if (lhsType.template isa<Torch::NoneType>() &&
-      !rhsType.template isa<Torch::OptionalType>())
-    return IntegerAttr::get(IntegerType::get(op.getContext(), 1), !equalIsTrue);
+  // If either type is a NoneType, make it be the lhsType.
+  if (rhsType.isa<Torch::NoneType>()) {
+    std::swap(lhsType, rhsType);
+    std::swap(lhs, rhs);
+  }
+
+  // For now, check a few specific cases.
+
+  // If both types are the singleton `!torch.none` type, then we don't even need
+  // to look at the values.
+  if (lhsType.isa<Torch::NoneType>() && rhsType.isa<Torch::NoneType>())
+    return IntegerAttr::get(IntegerType::get(op->getContext(), 1), equalIsTrue);
+
+  // If neither type is a subtype of the other, then the result is false.
+  // TODO: Implement and use subtype infra for this.
+  // For now, check a specific case.
+  // If the rhs is not OptionalType, then we know it cannot be None.
+  if (lhsType.isa<Torch::NoneType>() && !rhsType.isa<Torch::OptionalType>()) {
+    return IntegerAttr::get(IntegerType::get(op->getContext(), 1),
+                            !equalIsTrue);
+  }
 
   return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// Aten__RangeLengthOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult Aten__RangeLengthOp::fold(ArrayRef<Attribute> operands) {
+  auto lo = operands[0];
+  auto hi = operands[1];
+  auto step = operands[2];
+  if (!lo || !hi || !step)
+    return nullptr;
+  auto loInt = lo.dyn_cast_or_null<IntegerAttr>().getValue();
+  auto hiInt = hi.dyn_cast_or_null<IntegerAttr>().getValue();
+  auto stepInt = step.dyn_cast_or_null<IntegerAttr>().getValue();
+  // TODO: Implement folding for negative steps.
+  if (stepInt.isNegative())
+    return nullptr;
+  // From Python language spec:
+  // r[i] = lo + step*i such that i >= 0 and r[i] < hi
+  // So maximize `i` such that lo + step * i < hi
+  // ==> i == ceildiv(hi - lo, step)
+  return IntegerAttr::get(lo.getType(),
+                          llvm::APIntOps::RoundingSDiv(hiInt - loInt, stepInt,
+                                                       APInt::Rounding::UP));
+}
+
+//===----------------------------------------------------------------------===//
+// Aten__DeriveIndexOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult Aten__DeriveIndexOp::fold(ArrayRef<Attribute> operands) {
+  auto index = operands[0];
+  auto start = operands[1];
+  auto step = operands[2];
+  if (!index || !start || !step)
+    return nullptr;
+  auto indexInt = index.dyn_cast_or_null<IntegerAttr>().getValue();
+  auto startInt = start.dyn_cast_or_null<IntegerAttr>().getValue();
+  auto stepInt = step.dyn_cast_or_null<IntegerAttr>().getValue();
+  return IntegerAttr::get(index.getType(), startInt + stepInt * indexInt);
 }
 
 //===----------------------------------------------------------------------===//
@@ -500,11 +663,15 @@ OpFoldResult AtenToDtypeOp::fold(ArrayRef<Attribute> operands) {
   if (!memory_format().getType().isa<Torch::NoneType>())
     return nullptr;
 
-  auto inputType = getOperand(0).getType().dyn_cast<BaseTensorType>();
-  if (!inputType || !inputType.hasSizes())
+  auto inputType = self().getType().cast<BaseTensorType>();
+  auto resType = getType().cast<BaseTensorType>();
+  // If the types aren't equal, then we can't fold.
+  if (inputType != resType)
     return nullptr;
-  auto resType = getType().dyn_cast<BaseTensorType>();
-  if (!resType || !resType.hasSizes() || inputType != resType)
+  // If the type does not have a statically known dtype, then we cannot fold.
+  // For example, folding `tensor<*,unk>` to `tensor<*,unk>` would be wrong,
+  // since the `unk` could be dynamically different for the operand and result.
+  if (!inputType.hasDtype())
     return nullptr;
   // Fold when both the input tensor and result are of the same type.
   return getOperand(0);
@@ -543,11 +710,13 @@ OpFoldResult AtenDimOp::fold(ArrayRef<Attribute> operands) {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult AtenLenTOp::fold(ArrayRef<Attribute> operands) {
-  // `len([1,1,1])` -> `3`
+  // `len([1,1,1])` -> `3`, if it is not mutated.
   if (auto listConstruct =
           getOperand().getDefiningOp<Torch::PrimListConstructOp>()) {
-    return IntegerAttr::get(IntegerType::get(getContext(), 64),
-                            listConstruct.getNumOperands());
+    if (!isListPotentiallyMutated(listConstruct)) {
+      return IntegerAttr::get(IntegerType::get(getContext(), 64),
+                              listConstruct.getNumOperands());
+    }
   }
   return nullptr;
 }
@@ -675,15 +844,46 @@ using ConstantIntComparator = std::function<bool(int64_t, int64_t)>;
 template <typename OpTy>
 static OpFoldResult intComparatorFoldHelper(OpTy op,
                                             ConstantIntComparator comparator) {
-  if (op.getOperand(0) == op.getOperand(1))
+
+  Value lhsValue = op->getOperand(0);
+  Value rhsValue = op->getOperand(1);
+  if (lhsValue == rhsValue)
     return getI1IntegerAttr(op.getContext(), comparator(0, 0));
 
   int64_t lhs, rhs;
-  if (!matchPattern(op.getOperand(0), m_TorchConstantInt(&lhs)) ||
-      !matchPattern(op.getOperand(1), m_TorchConstantInt(&rhs)))
-    return nullptr;
+  bool lhsIsConstant = matchPattern(lhsValue, m_TorchConstantInt(&lhs));
+  bool rhsIsConstant = matchPattern(rhsValue, m_TorchConstantInt(&rhs));
+  if (lhsIsConstant && rhsIsConstant)
+    return getI1IntegerAttr(op.getContext(), comparator(lhs, rhs));
 
-  return getI1IntegerAttr(op.getContext(), comparator(lhs, rhs));
+  // Ensure that if there is a constant, it is on the right.
+  if (lhsIsConstant && !rhsIsConstant) {
+    std::swap(lhs, rhs);
+    std::swap(lhsValue, rhsValue);
+    std::swap(lhsIsConstant, rhsIsConstant);
+    auto newComparator = [comparator](int64_t lhs, int64_t rhs) {
+      return comparator(rhs, lhs);
+    };
+    comparator = newComparator;
+  }
+  // Fold comparisons of negative values with the result of AtenSizeIntOp, which
+  // is known to always be non-negative.
+  if (rhsIsConstant && rhs < 0) {
+    // We can return `comparator(0, -1)` here because of the property:
+    // If x >= 0 && y < 0, then:
+    // - cmp(x, y) == cmp(x + 1, y)
+    // - cmp(x, y) == cmp(x, y - 1)
+    // By induction all cases here are covered.
+    if (auto size = lhsValue.getDefiningOp<AtenSizeIntOp>())
+      return getI1IntegerAttr(op->getContext(), comparator(0, -1));
+  }
+  // A special case of importance: size.int >= 0 ==> True.
+  if (rhsIsConstant && rhs == 0 && isa<AtenGeIntOp>(op)) {
+    if (auto size = lhsValue.getDefiningOp<AtenSizeIntOp>())
+      return getI1IntegerAttr(op->getContext(), true);
+  }
+
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//
@@ -754,6 +954,23 @@ OpFoldResult AtenGtIntOp::fold(ArrayRef<Attribute> operands) {
 OpFoldResult AtenGeIntOp::fold(ArrayRef<Attribute> operands) {
   return intComparatorFoldHelper(*this,
                                  [](int64_t a, int64_t b) { return a >= b; });
+}
+
+//===----------------------------------------------------------------------===//
+// AtenFloatScalarOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenFloatScalarOp::fold(ArrayRef<Attribute> operands) {
+  // Constant fold int -> float conversion.
+  if (auto integerAttr = operands[0].dyn_cast_or_null<IntegerAttr>()) {
+    return FloatAttr::get(
+        mlir::Float64Type::get(getContext()),
+        static_cast<double>(integerAttr.getValue().getSExtValue()));
+  }
+  // If the input is float type already, the op is an identity.
+  if (getType() == getOperand().getType())
+    return getOperand();
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//
@@ -838,6 +1055,17 @@ void TensorStaticInfoCastOp::getCanonicalizationPatterns(
 
     rewriter.replaceOp(op, reverseCast.operand());
     return success();
+  });
+  patterns.add(+[](TensorStaticInfoCastOp op, PatternRewriter &rewriter) {
+    if (isValidSubtype(op.getOperand().getType(), op.getType()) &&
+        llvm::all_of(op->getUsers(), [](Operation *op) {
+          return op
+              ->hasTrait<mlir::torch::Torch::OpTrait::AllowsTypeRefinement>();
+        })) {
+      rewriter.replaceOp(op, op.getOperand());
+      return success();
+    }
+    return failure();
   });
 }
 
@@ -1036,24 +1264,70 @@ void Aten__Getitem__TOp::getCanonicalizationPatterns(
     RewritePatternSet &patterns, MLIRContext *context) {
   patterns.add(+[](Aten__Getitem__TOp op, PatternRewriter &rewriter) {
     auto torchList = op.getOperand(0);
-    // TODO: Use a proper effects interface when more operands taking a list
-    // are implemented.
-    if (!llvm::all_of(torchList.getUsers(), [](Operation *op) {
-          return isa<Aten__Getitem__TOp, AtenLenTOp>(op);
-        }))
+    if (isListPotentiallyMutated(torchList))
       return failure();
 
     auto listConstruct = torchList.getDefiningOp<Torch::PrimListConstructOp>();
     if (!listConstruct)
       return failure();
 
+    // Get the index, but be careful because it might be statically invalid.
     int64_t index;
     if (!matchPattern(op.getOperand(1), m_TorchConstantInt(&index)))
       return failure();
+    int64_t positiveDim = toPositiveDim(index, listConstruct.getNumOperands());
+    if (!isValidDim(positiveDim, listConstruct.getNumOperands()))
+      return rewriter.notifyMatchFailure(op, "statically invalid index");
 
-    rewriter.replaceOp(op, {listConstruct.getOperand(index)});
+    rewriter.replaceOp(op, {listConstruct.getOperand(positiveDim)});
     return success();
   });
+  patterns.add(+[](Aten__Getitem__TOp op, PatternRewriter &rewriter) {
+    auto sizeOp = op.list().getDefiningOp<AtenSizeOp>();
+    if (!sizeOp)
+      return failure();
+    // This assumes tht the size doesn't change between the
+    // AtenSizeOp and the Aten__Getitem__TOp.
+    // `t_` is the only op I can find that changes the shape in-place. It seems
+    // like otherwise we can treat the size of a tensor as having value
+    // semantics. The other view-like ops don't have in-place variants --
+    // they always return a new SSA value that is aliased to the input.
+    // Can we have a pass to normalize the `t_` case and then elsewhere in the
+    // compiler treat the size as having value semantics?
+    // There's a small number of such ops, and they are marked as `inplace_view`
+    // in PyTorch's `native_functions.yaml` file.
+    rewriter.replaceOpWithNewOp<AtenSizeIntOp>(op, sizeOp.self(), op.idx());
+    return success();
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// AtenEqIntListOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenEqIntListOp::fold(ArrayRef<Attribute> operands) {
+  auto lhsLiteral = a().getDefiningOp<Torch::PrimListConstructOp>();
+  if (!lhsLiteral)
+    return nullptr;
+  auto rhsLiteral = b().getDefiningOp<Torch::PrimListConstructOp>();
+  if (!rhsLiteral)
+    return nullptr;
+
+  // If the sizes don't match, then we know the lists aren't equal.
+  if (lhsLiteral.getNumOperands() != rhsLiteral.getNumOperands())
+    return getI1IntegerAttr(getContext(), false);
+
+  // If the sizes match and all corresponding list elements are the same Value,
+  // then we know the lists are equal.
+  // Note that we can't prove that the lists are not-equal with this method,
+  // since two different Value's might dynamically be equal.
+  if (llvm::all_of(
+          llvm::zip(lhsLiteral.getOperands(), rhsLiteral.getOperands()),
+          [](const auto &pair) {
+            return std::get<0>(pair) == std::get<1>(pair);
+          }))
+    return getI1IntegerAttr(getContext(), true);
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1075,6 +1349,20 @@ void PrimTupleIndexOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
       return failure();
 
     rewriter.replaceOp(op, tupleConstruct.elements()[i]);
+    return success();
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// PrimUninitializedOp
+//===----------------------------------------------------------------------===//
+
+void PrimUninitializedOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add(+[](PrimUninitializedOp op, PatternRewriter &rewriter) {
+    if (!op.use_empty())
+      return failure();
+    rewriter.eraseOp(op);
     return success();
   });
 }
@@ -1253,6 +1541,92 @@ OpFoldResult AtenFloatTensorOp::fold(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// PrimMaxIntOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult PrimMaxIntOp::fold(ArrayRef<Attribute> operands) {
+  // If both operands are the same, then the operation is an identity.
+  if (a() == b())
+    return a();
+
+  auto lhs = operands[0].dyn_cast_or_null<IntegerAttr>();
+  auto rhs = operands[1].dyn_cast_or_null<IntegerAttr>();
+  if (!lhs || !rhs)
+    return nullptr;
+  // Torch semantics are that !torch.int is 64-bit signed.
+  return IntegerAttr::get(
+      lhs.getType(),
+      std::max(lhs.getValue().getSExtValue(), rhs.getValue().getSExtValue()));
+}
+
+//===----------------------------------------------------------------------===//
+// PrimMinSelfIntOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult PrimMinSelfIntOp::fold(ArrayRef<Attribute> operands) {
+  auto list = getOperand().getDefiningOp<PrimListConstructOp>();
+  if (!list)
+    return nullptr;
+  // TODO: What does it return for an empty list?
+  if (list->getNumOperands() == 0)
+    return nullptr;
+
+  SmallVector<int64_t> values;
+  for (auto operand : list->getOperands()) {
+    int64_t value;
+    if (!matchPattern(operand, m_TorchConstantInt(&value)))
+      return nullptr;
+    values.push_back(value);
+  }
+  return getI64IntegerAttr(getContext(),
+                           *std::min_element(values.begin(), values.end()));
+}
+
+//===----------------------------------------------------------------------===//
+// ShapeCalculateOp
+//===----------------------------------------------------------------------===//
+
+void ShapeCalculateOp::getSuccessorRegions(
+    Optional<unsigned> index, ArrayRef<Attribute> operands,
+    SmallVectorImpl<RegionSuccessor> &regions) {
+  (void)operands;
+
+  if (!index.hasValue()) {
+    // First thing the op does is branch into the shape calculation.
+    regions.emplace_back(&shapeCalculation());
+    return;
+  }
+  if (*index == 0) {
+    // Body returns control to the outer op, passing through results.
+    regions.emplace_back(getResults());
+    return;
+  }
+  assert(*index == 1);
+  // Shape calculation branches to the body.
+  regions.emplace_back(&body());
+}
+
+//===----------------------------------------------------------------------===//
+// ShapeCalculateYieldShapesOp
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange ShapeCalculateYieldShapesOp::getMutableSuccessorOperands(
+    Optional<unsigned> index) {
+  // The shape operands don't get forwarded to the body.
+  // MutableOperandRange always has an owning operation, even if empty, so
+  // create a 0-length range.
+  return MutableOperandRange(*this, /*start=*/0, /*length=*/0);
+}
+
+static LogicalResult verify(ShapeCalculateYieldShapesOp op) {
+  auto parent = op->getParentOfType<ShapeCalculateOp>();
+  if (parent.getNumResults() != op.getNumOperands())
+    return op.emitOpError(
+        "expected number of shapes to match number of results");
+  return success();
+}
 
 #define GET_OP_CLASSES
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.cpp.inc"

--- a/lib/Dialect/Torch/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Torch/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(TorchMLIRTorchPasses
   AdjustCallingConventions.cpp
   DecomposeComplexOps.cpp
+  DropShapeCalculations.cpp
   Passes.cpp
   GlobalizeObjectGraph.cpp
   InlineGlobalSlots.cpp
@@ -9,6 +10,9 @@ add_mlir_library(TorchMLIRTorchPasses
   ReduceOpVariants.cpp
   RefinePublicReturn.cpp
   RefineTypes.cpp
+  ReifyShapeCalculations.cpp
+  ShapeLibrary.cpp
+  SimplifyShapeCalculations.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/torch-mlir/Dialect/Torch/Transforms

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -789,8 +789,11 @@ public:
                                          "Only aten.var support floating type");
     }
     BaseTensorType rank0FloatTensorTy = op.getType().cast<BaseTensorType>();
-    assert(rank0FloatTensorTy.getSizes().size() == 0 &&
-           "Op should have rank 0 tensor type");
+    if (!rank0FloatTensorTy.hasSizes() ||
+        rank0FloatTensorTy.getSizes().size() != 0) {
+      return rewriter.notifyMatchFailure(
+          op, "expected aten.var to have a rank 0 tensor type");
+    }
 
     bool unbiased;
     if (!matchPattern(op.unbiased(), m_TorchConstantBool(&unbiased))) {

--- a/lib/Dialect/Torch/Transforms/DropShapeCalculations.cpp
+++ b/lib/Dialect/Torch/Transforms/DropShapeCalculations.cpp
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Parser.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/InliningUtils.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringSet.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+namespace {
+class DropShapeCalculateOp : public OpConversionPattern<ShapeCalculateOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ShapeCalculateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Block *block = &op.body().front();
+    Operation *terminator = block->getTerminator();
+    ValueRange results = terminator->getOperands();
+    rewriter.mergeBlockBefore(block, op);
+    rewriter.replaceOp(op, results);
+    rewriter.eraseOp(terminator);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class DropShapeCalculationsPass
+    : public DropShapeCalculationsBase<DropShapeCalculationsPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.insert<DropShapeCalculateOp>(context);
+    ConversionTarget target(*context);
+    target.addIllegalOp<ShapeCalculateOp>();
+    target.addLegalOp<FuncOp>();
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::torch::Torch::createDropShapeCalculationsPass() {
+  return std::make_unique<DropShapeCalculationsPass>();
+}

--- a/lib/Dialect/Torch/Transforms/RefinePublicReturn.cpp
+++ b/lib/Dialect/Torch/Transforms/RefinePublicReturn.cpp
@@ -55,18 +55,30 @@ class RefinePublicReturnPass
       return signalPassFailure();
     }
 
-    // Get the new operands. Either the original operand, or if there is a
-    // TensorStaticInfoCastOp then the pre-casted operand, which is presumed to
-    // have a more precise type.
+    // Get the new operands. Either the original operand, or for tensors,
+    // looking through TensorStaticInfoCastOp/CopyToNonValueTensorOp which are
+    // presumed to have a more precise type.
     SmallVector<Value> newOperands;
     OpBuilder builder(returnOp);
     for (auto operand : returnOp.getOperands()) {
-      Value newOperand;
-      if (auto cast = operand.getDefiningOp<TensorStaticInfoCastOp>()) {
-        newOperand = cast.getOperand();
-      } else {
-        newOperand = operand;
+      Value newOperand = operand;
+      // Look through TensorStaticInfoCastOp's and CopyToNonValueTensorOp's.
+      for (;;) {
+        if (auto cast = newOperand.getDefiningOp<TensorStaticInfoCastOp>()) {
+          newOperand = cast.getOperand();
+        } else if (auto copy =
+                       newOperand.getDefiningOp<CopyToNonValueTensorOp>()) {
+          // If the return (or transitively other ops) are not the only users,
+          // then we can't be sure that the tensor hasn't been mutated, so stop
+          // here.
+          if (!llvm::hasSingleElement(copy->getUsers()))
+            break;
+          newOperand = copy.getOperand();
+        } else {
+          break;
+        }
       }
+
       if (auto tensorType = newOperand.getType().dyn_cast<BaseTensorType>()) {
         newOperands.push_back(
             copyTensorToType(builder, returnOp->getLoc(),

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -6,6 +6,53 @@
 // Also available under a BSD-style license. See LICENSE.
 //
 //===----------------------------------------------------------------------===//
+//
+// This file implements a dataflow analysis primarily used to infer dtypes
+// of tensors in the program. Shapes are handled separately with a
+// more involved mechanism (see createTorchShapeRefinementPipeline).
+//
+// The analysis performed in this file is implemented with MLIR's dataflow
+// analysis framework, which was originally developed for SCCP, and so is an
+// optimistic framework. It proceeds by assuming that all Value's have a
+// maximally optimistic ("bottom") lattice element associated with them, and
+// then the `visitOperation` method (and some built-in handling for control
+// flow) gradually relaxes that optimism until the lattice elements associated
+// with each Value either settle to a (optimistic) fixed-point, or need to fall
+// back on a suitable pessimistic lattice element.
+//
+// A note on dataflow analysis terminology:
+// In dataflow analysis (or other contexts where lattices appear), it is
+// frequently confusing because meet/join and related aspects of lattices
+// (such as what is "up"/"down" or "top"/"bottom" in the lattice) are dual to
+// each other and so a convention has to be chosen to ground the terminology.
+//
+// In the context of this dataflow analysis, we use the terms with the following
+// senses (many examples are given to build intuition):
+// - "top" means the state of least specific knowledge (i.e. most pessimistic
+// possible knowledge)
+// - "bottom" is the lattice element with such specific knowledge that "join"ing
+// with it is an identity operation. (i.e. most optimistic possible knowledge)
+// - "moving down the lattice" means moving towards having more specific
+// knowledge
+// - "moving up the lattice" means moving towards having less specific knowledge
+// - "top" means the state of least specific knowledge (i.e. most pessimistic
+// possible knowledge)
+// - "meet" means
+//   - "move down the lattice" (greatest lower bound)
+//   - "constrict"
+//   - "refine"
+//   - "assume union of information from both lattice elements"
+// - "join" means
+//   - "move up the lattice" (least upper bound)
+//   - "widen"
+//   - "relax"
+//   - "assume intersection of information from both lattice elements"
+//
+// Note: This pass is kept completely separate from
+// createShapeRefinementPipeline because any interaction between the two would
+// usually require a fixed-point iteration to work in generality.
+//
+//===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
 
@@ -26,23 +73,23 @@
 using namespace mlir;
 using namespace mlir::torch;
 using namespace mlir::torch::Torch;
-using namespace mlir::torch::torch_upstream; // For ScalarType and type
-                                             // promotion related helpers.
 
 // -----------------------------------------------------------------------------
 // Analysis.
 // -----------------------------------------------------------------------------
-static Type getTypeForScalarType(MLIRContext *context, ScalarType dtypeInt) {
+
+static Type getTypeForScalarType(MLIRContext *context,
+                                 torch_upstream::ScalarType dtypeInt) {
   switch (dtypeInt) {
-  case ScalarType::Float:
+  case torch_upstream::ScalarType::Float:
     return Float32Type::get(context);
-  case ScalarType::Double:
+  case torch_upstream::ScalarType::Double:
     return Float64Type::get(context);
-  case ScalarType::Long:
+  case torch_upstream::ScalarType::Long:
     return IntegerType::get(context, 64, IntegerType::Signed);
-  case ScalarType::Int:
+  case torch_upstream::ScalarType::Int:
     return IntegerType::get(context, 32, IntegerType::Signed);
-  case ScalarType::Bool:
+  case torch_upstream::ScalarType::Bool:
     return IntegerType::get(context, 1);
   default:
     return Type();
@@ -50,7 +97,7 @@ static Type getTypeForScalarType(MLIRContext *context, ScalarType dtypeInt) {
 }
 
 static Type getTypeForDTypeInteger(MLIRContext *context, int64_t dtypeInt) {
-  return getTypeForScalarType(context, (ScalarType)dtypeInt);
+  return getTypeForScalarType(context, (torch_upstream::ScalarType)dtypeInt);
 }
 
 static Type getDtypeOrDefault(MLIRContext *context, Value optionalDtype,
@@ -64,33 +111,47 @@ static Type getDtypeOrDefault(MLIRContext *context, Value optionalDtype,
 }
 
 static Type joinElementTypes(Type lhs, Type rhs) {
+  if (lhs == rhs)
+    return lhs;
+  return Type();
+}
+
+/// Returns the dtype that assumes information from both `lhs` and `rhs`.
+/// Returns `None` if the types are contradictory.
+static Optional<Type> meetElementTypes(Type lhs, Type rhs) {
   if (!lhs)
     return rhs;
   if (!rhs)
     return lhs;
   if (lhs == rhs)
     return lhs;
-  return Type();
+  return None;
 }
 
-// This is the type rule used for deciding dtype for:
-// 1. A new tensor created from given data.
-// 2. The scalar type for type promotion when a scalar is an operand of a tensor
-// and scalar binary operation.
-// If the data is floating-point, the `dtype` is inferred to be the
-// default dtype, see `torch.get_default_dtype`.
-static Type getDefaultDtypeForTorchScalar(Type type) {
-  MLIRContext *context = type.getContext();
-  if (type.isa<Torch::FloatType>()) {
-    // For now, use float32 which is the initial default dtype returned by
-    // `torch.get_default_dtype`.
-    return Float32Type::get(context);
-  }
-  if (type.isa<Torch::IntType>())
-    return IntegerType::get(context, 64, IntegerType::Signed);
-  if (type.isa<Torch::BoolType>())
-    return IntegerType::get(context, 1);
-  return Type();
+enum class OptionalKnowledge {
+  unKnown,
+  isNone,
+  notNone,
+};
+
+/// Returns the OptionalKnowledge that assumes information from both `lhs` and
+/// `rhs`. Returns `None` if the knowledges are contradictory.
+static Optional<OptionalKnowledge>
+meetOptionalKnowledge(OptionalKnowledge lhs, OptionalKnowledge rhs) {
+  if (lhs == OptionalKnowledge::unKnown)
+    return rhs;
+  if (rhs == OptionalKnowledge::unKnown)
+    return lhs;
+  if (lhs == rhs)
+    return lhs;
+  return None;
+}
+
+static OptionalKnowledge joinOptionalKnowledge(OptionalKnowledge lhs,
+                                               OptionalKnowledge rhs) {
+  if (lhs == rhs)
+    return lhs;
+  return OptionalKnowledge::unKnown;
 }
 
 namespace {
@@ -104,27 +165,14 @@ namespace {
 // we cannot claim to know something about a value which is false.
 // This class could also be called "dataflow facts", "lattice value", etc.
 struct ValueKnowledge {
-  enum class OptionalKnowledge {
-    unKnown,
-    isNone,
-    notNone,
-  };
   ValueKnowledge() = delete;
-  ValueKnowledge(bool hasSizes, std::vector<int64_t> sizes, Type dtype,
-                 OptionalKnowledge optionalKnowledge)
-      : hasSizes(hasSizes), sizes(sizes), dtype(dtype),
-        optional(optionalKnowledge) {
-    assert(sizes.size() == 0 || hasSizes);
-  }
+  ValueKnowledge(Type dtype, OptionalKnowledge optionalKnowledge)
+      : dtype(dtype), optional(optionalKnowledge) {}
 
   // Get the static knowledge intrinsic to `type`.
   static ValueKnowledge getKnowledgeFromType(Type type) {
     ValueKnowledge result = getPessimisticValueState(type.getContext());
     if (auto tensorType = type.dyn_cast<BaseTensorType>()) {
-      if (tensorType.hasSizes()) {
-        result.hasSizes = true;
-        result.sizes = tensorType.getSizes().vec();
-      }
       result.dtype = tensorType.getOptionalDtype();
       result.optional = OptionalKnowledge::notNone;
     } else if (auto optionalType = type.dyn_cast<Torch::NoneType>()) {
@@ -138,7 +186,7 @@ struct ValueKnowledge {
   // Return a pessimistic/conservative value state without assuming any knowlege
   // about the IR.
   static ValueKnowledge getPessimisticValueState(MLIRContext *context) {
-    return ValueKnowledge(false, {}, Type(), OptionalKnowledge::unKnown);
+    return ValueKnowledge(Type(), OptionalKnowledge::unKnown);
   }
   // Return a pessimistic/conservative value state only using knowlege already
   // recorded in the IR.
@@ -147,16 +195,24 @@ struct ValueKnowledge {
   }
 
   static ValueKnowledge getNotNonePessimisticValueState(MLIRContext *context) {
-    return ValueKnowledge(false, {}, Type(), OptionalKnowledge::notNone);
+    return ValueKnowledge(Type(), OptionalKnowledge::notNone);
   }
 
   bool operator==(const ValueKnowledge &rhs) const {
-    return std::make_tuple(hasSizes, sizes, dtype, optional) ==
-           std::make_tuple(rhs.hasSizes, rhs.sizes, rhs.dtype, rhs.optional);
+    return std::make_tuple(dtype, optional) ==
+           std::make_tuple(rhs.dtype, rhs.optional);
   }
 
-  // Given two pieces of static knowledge, calculate conservatively the
-  // information we can be sure about.
+  // Given two pieces of static knowledge, intersect the facts that are known in
+  // both knowledges. This always produces knowledge that has less (or equal)
+  // facts than both the lhs and rhs.
+  //
+  // This operator is used, for example, at control flow join points: if
+  // predecessors A and B forward a block argument to a common successor C, then
+  // we need to calculate what can be known for sure about the block argument if
+  // the control flow is coming from either A or B. So we can't assume facts
+  // just because they are true on one control flow edge. They must be true on
+  // both.
   static ValueKnowledge join(const ValueKnowledge &lhs,
                              const ValueKnowledge &rhs) {
     // Mental model: All conditions are checking how to change from the safe "no
@@ -164,48 +220,38 @@ struct ValueKnowledge {
     // consistent with lhs and rhs.
     ValueKnowledge result = getPessimisticValueState(nullptr);
 
-    // If lhs and rhs are not equal, the knowledge state must be the
-    // pessimistic state.
-    if (lhs.optional == rhs.optional)
-      result.optional = lhs.optional;
-
-    if (lhs.hasSizes && !rhs.hasSizes) {
-      result.hasSizes = true;
-      result.sizes = lhs.sizes;
-    } else if (!lhs.hasSizes && rhs.hasSizes) {
-      result.hasSizes = true;
-      result.sizes = rhs.sizes;
-    } else if (lhs.hasSizes && rhs.hasSizes &&
-               lhs.sizes.size() == rhs.sizes.size()) {
-      result.hasSizes = true;
-      result.sizes.resize(lhs.sizes.size(), kUnknownSize);
-      for (int i = 0, e = result.sizes.size(); i != e; i++) {
-        int64_t lhsSize = lhs.sizes[i];
-        int64_t rhsSize = rhs.sizes[i];
-        int64_t &resultSize = result.sizes[i];
-        if (lhsSize == kUnknownSize) {
-          resultSize = rhsSize;
-        } else if (rhsSize == kUnknownSize) {
-          resultSize = lhsSize;
-        } else if (lhsSize == rhsSize) {
-          resultSize = lhsSize;
-        }
-      }
-    }
-
+    result.optional = joinOptionalKnowledge(lhs.optional, rhs.optional);
     result.dtype = joinElementTypes(lhs.dtype, rhs.dtype);
+
     return result;
   }
 
-  // Whether the Value is known to have a list of sizes.
-  bool hasSizes;
-  // If `hasSizes`, the sizes along each rank. Unknown sizes are represented as
-  // `kUnknownSize`.
-  std::vector<int64_t> sizes;
+  // Given two pieces of static knowledge, calculate new knowledge that assumes
+  // the facts from both.
+  // If the two pieces of knowledge are contradictory, None is returned.
+  static Optional<ValueKnowledge> meet(const ValueKnowledge &lhs,
+                                       const ValueKnowledge &rhs) {
+    ValueKnowledge result = getPessimisticValueState(nullptr);
+
+    Optional<OptionalKnowledge> optional =
+        meetOptionalKnowledge(lhs.optional, rhs.optional);
+    if (!optional.hasValue())
+      return None;
+    result.optional = optional.getValue();
+
+    Optional<Type> dtype = meetElementTypes(lhs.dtype, rhs.dtype);
+    if (!dtype.hasValue())
+      return None;
+    result.dtype = dtype.getValue();
+
+    return result;
+  }
+
   // The dtype of a tensor.
   // This is equal to nullptr if we don't know that it is a specific concrete
   // type.
   Type dtype;
+  // What is known about an optional value.
   OptionalKnowledge optional;
 };
 
@@ -218,356 +264,28 @@ public:
   // the operands and any information intrinsic to `op`.
   ChangeResult
   visitOperation(Operation *op,
-                 ArrayRef<LatticeElement<ValueKnowledge> *> operands) final {
-    if (isa<TensorStaticInfoCastOp, CopyToValueTensorOp, CopyToNonValueTensorOp,
-            AtenTanhOp, AtenBatchNormOp, AtenReluOp, AtenGeluOp, AtenCeilOp,
-            AtenGeluBackwardOp, AtenBitwiseNotOp, AtenExpOp, AtenSinOp,
-            AtenCosOp, AtenSigmoidOp, DerefineOp, AtenToPrimDeviceOp, AtenCpuOp,
-            AtenContiguousOp, AtenFill_ScalarOp, AtenDetachOp, AtenReciprocalOp,
-            AtenMaskedFill_ScalarOp, AtenCopy_Op, AtenCumsumOp, AtenLayerNormOp,
-            AtenClampOp, AtenLogOp, AtenNegOp, AtenSqrtOp, AtenFloorOp,
-            AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp, AtenDropoutOp,
-            AtenTanhBackwardOp, Aten_LogSoftmaxBackwardDataOp, AtenAddIntOp,
-            AtenAbsOp, AtenThresholdOp, AtenSquareOp, PseudoAtenUniformOp,
-            AtenBernoulliOp, AtenBernoulli_FloatOp, AtenBernoulli_TensorOp,
-            PseudoAtenBernoulliFloatOp, PseudoAtenBernoulliTensorOp,
-            PseudoAtenFillScalarOp, AtenHardsigmoidOp, AtenCloneOp,
-            AtenHardswishOp, AtenErfOp, AtenSiluOp, AtenHardtanhOp>(op)) {
-      return getLatticeElement(op->getResult(0)).join(*operands[0]);
-    }
-
-    // These comparison ops return a tensor with 1-bit integer dtype.
-    if (isa<AtenEqScalarOp, AtenGeScalarOp, AtenGtScalarOp, AtenLtScalarOp,
-            AtenLeScalarOp, AtenNeScalarOp>(op)) {
-      auto operand = operands[0]->getValue();
-      auto knowledge =
-          ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-      if (operand.hasSizes) {
-        knowledge.hasSizes = true;
-        knowledge.sizes = operand.sizes;
-      }
-      knowledge.dtype = IntegerType::get(op->getContext(), 1);
-      return getLatticeElement(op->getResult(0)).join(knowledge);
-    }
-
-    // Resize to [1, 1] with integer dtype.
-    if (isa<AtenAnyOp, AtenAllOp>(op)) {
-      auto input = operands[0]->getValue();
-      auto knowledge =
-          ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-      knowledge.hasSizes = true;
-      knowledge.sizes.resize(1, 1);
-      knowledge.dtype = IntegerType::get(op->getContext(), 1);
-      return getLatticeElement(op->getResult(0)).join(knowledge);
-    }
-    // `torch.aten.masked_select` returns a new 1-D tensor which indexes the
-    // input tensor according to the boolean mask which is a BoolTensor.
-    // Resize to [unknown] with same dtype as the input.
-    if (auto maskedSelect = dyn_cast<AtenMaskedSelectOp>(op)) {
-      auto input = operands[0]->getValue();
-      auto knowledge =
-          ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-      knowledge.hasSizes = true;
-      knowledge.sizes.resize(1, kUnknownSize);
-      knowledge.dtype = input.dtype;
-      return getLatticeElement(op->getResult(0)).join(knowledge);
-    }
-    if (auto mm = llvm::dyn_cast<AtenMmOp>(op)) {
-      return visitAtenMmLikeOp(mm, operands, /*expectedRank=*/2);
-    } else if (auto addmm = llvm::dyn_cast<AtenAddmmOp>(op)) {
-      return visitAtenAddmmOp(addmm, operands);
-    } else if (auto linear = llvm::dyn_cast<AtenLinearOp>(op)) {
-      return visitAtenLinearOp(linear, operands);
-    } else if (auto conv2d = llvm::dyn_cast<AtenConv2dOp>(op)) {
-      return visitAtenConv2dOp(conv2d, operands);
-    } else if (auto maxPool2d = llvm::dyn_cast<AtenMaxPool2dOp>(op)) {
-      return visitAtenMaxPool2dOp(maxPool2d, operands);
-    } else if (auto avgPool2d = llvm::dyn_cast<AtenAdaptiveAvgPool2dOp>(op)) {
-      return visitAtenAdaptiveAvgPool2dOp(avgPool2d, operands);
-    } else if (isa<AtenAddScalarOp, AtenSubScalarOp, AtenMulScalarOp,
-                   AtenDivScalarOp, AtenFmodScalarOp, AtenFloorDivideScalarOp,
-                   AtenPowTensorScalarOp, AtenRsubScalarOp, AtenLeakyReluOp>(
-                   op)) {
-      return visitBinaryTensorScalarOp(op, operands);
-    } else if (isa<AtenAddTensorOp, AtenSubTensorOp, AtenMulTensorOp,
-                   AtenDivTensorOp, Aten__And__TensorOp, AtenMinimumOp,
-                   AtenMaximumOp, AtenBitwiseAndTensorOp,
-                   AtenThresholdBackwardOp>(op)) {
-      return visitBinaryBroadcastingOp(op, operands);
-    } else if (isa<AtenEqTensorOp, AtenGtTensorOp, AtenLtTensorOp>(op)) {
-      return visitBinaryBroadcastingComparisonOp(op, operands);
-    } else if (auto whereSelf = llvm::dyn_cast<AtenWhereSelfOp>(op)) {
-      return visitAtenWhereSelfOp(whereSelf, operands);
-    } else if (auto lerpTensor = llvm::dyn_cast<AtenLerpTensorOp>(op)) {
-      return visitAtenLerpTensorOp(lerpTensor, operands);
-    } else if (auto flatten = dyn_cast<AtenFlattenUsingIntsOp>(op)) {
-      return visitAtenFlattenUsingIntsOp(flatten, operands);
-    } else if (auto squeeze = dyn_cast<AtenSqueezeOp>(op)) {
-      return visitAtenSqueezeOp(squeeze, operands);
-    } else if (auto squeezeDim = dyn_cast<AtenSqueezeDimOp>(op)) {
-      return visitAtenSqueezeDimOp(squeezeDim, operands);
-    } else if (auto unsqueeze = dyn_cast<AtenUnsqueezeOp>(op)) {
-      return visitAtenUnsqueezeOp(unsqueeze, operands);
-    } else if (auto arange = dyn_cast<AtenArangeOp>(op)) {
-      return visitAtenArangeOp(arange);
-    } else if (auto arangeStart = dyn_cast<AtenArangeStartOp>(op)) {
-      return visitAtenArangeStartOp(arangeStart);
-    } else if (auto arangeStartStep = dyn_cast<AtenArangeStartStepOp>(op)) {
-      return visitAtenArangeStartStepOp(arangeStartStep);
-    } else if (auto sum = dyn_cast<AtenSumOp>(op)) {
-      Type defaultDtype = operands[0]->getValue().dtype;
-      Type dtype =
-          getDtypeOrDefault(sum.getContext(), sum.dtype(), defaultDtype);
-      return visitReductionAlongAllDimsOp(sum, dtype, operands);
-    } else if (auto sumDimIntList = dyn_cast<AtenSumDimIntListOp>(op)) {
-      Type defaultDtype = operands[0]->getValue().dtype;
-      Type dtype = getDtypeOrDefault(sumDimIntList.getContext(),
-                                     sumDimIntList.dtype(), defaultDtype);
-      return visitReductionAlongDimIntListOp(sumDimIntList, sumDimIntList.dim(),
-                                             sumDimIntList.keepdim(), dtype,
-                                             operands);
-    } else if (auto meanDim = dyn_cast<AtenMeanDimOp>(op)) {
-      Type defaultDtype = operands[0]->getValue().dtype;
-      Type dtype = getDtypeOrDefault(meanDim.getContext(), meanDim.dtype(),
-                                     defaultDtype);
-      return visitReductionAlongDimIntListOp(
-          meanDim, meanDim.dim(), meanDim.keepdim(), dtype, operands);
-    } else if (auto argmax = dyn_cast<AtenArgmaxOp>(op)) {
-      Value dim = argmax.dim();
-      Type dtype = IntegerType::get(op->getContext(), 64, IntegerType::Signed);
-      if (dim.getType().isa<Torch::NoneType>())
-        return visitReductionAlongAllDimsOp(op, dtype, operands);
-      if (dim.getType().isa<Torch::IntType>())
-        return visitReductionAlongDimIntOp(argmax, argmax.dim(),
-                                           argmax.keepdim(), dtype, operands);
-    } else if (auto anyDim = dyn_cast<AtenAnyDimOp>(op)) {
-      Type dtype = operands[0]->getValue().dtype;
-      return visitReductionAlongDimIntOp(anyDim, anyDim.dim(), anyDim.keepdim(),
-                                         dtype, operands);
-    } else if (auto maxDim = dyn_cast<AtenMaxDimOp>(op)) {
-      Type firstResDtype = operands[0]->getValue().dtype;
-      Type secondResDtype =
-          IntegerType::get(op->getContext(), 64, IntegerType::Signed);
-      ChangeResult firstRes = visitReductionAlongDimIntOp(
-          maxDim, maxDim.dim(), maxDim.keepdim(), firstResDtype, operands);
-      return firstRes | visitReductionAlongDimIntOp(
-                            maxDim, maxDim.dim(), maxDim.keepdim(),
-                            secondResDtype, operands, /*resNum=*/1);
-    } else if (auto view = dyn_cast<AtenViewOp>(op)) {
-      return visitReshapeLikeOp(view, operands, view.size());
-    } else if (auto unsafeView = dyn_cast<Aten_UnsafeViewOp>(op)) {
-      return visitReshapeLikeOp(unsafeView, operands, unsafeView.size());
-    } else if (auto reshape = dyn_cast<AtenReshapeOp>(op)) {
-      return visitReshapeLikeOp(reshape, operands, reshape.shape());
-    } else if (auto resize = dyn_cast<AtenResize_Op>(op)) {
-      return visitReshapeLikeOp(resize, operands, resize.size());
-    } else if (auto transposeInt = dyn_cast<AtenTransposeIntOp>(op)) {
-      return visitAtenTransposeIntOp(transposeInt, operands);
-    } else if (auto t = dyn_cast<AtenTOp>(op)) {
-      return visitAtenTOp(t, operands);
-    } else if (auto permute = dyn_cast<AtenPermuteOp>(op)) {
-      return visitAtenPermuteOp(permute, operands);
-    } else if (auto tensorFloat = dyn_cast<AtenTensorFloatOp>(op)) {
-      return visitScalarToTensorConversionOp<AtenTensorFloatOp>(tensorFloat);
-    } else if (auto tensorInt = dyn_cast<AtenTensorIntOp>(op)) {
-      return visitScalarToTensorConversionOp<AtenTensorIntOp>(tensorInt);
-    } else if (auto tensorBool = dyn_cast<AtenTensorBoolOp>(op)) {
-      return visitScalarToTensorConversionOp<AtenTensorBoolOp>(tensorBool);
-    } else if (auto tensor = dyn_cast<AtenTensorOp>(op)) {
-      return visitAtenTensorOp(tensor);
-    } else if (auto zeros = dyn_cast<AtenZerosOp>(op)) {
-      return visitConstantTensorAllocOp<AtenZerosOp>(zeros, /*dataType=*/{});
-    } else if (auto ones = dyn_cast<AtenOnesOp>(op)) {
-      return visitConstantTensorAllocOp<AtenOnesOp>(ones, /*dataType=*/{});
-    } else if (auto emptyMemoryFormat = dyn_cast<AtenEmptyMemoryFormatOp>(op)) {
-      return visitConstantTensorAllocOp<AtenEmptyMemoryFormatOp>(
-          emptyMemoryFormat, /*dataType=*/{});
-    } else if (auto full = dyn_cast<AtenFullOp>(op)) {
-      return visitConstantTensorAllocOp<AtenFullOp>(
-          full, /*dataType=*/full.fill_value().getType());
-    } else if (auto zerosLike = dyn_cast<AtenZerosLikeOp>(op)) {
-      return visitConstantTensorAllocLikeOp<AtenZerosLikeOp>(zerosLike,
-                                                             operands);
-    } else if (auto onesLike = dyn_cast<AtenOnesLikeOp>(op)) {
-      return visitConstantTensorAllocLikeOp<AtenOnesLikeOp>(onesLike, operands);
-    } else if (auto emptyLike = dyn_cast<AtenEmptyLikeOp>(op)) {
-      return visitConstantTensorAllocLikeOp<AtenEmptyLikeOp>(emptyLike,
-                                                             operands);
-    } else if (auto fullLike = dyn_cast<AtenFullLikeOp>(op)) {
-      return visitConstantTensorAllocLikeOp<AtenFullLikeOp>(fullLike, operands);
-    } else if (auto newZeros = dyn_cast<AtenNewZerosOp>(op)) {
-      return visitConstantTensorNewLikeOp<AtenNewZerosOp>(newZeros, operands);
-    } else if (auto newOnes = dyn_cast<AtenNewOnesOp>(op)) {
-      return visitConstantTensorNewLikeOp<AtenNewOnesOp>(newOnes, operands);
-    } else if (auto randLike = dyn_cast<AtenRandLikeOp>(op)) {
-      return visitConstantTensorAllocLikeOp<AtenRandLikeOp>(randLike, operands);
-    } else if (auto toDtype = dyn_cast<AtenToDtypeOp>(op)) {
-      return visitAtenToDtypeOp(toDtype, operands);
-    } else if (auto toOther = dyn_cast<AtenToOtherOp>(op)) {
-      return visitTypeConversionOp<AtenToOtherOp>(toOther, operands);
-    } else if (auto typeAs = dyn_cast<AtenTypeAsOp>(op)) {
-      return visitTypeConversionOp<AtenTypeAsOp>(typeAs, operands);
-    } else if (auto indexSelect = dyn_cast<AtenIndexSelectOp>(op)) {
-      // The index tensor index into the dimension specified by the dim. The dim
-      // of output is the same size as the length of index (index must be one
-      // dimensional)
-      auto setDim = [](int64_t &targetDim, int64_t dim,
-                       ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-        auto indexes = operands[2]->getValue();
-        targetDim = indexes.hasSizes && indexes.sizes.size() != 0
-                        ? indexes.sizes[0]
-                        : kUnknownSize;
-      };
-      return visitSliceLikeOp(indexSelect, operands, setDim);
-    } else if (auto selectInt = dyn_cast<AtenSelectIntOp>(op)) {
-      // Slices along dim at index. Result shape same as input except dim is
-      // removed.
-      auto setDim = [](int64_t &targetDim, int64_t dim,
-                       ArrayRef<LatticeElement<ValueKnowledge> *> operands) {};
-      return visitSliceLikeOp(selectInt, operands, setDim, /*keepDim=*/false);
-    } else if (auto sliceTensor = dyn_cast<AtenSliceTensorOp>(op)) {
-      // Select several elements from the target dim according to the start,
-      // end, step. All the other dims are the same as input.
-      auto setDim = [](int64_t &targetDim, int64_t dim,
-                       ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-        targetDim = kUnknownSize;
-      };
-      return visitSliceLikeOp(sliceTensor, operands, setDim);
-    } else if (auto gather = dyn_cast<AtenGatherOp>(op)) {
-      return visitAtenGatherOp(gather, operands);
-    } else if (isa<AtenExpandOp, AtenBroadcastToOp>(op)) {
-      // Broadcast dimensions of size 1 withs sizes
-      // spcecified by the `size` operand. -1 in the `size` list means the
-      // dimension is kept unchanged.
-      auto setDim = [](int64_t &targetDim, int64_t inputDim, int64_t size) {
-        targetDim = size == -1 ? inputDim : size;
-      };
-      Value size;
-      if (auto expand = dyn_cast<AtenExpandOp>(op))
-        size = expand.size();
-      else if (auto broadcast = dyn_cast<AtenBroadcastToOp>(op))
-        size = broadcast.size();
-      return visitExpandLikeOp(op, size, operands, setDim);
-    } else if (auto repeat = dyn_cast<AtenRepeatOp>(op)) {
-      // The repeats list specify the number of times to repeat along each dim
-      // of the original tensor.
-      auto setDim = [](int64_t &targetDim, int64_t inputDim, int64_t repeat) {
-        if (inputDim != kUnknownSize)
-          targetDim = inputDim * repeat;
-      };
-      return visitExpandLikeOp(repeat, repeat.repeats(), operands, setDim);
-    } else if (auto cat = dyn_cast<AtenCatOp>(op)) {
-      return visitAtenCatOp(cat, operands);
-    } else if (auto shapeAsTensor = dyn_cast<Aten_ShapeAsTensorOp>(op)) {
-      return visitAtenShapeAsTensorOp(shapeAsTensor, operands);
-    } else if (auto embedding = dyn_cast<AtenEmbeddingOp>(op)) {
-      return visitAtenEmbeddingOp(embedding, operands);
-    } else if (auto bmm = dyn_cast<AtenBmmOp>(op)) {
-      return visitAtenMmLikeOp(bmm, operands, /*expectedRank=*/3);
-    } else if (auto matmul = dyn_cast<AtenMatmulOp>(op)) {
-      return visitAtenMatmulOp(matmul, operands);
-    } else if (auto mean = dyn_cast<AtenMeanOp>(op)) {
-      Type defaultDtype = operands[0]->getValue().dtype;
-      Type dtype =
-          getDtypeOrDefault(mean.getContext(), mean.dtype(), defaultDtype);
-      return visitReductionAlongAllDimsOp(mean, dtype, operands);
-    } else if (auto max = dyn_cast<AtenMaxOp>(op)) {
-      Type dtype = operands[0]->getValue().dtype;
-      return visitReductionAlongAllDimsOp(max, dtype, operands);
-    } else if (isa<AtenStdOp, AtenVarOp>(op)) {
-      auto input = operands[0]->getValue();
-      return visitReductionAlongAllDimsOp(op, input.dtype, operands);
-    } else if (auto softmaxIntOp = dyn_cast<AtenSoftmaxIntOp>(op)) {
-      return visitAtenSoftmaxLikeOp(softmaxIntOp, operands);
-    } else if (auto _softmaxOp = dyn_cast<Aten_SoftmaxOp>(op)) {
-      return visitAten_SoftmaxLikeOp(_softmaxOp, operands);
-    } else if (auto _logSoftmaxOp = dyn_cast<Aten_LogSoftmaxOp>(op)) {
-      return visitAten_SoftmaxLikeOp(_logSoftmaxOp, operands);
-    } else if (auto logSoftmaxIntOp = dyn_cast<AtenLogSoftmaxIntOp>(op)) {
-      return visitAtenSoftmaxLikeOp(logSoftmaxIntOp, operands);
-    } else if (auto numToTensorOp = dyn_cast<PrimNumToTensorScalarOp>(op)) {
-      return visitNumToTensorOp(numToTensorOp);
-    } else if (isa<AtenAddcmulOp, AtenAddcdivOp>(op)) {
-      return visitAtenAddCLikeOp(op, operands);
-    } else if (isa<AtenAddIntOp, AtenSubIntOp, AtenMulIntOp>(op)) {
-      return visitBinaryScalarOp(op, operands);
-    } else if (auto nllForwardOp = dyn_cast<AtenNllLossForwardOp>(op)) {
-      return visitAtenNllLossForwardOp(nllForwardOp, operands);
-    } else if (auto nllBackwardOp = dyn_cast<AtenNllLossBackwardOp>(op)) {
-      return visitAtenNllLossBackwardOp(nllBackwardOp, operands);
-    } else if (auto nativeLayerNormOp = dyn_cast<AtenNativeLayerNormOp>(op)) {
-      return visitAtenNativeLayerNormOp(nativeLayerNormOp, operands);
-    } else if (auto nativeBatchNormOp = dyn_cast<AtenNativeBatchNormOp>(op)) {
-      return visitAtenNativeBatchNormOp(nativeBatchNormOp, operands);
-    } else if (auto constantPadNdOp = dyn_cast<AtenConstantPadNdOp>(op)) {
-      return visitAtenConstantPadNdOp(constantPadNdOp, operands);
-    } else if (auto indexTensorOp = dyn_cast<AtenIndexTensorOp>(op)) {
-      return visitAtenIndexTensorOp(indexTensorOp, operands);
-    } else if (auto bincountOp = dyn_cast<AtenBincountOp>(op)) {
-      return visitAtenBincountOp(bincountOp, operands);
-    }
-
-    // Otherwise, this is an unknown operation. Just mark all results as
-    // having reached a pessimistic fixpoint.
-    return markAllPessimisticFixpoint(op->getResults());
-  }
+                 ArrayRef<LatticeElement<ValueKnowledge> *> operands) final;
 
 private:
-  ChangeResult
-  visitAtenMmLikeOp(Operation *op,
-                    ArrayRef<LatticeElement<ValueKnowledge> *> operands,
-                    size_t expectedRank);
-  ChangeResult
-  visitAtenAddmmOp(AtenAddmmOp op,
-                   ArrayRef<LatticeElement<ValueKnowledge> *> operands);
+  /// Incorporates `knowledge` into the lattice state of `v`.
+  ///
+  /// This method should be used instead of
+  /// `getLatticeElement(v).join(knowledge)`, because this method knows how to
+  /// correctly handle the case of existing static knowledge from the type
+  /// of `v`.
+  ChangeResult incorporateKnowledge(Value v, const ValueKnowledge &knowledge);
+
   ChangeResult
   visitAtenLinearOp(AtenLinearOp op,
                     ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenConv2dOp(AtenConv2dOp op,
-                    ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenMaxPool2dOp(AtenMaxPool2dOp op,
-                       ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenConstantPadNdOp(AtenConstantPadNdOp op,
-                           ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult visitAtenAdaptiveAvgPool2dOp(
-      AtenAdaptiveAvgPool2dOp op,
-      ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult visitBinaryTensorScalarOp(
-      Operation *op, ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult visitBinaryBroadcastingOp(
-      Operation *op, ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult visitBinaryBroadcastingComparisonOp(
-      Operation *op, ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenWhereSelfOp(AtenWhereSelfOp op,
-                       ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenLerpTensorOp(AtenLerpTensorOp op,
-                        ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult visitAtenFlattenUsingIntsOp(
-      AtenFlattenUsingIntsOp op,
-      ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenSqueezeOp(AtenSqueezeOp op,
-                     ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenSqueezeDimOp(AtenSqueezeDimOp op,
-                        ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenUnsqueezeOp(AtenUnsqueezeOp op,
-                       ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-
+  ChangeResult visitAtenArangeStartStepOp(AtenArangeStartStepOp op);
+  ChangeResult visitAtenArangeStartOp(AtenArangeStartOp op);
+  ChangeResult visitAtenArangeOp(AtenArangeOp op);
   ChangeResult visitAtenArangeLikeOpHelper(Operation *op,
                                            llvm::Optional<Value> start,
                                            Value end,
                                            llvm::Optional<Value> step,
                                            Value dtype);
-  ChangeResult visitAtenArangeStartStepOp(AtenArangeStartStepOp op);
-  ChangeResult visitAtenArangeStartOp(AtenArangeStartOp op);
-  ChangeResult visitAtenArangeOp(AtenArangeOp op);
   ChangeResult visitReductionAlongAllDimsOp(
       Operation *op, Type dtype,
       ArrayRef<LatticeElement<ValueKnowledge> *> operands);
@@ -577,20 +295,6 @@ private:
   ChangeResult visitReductionAlongDimIntOp(
       Operation *op, Value dim, Value keepdim, Type dtype,
       ArrayRef<LatticeElement<ValueKnowledge> *> operands, int resNum = 0);
-  template <typename OpTy>
-  ChangeResult
-  visitReshapeLikeOp(OpTy op,
-                     ArrayRef<LatticeElement<ValueKnowledge> *> operands,
-                     Value sizeList);
-  ChangeResult
-  visitAtenTransposeIntOp(AtenTransposeIntOp op,
-                          ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenTOp(AtenTOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenPermuteOp(AtenPermuteOp op,
-                     ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult visitNumToTensorOp(PrimNumToTensorScalarOp op);
   template <typename OpTy>
   ChangeResult visitScalarToTensorConversionOp(OpTy op);
   ChangeResult visitAtenTensorOp(AtenTensorOp op);
@@ -610,79 +314,52 @@ private:
   ChangeResult
   visitTypeConversionOp(OpTy op,
                         ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  using SetDimSizeFn =
-      std::function<void(int64_t &targetDim, int64_t dim,
-                         ArrayRef<LatticeElement<ValueKnowledge> *> operands)>;
-  template <typename OpTy>
-  ChangeResult
-  visitSliceLikeOp(OpTy op, ArrayRef<LatticeElement<ValueKnowledge> *> operands,
-                   SetDimSizeFn setDim, bool keepDim = true);
-  ChangeResult
-  visitAtenGatherOp(AtenGatherOp op,
-                    ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-
-  using SetDimSizePerListItemFn = std::function<void(
-      int64_t &targetDim, int64_t inputDim, int64_t listValue)>;
-  ChangeResult
-  visitExpandLikeOp(Operation *op, Value list,
-                    ArrayRef<LatticeElement<ValueKnowledge> *> operands,
-                    SetDimSizePerListItemFn setDim);
   ChangeResult
   visitAtenCatOp(AtenCatOp op,
                  ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenShapeAsTensorOp(Aten_ShapeAsTensorOp op,
-                           ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenEmbeddingOp(AtenEmbeddingOp op,
-                       ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitBinaryScalarOp(Operation *op,
-                      ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-
-  ChangeResult
-  visitAtenMatmulOp(AtenMatmulOp op,
-                    ArrayRef<LatticeElement<ValueKnowledge> *> operands);
 
   template <typename OpTy>
   ChangeResult
   visitAtenSoftmaxLikeOp(OpTy op,
                          ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-
-  ChangeResult
-  visitAtenAddCLikeOp(Operation *op,
-                      ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-
   template <typename OpTy>
   ChangeResult
   visitAten_SoftmaxLikeOp(OpTy op,
-                      ArrayRef<LatticeElement<ValueKnowledge> *> operands);
+                          ArrayRef<LatticeElement<ValueKnowledge> *> operands);
 
-  ChangeResult visitAtenNllLossForwardOp(
-      AtenNllLossForwardOp op,
-      ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult visitAtenNllLossBackwardOp(
-      AtenNllLossBackwardOp op,
-      ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult visitAtenNativeLayerNormOp(
-      AtenNativeLayerNormOp op,
-      ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult visitAtenNativeBatchNormOp(
-      AtenNativeBatchNormOp op,
-      ArrayRef<LatticeElement<ValueKnowledge> *> operands);
+  ChangeResult visitNumToTensorOp(PrimNumToTensorScalarOp op);
   ChangeResult
-  visitAtenIndexTensorOp(AtenIndexTensorOp op,
-                         ArrayRef<LatticeElement<ValueKnowledge> *> operands);
-  ChangeResult
-  visitAtenBincountOp(AtenBincountOp op,
+  visitBinaryScalarOp(Operation *op,
                       ArrayRef<LatticeElement<ValueKnowledge> *> operands);
 };
 } // namespace
 
-static ResultTypeState updateResultTypeState(Type scalarType,
-                                             const ResultTypeState &inState) {
-  ResultTypeState new_state = inState;
-  ScalarType current =
+// This is the type rule used for deciding dtype for:
+// 1. A new tensor created from given data.
+// 2. The scalar type for type promotion when a scalar is an operand of a tensor
+// and scalar binary operation.
+// If the data is floating-point, the `dtype` is inferred to be the
+// default dtype, see `torch.get_default_dtype`.
+static Type getDefaultDtypeForTorchScalar(Type type) {
+  MLIRContext *context = type.getContext();
+  if (type.isa<Torch::FloatType>()) {
+    // For now, use float32 which is the initial default dtype returned by
+    // `torch.get_default_dtype`.
+    return Float32Type::get(context);
+  }
+  if (type.isa<Torch::IntType>())
+    return IntegerType::get(context, 64, IntegerType::Signed);
+  if (type.isa<Torch::BoolType>())
+    return IntegerType::get(context, 1);
+  llvm_unreachable(
+      "getDefaultDtypeForTorchScalar called on an unsupported type");
+}
+
+static torch_upstream::ResultTypeState
+updateResultTypeState(Type scalarType,
+                      const torch_upstream::ResultTypeState &inState) {
+  torch_upstream::ResultTypeState new_state = inState;
+  torch_upstream::ScalarType current =
       getScalarTypeForType(getDefaultDtypeForTorchScalar(scalarType));
   new_state.wrappedResult =
       promote_skip_undefined(inState.wrappedResult, current);
@@ -697,18 +374,23 @@ static ResultTypeState updateResultTypeState(Type scalarType,
 // Normally, tensor dimensions need to be known at compile time to do type
 // promotion. `skipRankCheck`, when equal to `true`, is used for special cases
 // where rank doesn't matter. This could be because that operands can sometimes
-// guaranteed to be none zero rank or that the result ResultTypeState is
-// promoted with a scalar which is guaranteed to be lower priority.
-static ResultTypeState updateResultTypeState(ValueKnowledge *tensor,
-                                             const ResultTypeState &inState,
-                                             bool skipRankCheck = false) {
-  if (!tensor->hasSizes && !skipRankCheck)
-    return ResultTypeState{};
+// guaranteed to be none zero rank or that the result
+// torch_upstream::ResultTypeState is promoted with a scalar which is guaranteed
+// to be lower priority.
+//
+// The `rankIsNonZero` argument indicates whether the rank is nonzero, zero, or
+// unknown (None variant of the optional).
+static torch_upstream::ResultTypeState
+updateResultTypeState(ValueKnowledge *tensor, Optional<bool> rankIsNonZero,
+                      const torch_upstream::ResultTypeState &inState,
+                      bool skipRankCheck = false) {
+  if (!rankIsNonZero.hasValue() && !skipRankCheck)
+    return torch_upstream::ResultTypeState{};
   assert(tensor->dtype && "tensor.dtype must be not none");
 
-  ResultTypeState new_state = inState;
-  ScalarType current = getScalarTypeForType(tensor->dtype);
-  if (skipRankCheck || tensor->sizes.size() > 0)
+  torch_upstream::ResultTypeState new_state = inState;
+  torch_upstream::ScalarType current = getScalarTypeForType(tensor->dtype);
+  if (skipRankCheck || rankIsNonZero.getValue())
     new_state.dimResult = promote_skip_undefined(inState.dimResult, current);
   else
     new_state.zeroResult = promote_skip_undefined(inState.zeroResult, current);
@@ -717,7 +399,7 @@ static ResultTypeState updateResultTypeState(ValueKnowledge *tensor,
 }
 
 static Type getPromotedResultType(ArrayRef<Type> scalarTypes) {
-  ResultTypeState state = {};
+  torch_upstream::ResultTypeState state = {};
   for (const Type &scalarType : scalarTypes)
     state = updateResultTypeState(scalarType, state);
   return getTypeForScalarType(scalarTypes[0].getContext(), result_type(state));
@@ -727,12 +409,27 @@ static Type getPromotedResultType(ArrayRef<Type> scalarTypes) {
 static Type getPromotedResultType(ValueKnowledge *tensor, Type scalarType) {
   if (!tensor->dtype)
     return Type();
-  ResultTypeState state = {};
+  torch_upstream::ResultTypeState state = {};
   // No need to check if rank is zero for tensor because scalar uses
   // wrappedResult which is a lower priority than both dimResult and zeroResult.
-  state = updateResultTypeState(tensor, state, /*skipRankCheck=*/true);
+  state = updateResultTypeState(tensor, /*rankIsNonZero=*/None, state,
+                                /*skipRankCheck=*/true);
   state = updateResultTypeState(scalarType, state);
   return getTypeForScalarType(scalarType.getContext(), result_type(state));
+}
+
+static SmallVector<Optional<bool>> getRankIsNonZeroArray(ValueRange values) {
+  SmallVector<Optional<bool>> rankIsNonZero;
+  for (Value v : values) {
+    if (auto tensorType = v.getType().dyn_cast<BaseTensorType>()) {
+      if (tensorType.hasSizes()) {
+        rankIsNonZero.push_back(tensorType.getSizes().size() != 0);
+      } else {
+        rankIsNonZero.push_back(None);
+      }
+    }
+  }
+  return rankIsNonZero;
 }
 
 // Normally, tensor dimensions need to be known at compile time to do type
@@ -743,12 +440,16 @@ static Type getPromotedResultType(ValueKnowledge *tensor, Type scalarType) {
 // Returns most generic type Type() if the tensor dtype is unknown.
 static Type getPromotedResultType(MLIRContext *context,
                                   ArrayRef<ValueKnowledge *> tensors,
+                                  ArrayRef<Optional<bool>> rankIsNonZero,
                                   bool skipRankCheck = false) {
-  ResultTypeState state = {};
-  for (ValueKnowledge *tensor : tensors) {
+  torch_upstream::ResultTypeState state = {};
+  assert(tensors.size() == rankIsNonZero.size());
+  for (auto t : llvm::zip(tensors, rankIsNonZero)) {
+    ValueKnowledge *tensor = std::get<0>(t);
+    Optional<bool> rankIsNonZero = std::get<1>(t);
     if (!tensor->dtype)
       return Type();
-    state = updateResultTypeState(tensor, state, skipRankCheck);
+    state = updateResultTypeState(tensor, rankIsNonZero, state, skipRankCheck);
   }
   return getTypeForScalarType(context, result_type(state));
 }
@@ -756,7 +457,9 @@ static Type getPromotedResultType(MLIRContext *context,
 static Type
 getPromotedResultTypeAssumingNonZeroRank(MLIRContext *context,
                                          ArrayRef<ValueKnowledge *> tensors) {
-  return getPromotedResultType(context, tensors, /*skipRankCheck=*/true);
+  SmallVector<Optional<bool>> rankIsNonZero(tensors.size(), true);
+  return getPromotedResultType(context, tensors, rankIsNonZero,
+                               /*skipRankCheck=*/true);
 }
 
 // Get the MLIR type of the tensor dtype given the dtype integer value and the
@@ -784,519 +487,354 @@ static void fillInDTypeGivenDTypeAndDataType(ValueKnowledge &knowledge,
   fillInDTypeGivenDTypeIntAndInputDType(knowledge, dtype, dtypeForDataType);
 }
 
-static void fillInSizesGivenSizesList(ValueKnowledge &knowledge, Value sizes) {
-  // TODO: This is not safe. Need to check the list users and use aliasing
-  // info to safely detect the list is not modified.
-  if (auto listConstruct = sizes.getDefiningOp<PrimListConstructOp>()) {
-    knowledge.hasSizes = true;
-    auto sizes = listConstruct.elements();
-    int64_t size;
-    for (auto sizeValue : sizes) {
-      if (matchPattern(sizeValue, m_TorchConstantInt(&size)))
-        knowledge.sizes.push_back(size);
-      else
-        knowledge.sizes.push_back(kUnknownSize);
-    }
+ChangeResult TypeAnalyzer::visitOperation(
+    Operation *op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
+
+  // These ops have results that are dynamically the same as their operands.
+  if (isa<TensorStaticInfoCastOp, DerefineOp>(op)) {
+    return incorporateKnowledge(op->getResult(0), operands[0]->getValue());
   }
+
+  // Take dtype from first operand.
+  if (isa<CopyToValueTensorOp, CopyToNonValueTensorOp, AtenTanhOp,
+          AtenBatchNormOp, AtenReluOp, AtenGeluOp, AtenCeilOp,
+          AtenGeluBackwardOp, AtenBitwiseNotOp, AtenExpOp, AtenSinOp, AtenCosOp,
+          AtenSigmoidOp, AtenToPrimDeviceOp, AtenCpuOp, AtenContiguousOp,
+          AtenFill_ScalarOp, AtenDetachOp, AtenReciprocalOp,
+          AtenMaskedFill_ScalarOp, AtenCopy_Op, AtenCumsumOp, AtenLayerNormOp,
+          AtenClampOp, AtenLogOp, AtenNegOp, AtenSqrtOp, AtenFloorOp,
+          AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp, AtenDropoutOp,
+          AtenTanhBackwardOp, Aten_LogSoftmaxBackwardDataOp, AtenAddIntOp,
+          AtenAbsOp, AtenThresholdOp, AtenSquareOp, PseudoAtenUniformOp,
+          AtenBernoulliOp, AtenBernoulli_FloatOp, AtenBernoulli_TensorOp,
+          PseudoAtenBernoulliFloatOp, PseudoAtenBernoulliTensorOp,
+          PseudoAtenFillScalarOp, AtenHardsigmoidOp, AtenCloneOp,
+          AtenHardswishOp, AtenErfOp, AtenSiluOp, AtenHardtanhOp,
+          AtenMaskedSelectOp, AtenMaxPool2dOp, AtenAdaptiveAvgPool2dOp,
+          AtenFlattenUsingIntsOp, AtenSqueezeOp, AtenSqueezeDimOp,
+          AtenUnsqueezeOp, AtenViewOp, Aten_UnsafeViewOp, AtenReshapeOp,
+          AtenResize_Op, AtenTransposeIntOp, AtenTOp, AtenPermuteOp,
+          AtenIndexSelectOp, AtenSelectIntOp, AtenSliceTensorOp, AtenGatherOp,
+          AtenExpandOp, AtenBroadcastToOp, AtenRepeatOp, AtenConstantPadNdOp,
+          AtenIndexTensorOp>(op)) {
+    ValueKnowledge knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype = operands[0]->getValue().dtype;
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+
+  // Take dtype from second operand.
+  if (isa<AtenNllLossBackwardOp>(op)) {
+    auto self = operands[1]->getValue();
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype = self.dtype;
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+
+  // Dtype is always i1.
+  if (isa<AtenEqScalarOp, AtenGeScalarOp, AtenGtScalarOp, AtenLtScalarOp,
+          AtenLeScalarOp, AtenNeScalarOp, AtenAnyOp, AtenAllOp, AtenEqTensorOp,
+          AtenGtTensorOp, AtenLtTensorOp>(op)) {
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype = IntegerType::get(op->getContext(), 1);
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+
+  // Dtype is always si64.
+  if (isa<AtenBincountOp>(op)) {
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype =
+        IntegerType::get(op->getContext(), 64, IntegerType::Signed);
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+
+  // Promote the two dtypes assuming non-zero rank.
+  if (isa<AtenMmOp, AtenBmmOp, AtenMatmulOp, AtenConv2dOp>(op)) {
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype = getPromotedResultTypeAssumingNonZeroRank(
+        op->getContext(), {&operands[0]->getValue(), &operands[1]->getValue()});
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+
+  // Promote the two dtypes assuming possibly-zero rank.
+  if (isa<AtenAddTensorOp, AtenSubTensorOp, AtenMulTensorOp, AtenDivTensorOp,
+          Aten__And__TensorOp, AtenMinimumOp, AtenMaximumOp,
+          AtenBitwiseAndTensorOp, AtenThresholdBackwardOp>(op)) {
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype = getPromotedResultType(
+        op->getContext(), {&operands[0]->getValue(), &operands[1]->getValue()},
+        getRankIsNonZeroArray(op->getOperands()));
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+
+  // Promote three dtypes.
+  if (isa<AtenAddmmOp, AtenLerpTensorOp, AtenAddcmulOp, AtenAddcdivOp>(op)) {
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype = getPromotedResultTypeAssumingNonZeroRank(
+        op->getContext(), {&operands[0]->getValue(), &operands[1]->getValue(),
+                           &operands[2]->getValue()});
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+
+  if (auto linear = llvm::dyn_cast<AtenLinearOp>(op)) {
+    return visitAtenLinearOp(linear, operands);
+  }
+
+  // Promote LHS with scalar RHS.
+  if (isa<AtenAddScalarOp, AtenSubScalarOp, AtenMulScalarOp, AtenDivScalarOp,
+          AtenFmodScalarOp, AtenFloorDivideScalarOp, AtenPowTensorScalarOp,
+          AtenRsubScalarOp, AtenLeakyReluOp>(op)) {
+    auto lhs = operands[0]->getValue();
+    Value scalar = op->getOperand(1);
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(getContext());
+    knowledge.dtype = getPromotedResultType(&lhs, scalar.getType());
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+
+  // Promote 2nd and 3rd operands.
+  if (isa<AtenWhereSelfOp>(op)) {
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(getContext());
+    knowledge.dtype = getPromotedResultType(
+        getContext(), {&operands[1]->getValue(), &operands[2]->getValue()},
+        getRankIsNonZeroArray(op->getOperands().slice(1, 2)));
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+
+  // 2 results take dtype from first operand.
+  if (isa<AtenNllLossForwardOp>(op)) {
+    auto self = operands[0]->getValue();
+    auto result0Knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    result0Knowledge.dtype = self.dtype;
+    auto result1Knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    result1Knowledge.dtype = self.dtype;
+    auto changed = incorporateKnowledge(op->getResult(0), result0Knowledge);
+    changed |= incorporateKnowledge(op->getResult(1), result1Knowledge);
+    return changed;
+  }
+
+  // 3 results take dtype from first operand.
+  if (isa<AtenNativeLayerNormOp, AtenNativeBatchNormOp>(op)) {
+    auto self = operands[0]->getValue();
+    auto result0Knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    result0Knowledge.dtype = self.dtype;
+    auto result1Knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    result1Knowledge.dtype = self.dtype;
+    auto result2Knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    result2Knowledge.dtype = self.dtype;
+    auto changed = incorporateKnowledge(op->getResult(0), result0Knowledge);
+    changed |= incorporateKnowledge(op->getResult(1), result1Knowledge);
+    changed |= incorporateKnowledge(op->getResult(2), result1Knowledge);
+    return changed;
+  }
+
+  if (auto arange = dyn_cast<AtenArangeOp>(op)) {
+    return visitAtenArangeOp(arange);
+  }
+  if (auto arangeStart = dyn_cast<AtenArangeStartOp>(op)) {
+    return visitAtenArangeStartOp(arangeStart);
+  }
+  if (auto arangeStartStep = dyn_cast<AtenArangeStartStepOp>(op)) {
+    return visitAtenArangeStartStepOp(arangeStartStep);
+  }
+
+  if (auto sum = dyn_cast<AtenSumOp>(op)) {
+    Type defaultDtype = operands[0]->getValue().dtype;
+    Type dtype = getDtypeOrDefault(sum.getContext(), sum.dtype(), defaultDtype);
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype = dtype;
+    return incorporateKnowledge(op->getResult(0), knowledge);
+  }
+  if (auto sumDimIntList = dyn_cast<AtenSumDimIntListOp>(op)) {
+    Type defaultDtype = operands[0]->getValue().dtype;
+    Type dtype = getDtypeOrDefault(sumDimIntList.getContext(),
+                                   sumDimIntList.dtype(), defaultDtype);
+    return visitReductionAlongDimIntListOp(sumDimIntList, sumDimIntList.dim(),
+                                           sumDimIntList.keepdim(), dtype,
+                                           operands);
+  }
+  if (auto meanDim = dyn_cast<AtenMeanDimOp>(op)) {
+    Type defaultDtype = operands[0]->getValue().dtype;
+    Type dtype =
+        getDtypeOrDefault(meanDim.getContext(), meanDim.dtype(), defaultDtype);
+    return visitReductionAlongDimIntListOp(meanDim, meanDim.dim(),
+                                           meanDim.keepdim(), dtype, operands);
+  }
+  if (auto argmax = dyn_cast<AtenArgmaxOp>(op)) {
+    Value dim = argmax.dim();
+    Type dtype = IntegerType::get(op->getContext(), 64, IntegerType::Signed);
+    if (dim.getType().isa<Torch::NoneType>())
+      return visitReductionAlongAllDimsOp(op, dtype, operands);
+    if (dim.getType().isa<Torch::IntType>())
+      return visitReductionAlongDimIntOp(argmax, argmax.dim(), argmax.keepdim(),
+                                         dtype, operands);
+  }
+  if (auto anyDim = dyn_cast<AtenAnyDimOp>(op)) {
+    Type dtype = operands[0]->getValue().dtype;
+    return visitReductionAlongDimIntOp(anyDim, anyDim.dim(), anyDim.keepdim(),
+                                       dtype, operands);
+  }
+  if (auto maxDim = dyn_cast<AtenMaxDimOp>(op)) {
+    Type firstResDtype = operands[0]->getValue().dtype;
+    Type secondResDtype =
+        IntegerType::get(op->getContext(), 64, IntegerType::Signed);
+    ChangeResult firstRes = visitReductionAlongDimIntOp(
+        maxDim, maxDim.dim(), maxDim.keepdim(), firstResDtype, operands);
+    return firstRes |
+           visitReductionAlongDimIntOp(maxDim, maxDim.dim(), maxDim.keepdim(),
+                                       secondResDtype, operands, /*resNum=*/1);
+  }
+  if (auto mean = dyn_cast<AtenMeanOp>(op)) {
+    Type defaultDtype = operands[0]->getValue().dtype;
+    Type dtype =
+        getDtypeOrDefault(mean.getContext(), mean.dtype(), defaultDtype);
+    return visitReductionAlongAllDimsOp(mean, dtype, operands);
+  } else if (auto max = dyn_cast<AtenMaxOp>(op)) {
+    Type dtype = operands[0]->getValue().dtype;
+    return visitReductionAlongAllDimsOp(max, dtype, operands);
+  } else if (isa<AtenStdOp, AtenVarOp>(op)) {
+    auto input = operands[0]->getValue();
+    return visitReductionAlongAllDimsOp(op, input.dtype, operands);
+  }
+
+  if (auto tensorFloat = dyn_cast<AtenTensorFloatOp>(op)) {
+    return visitScalarToTensorConversionOp<AtenTensorFloatOp>(tensorFloat);
+  } else if (auto tensorInt = dyn_cast<AtenTensorIntOp>(op)) {
+    return visitScalarToTensorConversionOp<AtenTensorIntOp>(tensorInt);
+  } else if (auto tensorBool = dyn_cast<AtenTensorBoolOp>(op)) {
+    return visitScalarToTensorConversionOp<AtenTensorBoolOp>(tensorBool);
+  }
+
+  if (auto tensor = dyn_cast<AtenTensorOp>(op)) {
+    return visitAtenTensorOp(tensor);
+  }
+
+  if (auto zeros = dyn_cast<AtenZerosOp>(op)) {
+    return visitConstantTensorAllocOp<AtenZerosOp>(zeros, /*dataType=*/{});
+  } else if (auto ones = dyn_cast<AtenOnesOp>(op)) {
+    return visitConstantTensorAllocOp<AtenOnesOp>(ones, /*dataType=*/{});
+  } else if (auto emptyMemoryFormat = dyn_cast<AtenEmptyMemoryFormatOp>(op)) {
+    return visitConstantTensorAllocOp<AtenEmptyMemoryFormatOp>(
+        emptyMemoryFormat, /*dataType=*/{});
+  } else if (auto full = dyn_cast<AtenFullOp>(op)) {
+    return visitConstantTensorAllocOp<AtenFullOp>(
+        full, /*dataType=*/full.fill_value().getType());
+  } else if (auto zerosLike = dyn_cast<AtenZerosLikeOp>(op)) {
+    return visitConstantTensorAllocLikeOp<AtenZerosLikeOp>(zerosLike, operands);
+  } else if (auto onesLike = dyn_cast<AtenOnesLikeOp>(op)) {
+    return visitConstantTensorAllocLikeOp<AtenOnesLikeOp>(onesLike, operands);
+  } else if (auto emptyLike = dyn_cast<AtenEmptyLikeOp>(op)) {
+    return visitConstantTensorAllocLikeOp<AtenEmptyLikeOp>(emptyLike, operands);
+  } else if (auto fullLike = dyn_cast<AtenFullLikeOp>(op)) {
+    return visitConstantTensorAllocLikeOp<AtenFullLikeOp>(fullLike, operands);
+  } else if (auto newZeros = dyn_cast<AtenNewZerosOp>(op)) {
+    return visitConstantTensorNewLikeOp<AtenNewZerosOp>(newZeros, operands);
+  } else if (auto newOnes = dyn_cast<AtenNewOnesOp>(op)) {
+    return visitConstantTensorNewLikeOp<AtenNewOnesOp>(newOnes, operands);
+  } else if (auto randLike = dyn_cast<AtenRandLikeOp>(op)) {
+    return visitConstantTensorAllocLikeOp<AtenRandLikeOp>(randLike, operands);
+  }
+
+  if (auto toDtype = dyn_cast<AtenToDtypeOp>(op)) {
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    int64_t dtypeInt;
+    if (matchPattern(toDtype.dtype(), m_TorchConstantInt(&dtypeInt)))
+      knowledge.dtype = getTypeForDTypeInteger(op->getContext(), dtypeInt);
+    return incorporateKnowledge(toDtype.getResult(), knowledge);
+  }
+
+  if (auto toOther = dyn_cast<AtenToOtherOp>(op)) {
+    return visitTypeConversionOp<AtenToOtherOp>(toOther, operands);
+  } else if (auto typeAs = dyn_cast<AtenTypeAsOp>(op)) {
+    return visitTypeConversionOp<AtenTypeAsOp>(typeAs, operands);
+  }
+
+  if (auto cat = dyn_cast<AtenCatOp>(op)) {
+    return visitAtenCatOp(cat, operands);
+  }
+
+  if (auto shapeAsTensor = dyn_cast<Aten_ShapeAsTensorOp>(op)) {
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype =
+        IntegerType::get(op->getContext(), 64, IntegerType::Signed);
+    return incorporateKnowledge(shapeAsTensor.getResult(), knowledge);
+  }
+
+  if (auto embedding = dyn_cast<AtenEmbeddingOp>(op)) {
+    auto knowledge =
+        ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+    knowledge.dtype = Float32Type::get(op->getContext());
+    return incorporateKnowledge(embedding.getResult(), knowledge);
+  }
+
+  if (auto softmaxIntOp = dyn_cast<AtenSoftmaxIntOp>(op)) {
+    return visitAtenSoftmaxLikeOp(softmaxIntOp, operands);
+  }
+  if (auto _softmaxOp = dyn_cast<Aten_SoftmaxOp>(op)) {
+    return visitAten_SoftmaxLikeOp(_softmaxOp, operands);
+  } else if (auto _logSoftmaxOp = dyn_cast<Aten_LogSoftmaxOp>(op)) {
+    return visitAten_SoftmaxLikeOp(_logSoftmaxOp, operands);
+  } else if (auto logSoftmaxIntOp = dyn_cast<AtenLogSoftmaxIntOp>(op)) {
+    return visitAtenSoftmaxLikeOp(logSoftmaxIntOp, operands);
+  }
+
+  if (auto numToTensorOp = dyn_cast<PrimNumToTensorScalarOp>(op)) {
+    return visitNumToTensorOp(numToTensorOp);
+  }
+
+  if (isa<AtenAddIntOp, AtenSubIntOp, AtenMulIntOp>(op)) {
+    return visitBinaryScalarOp(op, operands);
+  }
+
+  // Otherwise, this is an unknown operation. Just mark all results as
+  // having reached a pessimistic fixpoint.
+  return markAllPessimisticFixpoint(op->getResults());
 }
 
-static void fillInSizesForBinaryBroadcastingOp(ValueKnowledge &lhs,
-                                               ValueKnowledge &rhs,
-                                               ValueKnowledge &knowledge) {
-  if (lhs.hasSizes && rhs.hasSizes) {
-    knowledge.hasSizes = true;
-    knowledge.sizes.resize(std::max(lhs.sizes.size(), rhs.sizes.size()),
-                           kUnknownSize);
-
-    int64_t resultRank = knowledge.sizes.size();
-    auto increaseRankToResultRank =
-        [&](const std::vector<int64_t> &sizes) -> std::vector<int64_t> {
-      int offset = resultRank - sizes.size();
-      std::vector<int64_t> newSizes(std::max(offset, 0), 1);
-      newSizes.insert(newSizes.end(), sizes.begin(), sizes.end());
-      return newSizes;
-    };
-
-    std::vector<int64_t> rankAdjustedSizesLhs =
-        increaseRankToResultRank(lhs.sizes);
-    std::vector<int64_t> rankAdjustedSizesRhs =
-        increaseRankToResultRank(rhs.sizes);
-
-    for (int64_t i = 0; i < resultRank; i++) {
-      int64_t lhsDimSize = rankAdjustedSizesLhs[i];
-      int64_t rhsDimSize = rankAdjustedSizesRhs[i];
-      // Dynamic shape can't be decided at compilation.
-      if (lhsDimSize == kUnknownSize || rhsDimSize == kUnknownSize)
-        continue;
-
-      // Incompatible broadcasting shape.
-      if (lhsDimSize != rhsDimSize && lhsDimSize != 1 && rhsDimSize != 1) {
-        knowledge.hasSizes = false;
-        knowledge.sizes.clear();
-        return;
-      }
-
-      knowledge.sizes[i] = std::max(lhsDimSize, rhsDimSize);
-    }
-  }
-}
-
-// Visitor for AtenMmOp and AtenBmmOp
-ChangeResult TypeAnalyzer::visitAtenMmLikeOp(
-    Operation *op, ArrayRef<LatticeElement<ValueKnowledge> *> operands,
-    size_t expectedRank) {
-  assert(expectedRank >= 2 && "expected rank must be >= 2");
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  ValueKnowledge self = operands[0]->getValue();
-  ValueKnowledge mat2 = operands[1]->getValue();
-  bool hasBatchDim = expectedRank > 2;
-
-  auto hasExpectedRank = [&](const ValueKnowledge &operand) {
-    return operand.hasSizes && operand.sizes.size() == expectedRank;
-  };
-  if (!hasExpectedRank(self) || !hasExpectedRank(mat2))
-    return getLatticeElement(op->getResult(0)).join(knowledge);
-
-  // If static information is available, check that the dimensions that
-  // the two tensors have in common are compatible.
-  auto dimsAreCompatible = [](int64_t dim1, int64_t dim2) {
-    return dim1 == kUnknownSize || dim2 == kUnknownSize || dim1 == dim2;
-  };
-  int64_t selfBatchDimSize = hasBatchDim ? self.sizes[0] : 0;
-  int64_t mat2BatchDimSize = hasBatchDim ? mat2.sizes[0] : 0;
-  if (!dimsAreCompatible(selfBatchDimSize, mat2BatchDimSize) ||
-      !dimsAreCompatible(self.sizes[expectedRank - 1],
-                         mat2.sizes[expectedRank - 2]))
-    return getLatticeElement(op->getResult(0)).join(knowledge);
-
-  knowledge.hasSizes = true;
-  if (hasBatchDim) {
-    int64_t batchDimSize =
-        selfBatchDimSize == kUnknownSize ? mat2BatchDimSize : selfBatchDimSize;
-    knowledge.sizes = {batchDimSize};
-  }
-  knowledge.sizes.push_back(self.sizes[expectedRank - 2]);
-  knowledge.sizes.push_back(mat2.sizes[expectedRank - 1]);
-  knowledge.dtype = getPromotedResultTypeAssumingNonZeroRank(op->getContext(),
-                                                             {&self, &mat2});
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenAddmmOp(
-    AtenAddmmOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto &input = operands[0]->getValue();
-  auto &mat1 = operands[1]->getValue();
-  auto &mat2 = operands[2]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.hasSizes = true;
-  knowledge.sizes.resize(2, kUnknownSize);
-  knowledge.dtype = getPromotedResultTypeAssumingNonZeroRank(
-      op->getContext(), {&input, &mat1, &mat2});
-  return getLatticeElement(op->getResult(0)).join(knowledge);
+ChangeResult
+TypeAnalyzer::incorporateKnowledge(Value v, const ValueKnowledge &knowledge) {
+  auto updatedKnowledge = ValueKnowledge::meet(
+      knowledge, ValueKnowledge::getPessimisticValueState(v));
+  assert(updatedKnowledge.hasValue() && "IR has contradictory type!");
+  return getLatticeElement(v).join(updatedKnowledge.getValue());
 }
 
 ChangeResult TypeAnalyzer::visitAtenLinearOp(
     AtenLinearOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  // The output shape is the input shape with the last dimension changed
-  // to the weight's output dimension.
-  auto knowledge = operands[0]->getValue();
+  auto knowledge =
+      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
+  auto input = operands[0]->getValue();
   auto weight = operands[1]->getValue();
   auto bias = operands[2]->getValue();
-  if (knowledge.hasSizes && knowledge.sizes.size() > 0) {
-    if (weight.hasSizes)
-      knowledge.sizes[knowledge.sizes.size() - 1] = weight.sizes[0];
-    else
-      knowledge.sizes[knowledge.sizes.size() - 1] = kUnknownSize;
-  }
   switch (bias.optional) {
-  case ValueKnowledge::OptionalKnowledge::isNone:
+  case OptionalKnowledge::isNone:
     knowledge.dtype = getPromotedResultTypeAssumingNonZeroRank(
-        op->getContext(), {&knowledge, &weight});
+        op->getContext(), {&input, &weight});
     break;
-  case ValueKnowledge::OptionalKnowledge::notNone:
+  case OptionalKnowledge::notNone:
     knowledge.dtype = getPromotedResultTypeAssumingNonZeroRank(
-        op->getContext(), {&knowledge, &weight, &bias});
+        op->getContext(), {&input, &weight, &bias});
     break;
-  case ValueKnowledge::OptionalKnowledge::unKnown:
+  case OptionalKnowledge::unKnown:
     // When it's unknown, type promotion can't be decided at compile time.
     break;
   }
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-static int64_t getOutputDimForOpWithKernel(int64_t dimIn, int64_t padding,
-                                           int64_t dilation, int64_t kernelSize,
-                                           int64_t stride) {
-  return ((dimIn + 2 * padding - dilation * (kernelSize - 1) - 1) / stride) + 1;
-}
-
-template <class Op>
-std::vector<int64_t>
-computeOpWithKernelOutputShape(Op op, const ValueKnowledge &ifm,
-                               int64_t features, int64_t kernelHeight,
-                               int64_t kernelWidth) {
-  std::vector<int64_t> result = {ifm.sizes[0], // N
-                                 features,     // F
-                                 kUnknownSize, kUnknownSize};
-
-  SmallVector<int64_t> padding;
-  if (!matchPattern(op.padding(), m_TorchConstantIntList(padding)))
-    return result;
-  SmallVector<int64_t, 2> stride;
-  if (!matchPattern(op.stride(), m_TorchConstantIntList(stride)))
-    return result;
-  SmallVector<int64_t, 2> dilation;
-  if (!matchPattern(op.dilation(), m_TorchConstantIntList(dilation)))
-    return result;
-
-  int64_t ifmHeight = ifm.sizes[2];
-  if (ifmHeight != kUnknownSize && kernelHeight != kUnknownSize)
-    result[2] = getOutputDimForOpWithKernel(ifmHeight, padding[0], dilation[0],
-                                            kernelHeight, stride[0]);
-
-  int64_t ifmWidth = ifm.sizes[3];
-  if (ifmWidth != kUnknownSize && kernelWidth != kUnknownSize)
-    result[3] = getOutputDimForOpWithKernel(ifmWidth, padding[1], dilation[1],
-                                            kernelWidth, stride[1]);
-
-  return result;
-}
-
-ChangeResult TypeAnalyzer::visitAtenConv2dOp(
-    AtenConv2dOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.hasSizes = true;
-  auto &input = operands[0]->getValue();
-  auto &weights = operands[1]->getValue();
-  if (weights.hasSizes && input.hasSizes)
-    knowledge.sizes = computeOpWithKernelOutputShape(
-        op, input, weights.sizes[0], weights.sizes[2], weights.sizes[3]);
-  else
-    knowledge.sizes.resize(4, kUnknownSize);
-
-  // Running some experiments in PyTorch, the bias doesn't seem to
-  // contribute to the final element type.
-  knowledge.dtype = getPromotedResultTypeAssumingNonZeroRank(
-      op->getContext(), {&input, &weights});
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenMaxPool2dOp(
-    AtenMaxPool2dOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.hasSizes = true;
-  auto &input = operands[0]->getValue();
-  SmallVector<int64_t, 2> kernelSize;
-  if (!matchPattern(op.kernel_size(), m_TorchConstantIntList(kernelSize)))
-    kernelSize = SmallVector<int64_t, 2>{kUnknownSize, kUnknownSize};
-  if (input.hasSizes)
-    knowledge.sizes = computeOpWithKernelOutputShape(
-        op, input, input.sizes[1], kernelSize[0], kernelSize[1]);
-  else
-    knowledge.sizes.resize(4, kUnknownSize);
-  knowledge.dtype = operands[0]->getValue().dtype;
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenConstantPadNdOp(
-    AtenConstantPadNdOp op,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  auto &input = operands[0]->getValue();
-  if (input.hasSizes) {
-    knowledge.hasSizes = true;
-    SmallVector<int64_t> padInts;
-    if (matchPattern(op.pad(), m_TorchConstantIntList(padInts))) {
-      knowledge.sizes = input.sizes;
-      uint64_t padRank = padInts.size() / 2;
-      uint64_t padOffset = knowledge.sizes.size() - padRank;
-      // op.pad() is highest dim first ordered pairs of low,high.
-      for (uint64_t i = padRank, r = padOffset; i > 0; --i, ++r) {
-        if (knowledge.sizes[r] != kUnknownSize)
-          knowledge.sizes[r] += padInts[i * 2 - 2] + padInts[i * 2 - 1];
-      }
-    } else
-      knowledge.sizes.resize(input.sizes.size(), kUnknownSize);
-  }
-
-  knowledge.dtype = operands[0]->getValue().dtype;
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenAdaptiveAvgPool2dOp(
-    AtenAdaptiveAvgPool2dOp op,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto &input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  if (input.hasSizes) {
-    knowledge.hasSizes = true;
-    knowledge.sizes.resize(input.sizes.size(), kUnknownSize);
-    uint32_t index = 0;
-    knowledge.sizes[index++] = input.sizes[0];
-    if (input.sizes.size() == 4)
-      knowledge.sizes[index++] = input.sizes[1];
-    SmallVector<int64_t> output_size;
-    if (matchPattern(op.output_size(), m_TorchConstantIntList(output_size))) {
-      knowledge.sizes[index++] = output_size[0];
-      knowledge.sizes[index++] = output_size[1];
-    }
-  }
-  knowledge.dtype = input.dtype;
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitBinaryTensorScalarOp(
-    Operation *op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto lhs = operands[0]->getValue();
-  Value scalar = op->getOperand(1);
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(getContext());
-  if (lhs.hasSizes) {
-    knowledge.hasSizes = true;
-    knowledge.sizes = lhs.sizes;
-  }
-  knowledge.dtype = getPromotedResultType(&lhs, scalar.getType());
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitBinaryBroadcastingOp(
-    Operation *op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  // This is a general binary broadcasting shape transfer function.
-  // We currently don't track "size 1" in our lattice, but we might want to.
-  // We could make this more precise as well. But again, as with the other
-  // shape transfer functions, handling the statically-invalid case is
-  // tricky, so we defer that until we need it.
-  auto lhs = operands[0]->getValue();
-  auto rhs = operands[1]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(getContext());
-  fillInSizesForBinaryBroadcastingOp(lhs, rhs, knowledge);
-
-  // The alpha in `aten.add.Tensor` and `aten.sub.Tensor` has to be lower type
-  // category than the lhs and rhs and therefore doesn't really contribute to
-  // type promotion.
-  knowledge.dtype = getPromotedResultType(getContext(), {&lhs, &rhs});
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitBinaryBroadcastingComparisonOp(
-    Operation *op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto lhs = operands[0]->getValue();
-  auto rhs = operands[1]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(getContext());
-  fillInSizesForBinaryBroadcastingOp(lhs, rhs, knowledge);
-  knowledge.dtype = IntegerType::get(op->getContext(), 1);
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenWhereSelfOp(
-    AtenWhereSelfOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto condition = operands[0]->getValue();
-  auto lhs = operands[1]->getValue();
-  auto rhs = operands[2]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(getContext());
-  if (condition.hasSizes && lhs.hasSizes && rhs.hasSizes) {
-    knowledge.hasSizes = true;
-    knowledge.sizes.resize(
-        std::max(condition.sizes.size(),
-                 std::max(lhs.sizes.size(), rhs.sizes.size())),
-        kUnknownSize);
-  }
-
-  knowledge.dtype = getPromotedResultType(getContext(), {&lhs, &rhs});
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenLerpTensorOp(
-    AtenLerpTensorOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  // This is a general broadcasting shape transfer function.
-  // We currently don't track "size 1" in our lattice, but we might want to.
-  // We could make this more precise as well. But again, as with the other
-  // shape transfer functions, handling the statically-invalid case is
-  // tricky, so we defer that until we need it.
-  auto self = operands[0]->getValue();
-  auto end = operands[1]->getValue();
-  auto weight = operands[2]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  if (self.hasSizes && end.hasSizes && weight.hasSizes) {
-    knowledge.hasSizes = true;
-    knowledge.sizes.resize(
-        std::max(std::max(self.sizes.size(), end.sizes.size()),
-                 weight.sizes.size()),
-        kUnknownSize);
-  }
-  knowledge.dtype = getPromotedResultType(getContext(), {&self, &end, &weight});
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenFlattenUsingIntsOp(
-    AtenFlattenUsingIntsOp op,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  int64_t startDim;
-  int64_t endDim;
-  auto operand = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-  knowledge.dtype = operand.dtype;
-  if (operand.hasSizes && operand.sizes.size() == 0) {
-    // Rank 0 is special and flattens to rank 1 with size 1.
-    knowledge.hasSizes = true;
-    knowledge.sizes.push_back(1);
-  } else if (operand.hasSizes &&
-             matchPattern(op.start_dim(), m_TorchConstantInt(&startDim)) &&
-             matchPattern(op.end_dim(), m_TorchConstantInt(&endDim))) {
-    int64_t inputRank = operand.sizes.size();
-    if (startDim < 0)
-      startDim += inputRank;
-    if (endDim < 0)
-      endDim += inputRank;
-    // Careful: dimension numbers might be out of bounds.
-    if (0 <= startDim && startDim <= (inputRank - 1) && 0 <= endDim &&
-        endDim <= (inputRank - 1) && startDim <= endDim) {
-      knowledge.hasSizes = true;
-      for (auto i = 0; i < startDim; i++)
-        knowledge.sizes.push_back(operand.sizes[i]);
-      int64_t dimProduct = 1;
-      for (auto i = startDim; i <= endDim; i++) {
-        if (operand.sizes[i] == kUnknownSize) {
-          dimProduct = kUnknownSize;
-          break;
-        }
-        dimProduct *= operand.sizes[i];
-      }
-      knowledge.sizes.push_back(dimProduct);
-      for (auto i = endDim + 1; i < inputRank; i++)
-        knowledge.sizes.push_back(operand.sizes[i]);
-    }
-  }
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenSqueezeOp(
-    AtenSqueezeOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto operand = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-  knowledge.dtype = operand.dtype;
-  if (operand.hasSizes) {
-    int64_t inputRank = operand.sizes.size();
-    knowledge.hasSizes = true;
-    // `knowledge.sizes` will be empty when either `inputRank` is 0 or operand
-    // tensor type is statically shaped with all dimensions being unit.
-    // Note: size-1 dynamic dimensions are not supported yet.
-    for (auto i = 0; i < inputRank; i++)
-      if (operand.sizes[i] != 1)
-        knowledge.sizes.push_back(operand.sizes[i]);
-  }
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenNllLossForwardOp(
-    AtenNllLossForwardOp op,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto self = operands[0]->getValue();
-  auto outputKnowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-  auto totalWeightKnowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-
-  // `AtenNllLossForward` op returns two outputs, output and total_weight.
-  // The rank of the output depends on the reduction parameter and total_weight
-  // is a scalar value.
-  outputKnowledge.dtype = self.dtype;
-  totalWeightKnowledge.dtype = self.dtype;
-  totalWeightKnowledge.hasSizes = true;
-  if (self.hasSizes) {
-    int64_t reduction;
-    if (matchPattern(op.reduction(), m_TorchConstantInt(&reduction))) {
-      outputKnowledge.hasSizes = true;
-      unsigned resultRank = self.sizes.size();
-      if (reduction == Reduction::None)
-        outputKnowledge.sizes.resize(resultRank - 1, kUnknownSize);
-    }
-  }
-  auto resultLattice = getLatticeElement(op.getResult(0)).join(outputKnowledge);
-  resultLattice |=
-      getLatticeElement(op.getResult(1)).join(totalWeightKnowledge);
-  return resultLattice;
-}
-
-ChangeResult TypeAnalyzer::visitAtenNllLossBackwardOp(
-    AtenNllLossBackwardOp op,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto self = operands[1]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-
-  knowledge.dtype = self.dtype;
-  if (self.hasSizes) {
-    unsigned resultRank = self.sizes.size();
-    knowledge.sizes.resize(resultRank, kUnknownSize);
-    knowledge.hasSizes = true;
-  }
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenSqueezeDimOp(
-    AtenSqueezeDimOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto operand = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-  knowledge.dtype = operand.dtype;
-  int64_t dim;
-  if (operand.hasSizes && matchPattern(op.dim(), m_TorchConstantInt(&dim))) {
-    int64_t inputRank = operand.sizes.size();
-    if (inputRank == 0) {
-      if (dim == -1 || dim == 0) {
-        knowledge.hasSizes = true;
-      }
-      return getLatticeElement(op.getResult()).join(knowledge);
-    }
-    // The dim value is allowed to be in the range `[-inputRank, inputRank)`.
-    if (dim < 0)
-      dim += inputRank;
-    if (0 <= dim && dim < inputRank && operand.sizes[dim] != kUnknownSize) {
-      knowledge.hasSizes = true;
-      knowledge.sizes = operand.sizes;
-      if (operand.sizes[dim] == 1)
-        knowledge.sizes.erase(knowledge.sizes.begin() + dim);
-    }
-  }
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenUnsqueezeOp(
-    AtenUnsqueezeOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto operand = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-  knowledge.dtype = operand.dtype;
-  int64_t dim;
-  if (operand.hasSizes && matchPattern(op.dim(), m_TorchConstantInt(&dim))) {
-    int64_t inputRank = operand.sizes.size();
-    // Careful, it's easy to be off by one here for negative values.
-    // The dim value is allowed to be in the range
-    // `[-inputRank - 1, inputRank]`.
-    // And negative values have `inputRank + 1` added to them rather
-    // than the more typical `inputRank`.
-    if (dim < 0)
-      dim += inputRank + 1;
-    if (0 <= dim && dim <= inputRank) {
-      knowledge.hasSizes = true;
-      knowledge.sizes = operand.sizes;
-      knowledge.sizes.insert(knowledge.sizes.begin() + dim, 1);
-    }
-  }
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op->getResult(0), knowledge);
 }
 
 // Arange like ops returns a 1-D tensor of size ceil(end - start).
@@ -1305,8 +843,6 @@ ChangeResult TypeAnalyzer::visitAtenArangeLikeOpHelper(
     llvm::Optional<Value> step, Value dtype) {
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.sizes.resize(1, kUnknownSize);
-  knowledge.hasSizes = true;
   int64_t dtypeInt;
   if (matchPattern(dtype, m_TorchConstantInt(&dtypeInt))) {
     knowledge.dtype = getTypeForDTypeInteger(op->getContext(), dtypeInt);
@@ -1327,7 +863,7 @@ ChangeResult TypeAnalyzer::visitAtenArangeLikeOpHelper(
       knowledge.dtype =
           IntegerType::get(op->getContext(), 64, IntegerType::Signed);
   }
-  return getLatticeElement(op->getResult(0)).join(knowledge);
+  return incorporateKnowledge(op->getResult(0), knowledge);
 }
 
 ChangeResult
@@ -1349,10 +885,7 @@ ChangeResult TypeAnalyzer::visitReductionAlongAllDimsOp(
     ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
   auto knowledge = ValueKnowledge::getPessimisticValueState(op->getContext());
   knowledge.dtype = dtype;
-  // Reduction along all dims always results in a tensor of rank zero,
-  // which is represented by the default empty `knowledge.sizes` vector
-  knowledge.hasSizes = true;
-  return getLatticeElement(op->getResult(0)).join(knowledge);
+  return incorporateKnowledge(op->getResult(0), knowledge);
 }
 
 // These ops do caculation along the dims given by the integer list and reduce
@@ -1360,151 +893,20 @@ ChangeResult TypeAnalyzer::visitReductionAlongAllDimsOp(
 ChangeResult TypeAnalyzer::visitReductionAlongDimIntListOp(
     Operation *op, Value dim, Value keepdim, Type dtype,
     ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
   knowledge.dtype = dtype;
-  llvm::SmallVector<int64_t> dimList;
-  bool keepDim;
-  if (matchPattern(keepdim, m_TorchConstantBool(&keepDim))) {
-    knowledge.hasSizes = true;
-    int64_t inputRank = input.sizes.size();
-    // TODO: This is not safe. Need to check the list users and use aliasing
-    // info to safely detect the list is not modified.
-    if (matchPattern(dim, m_TorchConstantIntList(dimList))) {
-      llvm::for_each(
-          dimList, [&](int64_t &dim) { dim = toPositiveDim(dim, inputRank); });
-      DenseSet<int64_t> dimSet(dimList.begin(), dimList.end());
-      for (auto en : llvm::enumerate(input.sizes)) {
-        if (dimSet.contains(en.index())) {
-          if (keepDim)
-            knowledge.sizes.push_back(1);
-        } else {
-          knowledge.sizes.push_back(en.value());
-        }
-      }
-    } else if (auto listConstruct = dim.getDefiningOp<PrimListConstructOp>()) {
-      auto sizes = listConstruct.elements();
-      knowledge.sizes.resize(keepDim ? inputRank : inputRank - sizes.size(),
-                             kUnknownSize);
-    }
-  }
-  return getLatticeElement(op->getResult(0)).join(knowledge);
+  return incorporateKnowledge(op->getResult(0), knowledge);
 }
 
 ChangeResult TypeAnalyzer::visitReductionAlongDimIntOp(
     Operation *op, Value dim, Value keepdim, Type dtype,
     ArrayRef<LatticeElement<ValueKnowledge> *> operands, int resNum) {
   assert(dim.getType().isa<Torch::IntType>() && "dim must be int type");
-  auto input = operands[0]->getValue();
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
   knowledge.dtype = dtype;
-  int64_t dimInt;
-  bool keepDim;
-  if (matchPattern(keepdim, m_TorchConstantBool(&keepDim))) {
-    int64_t inputRank = input.sizes.size();
-    knowledge.hasSizes = true;
-    if (matchPattern(dim, m_TorchConstantInt(&dimInt))) {
-      knowledge.sizes = input.sizes;
-      dimInt = toPositiveDim(dimInt, inputRank);
-      if (isValidDim(dimInt, inputRank)) {
-        if (keepDim)
-          knowledge.sizes[dimInt] = 1;
-        else
-          knowledge.sizes.erase(knowledge.sizes.begin() + dimInt);
-      }
-    } else {
-      knowledge.sizes.resize(keepDim ? inputRank : inputRank - 1, kUnknownSize);
-    }
-  }
-  return getLatticeElement(op->getResult(resNum)).join(knowledge);
-}
-
-// Reshape like ops are given a size list which specify the shape of the
-// result tensor.
-template <typename OpTy>
-ChangeResult TypeAnalyzer::visitReshapeLikeOp(
-    OpTy op, ArrayRef<LatticeElement<ValueKnowledge> *> operands,
-    Value sizeList) {
-  auto input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-  knowledge.dtype = input.dtype;
-
-  fillInSizesGivenSizesList(knowledge, sizeList);
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenTransposeIntOp(
-    AtenTransposeIntOp op,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-  knowledge.dtype = input.dtype;
-  knowledge.hasSizes = input.hasSizes;
-  auto dim0 = op.dim0();
-  auto dim1 = op.dim1();
-  int64_t dim0Int;
-  int64_t dim1Int;
-  if (matchPattern(dim0, m_TorchConstantInt(&dim0Int)) &&
-      matchPattern(dim1, m_TorchConstantInt(&dim1Int))) {
-    knowledge.sizes = input.sizes;
-    int64_t inputRank = input.sizes.size();
-    dim0Int = toPositiveDim(dim0Int, inputRank);
-    dim1Int = toPositiveDim(dim1Int, inputRank);
-    if (isValidDim(dim0Int, inputRank) && isValidDim(dim1Int, inputRank)) {
-      std::swap(knowledge.sizes[dim0Int], knowledge.sizes[dim1Int]);
-      return getLatticeElement(op.getResult()).join(knowledge);
-    }
-  }
-
-  knowledge.sizes.resize(input.sizes.size(), kUnknownSize);
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenTOp(
-    AtenTOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-  knowledge.dtype = input.dtype;
-  if (!input.hasSizes)
-    return getLatticeElement(op.getResult()).join(knowledge);
-  int64_t inputRank = input.sizes.size();
-  if (inputRank >= 0 && inputRank <= 2) {
-    knowledge.hasSizes = input.hasSizes;
-    knowledge.sizes = input.sizes;
-    if (inputRank == 2)
-      std::swap(knowledge.sizes[0], knowledge.sizes[1]);
-  }
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenPermuteOp(
-    AtenPermuteOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
-  knowledge.dtype = input.dtype;
-  if (!input.hasSizes)
-    return getLatticeElement(op.getResult()).join(knowledge);
-  knowledge.hasSizes = input.hasSizes;
-  knowledge.sizes.resize(input.sizes.size(), kUnknownSize);
-  Value dims = op.dims();
-  SmallVector<int64_t> dimensions;
-  if (matchPattern(dims, m_TorchConstantIntList(dimensions))) {
-    int64_t inputRank = input.sizes.size();
-    for (unsigned i = 0; i < inputRank; i++) {
-      int64_t dim = toPositiveDim(dimensions[i], inputRank);
-      if (!isValidDim(dim, inputRank)) {
-        return getLatticeElement(op.getResult()).join(knowledge);
-      }
-      knowledge.sizes[i] = input.sizes[dim];
-    }
-  }
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op->getResult(resNum), knowledge);
 }
 
 template <typename OpTy>
@@ -1513,9 +915,8 @@ ChangeResult TypeAnalyzer::visitScalarToTensorConversionOp(OpTy op) {
       ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
   Value t = op.t();
   Value dtype = op.dtype();
-  knowledge.hasSizes = true;
   fillInDTypeGivenDTypeAndDataType(knowledge, dtype, t.getType());
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 ChangeResult TypeAnalyzer::visitBinaryScalarOp(
@@ -1524,29 +925,20 @@ ChangeResult TypeAnalyzer::visitBinaryScalarOp(
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
   knowledge.dtype = getPromotedResultType(
       {op->getOperand(0).getType(), op->getOperand(1).getType()});
-  return getLatticeElement(op->getResult(0)).join(knowledge);
+  return incorporateKnowledge(op->getResult(0), knowledge);
 }
 
-// `torch.aten.tensor` get a tensor from a list. Each layer of the list
-// corresponds to one dim of the tensor.
 ChangeResult TypeAnalyzer::visitAtenTensorOp(AtenTensorOp op) {
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op.getContext());
   Value data = op.data();
   Value dtype = op.dtype();
   Type type = data.getType();
-  int64_t rank = 0;
   while (auto listType = type.dyn_cast<ListType>()) {
     type = listType.getContainedType();
-    rank++;
-  }
-
-  if (rank != 0) {
-    knowledge.hasSizes = true;
-    knowledge.sizes.resize(rank, kUnknownSize);
   }
   fillInDTypeGivenDTypeAndDataType(knowledge, dtype, type);
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 template <typename OpTy>
@@ -1555,11 +947,10 @@ TypeAnalyzer::visitConstantTensorAllocOp(OpTy op,
                                          llvm::Optional<Type> dataType) {
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  fillInSizesGivenSizesList(knowledge, op.size());
   if (!dataType)
     dataType = Torch::FloatType::get(op->getContext());
   fillInDTypeGivenDTypeAndDataType(knowledge, op.dtype(), dataType.getValue());
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 template <typename OpTy>
@@ -1568,12 +959,8 @@ ChangeResult TypeAnalyzer::visitConstantTensorAllocLikeOp(
   auto input = operands[0]->getValue();
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  if (input.hasSizes) {
-    knowledge.hasSizes = true;
-    knowledge.sizes = input.sizes;
-  }
   fillInDTypeGivenDTypeIntAndInputDType(knowledge, op.dtype(), input.dtype);
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 template <typename OpTy>
@@ -1582,137 +969,33 @@ ChangeResult TypeAnalyzer::visitConstantTensorNewLikeOp(
   auto input = operands[0]->getValue();
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  fillInSizesGivenSizesList(knowledge, op.size());
   fillInDTypeGivenDTypeIntAndInputDType(knowledge, op.dtype(), input.dtype);
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 // Convert input tensor type to the given `dtype`.
 ChangeResult TypeAnalyzer::visitAtenToDtypeOp(
     AtenToDtypeOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.hasSizes = input.hasSizes;
-  if (input.hasSizes)
-    knowledge.sizes = input.sizes;
   Value dtype = op.dtype();
   int64_t dtypeInt;
   if (matchPattern(dtype, m_TorchConstantInt(&dtypeInt)))
     knowledge.dtype = getTypeForDTypeInteger(op->getContext(), dtypeInt);
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 // Convert input tensor type to the same as the other tensor.
 template <typename OpTy>
 ChangeResult TypeAnalyzer::visitTypeConversionOp(
     OpTy op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.hasSizes = input.hasSizes;
-  knowledge.sizes = input.sizes;
   Value other = op.other();
   BaseTensorType type = other.getType().cast<BaseTensorType>();
   if (type.hasDtype())
     knowledge.dtype = type.getDtype();
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-// The returned tensor has the same number of dimensions as the input tensor.
-// The dimension specified by dim has size decided by \p setDim and other
-// dimensions have the same size as in the original tensor.
-template <typename OpTy>
-ChangeResult TypeAnalyzer::visitSliceLikeOp(
-    OpTy op, ArrayRef<LatticeElement<ValueKnowledge> *> operands,
-    SetDimSizeFn setDim, bool keepDim) {
-  auto input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.dtype = input.dtype;
-  if (!input.hasSizes)
-    return getLatticeElement(op.getResult()).join(knowledge);
-
-  knowledge.hasSizes = true;
-  bool dimIsUnknown = false;
-  int64_t dim;
-  if (!matchPattern(op.dim(), m_TorchConstantInt(&dim)))
-    dimIsUnknown = true;
-  else {
-    int64_t inputRank = input.sizes.size();
-    dim = toPositiveDim(dim, inputRank);
-    if (!isValidDim(dim, inputRank))
-      dimIsUnknown = true;
-  }
-
-  if (dimIsUnknown) {
-    knowledge.sizes.resize(input.sizes.size(), kUnknownSize);
-    return getLatticeElement(op.getResult()).join(knowledge);
-  }
-  knowledge.sizes = input.sizes;
-  setDim(knowledge.sizes[dim], dim, operands);
-  if (!keepDim)
-    knowledge.sizes.erase(knowledge.sizes.begin() + dim);
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-// For `torch.aten.gather` input and index must have the same number of
-// dimensions. Out will have the same shape as index. Note that input and index
-// do not broadcast against each other.
-ChangeResult TypeAnalyzer::visitAtenGatherOp(
-    AtenGatherOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-  auto index = operands[2]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.dtype = input.dtype;
-  knowledge.hasSizes = index.hasSizes;
-  knowledge.sizes = index.sizes;
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-// A list is given for setting dims of the output tensor. Each item in the list
-// corresponds to each dim and specifies how to transform the dim from input to
-// the output.
-ChangeResult TypeAnalyzer::visitExpandLikeOp(
-    Operation *op, Value list,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands,
-    SetDimSizePerListItemFn setDim) {
-  auto input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.dtype = input.dtype;
-  if (!input.hasSizes)
-    return getLatticeElement(op->getResult(0)).join(knowledge);
-  int64_t inputRank = input.sizes.size();
-
-  SmallVector<Value, 4> listItems;
-  if (!getListConstructElements(list, listItems))
-    return getLatticeElement(op->getResult(0)).join(knowledge);
-  int64_t listRank = listItems.size();
-  knowledge.hasSizes = true;
-  knowledge.sizes.resize(listRank, kUnknownSize);
-
-  if (listRank < inputRank)
-    return getLatticeElement(op->getResult(0)).join(knowledge);
-
-  for (auto en : llvm::enumerate(listItems)) {
-    int64_t listDim = en.index();
-    // Given list rank could be larger than the inputRank, subtract the offset
-    // to get the inputDim.
-    int64_t inputDim = listDim - (listRank - inputRank);
-    int64_t size;
-    if (!matchPattern(en.value(), m_TorchConstantInt(&size)))
-      continue;
-
-    if (inputDim < 0) {
-      knowledge.sizes[listDim] = size;
-      continue;
-    }
-
-    setDim(knowledge.sizes[listDim], input.sizes[inputDim], size);
-  }
-  return getLatticeElement(op->getResult(0)).join(knowledge);
+  return incorporateKnowledge(op->getResult(0), knowledge);
 }
 
 // `torch.aten.cat` concatenates the given sequence of seq tensors in the given
@@ -1725,57 +1008,24 @@ ChangeResult TypeAnalyzer::visitAtenCatOp(
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
   auto listConstruct = tensorList.getDefiningOp<PrimListConstructOp>();
   if (!listConstruct)
-    return getLatticeElement(op.getResult()).join(knowledge);
+    return incorporateKnowledge(op.getResult(), knowledge);
 
   auto tensors = llvm::to_vector<4>(
       llvm::map_range(listConstruct.elements(), [&](Value v) -> ValueKnowledge {
         return getLatticeElement(v).getValue();
       }));
-  for (auto tensor : tensors)
-    knowledge = ValueKnowledge::join(knowledge, tensor);
-  if (!knowledge.hasSizes)
-    return getLatticeElement(op.getResult()).join(knowledge);
-
-  int64_t dim;
-  bool dimIsUnknown = false;
-  if (!matchPattern(op.dim(), m_TorchConstantInt(&dim))) {
-    dimIsUnknown = true;
-  } else {
-    int64_t inputRank = knowledge.sizes.size();
-    dim = toPositiveDim(dim, inputRank);
-    if (!isValidDim(dim, inputRank))
-      dimIsUnknown = true;
+  for (auto tensor : tensors) {
+    auto newDtype = meetElementTypes(knowledge.dtype, tensor.dtype);
+    if (!newDtype.hasValue())
+      return incorporateKnowledge(op.getResult(), knowledge);
+    knowledge.dtype = newDtype.getValue();
   }
-
-  if (dimIsUnknown) {
-    knowledge.sizes.assign(knowledge.sizes.size(), kUnknownSize);
-    return getLatticeElement(op.getResult()).join(knowledge);
-  }
-  knowledge.sizes[dim] = kUnknownSize;
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-// Get the shape of the input tensor as a 1-D tensor.
-ChangeResult TypeAnalyzer::visitAtenShapeAsTensorOp(
-    Aten_ShapeAsTensorOp op,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  if (input.hasSizes)
-    knowledge.sizes.resize(1, input.sizes.size());
-  else
-    knowledge.sizes.push_back(kUnknownSize);
-  knowledge.hasSizes = true;
-  knowledge.dtype = IntegerType::get(op->getContext(), 64, IntegerType::Signed);
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 ChangeResult TypeAnalyzer::visitNumToTensorOp(PrimNumToTensorScalarOp op) {
   auto knowledge =
       ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.hasSizes = true;
-
   // The resulting type from converting a Scalar into a Tensor is different
   // if the scalar is part of a tensor operation (such as AtenMulScalar) or
   // not. In the former case, the type promotion rules are captured by the
@@ -1790,38 +1040,7 @@ ChangeResult TypeAnalyzer::visitNumToTensorOp(PrimNumToTensorScalarOp op) {
     knowledge.dtype =
         IntegerType::get(op.getContext(), 64, IntegerType::Signed);
 
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenEmbeddingOp(
-    AtenEmbeddingOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  auto weight = operands[0]->getValue();
-  auto indices = operands[1]->getValue();
-  if (indices.hasSizes) {
-    knowledge.hasSizes = true;
-    knowledge.sizes = indices.sizes;
-    // Weight's shape is [num_embedding, embedding_dim] and the last dim of the
-    // output should also be embedding_dim.
-    if (weight.hasSizes && weight.sizes.size() == 2)
-      knowledge.sizes.push_back(weight.sizes[1]);
-    else
-      knowledge.sizes.push_back(kUnknownSize);
-  }
-  knowledge.dtype = Float32Type::get(op->getContext());
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-static ValueKnowledge
-getSameSizeAsInput(Operation *op,
-                   ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.hasSizes = input.hasSizes;
-  knowledge.sizes = input.sizes;
-  return knowledge;
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 // Common template for softmax like ops, eg., log_softmax.
@@ -1830,9 +1049,10 @@ ChangeResult TypeAnalyzer::visitAtenSoftmaxLikeOp(
     OpTy op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
   auto input = operands[0]->getValue();
   auto dtype = op.dtype();
-  ValueKnowledge knowledge = getSameSizeAsInput(op, operands);
+  ValueKnowledge knowledge =
+      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
   fillInDTypeGivenDTypeIntAndInputDType(knowledge, dtype, input.dtype);
-  return getLatticeElement(op.getResult()).join(knowledge);
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 // Common template for softmax like ops, eg., log_softmax.(underscore variant)
@@ -1840,179 +1060,14 @@ template <typename OpTy>
 ChangeResult TypeAnalyzer::visitAten_SoftmaxLikeOp(
     OpTy op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
   auto input = operands[0]->getValue();
-  ValueKnowledge knowledge = getSameSizeAsInput(op, operands);
+  ValueKnowledge knowledge =
+      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
   bool halfToFloat;
   if (matchPattern(op.half_to_float(), m_TorchConstantBool(&halfToFloat))) {
     knowledge.dtype =
         halfToFloat ? Float32Type::get(op->getContext()) : input.dtype;
   }
-  return getLatticeElement(op.getResult()).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenMatmulOp(
-    AtenMatmulOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  auto self = operands[0]->getValue();
-  auto other = operands[1]->getValue();
-  if (!self.hasSizes || !other.hasSizes)
-    return getLatticeElement(op->getResult(0)).join(knowledge);
-  unsigned maxRank = self.sizes.size() > other.sizes.size()
-                         ? self.sizes.size()
-                         : other.sizes.size();
-  unsigned lhsDim = self.sizes.size() > 2 ? 2 : self.sizes.size();
-  unsigned rhsDim = other.sizes.size() > 2 ? 2 : other.sizes.size();
-  unsigned batchDim = maxRank > 2 ? maxRank - 2 : 0;
-  unsigned matDim = (lhsDim - 1) + (rhsDim - 1);
-  unsigned resultRank = batchDim + matDim;
-  knowledge.sizes.resize(resultRank, kUnknownSize);
-  knowledge.dtype = joinElementTypes(self.dtype, other.dtype);
-  knowledge.hasSizes = true;
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenAddCLikeOp(
-    Operation *op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  auto self = operands[0]->getValue();
-  auto tensor1 = operands[1]->getValue();
-  auto tensor2 = operands[2]->getValue();
-  if (tensor1.hasSizes && tensor2.hasSizes && self.hasSizes) {
-    knowledge.hasSizes = true;
-    knowledge.sizes.resize(
-        std::max(self.sizes.size(),
-                 std::max(tensor1.sizes.size(), tensor2.sizes.size())),
-        kUnknownSize);
-  }
-  knowledge.dtype =
-      getPromotedResultType(getContext(), {&self, &tensor1, &tensor2});
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-ChangeResult TypeAnalyzer::visitAtenNativeBatchNormOp(
-    AtenNativeBatchNormOp op,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-
-  auto batchNormKnowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  auto meanKnowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  auto invStdKnowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-
-  batchNormKnowledge.dtype = input.dtype;
-  meanKnowledge.dtype = input.dtype;
-  invStdKnowledge.dtype = input.dtype;
-
-  // Rank of the input tensor must be greater than or equal to 2. The size of
-  // the input tensor as well as the output tensor should be (N, C, D?, H?, W?).
-  // The running_mean, running_var, weight, and bias should be of size (C).
-  bool training = false;
-  if (matchPattern(op.training(), m_TorchConstantBool(&training)) &&
-      input.hasSizes && input.sizes.size() >= 2) {
-    batchNormKnowledge.hasSizes = true;
-    meanKnowledge.hasSizes = true;
-    invStdKnowledge.hasSizes = true;
-    batchNormKnowledge.sizes = input.sizes;
-    meanKnowledge.sizes = {0};
-    invStdKnowledge.sizes = {0};
-    if (training) {
-      meanKnowledge.sizes[0] = input.sizes[1];
-      invStdKnowledge.sizes[0] = input.sizes[1];
-    }
-  }
-
-  auto resultLattice =
-      getLatticeElement(op.getResult(0)).join(batchNormKnowledge);
-  resultLattice |= getLatticeElement(op.getResult(1)).join(meanKnowledge);
-  resultLattice |= getLatticeElement(op.getResult(2)).join(invStdKnowledge);
-  return resultLattice;
-}
-
-ChangeResult TypeAnalyzer::visitAtenNativeLayerNormOp(
-    AtenNativeLayerNormOp op,
-    ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-
-  auto layerNormKnowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  auto meanKnowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  auto varKnowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-
-  layerNormKnowledge.hasSizes = input.hasSizes;
-  layerNormKnowledge.sizes = input.sizes;
-  layerNormKnowledge.dtype = input.dtype;
-
-  int64_t layerNormSize = input.sizes.size();
-  Value normalizedShape = op.normalized_shape();
-  SmallVector<Value> normalizedShapeSizesTorchInt;
-  getListConstructElements(normalizedShape, normalizedShapeSizesTorchInt);
-  std::vector<int64_t> meanVarSizes;
-  if (input.hasSizes) {
-    for (int i = normalizedShapeSizesTorchInt.size(); i < layerNormSize; i++)
-      meanVarSizes.push_back(input.sizes[i]);
-  }
-  meanKnowledge.hasSizes = input.hasSizes;
-  meanKnowledge.sizes = meanVarSizes;
-  meanKnowledge.dtype = input.dtype;
-  varKnowledge.hasSizes = input.hasSizes;
-  varKnowledge.sizes = meanVarSizes;
-  varKnowledge.dtype = input.dtype;
-
-  auto resultLattice =
-      getLatticeElement(op.getResult(0)).join(layerNormKnowledge);
-  resultLattice |= getLatticeElement(op.getResult(1)).join(meanKnowledge);
-  resultLattice |= getLatticeElement(op.getResult(2)).join(varKnowledge);
-
-  return resultLattice;
-}
-
-// `torch.aten.index.Tensor` return tensors elements selected by the index
-// tensors. Each index tensor in the list corresponds to each dim in the
-// input tensor.
-// Same number of dims but unknown size along each dim. Same dtype as the
-// input.
-ChangeResult TypeAnalyzer::visitAtenIndexTensorOp(
-    AtenIndexTensorOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-  auto indicesList = op.indices();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  auto listConstruct = indicesList.getDefiningOp<PrimListConstructOp>();
-  if (!listConstruct)
-    return getLatticeElement(op->getResult(0)).join(knowledge);
-
-  auto indices = llvm::to_vector(
-      llvm::map_range(listConstruct.elements(), [&](Value v) -> ValueKnowledge {
-        return getLatticeElement(v).getValue();
-      }));
-
-  knowledge.dtype = input.dtype;
-  // Case: If the input is a 1-d tensor and indices list size is equal
-  // to 1.
-  if (input.sizes.size() == 1 && indices.size() == 1 && indices[0].hasSizes) {
-    knowledge.hasSizes = true;
-    knowledge.sizes = indices[0].sizes;
-  }
-  return getLatticeElement(op->getResult(0)).join(knowledge);
-}
-
-// aten::bincount op counts the frequency of each value in a 1-d input tensor of
-// non-negative ints. It returns a 1-d tensor of size max(max(input), length) of
-// the type integer.
-ChangeResult TypeAnalyzer::visitAtenBincountOp(
-    AtenBincountOp op, ArrayRef<LatticeElement<ValueKnowledge> *> operands) {
-  auto input = operands[0]->getValue();
-  auto knowledge =
-      ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
-  knowledge.dtype = IntegerType::get(op.getContext(), 64, IntegerType::Signed);
-  knowledge.hasSizes = true;
-  knowledge.sizes.resize(1, kUnknownSize);
-  return getLatticeElement(op->getResult(0)).join(knowledge);
+  return incorporateKnowledge(op.getResult(), knowledge);
 }
 
 // -----------------------------------------------------------------------------
@@ -2024,10 +1079,9 @@ ChangeResult TypeAnalyzer::visitAtenBincountOp(
 static Type getMostRefinedStaticType(Value v, TypeAnalyzer &analyzer) {
   auto getRefinedTensorType = [](BaseTensorType tensorType,
                                  ValueKnowledge const &knowledge) {
-    return tensorType.getWithSizesAndDtype(
-        knowledge.hasSizes ? llvm::makeArrayRef(knowledge.sizes)
-                           : Optional<ArrayRef<int64_t>>(),
-        knowledge.dtype);
+    return tensorType
+        .getWithSizesAndDtype(tensorType.getOptionalSizes(), knowledge.dtype)
+        .cast<BaseTensorType>();
   };
 
   if (auto tensorType = v.getType().dyn_cast<BaseTensorType>()) {
@@ -2043,9 +1097,9 @@ static Type getMostRefinedStaticType(Value v, TypeAnalyzer &analyzer) {
     if (!latticeElement)
       return nullptr;
     const ValueKnowledge &knowledge = latticeElement->getValue();
-    if (knowledge.optional == ValueKnowledge::OptionalKnowledge::isNone)
+    if (knowledge.optional == OptionalKnowledge::isNone)
       return Torch::NoneType::get(v.getContext());
-    else if (knowledge.optional == ValueKnowledge::OptionalKnowledge::notNone) {
+    else if (knowledge.optional == OptionalKnowledge::notNone) {
       auto containedType = optionalType.getContainedType();
       if (auto tensorType = containedType.dyn_cast<BaseTensorType>())
         return getRefinedTensorType(tensorType, knowledge);

--- a/lib/Dialect/Torch/Transforms/ReifyShapeCalculations.cpp
+++ b/lib/Dialect/Torch/Transforms/ReifyShapeCalculations.cpp
@@ -1,0 +1,297 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Parser.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/InliningUtils.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringSet.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+static Value adjustShapeFunctionArg(Value operand, Type desiredType,
+                                    OpBuilder &b, Location loc);
+
+static Value adjustListArg(Value operand, Torch::ListType desiredType,
+                           OpBuilder &b, Location loc) {
+  auto providedType = operand.getType().cast<Torch::ListType>();
+
+  // Pseudocode:
+  //
+  // operand = ...
+  // adjusted_list = []
+  // for i in range(len(operand)):
+  //     adjusted_list.append(adjust(operand[i]))
+  // return adjusted_list
+  Value adjustedList =
+      b.create<PrimListConstructOp>(loc, desiredType, ValueRange({}));
+  // Create a for-like PrimLoopOp.
+  Value maxTripCount = b.create<AtenLenTOp>(loc, operand);
+  Value cTrue = b.create<Torch::ConstantBoolOp>(loc, true);
+  auto loop = b.create<PrimLoopOp>(loc, TypeRange({}), maxTripCount,
+                                   /*initialCondition=*/cTrue,
+                                   /*iterArgsInit=*/ValueRange({}));
+
+  // Create the loop body.
+  {
+    OpBuilder::InsertionGuard guard(b);
+    Block *body =
+        b.createBlock(&loop.region(), loop.region().begin(),
+                      TypeRange({b.getType<Torch::IntType>()}), {loc});
+    Value iterationNumber = body->getArgument(0);
+    Value element = b.create<Aten__Getitem__TOp>(
+        loc, providedType.getContainedType(), operand, iterationNumber);
+    Value adjustedElement =
+        adjustShapeFunctionArg(element, desiredType.getContainedType(), b, loc);
+    b.create<AtenAppendTOp>(loc, adjustedList.getType(), adjustedList,
+                            adjustedElement);
+    b.create<PrimLoopConditionOp>(loc, /*shouldContinue=*/cTrue,
+                                  /*iterArgs=*/ValueRange({}));
+  }
+
+  return adjustedList;
+}
+
+static Value adjustShapeFunctionArg(Value operand, Type desiredType,
+                                    OpBuilder &b, Location loc) {
+  auto operandType = operand.getType();
+
+  // No need for adjustment if they already match.
+  if (operandType == desiredType)
+    return operand;
+
+  if (desiredType.isa<Torch::AnyType>()) {
+    // Generator's are currently passed as Any because TorchScript cannot
+    // compile a function with Generator type arguments.
+    // Ignoring that hack, this is a correct handling of Any type should we need
+    // to actually support it in the future.
+    return b.create<DerefineOp>(loc, desiredType, operand);
+  }
+
+  // If the operand is NoneType, then we just need to derefine it to the
+  // optional type in the shape function signature.
+  if (operandType.isa<Torch::NoneType>()) {
+    assert(desiredType.isa<Torch::OptionalType>() &&
+           "Don't expect shape functions to have NoneType parameters");
+    return b.create<DerefineOp>(loc, desiredType, operand);
+  }
+
+  // If the operand type is statically !torch.optional, then we need to do
+  // different things for the None and non-None cases.
+  // For the None case, we just need to derefine it to the desired type.
+  // For the non-None case, we need to unwrap the optional type and then adjust
+  // it recursively (which also takes care of derefining it to ultimate desired
+  // type).
+  // A case where this happens is `!torch.optional<!torch.vtensor>` ->
+  // `!torch.optional<!torch.list<!torch.int>>>`.
+  if (auto operandOptionalType = operandType.dyn_cast<Torch::OptionalType>()) {
+    if (desiredType.isa<Torch::OptionalType>()) {
+      // if optional is None:
+      //     return derefine(None)
+      // else:
+      //     return adjust(unchecked_cast(optional))
+      auto none = b.create<ConstantNoneOp>(loc);
+      auto isNone = b.create<Aten__Is__Op>(loc, operand, none);
+      auto primIf = b.create<PrimIfOp>(loc, desiredType, isNone);
+      {
+        Region &thenRegion = primIf.thenRegion();
+        b.createBlock(&thenRegion, thenRegion.end());
+        auto derefineNone = b.create<DerefineOp>(loc, desiredType, none);
+        b.create<PrimIfYieldOp>(loc, ValueRange{derefineNone});
+      }
+      {
+        Region &elseRegion = primIf.elseRegion();
+        b.createBlock(&elseRegion, elseRegion.end());
+        auto downcasted = b.create<PrimUncheckedCastOp>(
+            loc, operandOptionalType.getContainedType(), operand);
+        auto adjusted = adjustShapeFunctionArg(downcasted, desiredType, b, loc);
+        b.create<PrimIfYieldOp>(loc, adjusted);
+      }
+      b.setInsertionPointAfter(primIf);
+      return primIf.getResult(0);
+    }
+  }
+
+  // If the desired type is OptionalType, then recursively adjust the operand to
+  // the contained type, then derefine it to `!torch.optional`. For example,
+  // `!torch.vtensor -> !torch.optional<!torch.list<!torch.int>>>`.
+  if (auto desiredOptionalType = desiredType.dyn_cast<Torch::OptionalType>()) {
+    auto adjusted = adjustShapeFunctionArg(
+        operand, desiredOptionalType.getContainedType(), b, loc);
+    return b.create<DerefineOp>(loc, desiredType, adjusted);
+  }
+
+  // The shape library functions have tensor operands replaced with
+  // `!torch.list<!torch.int>` types for the shape. Get the sizes.
+  if (operand.getType().isa<Torch::BaseTensorType>()) {
+    assert(desiredType.isa<Torch::ListType>() &&
+           "Don't expect shape functions to have tensor parameters");
+    return b.create<AtenSizeOp>(loc, desiredType, operand);
+  }
+
+  // Run this after `operand.getType().isa<Torch::BaseTensorType>()` so that
+  // `!torch.vtensor` -> `!torch.list<!torch.int>` is handled there specially
+  // first.
+  if (auto desiredListType = desiredType.dyn_cast<Torch::ListType>()) {
+    return adjustListArg(operand, desiredListType, b, loc);
+  }
+
+  // The shape library functions use `float` where the operator
+  // signature uses `Scalar` (see comments in torch_ods_gen.py for
+  // explanation).
+  if (desiredType.isa<Torch::FloatType>() &&
+      operand.getType().isa<Torch::IntType>()) {
+    return b.create<AtenFloatScalarOp>(loc, desiredType, operand);
+  }
+
+  // Pass the operand as-is.
+  return operand;
+}
+
+// Populates the shape calculation region with a call to the shape function
+// from the shape library.
+static LogicalResult
+populateShapeCalculationRegion(ShapeCalculateOp op, ValueRange originalOperands,
+                               mlir::FuncOp shapeFunction) {
+  // Create a call to the shape function in the `shapeCalculation` region.
+  // We will import the callee from the shape library later.
+  OpBuilder b(op.getContext());
+  Location loc = op->getLoc();
+  b.createBlock(&op.shapeCalculation());
+  // Massage the op operands to match the shape function signature.
+  // The shape function generally takes the same operands as the op, with a few
+  // systematic modifications, such as replacing tensors with their shapes.
+  SmallVector<Value> shapeFunctionArgs;
+  for (auto operandAndDesiredType :
+       llvm::zip(originalOperands, shapeFunction.getArgumentTypes())) {
+    Value operand;
+    Type desiredType;
+    std::tie(operand, desiredType) = operandAndDesiredType;
+    Value shapeFunctionArg =
+        adjustShapeFunctionArg(operand, desiredType, b, loc);
+    if (!shapeFunctionArg)
+      return failure();
+    shapeFunctionArgs.push_back(shapeFunctionArg);
+  }
+
+  // Create the call to the shape function!
+  auto call = b.create<mlir::CallOp>(loc, shapeFunction, shapeFunctionArgs);
+
+  // Python models multiple results with a tuple, so we need to unpack it
+  // if the op has multiple results.
+  SmallVector<Value> unpackedResults;
+  assert(call.getNumResults() == 1 &&
+         "Multiple results are packed in a tuple in Python!");
+  Value result = call.getResult(0);
+  if (auto tupleType = result.getType().dyn_cast<Torch::TupleType>()) {
+    auto unpack =
+        b.create<PrimTupleUnpackOp>(loc, tupleType.getContainedTypes(), result);
+    llvm::append_range(unpackedResults, unpack.getResults());
+  } else {
+    unpackedResults.push_back(result);
+  }
+
+  // Terminate the region.
+  b.create<ShapeCalculateYieldShapesOp>(loc, unpackedResults);
+  return success();
+}
+
+namespace {
+class ReifyShapeCalculationsPass
+    : public ReifyShapeCalculationsBase<ReifyShapeCalculationsPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp module = getOperation();
+
+    // TODO: Find a way to not have to parse this every time.
+    // The shape library is O(#ops we know about), and this pass should be
+    // O(#ops in the program) ideally.
+    auto shapeLibrary = parseSourceString(getShapeLibrary(), context);
+
+    // Walk all the operations, and if we have a shape function, wrap the op
+    // in a `torch.shape.calculate` op.
+    SmallVector<std::string> neededShapeFunctions;
+    bool hadError = false;
+    module.walk([&](Operation *op) {
+      Location loc = op->getLoc();
+      auto name = op->getName().stripDialect();
+      // For pseudo-ops (ops that are mechanically consistent with existing
+      // torch conventions, but simply not present, such as a missing in-place
+      // or out-of-place variant), remove the pseudo prefix.
+      if (name.startswith("pseudo."))
+        name = name.drop_front(strlen("pseudo."));
+      auto shapeFunctionName = ("__torch_mlir_shape_fn." + Twine(name)).str();
+      auto shapeFunction =
+          shapeLibrary->lookupSymbol<FuncOp>(shapeFunctionName);
+      if (!shapeFunction)
+        return;
+      neededShapeFunctions.push_back(shapeFunctionName);
+      auto shapeCalculate =
+          OpBuilder(op).create<ShapeCalculateOp>(loc, op->getResultTypes());
+      op->replaceAllUsesWith(shapeCalculate);
+      {
+        // Move the op into the body of the `torch.shape.calculate` op and yield
+        // its results.
+        OpBuilder b(context);
+        Block *block = b.createBlock(&shapeCalculate.body());
+        op->moveBefore(block, block->end());
+        b.setInsertionPointAfter(op);
+        b.create<ShapeCalculateYieldOp>(loc, op->getResults());
+      }
+      if (failed(populateShapeCalculationRegion(
+              shapeCalculate, op->getOperands(), shapeFunction))) {
+        hadError = true;
+        return;
+      }
+    });
+
+    if (hadError)
+      return signalPassFailure();
+
+    // Import just the functions we need. This includes transitive callees,
+    // so we use a worklist algorithm.
+    llvm::StringSet<> importedFunctions;
+    SmallVector<std::string> worklist;
+    llvm::append_range(worklist, neededShapeFunctions);
+    while (!worklist.empty()) {
+      auto symName = worklist.pop_back_val();
+      if (importedFunctions.count(symName))
+        continue;
+      auto func = shapeLibrary->lookupSymbol<mlir::FuncOp>(symName);
+      assert(func && "broken shape library");
+      // Move the shape function from the library to the module this pass
+      // is running on. (this mutates the library, but we re-parse it each time
+      // so this is safe to do).
+      func->moveBefore(&module.getBody()->front());
+      // Set the visibility to private so that the shape functions go away
+      // nicely after we are done with them.
+      func.setVisibility(SymbolTable::Visibility::Private);
+      // Continue the DFS.
+      importedFunctions.insert(symName);
+      func.walk([&](CallOp op) { worklist.push_back(op.getCallee().str()); });
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::torch::Torch::createReifyShapeCalculationsPass() {
+  return std::make_unique<ReifyShapeCalculationsPass>();
+}

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -1,0 +1,2817 @@
+//===-------------------------------------------------------------*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is auto-generated! Do not edit!!!
+// Generated with the script `build_tools/update_shape_lib.sh`.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+
+using namespace mlir;
+
+StringRef mlir::torch::Torch::getShapeLibrary() {
+// TODO: Find a way to embed this string nicely.
+// It is currently too long, and will probably break MSVC builds if anyone
+// attempts that.
+// We want to preserve the legibility of the shape library as a checked in file,
+// since that is sometimes useful for debugging / diffing.
+// Probably the ideal outcome is to have the shape library be a .mlir file
+// that is checked in, and then we embed it as part of the build process.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverlength-strings"
+  constexpr StringLiteral shapeLib(R"mlir(
+module {
+  func @"__torch_mlir_shape_fn.aten.tanh"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers._copy(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers._copy(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %true = torch.constant.bool true
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %1 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    torch.prim.Loop %1, %true, init() {
+    ^bb0(%arg1: !torch.int):
+      %2 = torch.aten.__getitem__.t %arg0, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %3 = torch.aten.append.t %0, %2 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.erf"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.sigmoid"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.hardsigmoid"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.square"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.hardswish"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.silu"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.hardtanh"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.sqrt"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.floor"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.log2"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.rsqrt"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.abs"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.reciprocal"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.tanh_backward"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.gelu_backward"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.str) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.ceil"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.log"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.relu"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten._softmax"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.softmax.int"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten._log_softmax"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.log_softmax.int"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.clamp"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.float>, %arg2: !torch.optional<!torch.float>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.rsub.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.to.dtype"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.bool, %arg3: !torch.bool, %arg4: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.to.other"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.bool, %arg3: !torch.bool, %arg4: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.type_as"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.dropout"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.gelu"(%arg0: !torch.list<!torch.int>, %arg1: !torch.str) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.contiguous"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.clone"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten._log_softmax_backward_data"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.int, %arg3: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.eq.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.ne.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.gt.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.ge.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.le.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.lt.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.add.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.sub.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.mul.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.div.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.floor_divide.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.pow.Tensor_Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.leaky_relu"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.gather"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.list<!torch.int>, %arg3: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg2) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.layer_norm"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.list<!torch.int>>, %arg3: !torch.optional<!torch.list<!torch.int>>, %arg4: !torch.float, %arg5: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten._softmax_backward_data"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.int, %arg3: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg1) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.any"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.all"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.max"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.sum"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.mean"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.var"(%arg0: !torch.list<!torch.int>, %arg1: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.std"(%arg0: !torch.list<!torch.int>, %arg1: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.argmax"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>, %arg2: !torch.bool) -> !torch.list<!torch.int> {
+    %none = torch.constant.none
+    %0 = torch.aten.__is__ %arg1, %none : !torch.optional<!torch.int>, !torch.none -> !torch.bool
+    %1 = torch.prim.If %0 -> (!torch.list<!torch.int>) {
+      %2 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+      torch.prim.If.yield %2 : !torch.list<!torch.int>
+    } else {
+      %2 = torch.prim.unchecked_cast %arg1 : !torch.optional<!torch.int> -> !torch.int
+      %3 = call @__torch__._reduce_along_dim(%arg0, %2, %arg2) : (!torch.list<!torch.int>, !torch.int, !torch.bool) -> !torch.list<!torch.int>
+      torch.prim.If.yield %3 : !torch.list<!torch.int>
+    }
+    return %1 : !torch.list<!torch.int>
+  }
+  func @__torch__._reduce_along_dim(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.bool) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %int9223372036854775807 = torch.constant.int 9223372036854775807
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg1, %0, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %2 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %3 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %4 = torch.prim.ListConstruct %int9223372036854775807, %3 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+    %5 = torch.prim.min.self_int %4 : !torch.list<!torch.int> -> !torch.int
+    torch.prim.Loop %5, %true, init() {
+    ^bb0(%arg3: !torch.int):
+      %6 = torch.aten.__getitem__.t %arg0, %arg3 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %7 = torch.aten.eq.int %arg3, %1 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %7 -> () {
+        torch.prim.If %arg2 -> () {
+          %8 = torch.aten.append.t %2, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+          torch.prim.If.yield
+        } else {
+          torch.prim.If.yield
+        }
+        torch.prim.If.yield
+      } else {
+        %8 = torch.aten.append.t %2, %6 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %2 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg0: !torch.int, %arg1: !torch.int, %arg2: !torch.bool) -> !torch.int {
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %0 = torch.aten.le.int %arg1, %int0 : !torch.int, !torch.int -> !torch.bool
+    %1 = torch.prim.If %0 -> (!torch.int) {
+      torch.prim.If %arg2 -> () {
+        torch.prim.If.yield
+      } else {
+        torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+        torch.prim.If.yield
+      }
+      torch.prim.If.yield %int1 : !torch.int
+    } else {
+      torch.prim.If.yield %arg1 : !torch.int
+    }
+    %2 = torch.aten.neg.int %1 : !torch.int -> !torch.int
+    %3 = torch.aten.sub.int %1, %int1 : !torch.int, !torch.int -> !torch.int
+    %4 = torch.aten.lt.int %arg0, %2 : !torch.int, !torch.int -> !torch.bool
+    %5 = torch.prim.If %4 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %9 = torch.aten.gt.int %arg0, %3 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %9 : !torch.bool
+    }
+    %6 = torch.aten.__not__ %5 : !torch.bool -> !torch.bool
+    torch.prim.If %6 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %7 = torch.aten.lt.int %arg0, %int0 : !torch.int, !torch.int -> !torch.bool
+    %8 = torch.prim.If %7 -> (!torch.int) {
+      %9 = torch.aten.add.int %arg0, %1 : !torch.int, !torch.int -> !torch.int
+      torch.prim.If.yield %9 : !torch.int
+    } else {
+      torch.prim.If.yield %arg0 : !torch.int
+    }
+    return %8 : !torch.int
+  }
+  func @"__torch_mlir_shape_fn.aten.any.dim"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = call @__torch__._reduce_along_dim(%arg0, %arg1, %arg2) : (!torch.list<!torch.int>, !torch.int, !torch.bool) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.max.dim"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.bool) -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>> {
+    %0 = call @__torch__._reduce_along_dim(%arg0, %arg1, %arg2) : (!torch.list<!torch.int>, !torch.int, !torch.bool) -> !torch.list<!torch.int>
+    %1 = torch.prim.TupleConstruct %0, %0 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+    return %1 : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+  }
+  func @"__torch_mlir_shape_fn.aten.mean.dim"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.bool, %arg3: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = torch.derefine %arg3 : !torch.optional<!torch.int> to !torch.any
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mean_dim(%arg0, %arg1, %arg2, %0) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.bool, !torch.any) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mean_dim(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.bool, %arg3: !torch.any) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %false = torch.constant.bool false
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %1 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    torch.prim.Loop %1, %true, init() {
+    ^bb0(%arg4: !torch.int):
+      %2 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+      %3 = torch.prim.Loop %2, %true, init(%false) {
+      ^bb0(%arg5: !torch.int, %arg6: !torch.bool):
+        %4 = torch.aten.__getitem__.t %arg1, %arg5 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %5 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+        %6 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%4, %5, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+        %7 = torch.aten.eq.int %arg4, %6 : !torch.int, !torch.int -> !torch.bool
+        %8 = torch.prim.If %7 -> (!torch.bool) {
+          torch.prim.If.yield %true : !torch.bool
+        } else {
+          torch.prim.If.yield %arg6 : !torch.bool
+        }
+        torch.prim.Loop.condition %true, iter(%8 : !torch.bool)
+      } : (!torch.int, !torch.bool, !torch.bool) -> !torch.bool
+      torch.prim.If %3 -> () {
+        torch.prim.If %arg2 -> () {
+          %4 = torch.aten.append.t %0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+          torch.prim.If.yield
+        } else {
+          torch.prim.If.yield
+        }
+        torch.prim.If.yield
+      } else {
+        %4 = torch.aten.__getitem__.t %arg0, %arg4 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %5 = torch.aten.append.t %0, %4 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.sum.dim_IntList"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.bool, %arg3: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = torch.derefine %arg3 : !torch.optional<!torch.int> to !torch.any
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mean_dim(%arg0, %arg1, %arg2, %0) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.bool, !torch.any) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.permute"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.permute(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.permute(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.aten.eq.int %0, %1 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %2 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %3 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %4 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %5 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    torch.prim.Loop %3, %true, init() {
+    ^bb0(%arg2: !torch.int):
+      %7 = torch.aten.__getitem__.t %arg1, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %8 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%7, %3, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+      %9 = torch.aten.append.t %4, %8 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      %10 = torch.aten.__getitem__.t %arg0, %8 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %11 = torch.aten.append.t %5, %10 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    %6 = torch.aten.__range_length %int1, %3, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %6, %true, init() {
+    ^bb0(%arg2: !torch.int):
+      %7 = torch.aten.__derive_index %arg2, %int1, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+      torch.prim.Loop %7, %true, init() {
+      ^bb0(%arg3: !torch.int):
+        %8 = torch.aten.__getitem__.t %4, %7 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %9 = torch.aten.__getitem__.t %4, %arg3 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %10 = torch.aten.ne.int %8, %9 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If %10 -> () {
+          torch.prim.If.yield
+        } else {
+          torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+          torch.prim.If.yield
+        }
+        torch.prim.Loop.condition %true, iter()
+      } : (!torch.int, !torch.bool) -> ()
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %5 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.transpose.int"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.transpose(%arg0, %arg1, %arg2) : (!torch.list<!torch.int>, !torch.int, !torch.int) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.transpose(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.int) -> !torch.list<!torch.int> {
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg1, %0, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %2 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg2, %0, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %3 = torch.aten.eq.int %1, %2 : !torch.int, !torch.int -> !torch.bool
+    %4 = torch.prim.If %3 -> (!torch.list<!torch.int>) {
+      %5 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers._copy(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+      torch.prim.If.yield %5 : !torch.list<!torch.int>
+    } else {
+      %5 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+      torch.prim.Loop %0, %true, init() {
+      ^bb0(%arg3: !torch.int):
+        %6 = torch.aten.eq.int %arg3, %1 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If %6 -> () {
+          %7 = torch.aten.__getitem__.t %arg0, %2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+          %8 = torch.aten.append.t %5, %7 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+          torch.prim.If.yield
+        } else {
+          %7 = torch.aten.eq.int %arg3, %2 : !torch.int, !torch.int -> !torch.bool
+          torch.prim.If %7 -> () {
+            %8 = torch.aten.__getitem__.t %arg0, %1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+            %9 = torch.aten.append.t %5, %8 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+            torch.prim.If.yield
+          } else {
+            %8 = torch.aten.__getitem__.t %arg0, %arg3 : !torch.list<!torch.int>, !torch.int -> !torch.int
+            %9 = torch.aten.append.t %5, %8 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+            torch.prim.If.yield
+          }
+          torch.prim.If.yield
+        }
+        torch.prim.Loop.condition %true, iter()
+      } : (!torch.int, !torch.bool) -> ()
+      torch.prim.If.yield %5 : !torch.list<!torch.int>
+    }
+    return %4 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.t"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.transpose(%arg0, %int0, %int1) : (!torch.list<!torch.int>, !torch.int, !torch.int) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.matmul"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.matmul(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.matmul(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %int2 = torch.constant.int 2
+    %int1 = torch.constant.int 1
+    %false = torch.constant.bool false
+    %int-2 = torch.constant.int -2
+    %true = torch.constant.bool true
+    %int-1 = torch.constant.int -1
+    %str = torch.constant.str "AssertionError: both  arguments to matmul need to be at least 1D"
+    %none = torch.constant.none
+    %0 = torch.prim.Uninitialized : !torch.list<!torch.int>
+    %1 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %3 = torch.aten.eq.int %1, %int1 : !torch.int, !torch.int -> !torch.bool
+    %4 = torch.prim.If %3 -> (!torch.bool) {
+      %6 = torch.aten.eq.int %2, %int1 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %6 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    %5 = torch.prim.If %4 -> (!torch.list<!torch.int>) {
+      %6 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.dot(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+      torch.prim.If.yield %6 : !torch.list<!torch.int>
+    } else {
+      %6 = torch.aten.eq.int %1, %int2 : !torch.int, !torch.int -> !torch.bool
+      %7 = torch.prim.If %6 -> (!torch.bool) {
+        %9 = torch.aten.eq.int %2, %int1 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If.yield %9 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      %8 = torch.prim.If %7 -> (!torch.list<!torch.int>) {
+        %9 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mv(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+        torch.prim.If.yield %9 : !torch.list<!torch.int>
+      } else {
+        %9 = torch.aten.eq.int %1, %int1 : !torch.int, !torch.int -> !torch.bool
+        %10 = torch.prim.If %9 -> (!torch.bool) {
+          %12 = torch.aten.eq.int %2, %int2 : !torch.int, !torch.int -> !torch.bool
+          torch.prim.If.yield %12 : !torch.bool
+        } else {
+          torch.prim.If.yield %false : !torch.bool
+        }
+        %11 = torch.prim.If %10 -> (!torch.list<!torch.int>) {
+          %12 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unsqueeze(%arg0, %int0) : (!torch.list<!torch.int>, !torch.int) -> !torch.list<!torch.int>
+          %13 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mm(%12, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+          %14 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.squeeze(%13, %int0) : (!torch.list<!torch.int>, !torch.int) -> !torch.list<!torch.int>
+          torch.prim.If.yield %14 : !torch.list<!torch.int>
+        } else {
+          %12 = torch.aten.eq.int %1, %int2 : !torch.int, !torch.int -> !torch.bool
+          %13 = torch.prim.If %12 -> (!torch.bool) {
+            %15 = torch.aten.eq.int %2, %int2 : !torch.int, !torch.int -> !torch.bool
+            torch.prim.If.yield %15 : !torch.bool
+          } else {
+            torch.prim.If.yield %false : !torch.bool
+          }
+          %14 = torch.prim.If %13 -> (!torch.list<!torch.int>) {
+            %15 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mm(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+            torch.prim.If.yield %15 : !torch.list<!torch.int>
+          } else {
+            %15 = torch.aten.ge.int %1, %int1 : !torch.int, !torch.int -> !torch.bool
+            %16 = torch.prim.If %15 -> (!torch.bool) {
+              %18 = torch.aten.ge.int %2, %int1 : !torch.int, !torch.int -> !torch.bool
+              torch.prim.If.yield %18 : !torch.bool
+            } else {
+              torch.prim.If.yield %false : !torch.bool
+            }
+            %17 = torch.prim.If %16 -> (!torch.list<!torch.int>) {
+              %18 = torch.aten.gt.int %1, %int1 : !torch.int, !torch.int -> !torch.bool
+              %19 = torch.prim.If %18 -> (!torch.int) {
+                %28 = torch.aten.__getitem__.t %arg0, %int-2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+                torch.prim.If.yield %28 : !torch.int
+              } else {
+                torch.prim.If.yield %int1 : !torch.int
+              }
+              %20 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+              %21 = torch.aten.sub.int %1, %int2 : !torch.int, !torch.int -> !torch.int
+              torch.prim.Loop %21, %true, init() {
+              ^bb0(%arg2: !torch.int):
+                %28 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+                %29 = torch.aten.append.t %20, %28 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+                torch.prim.Loop.condition %true, iter()
+              } : (!torch.int, !torch.bool) -> ()
+              %22 = torch.aten.__getitem__.t %arg1, %int-1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+              %23 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+              %24 = torch.aten.sub.int %2, %int2 : !torch.int, !torch.int -> !torch.int
+              torch.prim.Loop %24, %true, init() {
+              ^bb0(%arg2: !torch.int):
+                %28 = torch.aten.__getitem__.t %arg1, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+                %29 = torch.aten.append.t %23, %28 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+                torch.prim.Loop.condition %true, iter()
+              } : (!torch.int, !torch.bool) -> ()
+              %25 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%20, %23) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+              %26 = torch.aten.gt.int %1, %int1 : !torch.int, !torch.int -> !torch.bool
+              torch.prim.If %26 -> () {
+                %28 = torch.aten.append.t %25, %19 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+                torch.prim.If.yield
+              } else {
+                torch.prim.If.yield
+              }
+              %27 = torch.aten.gt.int %2, %int1 : !torch.int, !torch.int -> !torch.bool
+              torch.prim.If %27 -> () {
+                %28 = torch.aten.append.t %25, %22 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+                torch.prim.If.yield
+              } else {
+                torch.prim.If.yield
+              }
+              torch.prim.If.yield %25 : !torch.list<!torch.int>
+            } else {
+              torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+              torch.prim.If.yield %0 : !torch.list<!torch.int>
+            }
+            torch.prim.If.yield %17 : !torch.list<!torch.int>
+          }
+          torch.prim.If.yield %14 : !torch.list<!torch.int>
+        }
+        torch.prim.If.yield %11 : !torch.list<!torch.int>
+      }
+      torch.prim.If.yield %8 : !torch.list<!torch.int>
+    }
+    return %5 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.dot(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %false = torch.constant.bool false
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.eq.int %0, %int1 : !torch.int, !torch.int -> !torch.bool
+    %2 = torch.prim.If %1 -> (!torch.bool) {
+      %7 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+      %8 = torch.aten.eq.int %7, %int1 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %8 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    torch.prim.If %2 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %3 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %4 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %5 = torch.aten.eq.int %3, %4 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %5 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %6 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %6 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mv(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %false = torch.constant.bool false
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.eq.int %0, %int2 : !torch.int, !torch.int -> !torch.bool
+    %2 = torch.prim.If %1 -> (!torch.bool) {
+      %8 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+      %9 = torch.aten.eq.int %8, %int1 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %9 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    torch.prim.If %2 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %3 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %4 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %5 = torch.aten.eq.int %3, %4 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %5 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %6 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %7 = torch.prim.ListConstruct %6 : (!torch.int) -> !torch.list<!torch.int>
+    return %7 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.squeeze(%arg0: !torch.list<!torch.int>, %arg1: !torch.int) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %1 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %2 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg1, %1, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %3 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    torch.prim.Loop %3, %true, init() {
+    ^bb0(%arg2: !torch.int):
+      %4 = torch.aten.eq.int %arg2, %2 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %4 -> () {
+        %5 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %6 = torch.aten.ne.int %5, %int1 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If %6 -> () {
+          %7 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+          %8 = torch.aten.append.t %0, %7 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+          torch.prim.If.yield
+        } else {
+          torch.prim.If.yield
+        }
+        torch.prim.If.yield
+      } else {
+        %5 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %6 = torch.aten.append.t %0, %5 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mm(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %str = torch.constant.str "AssertionError: self must be a matrix"
+    %none = torch.constant.none
+    %str_0 = torch.constant.str "AssertionError: mat2 must be a matrix"
+    %str_1 = torch.constant.str "AssertionError: "
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.eq.int %0, %int2 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %3 = torch.aten.eq.int %2, %int2 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %3 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str_0, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %4 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %5 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %6 = torch.aten.eq.int %4, %5 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %6 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str_1, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %7 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %8 = torch.aten.__getitem__.t %arg1, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %9 = torch.prim.ListConstruct %7, %8 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+    return %9 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unsqueeze(%arg0: !torch.list<!torch.int>, %arg1: !torch.int) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.add.int %0, %int1 : !torch.int, !torch.int -> !torch.int
+    %2 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg1, %1, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %3 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers._copy(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    torch.aten.insert.t %3, %2, %int1 : !torch.list<!torch.int>, !torch.int, !torch.int
+    return %3 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %false = torch.constant.bool false
+    %str = torch.constant.str "The size of tensor a {} must match the size of tensor b ({}) at non-singleton dimension {}"
+    %str_0 = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.prim.max.int %0, %1 : !torch.int, !torch.int -> !torch.int
+    %3 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    torch.prim.Loop %2, %true, init() {
+    ^bb0(%arg2: !torch.int):
+      %4 = torch.aten.sub.int %2, %int1 : !torch.int, !torch.int -> !torch.int
+      %5 = torch.aten.sub.int %4, %arg2 : !torch.int, !torch.int -> !torch.int
+      %6 = torch.aten.sub.int %0, %int1 : !torch.int, !torch.int -> !torch.int
+      %7 = torch.aten.sub.int %6, %5 : !torch.int, !torch.int -> !torch.int
+      %8 = torch.aten.sub.int %1, %int1 : !torch.int, !torch.int -> !torch.int
+      %9 = torch.aten.sub.int %8, %5 : !torch.int, !torch.int -> !torch.int
+      %10 = torch.aten.ge.int %7, %int0 : !torch.int, !torch.int -> !torch.bool
+      %11 = torch.prim.If %10 -> (!torch.int) {
+        %20 = torch.aten.__getitem__.t %arg0, %7 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        torch.prim.If.yield %20 : !torch.int
+      } else {
+        torch.prim.If.yield %int1 : !torch.int
+      }
+      %12 = torch.aten.ge.int %9, %int0 : !torch.int, !torch.int -> !torch.bool
+      %13 = torch.prim.If %12 -> (!torch.int) {
+        %20 = torch.aten.__getitem__.t %arg1, %9 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        torch.prim.If.yield %20 : !torch.int
+      } else {
+        torch.prim.If.yield %int1 : !torch.int
+      }
+      %14 = torch.aten.ne.int %11, %13 : !torch.int, !torch.int -> !torch.bool
+      %15 = torch.prim.If %14 -> (!torch.bool) {
+        %20 = torch.aten.ne.int %11, %int1 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If.yield %20 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      %16 = torch.prim.If %15 -> (!torch.bool) {
+        %20 = torch.aten.ne.int %13, %int1 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If.yield %20 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      torch.prim.If %16 -> () {
+        %20 = torch.aten.format(%str, %11, %13, %arg2) : !torch.str, !torch.int, !torch.int, !torch.int -> !torch.str
+        %21 = torch.aten.add.str %str_0, %20 : !torch.str, !torch.str -> !torch.str
+        torch.prim.RaiseException %21, %none : !torch.str, !torch.none
+        torch.prim.If.yield
+      } else {
+        torch.prim.If.yield
+      }
+      %17 = torch.aten.eq.int %11, %int1 : !torch.int, !torch.int -> !torch.bool
+      %18 = torch.prim.If %17 -> (!torch.int) {
+        torch.prim.If.yield %13 : !torch.int
+      } else {
+        torch.prim.If.yield %11 : !torch.int
+      }
+      %19 = torch.aten.append.t %3, %18 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %3 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.mm"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mm(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.addmm"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.list<!torch.int>, %arg3: !torch.float, %arg4: !torch.float) -> !torch.list<!torch.int> {
+    %0 = torch.derefine %arg3 : !torch.float to !torch.any
+    %1 = torch.derefine %arg4 : !torch.float to !torch.any
+    %2 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.addmm(%arg0, %arg1, %arg2, %0, %1) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.any, !torch.any) -> !torch.list<!torch.int>
+    return %2 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.addmm(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.list<!torch.int>, %arg3: !torch.any, %arg4: !torch.any) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mm(%arg1, %arg2) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %0) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.bmm"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %int0 = torch.constant.int 0
+    %int3 = torch.constant.int 3
+    %str = torch.constant.str "AssertionError: bmm only supports 3D tensors"
+    %none = torch.constant.none
+    %str_0 = torch.constant.str "AssertionError: mismatching batch dimension"
+    %str_1 = torch.constant.str "AssertionError: mismatching contracting dimension"
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.eq.int %0, %int3 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %3 = torch.aten.eq.int %2, %int3 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %3 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %4 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %5 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %6 = torch.aten.eq.int %4, %5 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %6 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str_0, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %7 = torch.aten.__getitem__.t %arg0, %int2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %8 = torch.aten.__getitem__.t %arg1, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %9 = torch.aten.eq.int %7, %8 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %9 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str_1, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %10 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %11 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %12 = torch.aten.__getitem__.t %arg1, %int2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %13 = torch.prim.ListConstruct %10, %11, %12 : (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
+    return %13 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.embedding"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.int, %arg3: !torch.bool, %arg4: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.embedding(%arg0, %arg1, %arg2, %arg3, %arg4) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int, !torch.bool, !torch.bool) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.embedding(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.int, %arg3: !torch.bool, %arg4: !torch.bool) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.eq.int %0, %int2 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %3 = torch.aten.eq.int %2, %int1 : !torch.int, !torch.int -> !torch.bool
+    %4 = torch.prim.If %3 -> (!torch.list<!torch.int>) {
+      %5 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.index_select(%arg0, %int0, %arg1) : (!torch.list<!torch.int>, !torch.int, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+      torch.prim.If.yield %5 : !torch.list<!torch.int>
+    } else {
+      %5 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers._copy(%arg1) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+      %6 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %7 = torch.aten.append.t %5, %6 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.If.yield %5 : !torch.list<!torch.int>
+    }
+    return %4 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.index_select(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg1, %0, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %2 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.multiply_integers(%arg2) : (!torch.list<!torch.int>) -> !torch.int
+    %3 = torch.aten.len.t %arg2 : !torch.list<!torch.int> -> !torch.int
+    %4 = torch.aten.le.int %3, %int1 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %4 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %5 = torch.aten.eq.int %1, %int0 : !torch.int, !torch.int -> !torch.bool
+    %6 = torch.prim.If %5 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %9 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+      %10 = torch.aten.lt.int %1, %9 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %10 : !torch.bool
+    }
+    torch.prim.If %6 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %7 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %8 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    torch.prim.Loop %8, %true, init() {
+    ^bb0(%arg3: !torch.int):
+      %9 = torch.aten.eq.int %1, %arg3 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %9 -> () {
+        %10 = torch.aten.append.t %7, %2 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+        torch.prim.If.yield
+      } else {
+        %10 = torch.aten.__getitem__.t %arg0, %arg3 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %11 = torch.aten.append.t %7, %10 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %7 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.multiply_integers(%arg0: !torch.list<!torch.int>) -> !torch.int {
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.prim.Loop %0, %true, init(%int1) {
+    ^bb0(%arg1: !torch.int, %arg2: !torch.int):
+      %2 = torch.aten.__getitem__.t %arg0, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %3 = torch.aten.mul.int %arg2, %2 : !torch.int, !torch.int -> !torch.int
+      torch.prim.Loop.condition %true, iter(%3 : !torch.int)
+    } : (!torch.int, !torch.bool, !torch.int) -> !torch.int
+    return %1 : !torch.int
+  }
+  func @"__torch_mlir_shape_fn.aten.expand"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.expand(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.expand(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %int-1 = torch.constant.int -1
+    %0 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.aten.ge.int %0, %1 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %2 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %3 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %4 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %5 = torch.aten.eq.int %3, %int0 : !torch.int, !torch.int -> !torch.bool
+    %6 = torch.prim.If %5 -> (!torch.list<!torch.int>) {
+      %7 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers._copy(%arg1) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+      torch.prim.If.yield %7 : !torch.list<!torch.int>
+    } else {
+      %7 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+      torch.prim.Loop %3, %true, init() {
+      ^bb0(%arg2: !torch.int):
+        %8 = torch.aten.sub.int %3, %int1 : !torch.int, !torch.int -> !torch.int
+        %9 = torch.aten.sub.int %8, %arg2 : !torch.int, !torch.int -> !torch.int
+        %10 = torch.aten.sub.int %4, %int1 : !torch.int, !torch.int -> !torch.int
+        %11 = torch.aten.sub.int %10, %9 : !torch.int, !torch.int -> !torch.int
+        %12 = torch.aten.ge.int %11, %int0 : !torch.int, !torch.int -> !torch.bool
+        %13 = torch.prim.If %12 -> (!torch.int) {
+          %20 = torch.aten.__getitem__.t %arg0, %11 : !torch.list<!torch.int>, !torch.int -> !torch.int
+          torch.prim.If.yield %20 : !torch.int
+        } else {
+          torch.prim.If.yield %int1 : !torch.int
+        }
+        %14 = torch.aten.__getitem__.t %arg1, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %15 = torch.aten.eq.int %14, %int-1 : !torch.int, !torch.int -> !torch.bool
+        %16 = torch.prim.If %15 -> (!torch.int) {
+          %20 = torch.aten.ge.int %11, %int0 : !torch.int, !torch.int -> !torch.bool
+          torch.prim.If %20 -> () {
+            torch.prim.If.yield
+          } else {
+            torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+            torch.prim.If.yield
+          }
+          torch.prim.If.yield %13 : !torch.int
+        } else {
+          torch.prim.If.yield %14 : !torch.int
+        }
+        %17 = torch.aten.ne.int %13, %16 : !torch.int, !torch.int -> !torch.bool
+        %18 = torch.prim.If %17 -> (!torch.int) {
+          %20 = torch.aten.eq.int %13, %int1 : !torch.int, !torch.int -> !torch.bool
+          torch.prim.If %20 -> () {
+            torch.prim.If.yield
+          } else {
+            torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+            torch.prim.If.yield
+          }
+          torch.prim.If.yield %16 : !torch.int
+        } else {
+          torch.prim.If.yield %13 : !torch.int
+        }
+        %19 = torch.aten.append.t %7, %18 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+        torch.prim.Loop.condition %true, iter()
+      } : (!torch.int, !torch.bool) -> ()
+      torch.prim.If.yield %7 : !torch.list<!torch.int>
+    }
+    return %6 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.broadcast_to"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.expand(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.view"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.view(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.view(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.numel(%arg0) : (!torch.list<!torch.int>) -> !torch.int
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.infer_size_impl(%arg1, %0) : (!torch.list<!torch.int>, !torch.int) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.infer_size_impl(%arg0: !torch.list<!torch.int>, %arg1: !torch.int) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %int-1 = torch.constant.int -1
+    %str = torch.constant.str "AssertionError: only one dimension can be inferred"
+    %str_0 = torch.constant.str "AssertionError: invalid shape dimensions"
+    %false = torch.constant.bool false
+    %str_1 = torch.constant.str "AssertionError: invalid shape"
+    %0 = torch.prim.Uninitialized : !torch.int
+    %1 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.derefine %none : !torch.none to !torch.optional<!torch.int>
+    %3:2 = torch.prim.Loop %1, %true, init(%int1, %2) {
+    ^bb0(%arg2: !torch.int, %arg3: !torch.int, %arg4: !torch.optional<!torch.int>):
+      %9 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %10 = torch.aten.eq.int %9, %int-1 : !torch.int, !torch.int -> !torch.bool
+      %11:2 = torch.prim.If %10 -> (!torch.int, !torch.optional<!torch.int>) {
+        %12 = torch.aten.__isnot__ %arg4, %none : !torch.optional<!torch.int>, !torch.none -> !torch.bool
+        torch.prim.If %12 -> () {
+          torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+          torch.prim.If.yield
+        } else {
+          torch.prim.If.yield
+        }
+        %13 = torch.derefine %arg2 : !torch.int to !torch.optional<!torch.int>
+        torch.prim.If.yield %arg3, %13 : !torch.int, !torch.optional<!torch.int>
+      } else {
+        %12 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %13 = torch.aten.ge.int %12, %int0 : !torch.int, !torch.int -> !torch.bool
+        %14 = torch.prim.If %13 -> (!torch.int) {
+          %15 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+          %16 = torch.aten.mul.int %arg3, %15 : !torch.int, !torch.int -> !torch.int
+          torch.prim.If.yield %16 : !torch.int
+        } else {
+          torch.prim.RaiseException %str_0, %none : !torch.str, !torch.none
+          torch.prim.If.yield %0 : !torch.int
+        }
+        torch.prim.If.yield %14, %arg4 : !torch.int, !torch.optional<!torch.int>
+      }
+      torch.prim.Loop.condition %true, iter(%11#0, %11#1 : !torch.int, !torch.optional<!torch.int>)
+    } : (!torch.int, !torch.bool, !torch.int, !torch.optional<!torch.int>) -> (!torch.int, !torch.optional<!torch.int>)
+    %4 = torch.aten.eq.int %arg1, %3#0 : !torch.int, !torch.int -> !torch.bool
+    %5 = torch.prim.If %4 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %9 = torch.aten.__isnot__ %3#1, %none : !torch.optional<!torch.int>, !torch.none -> !torch.bool
+      %10 = torch.prim.If %9 -> (!torch.bool) {
+        %12 = torch.prim.unchecked_cast %3#1 : !torch.optional<!torch.int> -> !torch.int
+        %13 = torch.aten.gt.int %3#0, %int0 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If.yield %13 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      %11 = torch.prim.If %10 -> (!torch.bool) {
+        %12 = torch.prim.unchecked_cast %3#1 : !torch.optional<!torch.int> -> !torch.int
+        %13 = torch.aten.remainder.int %arg1, %3#0 : !torch.int, !torch.int -> !torch.int
+        %14 = torch.aten.eq.int %13, %int0 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If.yield %14 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      torch.prim.If.yield %11 : !torch.bool
+    }
+    %6 = torch.aten.__not__ %5 : !torch.bool -> !torch.bool
+    torch.prim.If %6 -> () {
+      torch.prim.RaiseException %str_1, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    } else {
+      torch.prim.If.yield
+    }
+    %7 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers._copy(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    %8 = torch.aten.__isnot__ %3#1, %none : !torch.optional<!torch.int>, !torch.none -> !torch.bool
+    torch.prim.If %8 -> () {
+      %9 = torch.prim.unchecked_cast %3#1 : !torch.optional<!torch.int> -> !torch.int
+      %10 = torch.aten.floordiv.int %arg1, %3#0 : !torch.int, !torch.int -> !torch.int
+      %11 = torch.aten._set_item.t %7, %9, %10 : !torch.list<!torch.int>, !torch.int, !torch.int -> !torch.list<!torch.int>
+      torch.prim.If.yield
+    } else {
+      torch.prim.If.yield
+    }
+    return %7 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.numel(%arg0: !torch.list<!torch.int>) -> !torch.int {
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.prim.Loop %0, %true, init(%int1) {
+    ^bb0(%arg1: !torch.int, %arg2: !torch.int):
+      %2 = torch.aten.__getitem__.t %arg0, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %3 = torch.aten.mul.int %arg2, %2 : !torch.int, !torch.int -> !torch.int
+      torch.prim.Loop.condition %true, iter(%3 : !torch.int)
+    } : (!torch.int, !torch.bool, !torch.int) -> !torch.int
+    return %1 : !torch.int
+  }
+  func @"__torch_mlir_shape_fn.aten.reshape"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.view(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten._unsafe_view"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    return %arg1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.resize_"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    return %arg1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.max_pool2d"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.list<!torch.int>, %arg3: !torch.list<!torch.int>, %arg4: !torch.list<!torch.int>, %arg5: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.max_pool2d(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.bool) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.max_pool2d(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.list<!torch.int>, %arg3: !torch.list<!torch.int>, %arg4: !torch.list<!torch.int>, %arg5: !torch.bool) -> !torch.list<!torch.int> {
+    %int4 = torch.constant.int 4
+    %int3 = torch.constant.int 3
+    %int0 = torch.constant.int 0
+    %int2 = torch.constant.int 2
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %str = torch.constant.str "AssertionError: max_pool2d: kernel_size must either be a single int, or a tuple of two ints"
+    %none = torch.constant.none
+    %str_0 = torch.constant.str "AssertionError: max_pool2d: stride must either be omitted, a single int, or a tuple of two ints"
+    %str_1 = torch.constant.str "AssertionError: max_pool2d: padding must be either be a single int, or a tuple of two ints"
+    %str_2 = torch.constant.str "AssertionError: max_pool2d: dilation must be either a single int, or a tuple of two ints"
+    %str_3 = torch.constant.str "AssertionError: "
+    %int-4 = torch.constant.int -4
+    %int-3 = torch.constant.int -3
+    %int-2 = torch.constant.int -2
+    %int-1 = torch.constant.int -1
+    %0 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.eq.int %0, %int1 : !torch.int, !torch.int -> !torch.bool
+    %2 = torch.prim.If %1 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %46 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+      %47 = torch.aten.eq.int %46, %int2 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %47 : !torch.bool
+    }
+    torch.prim.If %2 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %3 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %4 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %5 = torch.aten.eq.int %4, %int1 : !torch.int, !torch.int -> !torch.bool
+    %6 = torch.prim.If %5 -> (!torch.int) {
+      torch.prim.If.yield %3 : !torch.int
+    } else {
+      %46 = torch.aten.__getitem__.t %arg1, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      torch.prim.If.yield %46 : !torch.int
+    }
+    %7 = torch.aten.len.t %arg2 : !torch.list<!torch.int> -> !torch.int
+    %8 = torch.aten.eq.int %7, %int0 : !torch.int, !torch.int -> !torch.bool
+    %9 = torch.prim.If %8 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %46 = torch.aten.len.t %arg2 : !torch.list<!torch.int> -> !torch.int
+      %47 = torch.aten.eq.int %46, %int1 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %47 : !torch.bool
+    }
+    %10 = torch.prim.If %9 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %46 = torch.aten.len.t %arg2 : !torch.list<!torch.int> -> !torch.int
+      %47 = torch.aten.eq.int %46, %int2 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %47 : !torch.bool
+    }
+    torch.prim.If %10 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str_0, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %11 = torch.aten.len.t %arg2 : !torch.list<!torch.int> -> !torch.int
+    %12 = torch.aten.eq.int %11, %int0 : !torch.int, !torch.int -> !torch.bool
+    %13 = torch.prim.If %12 -> (!torch.int) {
+      torch.prim.If.yield %3 : !torch.int
+    } else {
+      %46 = torch.aten.__getitem__.t %arg2, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      torch.prim.If.yield %46 : !torch.int
+    }
+    %14 = torch.aten.len.t %arg2 : !torch.list<!torch.int> -> !torch.int
+    %15 = torch.aten.eq.int %14, %int0 : !torch.int, !torch.int -> !torch.bool
+    %16 = torch.prim.If %15 -> (!torch.int) {
+      torch.prim.If.yield %6 : !torch.int
+    } else {
+      %46 = torch.aten.len.t %arg2 : !torch.list<!torch.int> -> !torch.int
+      %47 = torch.aten.eq.int %46, %int1 : !torch.int, !torch.int -> !torch.bool
+      %48 = torch.prim.If %47 -> (!torch.int) {
+        torch.prim.If.yield %13 : !torch.int
+      } else {
+        %49 = torch.aten.__getitem__.t %arg2, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        torch.prim.If.yield %49 : !torch.int
+      }
+      torch.prim.If.yield %48 : !torch.int
+    }
+    %17 = torch.aten.len.t %arg3 : !torch.list<!torch.int> -> !torch.int
+    %18 = torch.aten.eq.int %17, %int1 : !torch.int, !torch.int -> !torch.bool
+    %19 = torch.prim.If %18 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %46 = torch.aten.len.t %arg3 : !torch.list<!torch.int> -> !torch.int
+      %47 = torch.aten.eq.int %46, %int2 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %47 : !torch.bool
+    }
+    torch.prim.If %19 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str_1, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %20 = torch.aten.__getitem__.t %arg3, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %21 = torch.aten.len.t %arg3 : !torch.list<!torch.int> -> !torch.int
+    %22 = torch.aten.eq.int %21, %int1 : !torch.int, !torch.int -> !torch.bool
+    %23 = torch.prim.If %22 -> (!torch.int) {
+      torch.prim.If.yield %20 : !torch.int
+    } else {
+      %46 = torch.aten.__getitem__.t %arg3, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      torch.prim.If.yield %46 : !torch.int
+    }
+    %24 = torch.aten.len.t %arg4 : !torch.list<!torch.int> -> !torch.int
+    %25 = torch.aten.eq.int %24, %int1 : !torch.int, !torch.int -> !torch.bool
+    %26 = torch.prim.If %25 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %46 = torch.aten.len.t %arg4 : !torch.list<!torch.int> -> !torch.int
+      %47 = torch.aten.eq.int %46, %int2 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %47 : !torch.bool
+    }
+    torch.prim.If %26 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str_2, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %27 = torch.aten.__getitem__.t %arg4, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %28 = torch.aten.len.t %arg4 : !torch.list<!torch.int> -> !torch.int
+    %29 = torch.aten.eq.int %28, %int1 : !torch.int, !torch.int -> !torch.bool
+    %30 = torch.prim.If %29 -> (!torch.int) {
+      torch.prim.If.yield %27 : !torch.int
+    } else {
+      %46 = torch.aten.__getitem__.t %arg4, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      torch.prim.If.yield %46 : !torch.int
+    }
+    %31 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %32 = torch.aten.eq.int %31, %int3 : !torch.int, !torch.int -> !torch.bool
+    %33 = torch.prim.If %32 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %46 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+      %47 = torch.aten.eq.int %46, %int4 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %47 : !torch.bool
+    }
+    torch.prim.If %33 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str_3, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %34 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %35 = torch.aten.eq.int %34, %int4 : !torch.int, !torch.int -> !torch.bool
+    %36 = torch.prim.If %35 -> (!torch.int) {
+      %46 = torch.aten.__getitem__.t %arg0, %int-4 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      torch.prim.If.yield %46 : !torch.int
+    } else {
+      torch.prim.If.yield %int1 : !torch.int
+    }
+    %37 = torch.aten.__getitem__.t %arg0, %int-3 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %38 = torch.aten.__getitem__.t %arg0, %int-2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %39 = torch.aten.__getitem__.t %arg0, %int-1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %40 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.pooling_output_shape(%38, %3, %20, %13, %27, %arg5) : (!torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.bool) -> !torch.int
+    %41 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.pooling_output_shape(%39, %6, %23, %16, %30, %arg5) : (!torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.bool) -> !torch.int
+    %42 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.pool2d_shape_check(%arg0, %3, %6, %13, %16, %20, %23, %27, %30, %37, %38, %39, %40, %41) : (!torch.list<!torch.int>, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int) -> !torch.none
+    %43 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %44 = torch.aten.eq.int %43, %int3 : !torch.int, !torch.int -> !torch.bool
+    %45 = torch.prim.If %44 -> (!torch.list<!torch.int>) {
+      %46 = torch.prim.ListConstruct %37, %40, %41 : (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
+      torch.prim.If.yield %46 : !torch.list<!torch.int>
+    } else {
+      %46 = torch.prim.ListConstruct %36, %37, %40, %41 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
+      torch.prim.If.yield %46 : !torch.list<!torch.int>
+    }
+    return %45 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.pooling_output_shape(%arg0: !torch.int, %arg1: !torch.int, %arg2: !torch.int, %arg3: !torch.int, %arg4: !torch.int, %arg5: !torch.bool) -> !torch.int {
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: stride should not be zeero"
+    %none = torch.constant.none
+    %0 = torch.aten.ne.int %arg3, %int0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %0 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.pooling_output_shape_pad_lr(%arg0, %arg1, %arg2, %arg2, %arg3, %arg4, %arg5) : (!torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.int, !torch.bool) -> !torch.int
+    return %1 : !torch.int
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.pooling_output_shape_pad_lr(%arg0: !torch.int, %arg1: !torch.int, %arg2: !torch.int, %arg3: !torch.int, %arg4: !torch.int, %arg5: !torch.int, %arg6: !torch.bool) -> !torch.int {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %0 = torch.aten.add.int %arg0, %arg2 : !torch.int, !torch.int -> !torch.int
+    %1 = torch.aten.add.int %0, %arg3 : !torch.int, !torch.int -> !torch.int
+    %2 = torch.aten.sub.int %arg1, %int1 : !torch.int, !torch.int -> !torch.int
+    %3 = torch.aten.mul.int %arg5, %2 : !torch.int, !torch.int -> !torch.int
+    %4 = torch.aten.sub.int %1, %3 : !torch.int, !torch.int -> !torch.int
+    %5 = torch.aten.sub.int %4, %int1 : !torch.int, !torch.int -> !torch.int
+    %6 = torch.prim.If %arg6 -> (!torch.int) {
+      %11 = torch.aten.sub.int %arg4, %int1 : !torch.int, !torch.int -> !torch.int
+      torch.prim.If.yield %11 : !torch.int
+    } else {
+      torch.prim.If.yield %int0 : !torch.int
+    }
+    %7 = torch.aten.add.int %5, %6 : !torch.int, !torch.int -> !torch.int
+    %8 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.div_rtn(%7, %arg4) : (!torch.int, !torch.int) -> !torch.int
+    %9 = torch.aten.add.int %8, %int1 : !torch.int, !torch.int -> !torch.int
+    %10 = torch.prim.If %arg6 -> (!torch.int) {
+      %11 = torch.aten.sub.int %9, %int1 : !torch.int, !torch.int -> !torch.int
+      %12 = torch.aten.mul.int %11, %arg4 : !torch.int, !torch.int -> !torch.int
+      %13 = torch.aten.add.int %arg0, %arg2 : !torch.int, !torch.int -> !torch.int
+      %14 = torch.aten.ge.int %12, %13 : !torch.int, !torch.int -> !torch.bool
+      %15 = torch.prim.If %14 -> (!torch.int) {
+        %16 = torch.aten.sub.int %9, %int1 : !torch.int, !torch.int -> !torch.int
+        torch.prim.If.yield %16 : !torch.int
+      } else {
+        torch.prim.If.yield %9 : !torch.int
+      }
+      torch.prim.If.yield %15 : !torch.int
+    } else {
+      torch.prim.If.yield %9 : !torch.int
+    }
+    return %10 : !torch.int
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.div_rtn(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
+    %0 = torch.aten.floordiv.int %arg0, %arg1 : !torch.int, !torch.int -> !torch.int
+    return %0 : !torch.int
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.pool2d_shape_check(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.int, %arg3: !torch.int, %arg4: !torch.int, %arg5: !torch.int, %arg6: !torch.int, %arg7: !torch.int, %arg8: !torch.int, %arg9: !torch.int, %arg10: !torch.int, %arg11: !torch.int, %arg12: !torch.int, %arg13: !torch.int) -> !torch.none {
+    %int4 = torch.constant.int 4
+    %int3 = torch.constant.int 3
+    %int2 = torch.constant.int 2
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %false = torch.constant.bool false
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.gt.int %arg2, %int0 : !torch.int, !torch.int -> !torch.bool
+    %2 = torch.prim.If %1 -> (!torch.bool) {
+      %19 = torch.aten.gt.int %arg1, %int0 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %19 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    torch.prim.If %2 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %3 = torch.aten.gt.int %arg4, %int0 : !torch.int, !torch.int -> !torch.bool
+    %4 = torch.prim.If %3 -> (!torch.bool) {
+      %19 = torch.aten.gt.int %arg3, %int0 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %19 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    torch.prim.If %4 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %5 = torch.aten.gt.int %arg7, %int0 : !torch.int, !torch.int -> !torch.bool
+    %6 = torch.prim.If %5 -> (!torch.bool) {
+      %19 = torch.aten.gt.int %arg8, %int0 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %19 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    torch.prim.If %6 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %7 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %8 = torch.aten.ne.int %7, %int0 : !torch.int, !torch.int -> !torch.bool
+    %9 = torch.prim.If %8 -> (!torch.bool) {
+      %19 = torch.aten.__getitem__.t %arg0, %int2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %20 = torch.aten.ne.int %19, %int0 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %20 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    %10 = torch.aten.eq.int %0, %int3 : !torch.int, !torch.int -> !torch.bool
+    %11 = torch.prim.If %10 -> (!torch.bool) {
+      %19 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %20 = torch.aten.ne.int %19, %int0 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %20 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    %12 = torch.prim.If %11 -> (!torch.bool) {
+      torch.prim.If.yield %9 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    %13 = torch.prim.If %12 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %19 = torch.aten.eq.int %0, %int4 : !torch.int, !torch.int -> !torch.bool
+      %20 = torch.prim.If %19 -> (!torch.bool) {
+        torch.prim.If.yield %9 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      %21 = torch.prim.If %20 -> (!torch.bool) {
+        %22 = torch.aten.__getitem__.t %arg0, %int3 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %23 = torch.aten.ne.int %22, %int0 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If.yield %23 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      torch.prim.If.yield %21 : !torch.bool
+    }
+    torch.prim.If %13 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %14 = torch.aten.floordiv.int %arg2, %int2 : !torch.int, !torch.int -> !torch.int
+    %15 = torch.aten.ge.int %14, %arg6 : !torch.int, !torch.int -> !torch.bool
+    %16 = torch.prim.If %15 -> (!torch.bool) {
+      %19 = torch.aten.floordiv.int %arg1, %int2 : !torch.int, !torch.int -> !torch.int
+      %20 = torch.aten.ge.int %19, %arg5 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %20 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    torch.prim.If %16 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %17 = torch.aten.ge.int %arg13, %int1 : !torch.int, !torch.int -> !torch.bool
+    %18 = torch.prim.If %17 -> (!torch.bool) {
+      %19 = torch.aten.ge.int %arg12, %int1 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %19 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    torch.prim.If %18 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    return %none : !torch.none
+  }
+  func @"__torch_mlir_shape_fn.aten.adaptive_avg_pool2d"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.adaptive_avg_pool2d(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.adaptive_avg_pool2d(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int4 = torch.constant.int 4
+    %int3 = torch.constant.int 3
+    %int2 = torch.constant.int 2
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.eq.int %0, %int2 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %3 = torch.aten.eq.int %2, %int3 : !torch.int, !torch.int -> !torch.bool
+    %4 = torch.prim.If %3 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %12 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+      %13 = torch.aten.eq.int %12, %int4 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %13 : !torch.bool
+    }
+    torch.prim.If %4 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %5 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %6 = torch.aten.__range_length %int1, %5, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %6, %true, init() {
+    ^bb0(%arg2: !torch.int):
+      %12 = torch.aten.__derive_index %arg2, %int1, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+      %13 = torch.aten.__getitem__.t %arg0, %12 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %14 = torch.aten.ne.int %13, %int0 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %14 -> () {
+        torch.prim.If.yield
+      } else {
+        torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    %7 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %8 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %9 = torch.aten.sub.int %8, %int2 : !torch.int, !torch.int -> !torch.int
+    %10 = torch.aten.__range_length %int0, %9, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %10, %true, init() {
+    ^bb0(%arg2: !torch.int):
+      %12 = torch.aten.__derive_index %arg2, %int0, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+      %13 = torch.aten.__getitem__.t %arg0, %12 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %14 = torch.aten.append.t %7, %13 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    %11 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    torch.prim.Loop %11, %true, init() {
+    ^bb0(%arg2: !torch.int):
+      %12 = torch.aten.__getitem__.t %arg1, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %13 = torch.aten.append.t %7, %12 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %7 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.flatten.using_ints"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.flatten(%arg0, %arg1, %arg2) : (!torch.list<!torch.int>, !torch.int, !torch.int) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.flatten(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.int) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %true = torch.constant.bool true
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg1, %0, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %2 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %3 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg2, %2, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %4 = torch.aten.le.int %1, %3 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %4 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %5 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %6 = torch.aten.eq.int %5, %int0 : !torch.int, !torch.int -> !torch.bool
+    %7 = torch.prim.If %6 -> (!torch.list<!torch.int>) {
+      %8 = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<!torch.int>
+      torch.prim.If.yield %8 : !torch.list<!torch.int>
+    } else {
+      %8 = torch.aten.eq.int %1, %3 : !torch.int, !torch.int -> !torch.bool
+      %9 = torch.prim.If %8 -> (!torch.list<!torch.int>) {
+        %10 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+        %11 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+        torch.prim.Loop %11, %true, init() {
+        ^bb0(%arg3: !torch.int):
+          %12 = torch.aten.__getitem__.t %arg0, %arg3 : !torch.list<!torch.int>, !torch.int -> !torch.int
+          %13 = torch.aten.append.t %10, %12 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+          torch.prim.Loop.condition %true, iter()
+        } : (!torch.int, !torch.bool) -> ()
+        torch.prim.If.yield %10 : !torch.list<!torch.int>
+      } else {
+        %10 = torch.aten.add.int %3, %int1 : !torch.int, !torch.int -> !torch.int
+        %11 = torch.aten.__range_length %1, %10, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+        %12 = torch.prim.Loop %11, %true, init(%int1) {
+        ^bb0(%arg3: !torch.int, %arg4: !torch.int):
+          %18 = torch.aten.__derive_index %arg3, %1, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+          %19 = torch.aten.__getitem__.t %arg0, %18 : !torch.list<!torch.int>, !torch.int -> !torch.int
+          %20 = torch.aten.mul.int %arg4, %19 : !torch.int, !torch.int -> !torch.int
+          torch.prim.Loop.condition %true, iter(%20 : !torch.int)
+        } : (!torch.int, !torch.bool, !torch.int) -> !torch.int
+        %13 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+        torch.prim.Loop %1, %true, init() {
+        ^bb0(%arg3: !torch.int):
+          %18 = torch.aten.__getitem__.t %arg0, %arg3 : !torch.list<!torch.int>, !torch.int -> !torch.int
+          %19 = torch.aten.append.t %13, %18 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+          torch.prim.Loop.condition %true, iter()
+        } : (!torch.int, !torch.bool) -> ()
+        %14 = torch.aten.append.t %13, %12 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+        %15 = torch.aten.add.int %3, %int1 : !torch.int, !torch.int -> !torch.int
+        %16 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+        %17 = torch.aten.__range_length %15, %16, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+        torch.prim.Loop %17, %true, init() {
+        ^bb0(%arg3: !torch.int):
+          %18 = torch.aten.__derive_index %arg3, %15, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+          %19 = torch.aten.__getitem__.t %arg0, %18 : !torch.list<!torch.int>, !torch.int -> !torch.int
+          %20 = torch.aten.append.t %13, %19 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+          torch.prim.Loop.condition %true, iter()
+        } : (!torch.int, !torch.bool) -> ()
+        torch.prim.If.yield %13 : !torch.list<!torch.int>
+      }
+      torch.prim.If.yield %9 : !torch.list<!torch.int>
+    }
+    return %7 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.linear"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.list<!torch.int>>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.linear(%arg0, %arg1, %arg2) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.optional<!torch.list<!torch.int>>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.linear(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.list<!torch.int>>) -> !torch.list<!torch.int> {
+    %none = torch.constant.none
+    %str = torch.constant.str "AssertionError: "
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.t(%arg1) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.matmul(%arg0, %0) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    %2 = torch.aten.__isnot__ %arg2, %none : !torch.optional<!torch.list<!torch.int>>, !torch.none -> !torch.bool
+    torch.prim.If %2 -> () {
+      %3 = torch.prim.unchecked_cast %arg2 : !torch.optional<!torch.list<!torch.int>> -> !torch.list<!torch.int>
+      %4 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%3, %1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+      %5 = torch.aten.eq.int_list %4, %1 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.bool
+      torch.prim.If %5 -> () {
+        torch.prim.If.yield
+      } else {
+        torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+        torch.prim.If.yield
+      }
+      torch.prim.If.yield
+    } else {
+      torch.prim.If.yield
+    }
+    return %1 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.t(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %int2 = torch.constant.int 2
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.le.int %0, %int2 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %3 = torch.aten.eq.int %2, %int0 : !torch.int, !torch.int -> !torch.bool
+    %4 = torch.prim.If %3 -> (!torch.list<!torch.int>) {
+      %5 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+      torch.prim.If.yield %5 : !torch.list<!torch.int>
+    } else {
+      %5 = torch.aten.eq.int %2, %int1 : !torch.int, !torch.int -> !torch.bool
+      %6 = torch.prim.If %5 -> (!torch.list<!torch.int>) {
+        %7 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %8 = torch.prim.ListConstruct %7 : (!torch.int) -> !torch.list<!torch.int>
+        torch.prim.If.yield %8 : !torch.list<!torch.int>
+      } else {
+        %7 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %8 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %9 = torch.prim.ListConstruct %7, %8 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+        torch.prim.If.yield %9 : !torch.list<!torch.int>
+      }
+      torch.prim.If.yield %6 : !torch.list<!torch.int>
+    }
+    return %4 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.zeros"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.Device>, %arg4: !torch.optional<!torch.bool>) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.ones"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.Device>, %arg4: !torch.optional<!torch.bool>) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.empty.memory_format"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.Device>, %arg4: !torch.optional<!torch.bool>, %arg5: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.full"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.int>, %arg4: !torch.optional<!torch.Device>, %arg5: !torch.optional<!torch.bool>) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.full_like"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.int>, %arg4: !torch.optional<!torch.Device>, %arg5: !torch.optional<!torch.bool>, %arg6: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.zeros_like"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.Device>, %arg4: !torch.optional<!torch.bool>, %arg5: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.ones_like"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.Device>, %arg4: !torch.optional<!torch.bool>, %arg5: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.empty_like"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.Device>, %arg4: !torch.optional<!torch.bool>, %arg5: !torch.optional<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.new_zeros"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.int>, %arg4: !torch.optional<!torch.Device>, %arg5: !torch.optional<!torch.bool>) -> !torch.list<!torch.int> {
+    return %arg1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.new_ones"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.int>, %arg4: !torch.optional<!torch.Device>, %arg5: !torch.optional<!torch.bool>) -> !torch.list<!torch.int> {
+    return %arg1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.fill.Scalar"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.uniform"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.float, %arg3: !torch.any) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.bernoulli.float"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.any) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.bernoulli.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.any) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.bernoulli"(%arg0: !torch.list<!torch.int>, %arg1: !torch.any) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.arange.start_step"(%arg0: !torch.float, %arg1: !torch.float, %arg2: !torch.float, %arg3: !torch.optional<!torch.int>, %arg4: !torch.optional<!torch.int>, %arg5: !torch.optional<!torch.Device>, %arg6: !torch.optional<!torch.bool>) -> !torch.list<!torch.int> {
+    %0 = torch.derefine %arg3 : !torch.optional<!torch.int> to !torch.any
+    %1 = torch.derefine %arg4 : !torch.optional<!torch.int> to !torch.any
+    %2 = torch.derefine %arg5 : !torch.optional<!torch.Device> to !torch.any
+    %3 = torch.derefine %arg6 : !torch.optional<!torch.bool> to !torch.any
+    %4 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.arange_start_step(%arg0, %arg1, %arg2, %0, %1, %2, %3) : (!torch.float, !torch.float, !torch.float, !torch.any, !torch.any, !torch.any, !torch.any) -> !torch.list<!torch.int>
+    return %4 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.arange_start_step(%arg0: !torch.float, %arg1: !torch.float, %arg2: !torch.float, %arg3: !torch.any, %arg4: !torch.any, %arg5: !torch.any, %arg6: !torch.any) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.operator "aten.ne.float_int"(%arg2, %int0) : (!torch.float, !torch.int) -> !torch.bool
+    torch.prim.If %0 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %1 = torch.aten.lt.float_int %arg2, %int0 : !torch.float, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      %6 = torch.operator "aten.ge.float"(%arg0, %arg1) : (!torch.float, !torch.float) -> !torch.bool
+      torch.prim.If %6 -> () {
+        torch.prim.If.yield
+      } else {
+        torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+        torch.prim.If.yield
+      }
+      torch.prim.If.yield
+    } else {
+      %6 = torch.operator "aten.ge.float"(%arg1, %arg0) : (!torch.float, !torch.float) -> !torch.bool
+      torch.prim.If %6 -> () {
+        torch.prim.If.yield
+      } else {
+        torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+        torch.prim.If.yield
+      }
+      torch.prim.If.yield
+    }
+    %2 = torch.operator "aten.sub.float"(%arg1, %arg0) : (!torch.float, !torch.float) -> !torch.float
+    %3 = torch.operator "aten.div.float"(%2, %arg2) : (!torch.float, !torch.float) -> !torch.float
+    %4 = torch.operator "aten.ceil.float"(%3) : (!torch.float) -> !torch.int
+    %5 = torch.prim.ListConstruct %4 : (!torch.int) -> !torch.list<!torch.int>
+    return %5 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.arange.start"(%arg0: !torch.float, %arg1: !torch.float, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.int>, %arg4: !torch.optional<!torch.Device>, %arg5: !torch.optional<!torch.bool>) -> !torch.list<!torch.int> {
+    %0 = torch.derefine %arg2 : !torch.optional<!torch.int> to !torch.any
+    %1 = torch.derefine %arg3 : !torch.optional<!torch.int> to !torch.any
+    %2 = torch.derefine %arg4 : !torch.optional<!torch.Device> to !torch.any
+    %3 = torch.derefine %arg5 : !torch.optional<!torch.bool> to !torch.any
+    %4 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.arange_start(%arg0, %arg1, %0, %1, %2, %3) : (!torch.float, !torch.float, !torch.any, !torch.any, !torch.any, !torch.any) -> !torch.list<!torch.int>
+    return %4 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.arange_start(%arg0: !torch.float, %arg1: !torch.float, %arg2: !torch.any, %arg3: !torch.any, %arg4: !torch.any, %arg5: !torch.any) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.operator "aten.ge.float_int"(%arg1, %int0) : (!torch.float, !torch.int) -> !torch.bool
+    torch.prim.If %0 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %1 = torch.operator "aten.ge.float"(%arg1, %arg0) : (!torch.float, !torch.float) -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = torch.operator "aten.sub.float"(%arg1, %arg0) : (!torch.float, !torch.float) -> !torch.float
+    %3 = torch.operator "aten.ceil.float"(%2) : (!torch.float) -> !torch.int
+    %4 = torch.prim.ListConstruct %3 : (!torch.int) -> !torch.list<!torch.int>
+    return %4 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.arange"(%arg0: !torch.float, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.Device>, %arg4: !torch.optional<!torch.bool>) -> !torch.list<!torch.int> {
+    %0 = torch.derefine %arg1 : !torch.optional<!torch.int> to !torch.any
+    %1 = torch.derefine %arg2 : !torch.optional<!torch.int> to !torch.any
+    %2 = torch.derefine %arg3 : !torch.optional<!torch.Device> to !torch.any
+    %3 = torch.derefine %arg4 : !torch.optional<!torch.bool> to !torch.any
+    %4 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.arange_end(%arg0, %0, %1, %2, %3) : (!torch.float, !torch.any, !torch.any, !torch.any, !torch.any) -> !torch.list<!torch.int>
+    return %4 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.arange_end(%arg0: !torch.float, %arg1: !torch.any, %arg2: !torch.any, %arg3: !torch.any, %arg4: !torch.any) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.operator "aten.ge.float_int"(%arg0, %int0) : (!torch.float, !torch.int) -> !torch.bool
+    torch.prim.If %0 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %1 = torch.operator "aten.ceil.float"(%arg0) : (!torch.float) -> !torch.int
+    %2 = torch.prim.ListConstruct %1 : (!torch.int) -> !torch.list<!torch.int>
+    return %2 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.add.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.sub.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.mul.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.div.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.__and__.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.minimum"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.maximum"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.bitwise_and.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.threshold"(%arg0: !torch.list<!torch.int>, %arg1: !torch.float, %arg2: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.threshold_backward"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.eq.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.gt.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.lt.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.unsqueeze"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unsqueeze(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.int) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.squeeze"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.squeeze_nodim(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.squeeze_nodim(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %1 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    torch.prim.Loop %1, %true, init() {
+    ^bb0(%arg1: !torch.int):
+      %2 = torch.aten.__getitem__.t %arg0, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %3 = torch.aten.ne.int %2, %int1 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %3 -> () {
+        %4 = torch.aten.__getitem__.t %arg0, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %5 = torch.aten.append.t %0, %4 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+        torch.prim.If.yield
+      } else {
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.squeeze.dim"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.squeeze(%arg0, %arg1) : (!torch.list<!torch.int>, !torch.int) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.prim.NumToTensor.Scalar"(%arg0: !torch.float) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.tensor.float"(%arg0: !torch.float, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.Device>, %arg3: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.tensor.int"(%arg0: !torch.int, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.Device>, %arg3: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.tensor.bool"(%arg0: !torch.bool, %arg1: !torch.optional<!torch.int>, %arg2: !torch.optional<!torch.Device>, %arg3: !torch.bool) -> !torch.list<!torch.int> {
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten._shape_as_tensor"(%arg0: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.prim.ListConstruct %0 : (!torch.int) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.where.self"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg1, %arg2) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %0) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.lerp.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg1, %arg2) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %0) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.addcmul"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.list<!torch.int>, %arg3: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg1, %arg2) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %0) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.addcdiv"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.list<!torch.int>, %arg3: !torch.float) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg1, %arg2) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg0, %0) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.topk"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.int, %arg3: !torch.bool, %arg4: !torch.bool) -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>> {
+    %str = torch.constant.str "k ({}) is too big for dimension {} of size {}"
+    %str_0 = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %1 = torch.aten.le.int %arg1, %0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      %4 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %5 = torch.aten.format(%str, %arg1, %arg2, %4) : !torch.str, !torch.int, !torch.int, !torch.int -> !torch.str
+      %6 = torch.aten.add.str %str_0, %5 : !torch.str, !torch.str -> !torch.str
+      torch.prim.RaiseException %6, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = torch.aten._set_item.t %arg0, %arg2, %arg1 : !torch.list<!torch.int>, !torch.int, !torch.int -> !torch.list<!torch.int>
+    %3 = torch.prim.TupleConstruct %arg0, %arg0 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+    return %3 : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+  }
+  func @"__torch_mlir_shape_fn.aten.conv2d"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.list<!torch.int>>, %arg3: !torch.list<!torch.int>, %arg4: !torch.list<!torch.int>, %arg5: !torch.list<!torch.int>, %arg6: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.conv2d(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.optional<!torch.list<!torch.int>>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.conv2d(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.list<!torch.int>>, %arg3: !torch.list<!torch.int>, %arg4: !torch.list<!torch.int>, %arg5: !torch.list<!torch.int>, %arg6: !torch.int) -> !torch.list<!torch.int> {
+    %int4 = torch.constant.int 4
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.eq.int %0, %int4 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %3 = torch.aten.eq.int %2, %int4 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %3 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %4 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.conv_output_size(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.optional<!torch.list<!torch.int>>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int) -> !torch.list<!torch.int>
+    return %4 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.conv_output_size(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.list<!torch.int>>, %arg3: !torch.list<!torch.int>, %arg4: !torch.list<!torch.int>, %arg5: !torch.list<!torch.int>, %arg6: !torch.int) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %int0 = torch.constant.int 0
+    %true = torch.constant.bool true
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_shape_forward(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.optional<!torch.list<!torch.int>>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int) -> !torch.none
+    %1 = torch.aten.len.t %arg5 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.aten.gt.int %1, %int0 : !torch.int, !torch.int -> !torch.bool
+    %3 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %4 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %5 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %6 = torch.aten.append.t %4, %5 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    %7 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %8 = torch.aten.append.t %4, %7 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    %9 = torch.aten.__range_length %int2, %3, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %9, %true, init() {
+    ^bb0(%arg7: !torch.int):
+      %10 = torch.aten.__derive_index %arg7, %int2, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+      %11 = torch.prim.If %2 -> (!torch.int) {
+        %27 = torch.aten.sub.int %10, %int2 : !torch.int, !torch.int -> !torch.int
+        %28 = torch.aten.__getitem__.t %arg5, %27 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        torch.prim.If.yield %28 : !torch.int
+      } else {
+        torch.prim.If.yield %int1 : !torch.int
+      }
+      %12 = torch.aten.__getitem__.t %arg1, %10 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %13 = torch.aten.sub.int %12, %int1 : !torch.int, !torch.int -> !torch.int
+      %14 = torch.aten.mul.int %11, %13 : !torch.int, !torch.int -> !torch.int
+      %15 = torch.aten.add.int %14, %int1 : !torch.int, !torch.int -> !torch.int
+      %16 = torch.aten.__getitem__.t %arg0, %10 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %17 = torch.aten.sub.int %10, %int2 : !torch.int, !torch.int -> !torch.int
+      %18 = torch.aten.__getitem__.t %arg4, %17 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %19 = torch.aten.mul.int %int2, %18 : !torch.int, !torch.int -> !torch.int
+      %20 = torch.aten.add.int %16, %19 : !torch.int, !torch.int -> !torch.int
+      %21 = torch.aten.sub.int %20, %15 : !torch.int, !torch.int -> !torch.int
+      %22 = torch.aten.sub.int %10, %int2 : !torch.int, !torch.int -> !torch.int
+      %23 = torch.aten.__getitem__.t %arg3, %22 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %24 = torch.aten.floordiv.int %21, %23 : !torch.int, !torch.int -> !torch.int
+      %25 = torch.aten.add.int %24, %int1 : !torch.int, !torch.int -> !torch.int
+      %26 = torch.aten.append.t %4, %25 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %4 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_shape_forward(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.list<!torch.int>>, %arg3: !torch.list<!torch.int>, %arg4: !torch.list<!torch.int>, %arg5: !torch.list<!torch.int>, %arg6: !torch.int) -> !torch.none {
+    %int2 = torch.constant.int 2
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %false = torch.constant.bool false
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %2 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_non_negative(%arg4) : (!torch.list<!torch.int>) -> !torch.bool
+    %3 = torch.aten.__not__ %2 : !torch.bool -> !torch.bool
+    torch.prim.If %3 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %4 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_non_negative(%arg3) : (!torch.list<!torch.int>) -> !torch.bool
+    %5 = torch.aten.__not__ %4 : !torch.bool -> !torch.bool
+    torch.prim.If %5 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %6 = torch.aten.eq.int %1, %0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %6 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %7 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %8 = torch.aten.ge.int %7, %arg6 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %8 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %9 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %10 = torch.aten.remainder.int %9, %arg6 : !torch.int, !torch.int -> !torch.int
+    %11 = torch.aten.eq.int %10, %int0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %11 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %12 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %13 = torch.aten.__getitem__.t %arg1, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %14 = torch.aten.mul.int %13, %arg6 : !torch.int, !torch.int -> !torch.int
+    %15 = torch.aten.eq.int %12, %14 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %15 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %16 = torch.aten.__is__ %arg2, %none : !torch.optional<!torch.list<!torch.int>>, !torch.none -> !torch.bool
+    %17 = torch.prim.If %16 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %19 = torch.prim.unchecked_cast %arg2 : !torch.optional<!torch.list<!torch.int>> -> !torch.list<!torch.int>
+      %20 = torch.aten.len.t %19 : !torch.list<!torch.int> -> !torch.int
+      %21 = torch.aten.eq.int %20, %int1 : !torch.int, !torch.int -> !torch.bool
+      %22 = torch.prim.If %21 -> (!torch.bool) {
+        %23 = torch.aten.__getitem__.t %19, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %24 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %25 = torch.aten.eq.int %23, %24 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If.yield %25 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      torch.prim.If.yield %22 : !torch.bool
+    }
+    torch.prim.If %17 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %18 = torch.aten.__range_length %int2, %0, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %18, %true, init() {
+    ^bb0(%arg7: !torch.int):
+      %19 = torch.aten.__derive_index %arg7, %int2, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+      %20 = torch.aten.__getitem__.t %arg0, %19 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %21 = torch.aten.sub.int %19, %int2 : !torch.int, !torch.int -> !torch.int
+      %22 = torch.aten.__getitem__.t %arg4, %21 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %23 = torch.aten.mul.int %int2, %22 : !torch.int, !torch.int -> !torch.int
+      %24 = torch.aten.add.int %20, %23 : !torch.int, !torch.int -> !torch.int
+      %25 = torch.aten.sub.int %19, %int2 : !torch.int, !torch.int -> !torch.int
+      %26 = torch.aten.__getitem__.t %arg5, %25 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %27 = torch.aten.__getitem__.t %arg1, %19 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %28 = torch.aten.sub.int %27, %int1 : !torch.int, !torch.int -> !torch.int
+      %29 = torch.aten.mul.int %26, %28 : !torch.int, !torch.int -> !torch.int
+      %30 = torch.aten.add.int %29, %int1 : !torch.int, !torch.int -> !torch.int
+      %31 = torch.aten.ge.int %24, %30 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %31 -> () {
+        torch.prim.If.yield
+      } else {
+        torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %none : !torch.none
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_non_negative(%arg0: !torch.list<!torch.int>) -> !torch.bool {
+    %int0 = torch.constant.int 0
+    %false = torch.constant.bool false
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.prim.Loop %0, %true, init(%false) {
+    ^bb0(%arg1: !torch.int, %arg2: !torch.bool):
+      %2 = torch.aten.__getitem__.t %arg0, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %3 = torch.aten.lt.int %2, %int0 : !torch.int, !torch.int -> !torch.bool
+      %4 = torch.prim.If %3 -> (!torch.bool) {
+        torch.prim.If.yield %true : !torch.bool
+      } else {
+        torch.prim.If.yield %arg2 : !torch.bool
+      }
+      torch.prim.Loop.condition %true, iter(%4 : !torch.bool)
+    } : (!torch.int, !torch.bool, !torch.bool) -> !torch.bool
+    return %1 : !torch.bool
+  }
+  func @"__torch_mlir_shape_fn.aten.batch_norm"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.list<!torch.int>>, %arg2: !torch.optional<!torch.list<!torch.int>>, %arg3: !torch.optional<!torch.list<!torch.int>>, %arg4: !torch.optional<!torch.list<!torch.int>>, %arg5: !torch.bool, %arg6: !torch.float, %arg7: !torch.float, %arg8: !torch.bool) -> !torch.list<!torch.int> {
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.slice.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.int>, %arg4: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.slice(%arg0, %arg1, %arg2, %arg3, %arg4) : (!torch.list<!torch.int>, !torch.int, !torch.optional<!torch.int>, !torch.optional<!torch.int>, !torch.int) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.slice(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.optional<!torch.int>, %arg3: !torch.optional<!torch.int>, %arg4: !torch.int) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.ne.int %0, %int0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg1, %0, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %3 = torch.aten.__isnot__ %arg2, %none : !torch.optional<!torch.int>, !torch.none -> !torch.bool
+    %4 = torch.prim.If %3 -> (!torch.int) {
+      %25 = torch.prim.unchecked_cast %arg2 : !torch.optional<!torch.int> -> !torch.int
+      torch.prim.If.yield %25 : !torch.int
+    } else {
+      torch.prim.If.yield %int0 : !torch.int
+    }
+    %5 = torch.aten.__isnot__ %arg3, %none : !torch.optional<!torch.int>, !torch.none -> !torch.bool
+    %6 = torch.prim.If %5 -> (!torch.int) {
+      %25 = torch.prim.unchecked_cast %arg3 : !torch.optional<!torch.int> -> !torch.int
+      torch.prim.If.yield %25 : !torch.int
+    } else {
+      %25 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.max_int() : () -> !torch.int
+      torch.prim.If.yield %25 : !torch.int
+    }
+    %7 = torch.aten.gt.int %arg4, %int0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %7 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %8 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.max_int() : () -> !torch.int
+    %9 = torch.aten.eq.int %4, %8 : !torch.int, !torch.int -> !torch.bool
+    %10 = torch.prim.If %9 -> (!torch.int) {
+      torch.prim.If.yield %int0 : !torch.int
+    } else {
+      torch.prim.If.yield %4 : !torch.int
+    }
+    %11 = torch.aten.lt.int %10, %int0 : !torch.int, !torch.int -> !torch.bool
+    %12 = torch.prim.If %11 -> (!torch.int) {
+      %25 = torch.aten.__getitem__.t %arg0, %2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %26 = torch.aten.add.int %10, %25 : !torch.int, !torch.int -> !torch.int
+      torch.prim.If.yield %26 : !torch.int
+    } else {
+      torch.prim.If.yield %10 : !torch.int
+    }
+    %13 = torch.aten.lt.int %6, %int0 : !torch.int, !torch.int -> !torch.bool
+    %14 = torch.prim.If %13 -> (!torch.int) {
+      %25 = torch.aten.__getitem__.t %arg0, %2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %26 = torch.aten.add.int %6, %25 : !torch.int, !torch.int -> !torch.int
+      torch.prim.If.yield %26 : !torch.int
+    } else {
+      torch.prim.If.yield %6 : !torch.int
+    }
+    %15 = torch.aten.lt.int %12, %int0 : !torch.int, !torch.int -> !torch.bool
+    %16 = torch.prim.If %15 -> (!torch.int) {
+      torch.prim.If.yield %int0 : !torch.int
+    } else {
+      %25 = torch.aten.__getitem__.t %arg0, %2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %26 = torch.aten.ge.int %12, %25 : !torch.int, !torch.int -> !torch.bool
+      %27 = torch.prim.If %26 -> (!torch.int) {
+        %28 = torch.aten.__getitem__.t %arg0, %2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        torch.prim.If.yield %28 : !torch.int
+      } else {
+        torch.prim.If.yield %12 : !torch.int
+      }
+      torch.prim.If.yield %27 : !torch.int
+    }
+    %17 = torch.aten.lt.int %14, %16 : !torch.int, !torch.int -> !torch.bool
+    %18 = torch.prim.If %17 -> (!torch.int) {
+      torch.prim.If.yield %16 : !torch.int
+    } else {
+      %25 = torch.aten.__getitem__.t %arg0, %2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %26 = torch.aten.ge.int %14, %25 : !torch.int, !torch.int -> !torch.bool
+      %27 = torch.prim.If %26 -> (!torch.int) {
+        %28 = torch.aten.__getitem__.t %arg0, %2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        torch.prim.If.yield %28 : !torch.int
+      } else {
+        torch.prim.If.yield %14 : !torch.int
+      }
+      torch.prim.If.yield %27 : !torch.int
+    }
+    %19 = torch.aten.sub.int %18, %16 : !torch.int, !torch.int -> !torch.int
+    %20 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers._copy(%arg0) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    %21 = torch.aten.add.int %19, %arg4 : !torch.int, !torch.int -> !torch.int
+    %22 = torch.aten.sub.int %21, %int1 : !torch.int, !torch.int -> !torch.int
+    %23 = torch.aten.floordiv.int %22, %arg4 : !torch.int, !torch.int -> !torch.int
+    %24 = torch.aten._set_item.t %20, %2, %23 : !torch.list<!torch.int>, !torch.int, !torch.int -> !torch.list<!torch.int>
+    return %20 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.max_int() -> !torch.int {
+    %int9223372036854775807 = torch.constant.int 9223372036854775807
+    return %int9223372036854775807 : !torch.int
+  }
+  func @"__torch_mlir_shape_fn.aten.select.int"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.select(%arg0, %arg1, %arg2) : (!torch.list<!torch.int>, !torch.int, !torch.int) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.select(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.int) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.ne.int %0, %int0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %1 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %2 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg1, %0, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %3 = torch.aten.__getitem__.t %arg0, %2 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %4 = torch.aten.neg.int %3 : !torch.int -> !torch.int
+    %5 = torch.aten.lt.int %arg2, %4 : !torch.int, !torch.int -> !torch.bool
+    %6 = torch.prim.If %5 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %9 = torch.aten.ge.int %arg2, %3 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %9 : !torch.bool
+    }
+    %7 = torch.aten.__not__ %6 : !torch.bool -> !torch.bool
+    torch.prim.If %7 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %8 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    torch.prim.Loop %0, %true, init() {
+    ^bb0(%arg3: !torch.int):
+      %9 = torch.aten.ne.int %arg3, %2 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %9 -> () {
+        %10 = torch.aten.__getitem__.t %arg0, %arg3 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %11 = torch.aten.append.t %8, %10 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+        torch.prim.If.yield
+      } else {
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %8 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.index_select"(%arg0: !torch.list<!torch.int>, %arg1: !torch.int, %arg2: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.index_select(%arg0, %arg1, %arg2) : (!torch.list<!torch.int>, !torch.int, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.nll_loss_forward"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.list<!torch.int>>, %arg3: !torch.int, %arg4: !torch.int) -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %int0 = torch.constant.int 0
+    %false = torch.constant.bool false
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %int-1 = torch.constant.int -1
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.aten.lt.int %int0, %0 : !torch.int, !torch.int -> !torch.bool
+    %3 = torch.prim.If %2 -> (!torch.bool) {
+      %15 = torch.aten.le.int %0, %int2 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %15 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    torch.prim.If %3 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %4 = torch.aten.le.int %1, %int1 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %4 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %5 = torch.aten.eq.int %0, %int1 : !torch.int, !torch.int -> !torch.bool
+    %6 = torch.prim.If %5 -> (!torch.bool) {
+      %15 = torch.aten.eq.int %1, %int0 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %15 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    %7 = torch.prim.If %6 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %15 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %16 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %17 = torch.aten.eq.int %15, %16 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %17 : !torch.bool
+    }
+    torch.prim.If %7 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %8 = torch.aten.__getitem__.t %arg0, %int-1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+    %9 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %10 = torch.aten.__is__ %arg2, %none : !torch.optional<!torch.list<!torch.int>>, !torch.none -> !torch.bool
+    %11 = torch.prim.If %10 -> (!torch.bool) {
+      torch.prim.If.yield %true : !torch.bool
+    } else {
+      %15 = torch.prim.unchecked_cast %arg2 : !torch.optional<!torch.list<!torch.int>> -> !torch.list<!torch.int>
+      %16 = torch.aten.len.t %15 : !torch.list<!torch.int> -> !torch.int
+      %17 = torch.aten.eq.int %16, %int1 : !torch.int, !torch.int -> !torch.bool
+      %18 = torch.prim.If %17 -> (!torch.bool) {
+        %19 = torch.aten.__getitem__.t %15, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %20 = torch.aten.eq.int %19, %8 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If.yield %20 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      torch.prim.If.yield %18 : !torch.bool
+    }
+    torch.prim.If %11 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %12 = torch.aten.eq.int %arg3, %int0 : !torch.int, !torch.int -> !torch.bool
+    %13 = torch.prim.If %12 -> (!torch.bool) {
+      %15 = torch.aten.eq.int %0, %int2 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %15 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    %14 = torch.prim.If %13 -> (!torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>) {
+      %15 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %16 = torch.prim.ListConstruct %15 : (!torch.int) -> !torch.list<!torch.int>
+      %17 = torch.prim.TupleConstruct %16, %9 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+      torch.prim.If.yield %17 : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+    } else {
+      %15 = torch.prim.TupleConstruct %9, %9 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+      torch.prim.If.yield %15 : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+    }
+    return %14 : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+  }
+  func @"__torch_mlir_shape_fn.aten.nll_loss_backward"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.list<!torch.int>, %arg3: !torch.optional<!torch.list<!torch.int>>, %arg4: !torch.int, %arg5: !torch.int, %arg6: !torch.list<!torch.int>) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg1) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.native_layer_norm"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.optional<!torch.list<!torch.int>>, %arg3: !torch.optional<!torch.list<!torch.int>>, %arg4: !torch.float) -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>> {
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %1 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %3 = torch.aten.__range_length %1, %2, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %3, %true, init() {
+    ^bb0(%arg5: !torch.int):
+      %5 = torch.aten.__derive_index %arg5, %1, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+      %6 = torch.aten.__getitem__.t %arg0, %5 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %7 = torch.aten.append.t %0, %6 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    %4 = torch.prim.TupleConstruct %arg0, %0, %0 : !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>>
+    return %4 : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>>
+  }
+  func @"__torch_mlir_shape_fn.aten.native_batch_norm"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.list<!torch.int>>, %arg2: !torch.optional<!torch.list<!torch.int>>, %arg3: !torch.optional<!torch.list<!torch.int>>, %arg4: !torch.optional<!torch.list<!torch.int>>, %arg5: !torch.bool, %arg6: !torch.float, %arg7: !torch.float) -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>> {
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %0 = torch.prim.If %arg5 -> (!torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>>) {
+      %1 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %2 = torch.prim.ListConstruct %1 : (!torch.int) -> !torch.list<!torch.int>
+      %3 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %4 = torch.prim.ListConstruct %3 : (!torch.int) -> !torch.list<!torch.int>
+      %5 = torch.prim.TupleConstruct %arg0, %2, %4 : !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>>
+      torch.prim.If.yield %5 : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>>
+    } else {
+      %1 = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<!torch.int>
+      %2 = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<!torch.int>
+      %3 = torch.prim.TupleConstruct %arg0, %1, %2 : !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>>
+      torch.prim.If.yield %3 : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>>
+    }
+    return %0 : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>>
+  }
+  func @"__torch_mlir_shape_fn.aten.constant_pad_nd"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.float) -> !torch.list<!torch.int> {
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %int2 = torch.constant.int 2
+    %str = torch.constant.str "AssertionError: Must have paired low-high pad amount values"
+    %none = torch.constant.none
+    %str_0 = torch.constant.str "AssertionError: Number of padded dimensions must be less than or equal to the input dimension"
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.remainder.int %0, %int2 : !torch.int, !torch.int -> !torch.int
+    %2 = torch.aten.eq.int %1, %int0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %2 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %3 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %4 = torch.aten.floordiv.int %3, %int2 : !torch.int, !torch.int -> !torch.int
+    %5 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %6 = torch.aten.le.int %4, %5 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %6 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str_0, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %7 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %8 = torch.aten.floordiv.int %7, %int2 : !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %8, %true, init() {
+    ^bb0(%arg3: !torch.int):
+      %9 = torch.aten.add.int %arg3, %int1 : !torch.int, !torch.int -> !torch.int
+      %10 = torch.aten.neg.int %9 : !torch.int -> !torch.int
+      %11 = torch.aten.mul.int %int2, %arg3 : !torch.int, !torch.int -> !torch.int
+      %12 = torch.aten.__getitem__.t %arg1, %11 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %13 = torch.aten.mul.int %int2, %arg3 : !torch.int, !torch.int -> !torch.int
+      %14 = torch.aten.add.int %13, %int1 : !torch.int, !torch.int -> !torch.int
+      %15 = torch.aten.__getitem__.t %arg1, %14 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %16 = torch.aten.add.int %12, %15 : !torch.int, !torch.int -> !torch.int
+      %17 = torch.aten.__getitem__.t %arg0, %10 : !torch.list<!torch.int>, !torch.int -> !torch.int
+      %18 = torch.aten.add.int %17, %16 : !torch.int, !torch.int -> !torch.int
+      %19 = torch.aten._set_item.t %arg0, %10, %18 : !torch.list<!torch.int>, !torch.int, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %arg0 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.index.Tensor"(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.optional<!torch.list<!torch.int>>>) -> !torch.list<!torch.int> {
+    %str = torch.constant.str "AssertionError: More indices than dimensions to index"
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg1 : !torch.list<!torch.optional<!torch.list<!torch.int>>> -> !torch.int
+    %1 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.aten.le.int %0, %1 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %2 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %3 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %4 = torch.aten.len.t %arg1 : !torch.list<!torch.optional<!torch.list<!torch.int>>> -> !torch.int
+    %5 = torch.prim.Loop %4, %true, init(%3) {
+    ^bb0(%arg2: !torch.int, %arg3: !torch.list<!torch.int>):
+      %6 = torch.aten.__getitem__.t %arg1, %arg2 : !torch.list<!torch.optional<!torch.list<!torch.int>>>, !torch.int -> !torch.optional<!torch.list<!torch.int>>
+      %7 = torch.aten.__isnot__ %6, %none : !torch.optional<!torch.list<!torch.int>>, !torch.none -> !torch.bool
+      %8 = torch.prim.If %7 -> (!torch.list<!torch.int>) {
+        %9 = torch.prim.unchecked_cast %6 : !torch.optional<!torch.list<!torch.int>> -> !torch.list<!torch.int>
+        %10 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.broadcast(%arg3, %9) : (!torch.list<!torch.int>, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+        torch.prim.If.yield %10 : !torch.list<!torch.int>
+      } else {
+        torch.prim.If.yield %arg3 : !torch.list<!torch.int>
+      }
+      torch.prim.Loop.condition %true, iter(%8 : !torch.list<!torch.int>)
+    } : (!torch.int, !torch.bool, !torch.list<!torch.int>) -> !torch.list<!torch.int>
+    return %5 : !torch.list<!torch.int>
+  }
+  func @"__torch_mlir_shape_fn.aten.cat"(%arg0: !torch.list<!torch.list<!torch.int>>, %arg1: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.cat(%arg0, %arg1) : (!torch.list<!torch.list<!torch.int>>, !torch.int) -> !torch.list<!torch.int>
+    return %0 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.cat(%arg0: !torch.list<!torch.list<!torch.int>>, %arg1: !torch.int) -> !torch.list<!torch.int> {
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_cat_no_zero_dim(%arg0) : (!torch.list<!torch.list<!torch.int>>) -> !torch.none
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.legacy_cat_wrap_dim(%arg1, %arg0) : (!torch.int, !torch.list<!torch.list<!torch.int>>) -> !torch.int
+    %2 = torch.aten.len.t %arg0 : !torch.list<!torch.list<!torch.int>> -> !torch.int
+    %3 = torch.aten.gt.int %2, %int0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %3 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %4 = torch.aten.len.t %arg0 : !torch.list<!torch.list<!torch.int>> -> !torch.int
+    %5 = torch.derefine %none : !torch.none to !torch.optional<!torch.list<!torch.int>>
+    %6 = torch.prim.Loop %4, %true, init(%5) {
+    ^bb0(%arg2: !torch.int, %arg3: !torch.optional<!torch.list<!torch.int>>):
+      %9 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.list<!torch.int>>, !torch.int -> !torch.list<!torch.int>
+      %10 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.should_skip(%9) : (!torch.list<!torch.int>) -> !torch.bool
+      %11 = torch.aten.__not__ %10 : !torch.bool -> !torch.bool
+      %12 = torch.prim.If %11 -> (!torch.optional<!torch.list<!torch.int>>) {
+        %13 = torch.derefine %9 : !torch.list<!torch.int> to !torch.optional<!torch.list<!torch.int>>
+        torch.prim.If.yield %13 : !torch.optional<!torch.list<!torch.int>>
+      } else {
+        torch.prim.If.yield %arg3 : !torch.optional<!torch.list<!torch.int>>
+      }
+      torch.prim.Loop.condition %true, iter(%12 : !torch.optional<!torch.list<!torch.int>>)
+    } : (!torch.int, !torch.bool, !torch.optional<!torch.list<!torch.int>>) -> !torch.optional<!torch.list<!torch.int>>
+    %7 = torch.aten.__is__ %6, %none : !torch.optional<!torch.list<!torch.int>>, !torch.none -> !torch.bool
+    %8 = torch.prim.If %7 -> (!torch.list<!torch.int>) {
+      %9 = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<!torch.int>
+      torch.prim.If.yield %9 : !torch.list<!torch.int>
+    } else {
+      %9 = torch.prim.unchecked_cast %6 : !torch.optional<!torch.list<!torch.int>> -> !torch.list<!torch.int>
+      %10 = torch.aten.len.t %arg0 : !torch.list<!torch.list<!torch.int>> -> !torch.int
+      %11 = torch.prim.Loop %10, %true, init(%int0) {
+      ^bb0(%arg2: !torch.int, %arg3: !torch.int):
+        %14 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<!torch.list<!torch.int>>, !torch.int -> !torch.list<!torch.int>
+        %15 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.should_skip(%14) : (!torch.list<!torch.int>) -> !torch.bool
+        %16 = torch.aten.__not__ %15 : !torch.bool -> !torch.bool
+        %17 = torch.prim.If %16 -> (!torch.int) {
+          %18 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_cat_shape_except_dim(%9, %14, %1, %arg2) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int, !torch.int) -> !torch.none
+          %19 = torch.aten.__getitem__.t %14, %1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+          %20 = torch.aten.add.int %arg3, %19 : !torch.int, !torch.int -> !torch.int
+          torch.prim.If.yield %20 : !torch.int
+        } else {
+          torch.prim.If.yield %arg3 : !torch.int
+        }
+        torch.prim.Loop.condition %true, iter(%17 : !torch.int)
+      } : (!torch.int, !torch.bool, !torch.int) -> !torch.int
+      %12 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers._copy(%9) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+      %13 = torch.aten._set_item.t %12, %1, %11 : !torch.list<!torch.int>, !torch.int, !torch.int -> !torch.list<!torch.int>
+      torch.prim.If.yield %12 : !torch.list<!torch.int>
+    }
+    return %8 : !torch.list<!torch.int>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_cat_no_zero_dim(%arg0: !torch.list<!torch.list<!torch.int>>) -> !torch.none {
+    %int0 = torch.constant.int 0
+    %true = torch.constant.bool true
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.list<!torch.int>> -> !torch.int
+    torch.prim.Loop %0, %true, init() {
+    ^bb0(%arg1: !torch.int):
+      %1 = torch.aten.__getitem__.t %arg0, %arg1 : !torch.list<!torch.list<!torch.int>>, !torch.int -> !torch.list<!torch.int>
+      %2 = torch.aten.len.t %1 : !torch.list<!torch.int> -> !torch.int
+      %3 = torch.aten.gt.int %2, %int0 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %3 -> () {
+        torch.prim.If.yield
+      } else {
+        torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %none : !torch.none
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.legacy_cat_wrap_dim(%arg0: !torch.int, %arg1: !torch.list<!torch.list<!torch.int>>) -> !torch.int {
+    %int0 = torch.constant.int 0
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %false = torch.constant.bool false
+    %0 = torch.aten.len.t %arg1 : !torch.list<!torch.list<!torch.int>> -> !torch.int
+    %1 = torch.derefine %none : !torch.none to !torch.optional<!torch.int>
+    %2 = torch.prim.Loop %0, %true, init(%1) {
+    ^bb0(%arg2: !torch.int, %arg3: !torch.optional<!torch.int>):
+      %5 = torch.aten.__getitem__.t %arg1, %arg2 : !torch.list<!torch.list<!torch.int>>, !torch.int -> !torch.list<!torch.int>
+      %6 = torch.aten.len.t %5 : !torch.list<!torch.int> -> !torch.int
+      %7 = torch.aten.ne.int %6, %int0 : !torch.int, !torch.int -> !torch.bool
+      %8 = torch.prim.If %7 -> (!torch.bool) {
+        %11 = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<!torch.int>
+        %12 = torch.aten.ne.int_list %5, %11 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.bool
+        torch.prim.If.yield %12 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      %9 = torch.prim.If %8 -> (!torch.bool) {
+        %11 = torch.aten.__isnot__ %arg3, %none : !torch.optional<!torch.int>, !torch.none -> !torch.bool
+        torch.prim.If.yield %11 : !torch.bool
+      } else {
+        torch.prim.If.yield %false : !torch.bool
+      }
+      %10 = torch.prim.If %9 -> (!torch.optional<!torch.int>) {
+        %11 = torch.aten.len.t %5 : !torch.list<!torch.int> -> !torch.int
+        %12 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg0, %11, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+        %13 = torch.derefine %12 : !torch.int to !torch.optional<!torch.int>
+        torch.prim.If.yield %13 : !torch.optional<!torch.int>
+      } else {
+        torch.prim.If.yield %arg3 : !torch.optional<!torch.int>
+      }
+      torch.prim.Loop.condition %true, iter(%10 : !torch.optional<!torch.int>)
+    } : (!torch.int, !torch.bool, !torch.optional<!torch.int>) -> !torch.optional<!torch.int>
+    %3 = torch.aten.__is__ %2, %none : !torch.optional<!torch.int>, !torch.none -> !torch.bool
+    %4 = torch.prim.If %3 -> (!torch.int) {
+      torch.prim.If.yield %arg0 : !torch.int
+    } else {
+      %5 = torch.prim.unchecked_cast %2 : !torch.optional<!torch.int> -> !torch.int
+      torch.prim.If.yield %5 : !torch.int
+    }
+    return %4 : !torch.int
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.should_skip(%arg0: !torch.list<!torch.int>) -> !torch.bool {
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %false = torch.constant.bool false
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.numel(%arg0) : (!torch.list<!torch.int>) -> !torch.int
+    %1 = torch.aten.eq.int %0, %int0 : !torch.int, !torch.int -> !torch.bool
+    %2 = torch.prim.If %1 -> (!torch.bool) {
+      %3 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+      %4 = torch.aten.eq.int %3, %int1 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If.yield %4 : !torch.bool
+    } else {
+      torch.prim.If.yield %false : !torch.bool
+    }
+    return %2 : !torch.bool
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_cat_shape_except_dim(%arg0: !torch.list<!torch.int>, %arg1: !torch.list<!torch.int>, %arg2: !torch.int, %arg3: !torch.int) -> !torch.none {
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: Tensors must have same number of dimensions"
+    %none = torch.constant.none
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %str_0 = torch.constant.str "AssertionError: Sizes of tensors must match except in dimension"
+    %0 = torch.aten.len.t %arg0 : !torch.list<!torch.int> -> !torch.int
+    %1 = torch.aten.len.t %arg1 : !torch.list<!torch.int> -> !torch.int
+    %2 = torch.aten.eq.int %0, %1 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %2 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
+    %3 = torch.aten.__range_length %int0, %0, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %3, %true, init() {
+    ^bb0(%arg4: !torch.int):
+      %4 = torch.aten.__derive_index %arg4, %int0, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+      %5 = torch.aten.ne.int %4, %arg2 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %5 -> () {
+        %6 = torch.aten.__getitem__.t %arg0, %4 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %7 = torch.aten.__getitem__.t %arg1, %4 : !torch.list<!torch.int>, !torch.int -> !torch.int
+        %8 = torch.aten.eq.int %6, %7 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If %8 -> () {
+          torch.prim.If.yield
+        } else {
+          torch.prim.RaiseException %str_0, %none : !torch.str, !torch.none
+          torch.prim.If.yield
+        }
+        torch.prim.If.yield
+      } else {
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %none : !torch.none
+  }
+  func @"__torch_mlir_shape_fn.aten.bincount"(%arg0: !torch.list<!torch.int>, %arg1: !torch.optional<!torch.list<!torch.int>>, %arg2: !torch.int) -> !torch.list<!torch.int> {
+    %0 = call @__torch__.hacky_get_unknown_dimension_size() : () -> !torch.int
+    %1 = torch.prim.ListConstruct %0 : (!torch.int) -> !torch.list<!torch.int>
+    return %1 : !torch.list<!torch.int>
+  }
+  func @__torch__.hacky_get_unknown_dimension_size() -> !torch.int {
+    %0 = torch.prim.CreateObject !torch.nn.Module<"__torch__.DummyClassType">
+    %1 = torch.prim.CallMethod %0["__init__"] () : !torch.nn.Module<"__torch__.DummyClassType">, () -> !torch.none
+    %2 = torch.operator "prim.id"(%0) : (!torch.nn.Module<"__torch__.DummyClassType">) -> !torch.int
+    return %2 : !torch.int
+  }
+  func @__torch__.DummyClassType.__init__(%arg0: !torch.nn.Module<"__torch__.DummyClassType">) -> !torch.none {
+    %none = torch.constant.none
+    return %none : !torch.none
+  }
+}
+)mlir");
+#pragma clang diagnostic pop
+  return shapeLib;
+}

--- a/lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp
+++ b/lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp
@@ -1,0 +1,421 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Parser.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/InliningUtils.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringSet.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+namespace {
+// TODO: Only unroll inside the shape calculation region.
+// Maybe do this by only applying patterns and folding greedily on the ops
+// inside the region + the shape.calculate op itself?
+class FullyUnrollPrimLoopOp : public OpRewritePattern<PrimLoopOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(PrimLoopOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    MLIRContext *context = op->getContext();
+    if (!op.isForLike())
+      return failure();
+    int64_t maxTripCount;
+    if (!matchPattern(op.maxTripCount(), m_TorchConstantInt(&maxTripCount)))
+      return failure();
+    SmallVector<Value> indices;
+    for (int64_t i = 0; i < maxTripCount; i++) {
+      // TODO: Add convenience builder.
+      indices.push_back(rewriter.create<ConstantIntOp>(
+          loc, rewriter.getIntegerAttr(IntegerType::get(context, 64), i)));
+    }
+    Block *beforeBlock = op->getBlock();
+    Block *afterBlock = rewriter.splitBlock(op->getBlock(), op->getIterator());
+
+    SmallVector<Block *> blocksToMerge;
+    BlockAndValueMapping bvm;
+    // TODO: Helper for region().front()
+    auto condition =
+        cast<PrimLoopConditionOp>(op.region().front().getTerminator());
+    for (int64_t i = 0; i < maxTripCount; i++) {
+      SmallVector<Value> iterArgs;
+      if (i == 0) {
+        llvm::append_range(iterArgs, op.iterArgsInit());
+      } else {
+        llvm::append_range(
+            iterArgs, llvm::map_range(condition.iterArgs(),
+                                      [&](Value v) { return bvm.lookup(v); }));
+      }
+      bvm.clear();
+      bvm.map(op.region().front().getArgument(0), indices[i]);
+      bvm.map(op.region().front().getArguments().slice(1), iterArgs);
+
+      op.region().cloneInto(afterBlock->getParent(), afterBlock->getIterator(),
+                            bvm);
+      Block *clonedBlock = bvm.lookup(&op.region().front());
+      rewriter.eraseOp(clonedBlock->getTerminator());
+      blocksToMerge.push_back(clonedBlock);
+    }
+
+    blocksToMerge.push_back(afterBlock);
+    for (Block *block : blocksToMerge)
+      rewriter.mergeBlocks(block, beforeBlock);
+    if (maxTripCount == 0) {
+      rewriter.replaceOp(op, op.iterArgsInit());
+    } else {
+      rewriter.replaceOp(op, llvm::to_vector<6>(llvm::map_range(
+                                 condition.iterArgs(),
+                                 [&](Value v) { return bvm.lookup(v); })));
+    }
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class AbstractlyInterpretListOpsWithinABlock
+    : public OpRewritePattern<PrimListConstructOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(PrimListConstructOp op,
+                                PatternRewriter &rewriter) const override {
+    Block *block = op->getBlock();
+    auto allUsers = llvm::to_vector<6>(op->getUsers());
+
+    // Sort the users into program order.
+    auto getParentInBlock = [&](Operation *op) {
+      while (op->getBlock() != block)
+        op = op->getParentOp();
+      return op;
+    };
+    // Use a stable sort for deterministic results when users are nested in two
+    // regions of the same parent op.
+    llvm::stable_sort(allUsers, [&](Operation *lhs, Operation *rhs) {
+      return getParentInBlock(lhs)->isBeforeInBlock(getParentInBlock(rhs));
+    });
+
+    // We cannot interpret all ops. So first do a check to see up until which
+    // point we can interpret.
+    int numUsersToInterpret = 0;
+    for (int i = 0, e = allUsers.size(); i != e; i++, numUsersToInterpret++) {
+      Operation *user = allUsers[i];
+      // If a user potentially mutates the list, then we require it to be in the
+      // same block for our simple abstract interpretation to work (we can't,
+      // for example, handle an "append" operation in a loop or other region).
+      // However, if the op is read-only, then from the purpose of our abstract
+      // interpretation, we can handle it effectively as though it was at the
+      // same position as the corresponding parent op in the block under
+      // consideration.
+      if (potentiallyMutatesListOperands(user)) {
+        if (user->getBlock() != block)
+          break;
+      }
+    }
+
+    // Truncate the list of users to the number of users we're going to
+    // interpret.
+    allUsers.resize(numUsersToInterpret);
+    auto usersToInterpret =
+        makeArrayRef(allUsers).take_front(numUsersToInterpret);
+
+    // For each mutating op (which must be in the same block), we save the
+    // current state of the list as a vector of Value's. These will then
+    // be converted to PrimListConstructOp's at the correct program points.
+    SmallVector<SmallVector<Value>> listLiterals;
+    SmallVector<Value> runningList;
+    llvm::append_range(runningList, op->getOperands());
+    bool generatedNewLiteral = false;
+    for (Operation *user : usersToInterpret) {
+      if (auto append = dyn_cast<AtenAppendTOp>(user)) {
+        if (!append.use_empty())
+          return failure();
+        if (append.self() == op) {
+          runningList.push_back(append.el());
+          generatedNewLiteral = true;
+        }
+        listLiterals.push_back(runningList);
+        continue;
+      }
+      if (auto insert = dyn_cast<AtenInsertTOp>(user)) {
+        if (!insert.use_empty())
+          return failure();
+        int64_t index;
+        if (!matchPattern(insert.idx(), m_TorchConstantInt(&index)))
+          return failure();
+        // The index might be statically out of bounds.
+        if (index < 0 || index > static_cast<int64_t>(runningList.size()))
+          return failure();
+        if (insert.self() == op) {
+          runningList.insert(runningList.begin() + index, insert.el());
+          generatedNewLiteral = true;
+        }
+        listLiterals.push_back(runningList);
+        continue;
+      }
+      if (auto setItem = dyn_cast<Aten_SetItemTOp>(user)) {
+        if (!setItem.use_empty())
+          return failure();
+        int64_t index;
+        if (!matchPattern(setItem.idx(), m_TorchConstantInt(&index)))
+          return failure();
+        // The index might be statically out of bounds.
+        if (index < 0 || index >= static_cast<int64_t>(runningList.size()))
+          return failure();
+        if (setItem.l() == op) {
+          runningList[index] = setItem.el();
+          generatedNewLiteral = true;
+        }
+        listLiterals.push_back(runningList);
+        continue;
+      }
+      // If this user potentially mutates the list and isn't handled above, then
+      // we can't abstractly interpret any further.
+      if (potentiallyMutatesListOperands(user))
+        break;
+    }
+
+    if (!generatedNewLiteral)
+      return failure();
+
+    // Rewrite all users to use the appropriate list literals.
+    Value latestLiteral = op;
+    int nextLiteral = 0;
+    for (Operation *user : usersToInterpret) {
+      if (auto append = dyn_cast<AtenAppendTOp>(user)) {
+        rewriter.setInsertionPoint(append);
+        latestLiteral = rewriter.create<PrimListConstructOp>(
+            append->getLoc(), op.getType(), listLiterals[nextLiteral++]);
+        if (append.self() == op)
+          rewriter.eraseOp(append);
+        continue;
+      }
+      if (auto insert = dyn_cast<AtenInsertTOp>(user)) {
+        rewriter.setInsertionPoint(insert);
+        latestLiteral = rewriter.create<PrimListConstructOp>(
+            insert->getLoc(), op.getType(), listLiterals[nextLiteral++]);
+        if (insert.self() == op)
+          rewriter.eraseOp(insert);
+        continue;
+      }
+      if (auto setItem = dyn_cast<Aten_SetItemTOp>(user)) {
+        rewriter.setInsertionPoint(setItem);
+        latestLiteral = rewriter.create<PrimListConstructOp>(
+            setItem->getLoc(), op.getType(), listLiterals[nextLiteral++]);
+        if (setItem.l() == op)
+          rewriter.eraseOp(setItem);
+        continue;
+      }
+      for (OpOperand &opOperand : user->getOpOperands()) {
+        if (opOperand.get() == op.getResult()) {
+          opOperand.set(latestLiteral);
+        }
+      }
+    }
+
+    // Any remaining uses should use the updated value of the latest literal.
+    rewriter.replaceOp(op, latestLiteral);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class DecomposeAtenSizeOp : public OpRewritePattern<AtenSizeOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AtenSizeOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value self = op.self();
+    MLIRContext *context = op.getContext();
+    auto tensorType = self.getType().cast<BaseTensorType>();
+    if (!tensorType.hasSizes())
+      return rewriter.notifyMatchFailure(op, "unranked tensor");
+    int64_t rank = tensorType.getSizes().size();
+    SmallVector<Value> sizes;
+    for (int i = 0; i < rank; i++) {
+      Value dim = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(i));
+      sizes.push_back(rewriter.create<AtenSizeIntOp>(loc, self, dim));
+    }
+
+    Value sizeList = rewriter.create<PrimListConstructOp>(
+        loc, Torch::ListType::get(Torch::IntType::get(context)), sizes);
+    rewriter.replaceOp(op, sizeList);
+    return success();
+  }
+};
+} // namespace
+
+static void refineShapeCalculateResult(ShapeCalculateOp op, int resultNum,
+                                       PatternRewriter &rewriter,
+                                       bool &madeChange) {
+  auto yieldValues = op.body().front().getTerminator();
+  auto yieldShapes = op.shapeCalculation().front().getTerminator();
+  auto shape = yieldShapes->getOperand(resultNum);
+  auto result = op->getResult(resultNum);
+
+  // If the yielded shape is not a list literal, we can't analyze it.
+  // AbstractlyInterpretListOpsWithinABlock should already have converted as
+  // much as possible to literals.
+  auto listConstruct = shape.getDefiningOp<PrimListConstructOp>();
+  if (!listConstruct)
+    return;
+  llvm::BitVector clobberedElements(listConstruct->getNumOperands());
+  // Analyze the users to determine if we can refine the shape.
+  for (Operation *user : listConstruct->getUsers()) {
+    // If an op doesn't mutate the list, then we can handle it.
+    if (!potentiallyMutatesListOperands(user))
+      continue;
+    // We can handle Aten_SetItemTOp specially, since we know that it doesn't
+    // change the size of the list. It might clobber some elements, which then
+    // become dimensions with unknown size.
+    if (auto setItem = dyn_cast<Aten_SetItemTOp>(user)) {
+      int64_t index;
+      // If the index is statically known, we can clobber only a single index.
+      // Otherwise, we conservatively clobber all of them.
+      if (matchPattern(setItem.idx(), m_TorchConstantInt(&index)) &&
+          isValidDim(index, listConstruct->getNumOperands())) {
+        clobberedElements.set(index);
+      } else {
+        clobberedElements.set();
+      }
+      continue;
+    }
+    // An unhandled op! We can't make any assumptions about the shape.
+    return;
+  }
+
+  // Construct the list of sizes implied by the yielded shape.
+  SmallVector<int64_t> sizes;
+  for (auto operand : llvm::enumerate(listConstruct->getOperands())) {
+    int64_t size;
+    if (matchPattern(operand.value(), m_TorchConstantInt(&size)) &&
+        !clobberedElements[operand.index()])
+      sizes.push_back(size);
+    else
+      sizes.push_back(kUnknownSize);
+  }
+
+  // Calculate the updated type incorporating the new shape information.
+  Type originalResultType = result.getType();
+  auto impliedTypesFromShape =
+      originalResultType.cast<BaseTensorType>().getWithSizesAndDtype(
+          makeArrayRef(sizes), nullptr);
+  auto updatedType =
+      meetTensorTypes(originalResultType.cast<BaseTensorType>(),
+                      impliedTypesFromShape.cast<BaseTensorType>());
+  // If we didn't get any new information, there is nothing left for us to do.
+  if (!updatedType || updatedType == originalResultType)
+    return;
+
+  // Update all the uses of the result type to the new type, if possible. Insert
+  // a TensorStaticInfoCastOp for any users that might require the exact
+  // previous type.
+  Value originalTypedValue;
+  for (OpOperand &use : result.getUses()) {
+    if (use.getOwner()
+            ->hasTrait<mlir::torch::Torch::OpTrait::AllowsTypeRefinement>()) {
+      continue;
+    }
+    if (!originalTypedValue) {
+      rewriter.setInsertionPointAfter(op);
+      originalTypedValue = rewriter.create<TensorStaticInfoCastOp>(
+          op->getLoc(), originalResultType, result);
+    }
+    use.set(originalTypedValue);
+  }
+  result.setType(updatedType);
+  madeChange = true;
+
+  // Update the value yielded from the body to match the new result type. If we
+  // can refine the def in place, do that, otherwise insert a
+  // TensorStaticInfoCastOp.
+  OpOperand &use = op.body().front().getTerminator()->getOpOperand(resultNum);
+  Value def = use.get();
+  Value newYieldedValue;
+  if (def.isa<OpResult>() &&
+      def.cast<OpResult>()
+          .getDefiningOp()
+          ->hasTrait<mlir::torch::Torch::OpTrait::AllowsTypeRefinement>()) {
+    newYieldedValue = def;
+  } else {
+    rewriter.setInsertionPoint(yieldValues);
+    newYieldedValue =
+        rewriter.create<TensorStaticInfoCastOp>(op->getLoc(), updatedType, def);
+  }
+  use.set(newYieldedValue);
+  newYieldedValue.setType(updatedType);
+}
+
+namespace {
+// This pattern propagates information out of the shape calculation region and
+// into the ShapeCalculateOp result types.
+class RefineShapeCalculateOp : public OpRewritePattern<ShapeCalculateOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(ShapeCalculateOp op,
+                                PatternRewriter &rewriter) const override {
+    bool madeChange = false;
+    for (int i = 0, e = op->getNumResults(); i != e; i++)
+      refineShapeCalculateResult(op, i, rewriter, madeChange);
+    return success(madeChange);
+  }
+};
+} // namespace
+
+namespace {
+class SimplifyShapeCalculationsPass
+    : public SimplifyShapeCalculationsBase<SimplifyShapeCalculationsPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.insert<FullyUnrollPrimLoopOp>(context);
+    patterns.insert<AbstractlyInterpretListOpsWithinABlock>(context);
+    patterns.insert<DecomposeAtenSizeOp>(context);
+    patterns.insert<RefineShapeCalculateOp>(context);
+
+    PrimIfOp::getCanonicalizationPatterns(patterns, context);
+    Aten__Getitem__TOp::getCanonicalizationPatterns(patterns, context);
+    AtenSizeOp::getCanonicalizationPatterns(patterns, context);
+    AtenLenTOp::getCanonicalizationPatterns(patterns, context);
+
+    // TODO: Debug visitation order to make this more efficient.
+    // A single linear scan should suffice.
+    GreedyRewriteConfig config;
+    config.useTopDownTraversal = true;
+    config.maxIterations = GreedyRewriteConfig::kNoIterationLimit;
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
+                                            config))) {
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::torch::Torch::createSimplifyShapeCalculationsPass() {
+  return std::make_unique<SimplifyShapeCalculationsPass>();
+}

--- a/lib/Dialect/TorchConversion/Transforms/VerifyInvariantsBeforeBackendLowering.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyInvariantsBeforeBackendLowering.cpp
@@ -30,7 +30,8 @@ static LogicalResult checkValueInvariants(Operation *errorReportOp, Value v) {
           .append("unsupported by backend lowering: tensor with unknown rank "
                   "or dtype")
           .attachNote()
-          .append("this is likely due to a missing case in RefineTypes");
+          .append("this is likely due to a missing case in RefineTypes or a "
+                  "missing shape transfer function in shape_lib_gen.py");
   }
   return success();
 }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/registry.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/registry.py
@@ -1,0 +1,306 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+"""Access to the Torch JIT operator registry."""
+
+from typing import Dict, List, Tuple, Union
+
+import io
+import itertools
+
+from .utils import TextEmitter
+
+# Note that this utility exists only in the c-extension.
+from torch_mlir._mlir_libs._jit_ir_importer import get_registered_ops # pytype: disable=import-error
+
+def _pytype_to_shape_fn_pytype(pytype: str) -> str:
+    """Convert a JitOperator pytype to the type relevant in shape functions.
+
+    In particular, this converts `Tensor` to `List[int]`, along with a few
+    other special cases.
+    """
+    # `Scalar` operands (which are represented with pytype "number") can
+    # be either `int` or `float`. TorchScript has no way to represent a
+    # signature of this type, so we hardcode it to `float`. `Scalar`
+    # operands don't participate in shape functions (since they are
+    # logically real-valued), so it doesn't really matter much, and
+    # `float` helps make it clearer that it's not part of the shape
+    # function.
+    if pytype == "number":
+        return "float"
+    if pytype == "Optional[number]":
+        return "Optional[float]"
+    # `torch.device` is lowercase.
+    if pytype == "Device":
+        return "device"
+    if pytype == "Optional[Device]":
+        return "Optional[device]"
+    # Shape functions only care about the shape of tensors.
+    if pytype == "Tensor":
+        return "List[int]"
+    if pytype == "Optional[Tensor]":
+        return "Optional[List[int]]"
+    if pytype == "List[Tensor]":
+        return "List[List[int]]"
+    if pytype == "List[Optional[Tensor]]":
+        return "List[Optional[List[int]]]"
+    # Generators don't contribute to shapes, and are not scriptable currently.
+    # So just hack them to be passed as "Any".
+    if pytype == "Generator":
+        return "Any"
+    if pytype == "Optional[Generator]":
+        return "Any"
+    return pytype
+
+class JitOperator:
+    """Information about a single registered `torch::jit::Operator`"""
+    def __init__(self, op_info: "OP_INFO_DICT"):
+        """Create a JitOperator from the raw OP_INFO_DICT extracted from
+        the PyTorch JIT operator registry.
+        """
+        namespace, _, unqualified_name = op_info["name"][0].partition("::")
+        self.namespace = namespace
+        self.unqualified_name = unqualified_name
+        self.overload_name = op_info["name"][1]
+        self.is_c10_op = op_info["is_c10_op"]
+        self.is_vararg = op_info["is_vararg"]
+        self.is_varret = op_info["is_varret"]
+        self.is_mutable = op_info["is_mutable"]
+        self.arguments = op_info["arguments"]
+        self.returns = op_info["returns"]
+
+        self.unique_key = self.create_unique_key()
+
+    def create_unique_key(self) -> str:
+        """Create a unique, human-readable key for this JitOperator.
+
+        The key consists of the operator name and its overload name, which
+        together form a unique identifier. We also redundantly
+        append a signature to the end, which gives some robustness to changes
+        in PyTorch and also generally makes things more readable.
+        The format is:
+        ```
+            namespace::unqualified_name[.overload_name] : (type1,type2) -> (type3,type4)
+        ```
+        This is a modified version of the signature strings seen throughout
+        PyTorch. The main difference is the inclusion of return types and the
+        extra spacing and `:`. E.g.the above would be just:
+        ```
+          namespace::kernel_name[.overload_name](type1,type2)
+        ```
+        (PyTorch doesn't canonically include the result types since they don't
+        participate in their dispatch overload resolution, which is of primary
+        concern for them)
+        """
+        overload = "" if not self.overload_name else f".{self.overload_name}"
+        if self.is_vararg:
+            arg_str = "..."
+        else:
+            arg_str = ", ".join(arg["type"] for arg in self.arguments)
+        if self.is_varret:
+            ret_str = "..."
+        else:
+            ret_str = ", ".join(ret["type"] for ret in self.returns)
+        return f"{self.namespace}::{self.unqualified_name}{overload} : ({arg_str}) -> ({ret_str})"
+
+    @property
+    def triple(self):
+        """Returns the unique 3-tuple identifying this operator.
+
+        This is a useful alternative to the "unique name" for programmatic
+        access, such as when needing to convert one op to a related op by
+        a programmatic transformation of the triple.
+        """
+        return self.namespace, self.unqualified_name, self.overload_name
+
+    def get_mlir_names(self):
+        """Gets the MLIR op name (excluding `torch.`) and td def name.
+
+        Not all ops are necessarily registered or in the .td file, but these
+        are useful in the repr for cross referencing, and it's useful to have
+        them in a single point of truth.
+        """
+        def uppercase_first_letter(s):
+            if not s:
+                return s
+            return s[0].upper() + s[1:]
+
+        op_name_atoms = [self.namespace, self.unqualified_name]
+        if self.overload_name:
+            op_name_atoms.append(self.overload_name)
+        op_name = ".".join(op_name_atoms)
+
+        op_class_name_atoms = []
+        for op_name_atom in op_name_atoms:
+            for s in op_name_atom.split("_"):
+                op_class_name_atoms.append(s if s else "_")
+        td_def_name = "Torch_" + "".join(
+            uppercase_first_letter(s) for s in op_class_name_atoms) + "Op"
+        return op_name, td_def_name
+
+    def get_shape_function_signature(self):
+        """Gets the Python function signature for this op's shape function.
+
+        While this is technically debug-only output, it is useful to copy-paste
+        it from the debug dump into the shape library definitions, as many
+        ops have extra default arguments and stuff that are tedious to write out
+        right.
+        """
+        mlir_op_name, _ = self.get_mlir_names()
+        # Replace `.` with a valid Python identifier character.
+        # `〇` vaguely looks like `.`.
+        def_name = "〇".join(mlir_op_name.split("."))
+        parameter_decls = []
+        for arg in self.arguments:
+            pytype = _pytype_to_shape_fn_pytype(arg["pytype"])
+            default = ""
+            if "default_debug" in arg:
+                if "List" in arg["pytype"]:
+                    # TorchScript doesn't allow lists as default parameters due
+                    # to the weird Python semantics of mutable default
+                    # arguments. So munge them into tuples, which work
+                    # fine here. We only need these to simplify the invocation
+                    # of the shape functions as valid Python for testing against
+                    # the real ops, and tuples work fine in all the places this
+                    # kicks in (e.g. conv dilations -- we aren't mutating those
+                    # lists).
+                    default_debug = arg["default_debug"].replace(
+                        '[', '(').replace(']', ')')
+                elif arg["pytype"] == "str":
+                    default_debug = repr(arg["default_debug"]).replace("'", '"')
+                else:
+                    default_debug = arg["default_debug"]
+                default = f" = {default_debug}"
+            parameter_name = arg["name"]
+            if parameter_name == "from":
+                parameter_name = "from_" # Avoid using a Python keyword.
+            parameter_decls.append(f"{parameter_name}: {pytype}{default}")
+        ret_decls = []
+        for ret in self.returns:
+            pytype = _pytype_to_shape_fn_pytype(ret["pytype"])
+            ret_decls.append(f"{pytype}")
+        parameters = ", ".join(parameter_decls)
+        result = ", ".join(ret_decls)
+        if len(ret_decls) >= 2:
+            result = f"Tuple[{result}]"
+
+        return f"def {def_name}({parameters}) -> {result}:"
+
+    def __repr__(self):
+        f = io.StringIO()
+        emitter = TextEmitter(f)
+        p = lambda *args: emitter.print(*args)
+        p(f"JitOperator '{self.unique_key}':")
+        with emitter.indent():
+
+            # Emit the MLIR names to allow easy reverse lookup if starting
+            # from an unregistered op.
+            op_name, td_def_name = self.get_mlir_names()
+            p(f"MLIR op name = torch.{op_name}")
+            p(f"MLIR td def name = {td_def_name}")
+
+            p(f"namespace = {self.namespace}")
+            p(f"unqualified_name = {self.unqualified_name}")
+            p(f"overload_name = {self.overload_name}")
+            p(f"is_c10_op = {self.is_c10_op}")
+            p(f"is_vararg = {self.is_vararg}")
+            p(f"is_varret = {self.is_varret}")
+            p(f"is_mutable = {self.is_mutable}")
+            if any(ret["type"] == "Tensor" for ret in self.returns):
+                p(f"shape_function_signature = {self.get_shape_function_signature()}")
+            if not self.arguments:
+                p("arguments = []")
+            else:
+                p("arguments:")
+                with emitter.indent():
+                    for arg in self.arguments:
+                        p(f"arg: {arg}")
+            if not self.returns:
+                p("returns = []")
+            else:
+                p("returns:")
+                with emitter.indent():
+                    for ret in self.returns:
+                        p(f"ret: {ret}")
+        return f.getvalue()
+
+    def has_value_semantics(self):
+        """Indicates whether the operator HasValueSemantics."""
+
+        # Delegate to is_readonly for handling some incorrectly annotated ops.
+        # HasValueSemantics implies ReadOnly.
+        if not self.is_readonly():
+            return False
+
+        # Vararg and varret ops don't have sufficient annotations for us to
+        # be sure whether they satisfy the requirements of HasValueSemantics.
+        if self.is_vararg or self.is_varret:
+            return False
+        # If no operands have aliasing relations, then the op has value semantics.
+        # Note that this is different from MLIR's NoSideEffect which is much
+        # stronger (for example, it cannot be applied to ops that might emit errors
+        # when operand shapes mismatch).
+        if any("alias_info" in x for x in itertools.chain(self.arguments, self.returns)):
+            return False
+        # It seems the FunctionSchema of "prim::unchecked_cast : (t) -> (t)" has
+        # incorrect alias information. The result can alias with other tensors
+        # but the alias annotation is empty.
+        if self.unique_key == "prim::unchecked_cast : (t) -> (t)":
+            return False
+        return True
+
+    def is_readonly(self):
+        """Indicates whether the operator is ReadOnly."""
+
+        triple = (self.namespace, self.unqualified_name, self.overload_name)
+        # TODO: Handle some exceptions of incorrectly annotated ops.
+        # We have incorrectly grown a reliance on the incorrect annotation of
+        # `aten::batch_norm`.
+        # See https://github.com/pytorch/pytorch/issues/73050#issuecomment-1051382044
+        # if triple in [("aten", "batch_norm", ""), ("aten", "instance_norm", "")]:
+        #     return False
+
+        # If any argument or return has an alias_info that indicates mutation,
+        # the op is not ReadOnly.
+        for x in itertools.chain(self.arguments, self.returns):
+            if "alias_info" in x:
+                if x["alias_info"]["is_write"]:
+                    return False
+        return True
+
+
+class Registry:
+    """An indexed collection of JitOperators"""
+    def __init__(self, operators: List[JitOperator]):
+        self.by_unique_key = {}
+        self.by_triple = {}
+        for o in operators:
+            self.by_unique_key[o.unique_key] = o
+            self.by_triple[o.triple] = o
+
+    @staticmethod
+    def load() -> "Registry":
+        return Registry([JitOperator(op_info) for op_info in get_registered_ops()])
+
+    def __getitem__(self, key: str):
+        """Looks up a JitOperator by its "unique key"."""
+        return self.by_unique_key[key]
+
+    def get_by_triple(self, key: Tuple[str, str, str]):
+        """Looks up a JitOperator by its unique "triple"."""
+        return self.by_triple[key]
+
+
+# A List[Dict[str, _]] mapping attribute names to:
+#   - str (e.g. {'name': 'dim'} )
+#   - int (e.g. {'N': 1} )
+#   - Dict[str, List[str]]
+#       (e.g. {'alias_info': {'before': ['alias::a'], 'after': ['alias::a']}} )
+SIGLIST_TYPE = List[Dict[str, Union[str, int, Dict[str, List[str]]]]]
+# A Dict[str, _] describing a registered op. Each field is either
+#   - bool (e.g. {'is_mutable': False} )
+#   - Tuple[str] (e.g. {'name': ('aten::size', 'int')} )
+#   - SIGLIST_TYPE (e.g. {'arguments': [...], 'returns': [...]} )
+OP_INFO_DICT = Dict[str, Union[bool, Tuple[str], SIGLIST_TYPE]]

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -1,0 +1,972 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+from typing import List, Optional, Any, Tuple, Union
+
+import os
+import argparse
+import inspect
+
+import torch
+from torch import device, Tensor
+
+from torch_mlir.dialects.torch.importer.jit_ir import ModuleBuilder
+from torch_mlir.passmanager import PassManager
+import torch_mlir.all_passes_registration
+
+from .registry import Registry
+import torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers as upstream_shape_helpers
+
+# ==============================================================================
+# Shape function testing infrastructure.
+# ==============================================================================
+
+# We expect all shape functions to be adequately tested. For shape functions
+# implemented with upstream helpers, additional testing is usually not needed.
+# But for shape functions that are authored/maintained by the Torch-MLIR
+# project, we expect adequate testing.
+#
+# To do this, we provide a decorator `@check_shape_function` which can be used
+# to specify a series of operator invocations (such as "call this operator with
+# two arguments -- a first tensor of size [2, 3] and a second tensor of size
+# [3, 4]"). These tests are then run as part of this script, and any mismatches
+# from the real op's behavior will be reported.
+#
+# A typical use of the decorator might look like:
+# ```
+# @check_shape_function([
+#     Invocation(TensorOfShape(2, 3, 4)), # Basic case.
+#     Invocation(TensorOfShape(2, 3, 4), dim=0), # Test explicit `dim`.
+#     Invocation(TensorOfShape(2, 3, 4), dim=0, keepdim=True), # `keepdim`.
+#     Invocation(TensorOfShape(2, 3, 4), dim=-3), # Negative `dim`.
+#     Invocation(TensorOfShape(2, 3, 4), dim=2), # Maximum valid `dim`.
+#     ErrorInvocation(TensorOfShape(2, 3, 4), dim=-4), # `dim` out of bounds.
+#     ErrorInvocation(TensorOfShape(2, 3, 4), dim=3), # `dim` out of bounds.
+# ])
+# ```
+# Each `Invocation` takes a list of args/kwargs which will be passed to both the
+# shape function and the real op and the results compared.
+# We expect both the successful and error cases to be tested.
+#
+# The typical iteration flow is to add invocations to the list and then re-run
+# `build_tools/update_shape_lib.sh` to re-run the tests.
+
+class TensorOfShape:
+    """Symbolic placeholder for a tensor argument to an operation.
+
+    Shape functions take tensor arguments as `List[int]`, whereas the real ops
+    take them as `Tensor`, so we need a symbolic representation of a tensor
+    argument to an op in order to represent an invocation that can drive both
+    the shape function and the real op (see `Invocation`).
+
+    A plain list doesn't work, because plain lists are actually legal arguments
+    to a shape function (e.g. conv dilations), and we don't want them to receive
+    this special treatment.
+
+    This class also tracks a dtype of the tensor, since some ops require a
+    specific dtype.
+    """
+    def __init__(self, *shape: int, dtype: torch.dtype = torch.float32):
+        self.shape = list(shape)
+        self.dtype = dtype
+    def __repr__(self):
+        args_str = ", ".join(repr(x) for x in self.shape)
+        if self.dtype is torch.float32:
+            return f"TensorOfShape({args_str})"
+        else:
+            return f"TensorOfShape({args_str}, dtype={self.dtype})"
+
+def LongTensorOfShape(*args, **kwargs):
+    """Helper for indicating a TensorOfShape with integer type."""
+    return TensorOfShape(*args, **kwargs, dtype=torch.long)
+
+def _recursively_convert_to_shape_function_args(o: Any) -> Any:
+    """Converts an Invocation argument to a shape function argument.
+
+    TensorOfShape is replaced with a List[int] for the shape.
+    """
+    if o is None:
+        return None
+    if isinstance(o, TensorOfShape):
+        # Make a copy of the size list, since a shape function might
+        # modify it in-place. In the compiler, the lowering always
+        # produces a new list via a fresh invocation of `AtenSizeOp`,
+        # which allocates a new, unaliased list. So in-place mutations
+        # are ok since they make it a bit easier to write some shape
+        # functions.
+        return list(o.shape)
+    if isinstance(o, list):
+        return [_recursively_convert_to_shape_function_args(x) for x in o]
+    if isinstance(o, tuple):
+        return tuple(_recursively_convert_to_shape_function_args(x) for x in o)
+    if isinstance(o, (float, int)):
+        return o
+    raise Exception(f"Unhandled type {type(o)}")
+
+def _recursively_convert_to_real_op_args(o: Any) -> Any:
+    """Converts a shape function argument to a real op argument.
+
+    TensorOfShape is replaced with a tensor of the given shape (and dtype).
+    """
+    if o is None:
+        return None
+    if isinstance(o, TensorOfShape):
+        return torch.ones(o.shape, dtype=o.dtype)
+    if isinstance(o, list):
+        return [_recursively_convert_to_real_op_args(x) for x in o]
+    if isinstance(o, tuple):
+        return tuple(_recursively_convert_to_real_op_args(x) for x in o)
+    if isinstance(o, (float, int)):
+        return o
+    raise Exception(f"Unhandled type {type(o)}")
+
+class Invocation:
+    """Representation of a single op invocation (i.e. list of args to the op).
+
+    This class is used to represent a single invocation of an op in a way that
+    we can use to both invoke the shape function and invoke the actual op,
+    which have slightly different signatures.
+
+    Specifically, this class has special knowledge of `TensorOfShape` and
+    translates it appropriately to either a tensor (for the real op) or a
+    `List[int]` (for the shape function).
+
+    This class also tracks whether the invocation is expected to raise an
+    exception for greater precision when interpreting errors raised during
+    testing.
+    """
+    def __init__(self, *args: Any, **kwargs: Any):
+        self.args = list(args)
+        # We assume kwargs don't contain tensors, so they don't need any
+        # special handling.
+        self.kwargs = kwargs
+
+    def is_expected_to_raise_exception(self) -> bool:
+        """Returns true if the invocation is expected to raise an exception.
+
+        The subclass ErrorInvocation overrides this to indicate an Invocation
+        that is expected to raise an exception.
+        """
+        return False
+
+    def to_shape_function_args(self):
+        """Gets positional arguments appropriate for a shape function."""
+        return _recursively_convert_to_shape_function_args(self.args)
+
+    def to_real_op_args(self):
+        """Gets positional arguments appropriate for the real op."""
+        return _recursively_convert_to_real_op_args(self.args)
+
+    def __repr__(self) -> str:
+        args_str = ", ".join(repr(x) for x in self.args)
+        kwargs_str = ""
+        if self.kwargs:
+            kwargs_str = ", " + ", ".join(f"{k}={v}" for k, v in self.kwargs.items())
+        return f"Invocation({args_str}{kwargs_str})"
+
+class ErrorInvocation(Invocation):
+    """An Invocation that raises an exception.
+
+    Explicitly knowing that an invocation is expected to raise an exception
+    avoids certain failure modes of the test infrastructure where a bug
+    slips through when both the shape function and the real op raise exceptions
+    due to independent bugs (that cancel each other out and spurioiusly make the
+    two appear to "agree" that an exception needs to be raised).
+    """
+    def is_expected_to_raise_exception(self) -> bool:
+        return True
+
+def _normalize_multiple_results_to_list(t: Union[Tensor, Tuple]):
+    """Returns a flat list of tensor results.
+
+    This normalizes the fact that Python represents multiple returns with a
+    tuple, but single returns as a single value. We just want a list with
+    N elements for N results.
+    """
+    if isinstance(t, tuple):
+        return list(t)
+    if isinstance(t, Tensor):
+        return [t]
+    # Shape functions return List[int] instead of tensors.
+    if isinstance(t, list):
+        return [t]
+    raise ValueError(f"Unexpected type {type(t)}")
+
+
+def check_shape_function(invocations: List[Invocation]):
+    """Decorator that automatically tests a shape function.
+    
+    The shape function, which is expected to be named systematically with
+    `〇` instead of `.`, is tested against the corresponding op in
+    `torch.ops.*` function using the given invocations.
+    """
+    def decorator(f):
+        # `torch.ops.*` functions are overloaded already, so we don't need
+        # to pass in the overload name.
+        ns, unqual = f.__name__.split("〇")[:2]
+        op = getattr(getattr(torch.ops, ns), unqual)
+        for invocation in invocations:
+            shape_fn_error, op_error = None, None
+            try:
+                result_shapes = _normalize_multiple_results_to_list(f(
+                    *invocation.to_shape_function_args(),
+                    **invocation.kwargs))
+            except Exception as e:
+                shape_fn_error = f"{e}"
+            try:
+                golden_results = _normalize_multiple_results_to_list(op(
+                    *invocation.to_real_op_args(),
+                    **invocation.kwargs))
+            except Exception as e:
+                op_error = f"{e}"
+
+            def report(error_message: str):
+                raise ValueError(f"For shape function {f.__name__!r} with invocation {invocation}: {error_message}")
+
+            # Check for error behavior.
+            if invocation.is_expected_to_raise_exception():
+                if shape_fn_error is None and op_error is None:
+                    report(f"Expected to raise an exception, but neither shape function nor op raised an exception")
+                if shape_fn_error is None:
+                    report(f"Op raised error {op_error!r}, but shape function did not.")
+                if op_error is None:
+                    report(f"Shape function raised error {shape_fn_error!r}, but op did not.")
+            else:
+                if shape_fn_error is not None and op_error is not None:
+                    report(f"Both shape function and op raised errors, but were not expected to. Shape function raised error {shape_fn_error!r} and op raised error {op_error!r}.")
+                if shape_fn_error is not None:
+                    report(f"Shape function raised error {shape_fn_error!r} but op did not raise any error.")
+                if op_error is not None:
+                    report(f"Op raised error {op_error!r} but shape function did not raise any error.")
+
+            if shape_fn_error is not None or op_error is not None:
+                # If both raised errors, then that is good -- the shape function
+                # and the real op should agree on the erroneous cases.
+                # The exact error message might differ though.
+                if shape_fn_error is not None and op_error is not None:
+                    continue
+
+
+            # Check for matching results.
+            if len(result_shapes) != len(golden_results):
+                report(f"Expected {len(golden_results)} result shapes, got {len(result_shapes)}")
+            for result_shape, golden_result in zip(result_shapes, golden_results):
+                for dimension_size, golden_dimension_size in zip(result_shape, golden_result.shape):
+                    if dimension_size != golden_dimension_size:
+                        report(f"Expected result shape {golden_result.shape}, got {result_shape}")
+        return f
+    return decorator
+
+
+def not_present_in_registry(f):
+    """Decorator for shape functions not present in the shape registry.
+
+    This can happen for "pseudo" ops that we have in Torch-MLIR, such as
+    torch.aten.fill.Scalar, which are consistent with PyTorch conventions (e.g.
+    being the value-semantic correspondent of torch.aten.fill_.Scalar), but
+    that for whatever reason are not present in PyTorch. Such ops are useful
+    to keep certain passes within Torch-MLIR as consistent as possible.
+
+    To check if this decorator has been applied, use
+    `hasattr(f, "_not_present_in_registry")`.
+    """
+    f._not_present_in_registry = None
+    return f
+
+# ==============================================================================
+# Shape functions
+# ==============================================================================
+
+def aten〇tanh(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇erf(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇sigmoid(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇hardsigmoid(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇square(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇hardswish(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇silu(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇hardtanh(self: List[int], min_val: float = -1, max_val: float = 1) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇sqrt(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇floor(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇log2(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇rsqrt(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇abs(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇reciprocal(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇tanh_backward(grad_output: List[int], output: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(grad_output)
+
+def aten〇gelu_backward(grad_output: List[int], self: List[int], approximate: str = "none") -> List[int]:
+    return upstream_shape_helpers.unary(grad_output)
+
+def aten〇ceil(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇log(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇relu(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇_softmax(self: List[int], dim: int, half_to_float: bool) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇softmax〇int(self: List[int], dim: int, dtype: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇_log_softmax(self: List[int], dim: int, half_to_float: bool) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇log_softmax〇int(self: List[int], dim: int, dtype: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇clamp(self: List[int], min: Optional[float] = None, max: Optional[float] = None) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇rsub〇Scalar(self: List[int], other: float, alpha: float = 1) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇to〇dtype(self: List[int], dtype: int, non_blocking: bool = False, copy: bool = False, memory_format: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇to〇other(self: List[int], other: List[int], non_blocking: bool = False, copy: bool = False, memory_format: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇type_as(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇dropout(input: List[int], p: float, train: bool) -> List[int]:
+    return upstream_shape_helpers.unary(input)
+
+def aten〇gelu(self: List[int], approximate: str = "none") -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇contiguous(self: List[int], memory_format: int = 0) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇clone(self: List[int], memory_format: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇_log_softmax_backward_data(grad_output: List[int], output: List[int], dim: int, input_dtype: int) -> List[int]:
+    return upstream_shape_helpers.unary(grad_output)
+
+def aten〇eq〇Scalar(self: List[int], other: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇ne〇Scalar(self: List[int], other: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇gt〇Scalar(self: List[int], other: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇ge〇Scalar(self: List[int], other: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇le〇Scalar(self: List[int], other: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇lt〇Scalar(self: List[int], other: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇add〇Scalar(self: List[int], other: float, alpha: float = 1) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇sub〇Scalar(self: List[int], other: float, alpha: float = 1) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇mul〇Scalar(self: List[int], other: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇div〇Scalar(self: List[int], other: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇floor_divide〇Scalar(self: List[int], other: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇pow〇Tensor_Scalar(self: List[int], exponent: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇rsub〇Scalar(self: List[int], other: float, alpha: float = 1) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇leaky_relu(self: List[int], negative_slope: float = 0.01) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇gather(self: List[int], dim: int, index: List[int], sparse_grad: bool = False) -> List[int]:
+    return upstream_shape_helpers.unary(index)
+
+def aten〇layer_norm(input: List[int], normalized_shape: List[int], weight: Optional[List[int]] = None, bias: Optional[List[int]] = None, eps: float = 1.0000000000000001e-05, cudnn_enable: bool = True) -> List[int]:
+    return upstream_shape_helpers.unary(input)
+
+def aten〇_softmax_backward_data(grad_output: List[int], output: List[int], dim: int, input_dtype: int) -> List[int]:
+    return upstream_shape_helpers.unary(output)
+
+def aten〇any(self: List[int]) -> List[int]:
+    return []
+
+def aten〇all(self: List[int]) -> List[int]:
+    return []
+
+def aten〇max(self: List[int]) -> List[int]:
+    return []
+
+def aten〇sum(self: List[int], dtype: Optional[int] = None) -> List[int]:
+    return []
+
+def aten〇mean(self: List[int], dtype: Optional[int] = None) -> List[int]:
+    return []
+
+def aten〇var(self: List[int], unbiased: bool = True) -> List[int]:
+    return []
+
+def aten〇std(self: List[int], unbiased: bool = True) -> List[int]:
+    return []
+
+def _reduce_along_dim(self: List[int], dim: int, keepdim: bool):
+    dim = upstream_shape_helpers.maybe_wrap_dim(dim, len(self))
+    out: List[int] = []
+    for i, self_dim in enumerate(self):
+        if i == dim:
+            if keepdim:
+                out.append(1)
+        else:
+            out.append(self_dim)
+    return out
+
+@check_shape_function([
+    Invocation(TensorOfShape(2, 3, 4)), # Basic case.
+    Invocation(TensorOfShape(2, 3, 4), dim=0), # Test explicit `dim`.
+    Invocation(TensorOfShape(2, 3, 4), dim=0, keepdim=True), # `keepdim`.
+    Invocation(TensorOfShape(2, 3, 4), dim=-3), # Negative `dim`.
+    Invocation(TensorOfShape(2, 3, 4), dim=2), # Maximum valid `dim`.
+    ErrorInvocation(TensorOfShape(2, 3, 4), dim=-4), # `dim` out of bounds.
+    ErrorInvocation(TensorOfShape(2, 3, 4), dim=3), # `dim` out of bounds.
+])
+def aten〇argmax(self: List[int], dim: Optional[int] = None, keepdim: bool = False) -> List[int]:
+    if dim is None:
+        return []
+    return _reduce_along_dim(self, dim, keepdim)
+
+def aten〇any〇dim(self: List[int], dim: int, keepdim: bool = False) -> List[int]:
+    return _reduce_along_dim(self, dim, keepdim)
+
+def aten〇max〇dim(self: List[int], dim: int, keepdim: bool = False) -> Tuple[List[int], List[int]]:
+    reduced_shape = _reduce_along_dim(self, dim, keepdim)
+    return reduced_shape, reduced_shape
+
+def aten〇mean〇dim(self: List[int], dim: List[int], keepdim: bool = False, dtype: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.mean_dim(self, dim, keepdim, dtype)
+
+def aten〇sum〇dim_IntList(self: List[int], dim: List[int], keepdim: bool = False, dtype: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.mean_dim(self, dim, keepdim, dtype)
+
+
+def aten〇permute(self: List[int], dims: List[int]) -> List[int]:
+    return upstream_shape_helpers.permute(self, dims)
+
+def aten〇transpose〇int(self: List[int], dim0: int, dim1: int) -> List[int]:
+    return upstream_shape_helpers.transpose(self, dim0, dim1)
+
+def aten〇t(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.transpose(self, 0, 1)
+
+def aten〇matmul(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.matmul(self, other)
+
+def aten〇mm(self: List[int], mat2: List[int]) -> List[int]:
+    return upstream_shape_helpers.mm(self, mat2)
+
+def aten〇addmm(self: List[int], mat1: List[int], mat2: List[int], beta: float = 1, alpha: float = 1) -> List[int]:
+    return upstream_shape_helpers.addmm(self, mat1, mat2, beta, alpha)
+
+@check_shape_function([
+    Invocation(TensorOfShape(2, 3, 4), TensorOfShape(2, 4, 5)), # Basic case.
+    ErrorInvocation(TensorOfShape(2, 3, 7), TensorOfShape(2, 4, 5)), # mismatching contracting dimension.
+    ErrorInvocation(TensorOfShape(7, 3, 4), TensorOfShape(2, 4, 5)), # mismatching batch dimension.
+    ErrorInvocation(TensorOfShape(7, 3), TensorOfShape(2, 4, 5)), # LHS is not rank 3.
+    ErrorInvocation(TensorOfShape(2, 3, 4), TensorOfShape(2, 4)), # RHS is not rank 3.
+])
+def aten〇bmm(self: List[int], mat2: List[int]) -> List[int]:
+    assert len(self) == 3, "bmm only supports 3D tensors"
+    assert len(mat2) == 3, "bmm only supports 3D tensors"
+    assert self[0] == mat2[0], "mismatching batch dimension"
+    assert self[2] == mat2[1], "mismatching contracting dimension"
+    return [self[0], self[1], mat2[2]]
+
+def aten〇embedding(weight: List[int], indices: List[int], padding_idx: int = -1, scale_grad_by_freq: bool = False, sparse: bool = False) -> List[int]:
+    return upstream_shape_helpers.embedding(weight, indices, padding_idx, scale_grad_by_freq, sparse)
+
+def aten〇expand(self: List[int], size: List[int], implicit: bool = False) -> List[int]:
+    return upstream_shape_helpers.expand(self, size)
+
+def aten〇broadcast_to(self: List[int], size: List[int]) -> List[int]:
+    return upstream_shape_helpers.expand(self, size)
+
+def aten〇view(self: List[int], size: List[int]) -> List[int]:
+    return upstream_shape_helpers.view(self, size)
+
+def aten〇reshape(self: List[int], shape: List[int]) -> List[int]:
+    return upstream_shape_helpers.view(self, shape)
+
+def aten〇_unsafe_view(self: List[int], size: List[int]) -> List[int]:
+    return size
+
+def aten〇resize_(self: List[int], size: List[int], memory_format: Optional[int] = None) -> List[int]:
+    return size
+
+def aten〇max_pool2d(self: List[int], kernel_size: List[int], stride: List[int] = (), padding: List[int] = (0, 0), dilation: List[int] = (1, 1), ceil_mode: bool = False) -> List[int]:
+    return upstream_shape_helpers.max_pool2d(self, kernel_size, stride, padding, dilation, ceil_mode)
+
+def aten〇adaptive_avg_pool2d(self: List[int], output_size: List[int]) -> List[int]:
+    return upstream_shape_helpers.adaptive_avg_pool2d(self, output_size)
+
+def aten〇flatten〇using_ints(self: List[int], start_dim: int = 0, end_dim: int = -1) -> List[int]:
+    return upstream_shape_helpers.flatten(self, start_dim, end_dim)
+
+def aten〇linear(input: List[int], weight: List[int], bias: Optional[List[int]] = None) -> List[int]:
+    return upstream_shape_helpers.linear(input, weight, bias)
+
+@check_shape_function([
+    Invocation([2, 3]),
+])
+def aten〇zeros(size: List[int], dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None) -> List[int]:
+    return size
+
+def aten〇ones(size: List[int], dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None) -> List[int]:
+    return size
+
+def aten〇empty〇memory_format(size: List[int], dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None, memory_format: Optional[int] = None) -> List[int]:
+    return size
+
+def aten〇full(size: List[int], fill_value: float, dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None) -> List[int]:
+    return size
+
+def aten〇full_like(self: List[int], fill_value: float, dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None, memory_format: Optional[int] = None) -> List[int]:
+    return self
+
+def aten〇zeros_like(self: List[int], dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None, memory_format: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇ones_like(self: List[int], dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None, memory_format: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇empty_like(self: List[int], dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None, memory_format: Optional[int] = None) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇new_zeros(self: List[int], size: List[int], dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None) -> List[int]:
+    return size
+
+def aten〇new_ones(self: List[int], size: List[int], dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None) -> List[int]:
+    return size
+
+@not_present_in_registry
+def aten〇fill〇Scalar(self: List[int], value: float) -> List[int]:
+    return self
+
+@not_present_in_registry
+def aten〇uniform(self: List[int], from_: float = 0., to: float = 1., generator: Any = None) -> List[int]:
+    return self
+
+@not_present_in_registry
+def aten〇bernoulli〇float(self: List[int], p: float = 0.5, generator: Any = None) -> List[int]:
+    return self
+
+@not_present_in_registry
+def aten〇bernoulli〇Tensor(self: List[int], p: List[int], generator: Any = None) -> List[int]:
+    return self
+
+def aten〇bernoulli(self: List[int], generator: Any = None) -> List[int]:
+    return self
+
+def aten〇arange〇start_step(start: float, end: float, step: float, dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None) -> List[int]:
+    return upstream_shape_helpers.arange_start_step(start, end, step, dtype, layout, device, pin_memory)
+
+def aten〇arange〇start(start: float, end: float, dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None) -> List[int]:
+    return upstream_shape_helpers.arange_start(start, end, dtype, layout, device, pin_memory)
+
+def aten〇arange(end: float, dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None) -> List[int]:
+    return upstream_shape_helpers.arange_end(end, dtype, layout, device, pin_memory)
+
+@check_shape_function([
+    Invocation(TensorOfShape(2, 3), TensorOfShape(2, 3)), # Basic case.
+    Invocation(TensorOfShape(2, 3), TensorOfShape(3)), # Rank broadcasting.
+    Invocation(TensorOfShape(2, 3), TensorOfShape(1, 3)), # Size-1 broadcasting.
+    ErrorInvocation(TensorOfShape(2, 3), TensorOfShape(4, 3)), # Non-size-1 dimension size mismatch.
+])
+def aten〇add〇Tensor(self: List[int], other: List[int], alpha: float = 1) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇sub〇Tensor(self: List[int], other: List[int], alpha: float = 1) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇mul〇Tensor(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇div〇Tensor(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇__and__〇Tensor(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇minimum(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇maximum(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇bitwise_and〇Tensor(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇threshold(self: List[int], threshold: float, value: float) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇threshold_backward(grad_output: List[int], self: List[int], threshold: float) -> List[int]:
+    return upstream_shape_helpers.broadcast(grad_output, self)
+
+def aten〇eq〇Tensor(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇gt〇Tensor(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇lt〇Tensor(self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, other)
+
+def aten〇unsqueeze(self: List[int], dim: int) -> List[int]:
+    return upstream_shape_helpers.unsqueeze(self, dim)
+
+def aten〇squeeze(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.squeeze_nodim(self)
+
+def aten〇squeeze〇dim(self: List[int], dim: int) -> List[int]:
+    return upstream_shape_helpers.squeeze(self, dim)
+
+def prim〇NumToTensor〇Scalar(a: float) -> List[int]:
+    return []
+
+def aten〇tensor〇float(t: float, dtype: Optional[int] = None, device: Optional[device] = None, requires_grad: bool = False) -> List[int]:
+    return []
+
+def aten〇tensor〇int(t: int, dtype: Optional[int] = None, device: Optional[device] = None, requires_grad: bool = False) -> List[int]:
+    return []
+
+def aten〇tensor〇bool(t: bool, dtype: Optional[int] = None, device: Optional[device] = None, requires_grad: bool = False) -> List[int]:
+    return []
+
+@check_shape_function([
+    Invocation(TensorOfShape()),
+    Invocation(TensorOfShape(2, 3)),
+])
+def aten〇_shape_as_tensor(self: List[int]) -> List[int]:
+    return [len(self)]
+
+def aten〇where〇self(condition: List[int], self: List[int], other: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(condition, upstream_shape_helpers.broadcast(self, other))
+
+def aten〇lerp〇Tensor(self: List[int], end: List[int], weight: List[int]) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, upstream_shape_helpers.broadcast(end, weight))
+
+def aten〇addcmul(self: List[int], tensor1: List[int], tensor2: List[int], value: float = 1) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, upstream_shape_helpers.broadcast(tensor1, tensor2))
+
+def aten〇addcdiv(self: List[int], tensor1: List[int], tensor2: List[int], value: float = 1) -> List[int]:
+    return upstream_shape_helpers.broadcast(self, upstream_shape_helpers.broadcast(tensor1, tensor2))
+
+@check_shape_function([
+    Invocation(TensorOfShape(2, 3), 1), # Basic case.
+    Invocation(TensorOfShape(2, 3), 2, dim=0), # Test explicit `dim`.
+    ErrorInvocation(TensorOfShape(2, 3), 10), # `k` too big.
+    ErrorInvocation(TensorOfShape(2, 3), 2, dim=100), # `dim` out of bounds.
+])
+def aten〇topk(self: List[int], k: int, dim: int = -1, largest: bool = True, sorted: bool = True) -> Tuple[List[int], List[int]]:
+    assert k <= self[dim], f"k ({k}) is too big for dimension {dim} of size {self[dim]}"
+    # All lists which represent tensor shapes are expected to be the result
+    # of a fresh invocation of `AtenSizeOp`, which allocates a new, unaliased
+    # list. So in-place mutations are ok.
+    self[dim] = k
+    return self, self
+
+def aten〇conv2d(input: List[int], weight: List[int], bias: Optional[List[int]] = None, stride: List[int] = (1, 1), padding: List[int] = (0, 0), dilation: List[int] = (1, 1), groups: int = 1) -> List[int]:
+    return upstream_shape_helpers.conv2d(input, weight, bias, stride, padding, dilation, groups)
+
+def aten〇batch_norm(input: List[int], weight: Optional[List[int]], bias: Optional[List[int]], running_mean: Optional[List[int]], running_var: Optional[List[int]], training: bool, momentum: float, eps: float, cudnn_enabled: bool) -> List[int]:
+    # Torch's symbolic shape analysis is a bit looser about optional
+    # arguments than we are, so their batch_norm helper function works
+    # even though the `weight` is not `Optional`.
+    # Upstream is working to make this more consistent.
+    # For now, since this function is so trivial, just write it ourselves.
+    #return upstream_shape_helpers.batch_norm(input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled)
+    return input
+
+def aten〇slice〇Tensor(self: List[int], dim: int = 0, start: Optional[int] = None, end: Optional[int] = None, step: int = 1) -> List[int]:
+    return upstream_shape_helpers.slice(self, dim, start, end, step)
+
+def aten〇select〇int(self: List[int], dim: int, index: int) -> List[int]:
+    return upstream_shape_helpers.select(self, dim, index)
+
+def aten〇index_select(self: List[int], dim: int, index: List[int]) -> List[int]:
+    return upstream_shape_helpers.index_select(self, dim, index)
+
+def aten〇embedding(weight: List[int], indices: List[int], padding_idx: int = -1, scale_grad_by_freq: bool = False, sparse: bool = False) -> List[int]:
+    return upstream_shape_helpers.embedding(weight, indices, padding_idx, scale_grad_by_freq, sparse)
+
+@check_shape_function([
+    Invocation(TensorOfShape(2, 3), LongTensorOfShape(2), None, 1, -100), # Basic case.
+    Invocation(TensorOfShape(3), LongTensorOfShape(), None, 1, -100), # No batch dim.
+    Invocation(TensorOfShape(2, 3), LongTensorOfShape(2), None, 0, -100), # No reduction.
+    ErrorInvocation(TensorOfShape(2, 3), LongTensorOfShape(7), None, 1, -100), # Mismatched batch dimension.
+])
+def aten〇nll_loss_forward(self: List[int], target: List[int], weight: Optional[List[int]], reduction: int, ignore_index: int) -> Tuple[List[int], List[int]]:
+    # This is taken shamelessly from the meta function in LossNLL.cpp
+    self_dim = len(self)
+    target_dim = len(target)
+    assert 0 < self_dim <= 2
+    assert target_dim <= 1
+    no_batch_dim = self_dim == 1 and target_dim == 0
+    assert no_batch_dim or (self[0] == target[0])
+    n_classes = self[-1]
+    scalar_shape: List[int] = []
+    assert weight is None or (len(weight) == 1 and weight[0] == n_classes)
+    if reduction == 0 and self_dim == 2:
+        return [self[0]], scalar_shape
+    else:
+        return scalar_shape, scalar_shape
+
+def aten〇nll_loss_backward(grad_output: List[int], self: List[int], target: List[int], weight: Optional[List[int]], reduction: int, ignore_index: int, total_weight: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+# TODO: Fix shape function (see body).
+# @check_shape_function([
+#     Invocation(TensorOfShape(2, 5, 2, 2, 3), [2, 2, 3], None, None, 1e-6), # Basic case.
+# ])
+def aten〇native_layer_norm(input: List[int], normalized_shape: List[int], weight: Optional[List[int]], bias: Optional[List[int]], eps: float) -> Tuple[List[int], List[int], List[int]]:
+    reduction_shape: List[int] = []
+    # TODO: Fix buggy behavior. TorchToLinalg needs to properly handle the
+    # correctly inferred shapes.
+    # With input=[2, 5, 2, 2, 3] and normalized_shape=[2, 2, 3], we should get
+    # [[2, 5, 2, 2, 3], [2, 5, 1, 1, 1], [2, 5, 1, 1, 1]]
+    for i in range(len(normalized_shape), len(input)):
+        reduction_shape.append(input[i])
+    # Correct code:
+    # num_unreduced_dimensions = len(input) - len(normalized_shape)
+    # assert num_unreduced_dimensions >= 0
+    # for i in range(num_unreduced_dimensions):
+    #     reduction_shape.append(input[i])
+    # for i in range(num_unreduced_dimensions, len(input)):
+    #     reduction_shape.append(1)
+    return input, reduction_shape, reduction_shape
+
+@check_shape_function([
+    Invocation(TensorOfShape(2, 3), None, None, None, None, True, 1e-4, 1e-6), # Training basic case.
+    Invocation(TensorOfShape(2, 3), None, None, TensorOfShape(3), TensorOfShape(3), False, 1e-4, 1e-6), # Inference basic case.
+    Invocation(TensorOfShape(2, 3, 4, 5, 6), None, None, None, None, True, 1e-4, 1e-6), # Training high-D case.
+    Invocation(TensorOfShape(2, 3, 4, 5, 6), None, None, TensorOfShape(3), TensorOfShape(3), False, 1e-4, 1e-6), # Inference high-D case.
+    ErrorInvocation(TensorOfShape(2), None, None, None, None, True, 1e-4, 1e-6) # Dimensionality too low.
+])
+def aten〇native_batch_norm(input: List[int], weight: Optional[List[int]], bias: Optional[List[int]], running_mean: Optional[List[int]], running_var: Optional[List[int]], training: bool, momentum: float, eps: float) -> Tuple[List[int], List[int], List[int]]:
+    if training:
+        return input, [input[1]], [input[1]]
+    return input, [0], [0]
+
+@check_shape_function([
+    Invocation(TensorOfShape(2), [1, 2]), # Basic case.
+    Invocation(TensorOfShape(2, 3), [1, 2, 3, 4]), # More dimensions.
+    Invocation(TensorOfShape(2, 3, 4), [1, 2, 3, 4]), # More dimensions than padded dimensions.
+    ErrorInvocation(TensorOfShape(2), [1, 2, 3, 4]), # Too many pad values.
+    ErrorInvocation(TensorOfShape(2), [1]), # Unpaired pad value.
+])
+def aten〇constant_pad_nd(self: List[int], pad: List[int], value: float = 0) -> List[int]:
+    assert len(pad) % 2 == 0, "Must have paired low-high pad amount values"
+    assert len(pad) // 2 <= len(self), "Number of padded dimensions must be less than or equal to the input dimension"
+    # The `pad` list takes the form of Low-high pairs starting at the
+    # *rightmost* dimension of `self`.
+    for i in range(len(pad) // 2):
+        self[-(i + 1)] += pad[2 * i] + pad[2 * i + 1]
+    return self
+
+@check_shape_function([
+    Invocation(TensorOfShape(2), [LongTensorOfShape(4)]), # Basic case.
+    Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4), LongTensorOfShape(4)]), # More dimensions.
+    Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4), LongTensorOfShape(6, 4)]), # Multidimensional index tensor along a dimension.
+    Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4), None]), # Explicit None value.
+    Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4, 5, 6), LongTensorOfShape(1, 5, 1)]), # Broadcasting of index tensors.
+    Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4)]), # Fewer index tensors than dimensions.
+    ErrorInvocation(TensorOfShape(2, 3), [LongTensorOfShape(4), LongTensorOfShape(4), LongTensorOfShape(4)]), # More index tensors than dimensions.
+])
+def aten〇index〇Tensor(self: List[int], indices: List[Optional[List[int]]]) -> List[int]:
+    assert len(indices) <= len(self), "More indices than dimensions to index"
+    broadcasted_shape: List[int] = []
+    for index_tensor_shape in indices:
+        if index_tensor_shape is not None:
+            broadcasted_shape = upstream_shape_helpers.broadcast(broadcasted_shape, index_tensor_shape)
+    return broadcasted_shape
+
+def aten〇cat(tensors: List[List[int]], dim: int = 0) -> List[int]:
+    return upstream_shape_helpers.cat(tensors, dim)
+
+class DummyClassType:
+    def __init__(self):
+        pass
+
+def hacky_get_unknown_dimension_size():
+    """Gets a value which symbolically represents an unknown dimension size.
+
+    Note that this is a pretty gross hack, because it breaks the invariant
+    that shape functions are executable code that calculates a correct shape.
+
+    We use this for ops that have data-dependent shapes, such as
+    `aten::bincount` -- for those, all we need is that
+    `torch-shape-refinement-pipeline` sees an opaque integer, but at least we
+    can return a shape with a known rank. The way we hackily accomplish that is
+    by calling `id` on a freshly allocated class type object, which isn't
+    something the compiler can easily reason about.
+
+    TODO: Fix this properly.
+    There are 4 main approaches I can think of for fixing this properly:
+    1. Add another mechanism in the compiler to allow writing symbolic shape
+       functions in C++, which only work for deducing e.g. ranks. The hard part
+       here is for this refinement to run to a fixed-point together with
+       the rest of the shape functions (i.e., it somehow needs to run in tandem
+       with torch-simplify-shape-calculations).
+    2. Teach the shape library mechanism how to handle data-dependent shapes,
+       such as by allowing passing the actual tensor value (not just its shape)
+       to the shape function. This could work for cases like bincount, but
+       for other ops the work of determining the size is equivalent to
+       actually executing the op (like `torch.unique`), so this gets recursive.
+    3. Teach the shape library mechanism about a new type of shape function
+       that only returns the rank of the tensor.
+    4. Teach the shape library mechanism how to properly indicate a symbolic
+       unknown dimension size, along with some sort of way of annotating that
+       such a shape function is "not executable".
+    Approach 4 seems the most promising, and could probably be implemented by
+    registering a custom Torch-MLIR-specific operator in the registry.
+    """
+    return id(DummyClassType())
+
+def aten〇bincount(self: List[int], weights: Optional[List[int]] = None, minlength: int = 0) -> List[int]:
+    return [hacky_get_unknown_dimension_size()]
+
+# ==============================================================================
+# Shape library generator main().
+# ==============================================================================
+
+def _verify_signature_matches_registry(f, registry: Registry):
+    source = inspect.getsource(f)
+    signature = None
+    for line in source.splitlines():
+        if line.startswith("def "):
+            signature = line
+            break
+    assert signature is not None, f"Could not find signature for {f.__name__}"
+    atoms = f.__name__.split("〇")
+    if len(atoms) == 2:
+        atoms += [""]
+    operator = registry.get_by_triple(tuple(atoms))
+    expected_signature = operator.get_shape_function_signature()
+    if signature != expected_signature:
+        raise ValueError(f"Signature mismatch for {f.__name__!r}: expected {expected_signature!r}, got {signature!r}")
+
+def main(args):
+    mb = ModuleBuilder()
+    # We use the registry to ensure that the shape functions are consistent
+    # with the ops.
+    registry = Registry.load()
+    for k, v in globals().items():
+        if "〇" not in k:
+            continue
+        if not hasattr(v, "_not_present_in_registry"):
+            _verify_signature_matches_registry(v, registry)
+        # Add it to the compilation unit.
+        torch.jit.script(v)
+    for function in torch.jit._state._python_cu.get_functions():
+        mb.import_function(function)
+    # Clean up the IR a bit before writing it out.
+    pm = PassManager.parse("canonicalize", context=mb.module.context)
+    pm.run(mb.module)
+    # Munge the IR a bit to make it more systematically accessible.
+    asm = mb.module.operation.get_asm()
+    # Put the `〇` back to a regular `.`.
+    asm = asm.replace("\\E3\\80\\87", ".")
+    # Use a unique prefix on functon names to avoid collisions with
+    # user-defined symbols.
+    asm = asm.replace("__torch__.aten", "__torch_mlir_shape_fn.aten")
+    asm = asm.replace("__torch__.prim", "__torch_mlir_shape_fn.prim")
+
+    # Write out the shape library .cpp file.
+    shape_lib_cpp_file = os.path.join(
+        args.torch_transforms_cpp_dir, "ShapeLibrary.cpp")
+    with open(shape_lib_cpp_file, "w") as f:
+        p = lambda *args: print(*args, file=f)
+        p(
+f"""//===-------------------------------------------------------------*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is auto-generated! Do not edit!!!
+// Generated with the script `build_tools/update_shape_lib.sh`.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+
+using namespace mlir;
+
+StringRef mlir::torch::Torch::getShapeLibrary() {{
+// TODO: Find a way to embed this string nicely.
+// It is currently too long, and will probably break MSVC builds if anyone
+// attempts that.
+// We want to preserve the legibility of the shape library as a checked in file,
+// since that is sometimes useful for debugging / diffing.
+// Probably the ideal outcome is to have the shape library be a .mlir file
+// that is checked in, and then we embed it as part of the build process.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverlength-strings"
+  constexpr StringLiteral shapeLib(R"mlir(
+{asm})mlir");
+#pragma clang diagnostic pop
+  return shapeLib;
+}}""")
+
+def _create_argparse() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="generate_ods")
+    parser.add_argument(
+        "--torch_transforms_cpp_dir",
+        required=True,
+        help="Directory containing the Torch transforms cpp files")
+    return parser
+
+if __name__ == "__main__":
+    main(_create_argparse().parse_args())

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/upstream_shape_helpers.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/upstream_shape_helpers.py
@@ -1,0 +1,616 @@
+# This source code is copied from PyTorch, and remains licensed under
+# the PyTorch BSD-style license available at
+# https://github.com/pytorch/pytorch/blob/master/LICENSE
+
+# Minimal imports needed for the code to compile.
+from typing import List, Any, Optional
+import torch
+number = float
+
+# Code taken from torch/csrc/jit/runtime/symbolic_shape_registry.cpp
+# Once https://github.com/pytorch/pytorch/pull/68564 lands, we can directly
+# use the code from upstream.
+
+####     SHAPE COMPUTE FUNCTIONS    ###
+def broadcast(a: List[int], b: List[int]):
+  dimsA = len(a)
+  dimsB = len(b)
+  ndim = max(dimsA, dimsB)
+  expandedSizes : List[int] = []
+
+  for i in range(ndim):
+    offset = ndim - 1 - i
+    dimA = dimsA - 1 - offset
+    dimB = dimsB - 1 - offset
+    sizeA = a[dimA] if (dimA >= 0) else 1
+    sizeB = b[dimB] if (dimB >= 0) else 1
+
+    if sizeA != sizeB and sizeA != 1 and sizeB != 1:
+        # TODO: only assertion error is bound in C++ compilation right now
+        raise AssertionError("The size of tensor a {} must match the size of tensor b ("
+                        "{}) at non-singleton dimension {}".format(sizeA, sizeB, i))
+
+    expandedSizes.append(sizeB if sizeA == 1 else sizeA)
+
+  return expandedSizes
+
+def adaptive_avg_pool2d(self: List[int], out: List[int]):
+  assert len(out) == 2
+  assert len(self) == 3 or len(self) == 4
+  for i in range (1, len(self)):
+    assert self[i] != 0
+
+  shape: List[int] = []
+  for i in range(0, len(self) -2):
+    shape.append(self[i])
+  for elem in out:
+    shape.append(elem)
+  return shape
+
+def _copy(self: List[int]):
+  out: List[int] = []
+  for elem in self:
+    out.append(elem)
+  return out
+
+def unary(self: List[int]):
+  return _copy(self)
+
+def broadcast_inplace(a: List[int], b: List[int]):
+  dimsA = len(a)
+  dimsB = len(b)
+  if dimsB > dimsA:
+    raise AssertionError("The dims of tensor b ({}) must be less than or equal to"
+                         "the dims of tensor a ({}) ".format(dimsB, dimsA))
+  for dimA in range(dimsA):
+    dimB = dimsB - dimsA + dimA
+    sizeA = a[dimA]
+    sizeB = b[dimB] if (dimB >= 0) else 1
+    if sizeA != sizeB and sizeB != 1:
+        # TODO: only assertion error is bound in C++ compilation right now
+        raise AssertionError("The size of tensor a {} must match the size of tensor b ("
+                        "{}) at non-singleton dimension {}".format(sizeA, sizeB, dimA))
+  return _copy(a)
+
+def expand(self: List[int], sizes: List[int]):
+  assert len(sizes) >= len(self)
+  ndim = len(sizes)
+  tensor_dim = len(self)
+  if ndim == 0:
+    return _copy(sizes)
+  out: List[int] = []
+  for i in range(ndim):
+    offset = ndim - 1 - i
+    dim = tensor_dim - 1 - offset
+    size = self[dim] if dim >=0 else 1
+    targetSize = sizes[i]
+    if targetSize == -1:
+      assert dim >= 0
+      targetSize = size
+    if size != targetSize:
+      assert size == 1
+      size = targetSize
+    out.append(size)
+  return out
+
+def expand_one_unused(self: List[int], sizes: List[int], inp0: Any):
+  return expand(self, sizes)
+
+def infer_size_impl(shape: List[int], numel: int) -> List[int]:
+  newsize = 1
+  infer_dim: Optional[int] = None
+  for dim in range(len(shape)):
+    if shape[dim] == -1:
+      if infer_dim is not None:
+        raise AssertionError("only one dimension can be inferred")
+      infer_dim = dim
+    elif shape[dim] >= 0:
+      newsize *= shape[dim]
+    else:
+      raise AssertionError("invalid shape dimensions")
+  if not (numel == newsize or (infer_dim is not None and newsize > 0 and numel % newsize == 0)):
+    raise AssertionError("invalid shape")
+  out = _copy(shape)
+  if infer_dim is not None:
+    out[infer_dim] = numel // newsize
+  return out
+
+def numel(sizes: List[int]):
+  numel = 1
+  for elem in sizes:
+    numel *= elem
+  return numel
+
+def view(self: List[int], sizes: List[int]):
+  return infer_size_impl(sizes, numel(self))
+
+def view_one_unused(self: List[int], sizes: List[int], *, implicit: bool=False):
+  return view(self, sizes)
+
+def mean_dim(self: List[int], dims: List[int], keep_dim: bool, dt : Any):
+  out: List[int] = []
+  for idx in range(len(self)):
+    is_mean_dim : bool = False
+    for reduce_dim in dims:
+      if idx == maybe_wrap_dim(reduce_dim, len(self)):
+        is_mean_dim = True
+    if is_mean_dim:
+      if keep_dim:
+        out.append(1)
+    else:
+      out.append(self[idx])
+  return out
+
+# note: python already rounds down towards negative infinity on integer division, special arithmetic not needed
+def div_rtn(x: int, y: int):
+  return x // y
+
+def pooling_output_shape_pad_lr(inputSize: int, kernelSize: int, pad_l: int, pad_r: int, stride: int, dilation: int, ceil_mode: bool):
+  outputSize = div_rtn(inputSize + pad_l + pad_r - dilation * (kernelSize - 1) - 1 + (stride - 1 if ceil_mode else 0), stride) + 1
+  if ceil_mode:
+    if (outputSize - 1) * stride >= inputSize + pad_l:
+      outputSize = outputSize - 1
+  return outputSize
+
+def pooling_output_shape(inputSize: int, kernelSize: int, pad_l: int, stride: int, dilation: int, ceil_mode: bool):
+  assert stride != 0, "stride should not be zeero"
+  return pooling_output_shape_pad_lr(inputSize, kernelSize, pad_l, pad_l, stride, dilation, ceil_mode)
+
+def pool2d_shape_check(input: List[int], kH: int, kW: int, dH: int, dW: int, padH: int, padW: int,
+                       dilationH: int, dilationW: int, nInputPlane: int, inputHeight: int, inputWidth: int, outputHeight: int, outputWidth: int):
+
+  ndim = len(input)
+  nOutputPlane = nInputPlane
+
+  assert kW > 0 and kH > 0
+  assert dW > 0 and dH > 0
+  assert dilationH > 0 and dilationW > 0
+
+  valid_dims = input[1] != 0 and input[2] != 0
+  assert ndim == 3 and input[0] != 0 and valid_dims or (ndim == 4 and valid_dims and input[3] != 0)
+
+  assert kW // 2 >= padW and kH // 2 >= padH
+  assert outputWidth >= 1 and outputHeight >= 1
+
+def max_pool2d(input: List[int], kernel_size: List[int], stride: List[int], padding: List[int], dilation: List[int], ceil_mode: bool):
+  assert len(kernel_size) == 1 or len(kernel_size) == 2, "max_pool2d: kernel_size must either be a single int, or a tuple of two ints"
+  kH = kernel_size[0]
+  kW = kH if len(kernel_size) == 1 else kernel_size[1]
+
+  assert len(stride) == 0 or len(stride) == 1 or len(stride) == 2, "max_pool2d: stride must either be omitted, a single int, or a tuple of two ints"
+  dH = kH if len(stride) == 0 else stride[0]
+  if len(stride) == 0:
+    dW = kW
+  elif len(stride) == 1:
+    dW = dH
+  else:
+    dW = stride[1]
+
+  assert len(padding) == 1 or len(padding) == 2, "max_pool2d: padding must be either be a single int, or a tuple of two ints"
+  padH = padding[0]
+  padW = padH if len(padding) == 1 else padding[1]
+
+  assert len(dilation) == 1 or len(dilation) == 2, "max_pool2d: dilation must be either a single int, or a tuple of two ints"
+  dilationH = dilation[0]
+  dilationW = dilationH if len(dilation) == 1 else dilation[1]
+
+  assert len(input) == 3 or len(input) == 4
+
+  nbatch = input[-4] if len(input) == 4 else 1
+  nInputPlane = input[-3]
+  inputHeight = input[-2]
+  inputWidth = input[-1]
+
+  outputHeight = pooling_output_shape(inputHeight, kH, padH, dH, dilationH, ceil_mode)
+  outputWidth = pooling_output_shape(inputWidth, kW, padW, dW, dilationW, ceil_mode)
+
+  pool2d_shape_check(input, kH, kW, dH, dW, padH, padW, dilationH, dilationW, nInputPlane,
+                     inputHeight, inputWidth, outputHeight, outputWidth)
+
+  if len(input) == 3:
+    return [nInputPlane, outputHeight, outputWidth]
+  else:
+    return [nbatch, nInputPlane, outputHeight, outputWidth]
+
+def max_pool2d_with_indices(input: List[int], kernel_size: List[int], stride: List[int], padding: List[int], dilation: List[int], ceil_mode: bool):
+  out = max_pool2d(input, kernel_size, stride, padding, dilation, ceil_mode)
+  return (out, out)
+
+def upsample_nearest2d(input: List[int], output_size: Optional[List[int]], scale_factors: Optional[List[float]]):
+  out: List[int] = []
+  out.append(input[0])
+  out.append(input[1])
+  if output_size is not None:
+    assert scale_factors is None, "Must specify exactly one of output_size and scale_factors"
+    assert len(output_size) == 2
+    out.append(output_size[0])
+    out.append(output_size[1])
+    return out
+
+  if scale_factors is not None:
+    assert output_size is None, "Must specify exactly one of output_size and scale_factors"
+    assert len(scale_factors) == 2
+    out.append(int(input[2] * scale_factors[0]))
+    out.append(int(input[3] * scale_factors[1]))
+    return out
+  assert 0, "Either output_size or scale_factors must be presented"
+
+def mm(self: List[int] , mat2: List[int]):
+  assert len(self) == 2, "self must be a matrix"
+  assert len(mat2) == 2, "mat2 must be a matrix"
+
+  assert self[1] == mat2[0]
+  return [self[0], mat2[1]]
+
+def dot(self: List[int], tensor: List[int]):
+  assert len(self) == 1 and len(tensor) == 1
+  assert self[0] == tensor[0]
+  out: List[int] = []
+  return out
+
+def mv(self: List[int], vec: List[int]):
+  assert len(self) == 2 and len(vec) == 1
+  assert self[1] == vec[0]
+  # TODO: return self
+  return [self[0]]
+
+def unsqueeze(li: List[int], dim: int):
+  dim = maybe_wrap_dim(dim, len(li) + 1)
+  out = _copy(li)
+  out.insert(dim, 1)
+  return out
+
+def squeeze_nodim(li: List[int]):
+  out: List[int] = []
+  for i in range(len(li)):
+    if li[i] != 1:
+      out.append(li[i])
+  return out
+
+def squeeze(li: List[int], dim: int):
+  out: List[int] = []
+  wrapped_dim = maybe_wrap_dim(dim, len(li))
+  for i in range(len(li)):
+    if i == wrapped_dim:
+      if li[i] != 1:
+        out.append(li[i])
+    else:
+      out.append(li[i])
+  return out
+
+def index_select(self: List[int], dim: int, index: List[int]):
+  dim = maybe_wrap_dim(dim, len(self))
+  numel = multiply_integers(index)
+  assert len(index) <= 1
+  assert dim == 0 or dim < len(self)
+  result_size: List[int] = []
+  for i in range(len(self)):
+    if dim == i:
+      result_size.append(numel)
+    else:
+      result_size.append(self[i])
+  return result_size
+
+def embedding(weight: List[int], indices: List[int], padding_idx:int = -1, scale_grad_by_freq:bool=False, sparse: bool=False):
+  assert len(weight) == 2
+  if len(indices) == 1:
+    return index_select(weight, 0, indices)
+  size = _copy(indices)
+  size.append(weight[1])
+  return size
+
+def max_int():
+  return 9223372036854775807
+
+def slice(self: List[int], dim: int, start: Optional[int], end: Optional[int], step: int):
+  ndim = len(self)
+  assert ndim != 0
+  dim = maybe_wrap_dim(dim, ndim)
+  start_val =  start if start is not None else 0
+  end_val = end if end is not None else max_int()
+  assert step > 0
+  if (start_val == max_int()):
+    start_val = 0
+  if start_val < 0:
+    start_val += self[dim]
+  if end_val < 0:
+    end_val += self[dim]
+  if start_val < 0:
+    start_val = 0
+  elif start_val >= self[dim]:
+    start_val = self[dim]
+  if end_val < start_val:
+    end_val = start_val
+  elif end_val >= self[dim]:
+    end_val = self[dim]
+  len = end_val - start_val
+  out = _copy(self)
+  out[dim] = (len + step - 1) // step
+  return out
+
+def check_cat_no_zero_dim(tensors: List[List[int]]):
+  for tensor in tensors:
+    assert(len(tensor) > 0)
+
+def legacy_cat_wrap_dim(dim: int, tensor_sizes: List[List[int]]):
+  out_dim : Optional[int] = None
+  for size in tensor_sizes:
+    if len(size) != 0 and size != [0] and out_dim is not None:
+      out_dim = maybe_wrap_dim(dim, len(size))
+  if out_dim is None:
+    out_dim = dim
+  return out_dim
+
+def should_skip(tensor: List[int]):
+  return numel(tensor) == 0 and len(tensor) == 1
+
+def check_cat_shape_except_dim(first: List[int], second: List[int], dimension: int, index: int):
+  first_dims = len(first)
+  second_dims = len(second)
+  assert first_dims == second_dims, "Tensors must have same number of dimensions"
+  for dim in range(0, first_dims):
+    if dim != dimension:
+      assert first[dim] == second[dim], "Sizes of tensors must match except in dimension"
+
+def cat(tensors: List[List[int]], dim: int):
+  check_cat_no_zero_dim(tensors)
+  dim = legacy_cat_wrap_dim(dim, tensors)
+  assert len(tensors) > 0
+  not_skipped_tensor: Optional[List[int]] = None
+  for tensor in tensors:
+    if not should_skip(tensor):
+      not_skipped_tensor = tensor
+  if not_skipped_tensor is None:
+    return [0]
+
+  cat_dim_size = 0
+
+  for i in range(len(tensors)):
+    tensor = tensors[i]
+    if not should_skip(tensor):
+      check_cat_shape_except_dim(not_skipped_tensor, tensor, dim, i)
+      cat_dim_size = cat_dim_size + tensor[dim]
+
+  result_size = _copy(not_skipped_tensor)
+  result_size[dim] = cat_dim_size
+  return result_size
+
+def select(self: List[int], dim: int, index: int):
+  ndim = len(self)
+  assert ndim != 0
+  dim = maybe_wrap_dim(dim, ndim)
+  size = self[dim]
+  assert not (index < -size or index >= size)
+  if index < 0:
+    index += size
+  out: List[int] = []
+  for i in range(ndim):
+    if i != dim:
+      out.append(self[i])
+  return out
+
+def matmul(tensor1: List[int] , tensor2: List[int]):
+  dim_tensor1 = len(tensor1)
+  dim_tensor2 = len(tensor2)
+  if dim_tensor1 == 1 and dim_tensor2 == 1:
+    return dot(tensor1, tensor2)
+  elif dim_tensor1 == 2 and dim_tensor2 == 1:
+    return mv(tensor1, tensor2)
+  elif dim_tensor1 == 1 and dim_tensor2 == 2:
+    return squeeze(mm(unsqueeze(tensor1, 0), tensor2), 0)
+  elif dim_tensor1 == 2 and dim_tensor2 == 2:
+    return mm(tensor1, tensor2)
+  elif dim_tensor1 >= 1 and dim_tensor2 >=1:
+    # We are multiplying b1 x n x m1 by x2 x m2 x p (where b1 can be a list);
+    # we track m1 vs m2 separately even though they must match for nicer error messages
+    n = tensor1[-2] if dim_tensor1 > 1 else 1
+    m1 = tensor1[-1]
+    batch_tensor1 : List[int] = []
+    # TODO: handling of slice
+    for i in range(dim_tensor1 - 2):
+      batch_tensor1.append(tensor1[i])
+    m2 = tensor2[-1] if dim_tensor2 > 1 else 1
+    p = tensor2[-1]
+    batch_tensor2 : List[int] = []
+    # TODO: handling of slice
+    for i in range(dim_tensor2 - 2):
+      batch_tensor2.append(tensor2[i])
+
+    # expand the batch portion (i.e. cut off matrix dimensions and expand rest)
+    expand_batch_portion = broadcast(batch_tensor1, batch_tensor2)
+
+    # todo: copy ?
+    output_shape = expand_batch_portion
+    if dim_tensor1 > 1:
+      output_shape.append(n)
+
+    if dim_tensor2 > 1:
+      output_shape.append(p)
+
+    return output_shape
+  else:
+    assert False, "both  arguments to matmul need to be at least 1D"
+
+def t(self: List[int]):
+  assert len(self) <= 2
+  self_len = len(self)
+  if self_len == 0:
+    out: List[int] = []
+    return out
+  elif self_len == 1:
+    return [self[0]]
+  else:
+    return [self[1], self[0]]
+
+def transpose(self: List[int], dim0: int, dim1: int):
+  ndims = len(self)
+  dim0 = maybe_wrap_dim(dim0, ndims)
+  dim1 = maybe_wrap_dim(dim1, ndims)
+  if (dim0 == dim1):
+    return _copy(self)
+  out: List[int] = []
+  for i in range(ndims):
+    if i == dim0:
+      out.append(self[dim1])
+    elif i == dim1:
+      out.append(self[dim0])
+    else:
+      out.append(self[i])
+  return out
+
+
+def linear(input: List[int], weight: List[int], bias: Optional[List[int]]):
+  out = matmul(input, t(weight))
+  if bias is not None:
+    assert broadcast(bias, out) == out
+  return out
+
+def addmm(self: List[int], mat1: List[int], mat2: List[int], beta: Any, alpha: Any):
+  return broadcast(self, mm(mat1, mat2))
+
+def check_non_negative(array: List[int]) -> bool:
+  # TODO: look into rewriting with early return and getting loop unrolling to fire
+  non_negative = False
+  for val in array:
+    if val < 0:
+      non_negative = True
+  return non_negative
+
+def check_shape_forward(input: List[int], weight_sizes: List[int], bias: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], groups: int):
+  k = len(input)
+  weight_dim = len(weight_sizes)
+
+  # TODO: assertions could be expanded with the error messages
+  assert not check_non_negative(padding)
+  assert not check_non_negative(stride)
+
+  assert weight_dim == k
+  assert weight_sizes[0] >= groups
+  assert (weight_sizes[0] % groups) == 0
+  # only handling not transposed
+  assert input[1] == weight_sizes[1] * groups
+  assert bias is None or (len(bias) == 1 and bias[0] == weight_sizes[0])
+
+  for i in range(2, k):
+    assert (input[i] + 2 * padding[i - 2]) >= (dilation[i - 2] * (weight_sizes[i] - 1) + 1)
+
+# this is not handling transposed convolution yet
+def conv_output_size(input_size: List[int], weight_size: List[int], bias: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], groups: int):
+  check_shape_forward(input_size, weight_size, bias, stride, padding, dilation, groups)
+
+  has_dilation = len(dilation) > 0
+  dim = len(input_size)
+  output_size: List[int] = []
+  input_batch_size_dim = 0
+  weight_output_channels_dim = 0
+  output_size.append(input_size[input_batch_size_dim])
+  output_size.append(weight_size[weight_output_channels_dim])
+
+  for d in range(2, dim):
+    dilation_ = dilation[d - 2] if has_dilation else 1
+    kernel = dilation_ * (weight_size[d] - 1) + 1
+    output_size.append((input_size[d] + (2 * padding[d - 2]) - kernel) // stride[d - 2] + 1)
+  return output_size
+
+def conv1d(input: List[int], weight: List[int], bias: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], groups: int):
+  assert len(weight) == 3
+  assert len(input) == 3
+  return conv_output_size(input, weight, bias, stride, padding, dilation, groups)
+
+def conv2d(input: List[int], weight: List[int], bias: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], groups: int):
+  assert len(weight) == 4
+  assert len(input) == 4
+  return conv_output_size(input, weight, bias, stride, padding, dilation, groups)
+
+def batch_norm(input: List[int], weight: List[int], bias: Optional[List[int]], running_mean: Optional[List[int]], running_var: Optional[List[int]], training: bool, momentum: float, eps: float, cudnn_enabled: bool):
+  out: List[int] = []
+  for elem in input:
+    out.append(elem)
+  return out
+
+def conv3d(input: List[int], weight: List[int], bias: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], groups: int):
+  assert len(weight) == 5
+  assert len(input) == 5
+  return conv_output_size(input, weight, bias, stride, padding, dilation, groups)
+
+def maybe_wrap_dim(dim: int, dim_post_expr: int, wrap_scalar: bool = True):
+  if dim_post_expr <= 0:
+    assert wrap_scalar
+    dim_post_expr = 1
+  min = -dim_post_expr
+  max = dim_post_expr - 1
+  assert not (dim < min or dim > max)
+  if dim < 0:
+    dim += dim_post_expr
+  return dim
+
+def zero_dim_tensor(input: Any):
+  out: List[int] = []
+  return out
+
+def multiply_integers(li: List[int]):
+  out = 1
+  for elem in li:
+    out = out * elem
+  return out
+
+def arange_end(end: number, inp0: Any, inp1: Any, inp2: Any, inp3: Any):
+  assert end >= 0
+  return [int(torch.ceil(end))]
+
+def arange_start(start: number, end: number, inp0: Any, inp1: Any, inp2: Any, inp3: Any):
+  assert end >= 0
+  assert end >= start
+  return [int(torch.ceil(end - start))]
+
+def arange_start_step(start: number, end: number, step: number, inp0: Any, inp1: Any, inp2: Any, inp3: Any):
+  assert step != 0
+  if step < 0:
+    assert start >= end
+  else:
+    assert end >= start
+  return [int(torch.ceil((end - start) / step))]
+
+def permute(input: List[int], dims: List[int]):
+  assert len(input) == len(dims)
+  ndim = len(dims)
+  seen_dims: List[int] = []
+  newSizes: List[int] = []
+  for i in range(ndim):
+    dim = maybe_wrap_dim(dims[i], ndim)
+    seen_dims.append(dim)
+    newSizes.append(input[dim])
+  for i in range(1, ndim):
+    for j in range(i):
+      assert seen_dims[i] != seen_dims[j]
+  return newSizes
+
+def flatten(input: List[int], start_dim: int, end_dim: int):
+  start_dim = maybe_wrap_dim(start_dim, len(input))
+  end_dim = maybe_wrap_dim(end_dim, len(input))
+  assert start_dim <= end_dim
+  if len(input) == 0:
+    return [1]
+  if (start_dim == end_dim):
+    # TODO: return self
+    out: List[int] = []
+    for elem in input:
+      out.append(elem)
+    return out
+  slice_numel = 1
+  for i in range(start_dim, end_dim + 1):
+    slice_numel *= input[i]
+  # TODO: use slicing when slice optimization has landed
+  # slice_numel = multiply_integers(input[start_dim:end_dim - start_dim + 1])
+  shape: List[int] = []
+  for i in range(start_dim):
+    shape.append(input[i])
+  shape.append(slice_numel)
+  for i in range(end_dim + 1, len(input)):
+    shape.append(input[i])
+  return shape
+
+def quantized_prepacked_conv2d(input: List[int], conv2dOpContext: Any):
+  assert isinstance(conv2dOpContext, __torch__.torch.classes.quantized.Conv2dPackedParamsBase)
+  (weight, bias, stride, padding, dilation, groups) = unchecked_cast(Tuple[List[int], Optional[List[int]], List[int], List[int], List[int], int], ops.quantized.conv2d_unpack_sizes(conv2dOpContext))
+  return conv2d(input, weight, bias, stride, padding, dilation, groups)

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/utils.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/utils.py
@@ -1,0 +1,45 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+from typing import TextIO
+
+from contextlib import contextmanager
+import textwrap
+
+class TextEmitter:
+    """Helper for emitting text files"""
+    _INDENT = "  "
+
+    def __init__(self, out: TextIO):
+        super().__init__()
+        self.out = out
+        self.indent_level = 0
+
+    @contextmanager
+    def indent(self, level: int = 1):
+        self.indent_level += level
+        yield
+        self.indent_level -= level
+        assert self.indent_level >= 0, "Unbalanced indentation"
+
+    def print(self, s: str):
+        current_indent = self._INDENT * self.indent_level
+        for line in s.splitlines():
+            self.out.write(current_indent + line + "\n")
+
+    def quote(self, s: str) -> str:
+        s = s.replace(r'"', r'\\"')
+        return f'"{s}"'
+
+    def quote_multiline_docstring(self, s: str, indent_level: int = 0) -> str:
+        # TODO: Possibly find a python module to markdown the docstring for
+        # better document generation.
+        # Unlikely to contain the delimiter and since just a docstring, be safe.
+        s = s.replace("}]", "")
+        # Strip each line.
+        s = "\n".join([l.rstrip() for l in s.splitlines()])
+        indent = self._INDENT * indent_level
+        s = textwrap.indent(s, indent + self._INDENT)
+        return "[{\n" + s + "\n" + indent + "}]"

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.cpp
@@ -116,7 +116,8 @@ void NodeImporter::importNode(Node *node, MlirBlock appendToBlock) {
   case c10::prim::ListUnpack:
   case c10::prim::ListConstruct:
   case c10::prim::TupleConstruct:
-  case c10::prim::DictConstruct: {
+  case c10::prim::DictConstruct:
+  case c10::prim::CreateObject: {
     createAndMapTrivialNode(
         node, "torch.prim." + std::string(kind.toUnqualString()), transformer);
     return;

--- a/python/torch_mlir_e2e_test/torchscript/reporting.py
+++ b/python/torch_mlir_e2e_test/torchscript/reporting.py
@@ -287,17 +287,17 @@ def report_results(results: List[TestResult],
         if expected_failure:
             if report.failed:
                 print(f'XFAIL - "{result.unique_name}"')
-                results_by_outcome['XFAIL'].append(result)
+                results_by_outcome['XFAIL'].append((result, report))
             else:
                 print(f'XPASS - "{result.unique_name}"')
-                results_by_outcome['XPASS'].append(result)
+                results_by_outcome['XPASS'].append((result, report))
         else:
             if not report.failed:
                 print(f'PASS - "{result.unique_name}"')
-                results_by_outcome['PASS'].append(result)
+                results_by_outcome['PASS'].append((result, report))
             else:
                 print(f'FAIL - "{result.unique_name}"')
-                results_by_outcome['FAIL'].append(result)
+                results_by_outcome['FAIL'].append((result, report))
 
     OUTCOME_MEANINGS = collections.OrderedDict()
     OUTCOME_MEANINGS['PASS'] = 'Passed'
@@ -320,7 +320,7 @@ def report_results(results: List[TestResult],
         if len(results) == 0:
             continue
         print(f'\n****** {OUTCOME_MEANINGS[outcome]} tests - {len(results)} tests')
-        for result in results:
+        for result, report in results:
             print(f'    {outcome} - "{result.unique_name}"')
             # If the test failed, print the error message.
             if outcome == 'FAIL' and verbose:

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -1,5 +1,26 @@
 // RUN: torch-mlir-opt %s -canonicalize | FileCheck %s
 
+// CHECK-LABEL:   func @torch.aten.__range_length$fold() -> (!torch.int, !torch.int, !torch.int, !torch.int) {
+// CHECK:           %[[INT1:.*]] = torch.constant.int 1
+// CHECK:           %[[INT2:.*]] = torch.constant.int 2
+// CHECK:           %[[INTM1:.*]] = torch.constant.int -1
+// CHECK:           %[[INT3:.*]] = torch.constant.int 3
+// CHECK:           %[[NEG_STEP:.*]] = torch.aten.__range_length %[[INT1]], %[[INT3]], %[[INTM1]] : !torch.int, !torch.int, !torch.int -> !torch.int
+// CHECK:           return %[[INT2]], %[[INT2]], %[[INT1]], %[[NEG_STEP]] : !torch.int, !torch.int, !torch.int, !torch.int
+func @torch.aten.__range_length$fold() -> (!torch.int, !torch.int, !torch.int, !torch.int) {
+  %int3 = torch.constant.int 3
+  %int4 = torch.constant.int 4
+  %int2 = torch.constant.int 2
+  %int1 = torch.constant.int 1
+  %int0 = torch.constant.int 0
+  %int-1 = torch.constant.int -1
+  %0 = torch.aten.__range_length %int0, %int4, %int2  : !torch.int, !torch.int, !torch.int -> !torch.int
+  %1 = torch.aten.__range_length %int1, %int4, %int2  : !torch.int, !torch.int, !torch.int -> !torch.int
+  %2 = torch.aten.__range_length %int1, %int3, %int2  : !torch.int, !torch.int, !torch.int -> !torch.int
+  %3 = torch.aten.__range_length %int1, %int3, %int-1  : !torch.int, !torch.int, !torch.int -> !torch.int
+  return %0, %1, %2, %3 : !torch.int, !torch.int, !torch.int, !torch.int
+}
+
 // CHECK-LABEL:   func @torch.aten.__is__
 // CHECK:           %[[FALSE:.*]] = torch.constant.bool false
 // CHECK:           return %[[FALSE]] : !torch.bool
@@ -23,6 +44,17 @@ func @torch.aten.__is__$derefine_is_none(%arg0: !torch.list<!torch.int>, %arg1: 
 func @torch.aten.__is__$none_is_none(%arg0: !torch.none, %arg1: !torch.none) -> !torch.bool {
   %0 = torch.aten.__is__ %arg0, %arg1 : !torch.none, !torch.none -> !torch.bool
   return %0 : !torch.bool
+}
+
+// CHECK-LABEL:   func @torch.aten.__is__$is_none$derefine(
+// CHECK-SAME:                                             %{{.*}}: !torch.vtensor) -> !torch.bool {
+// CHECK:           %[[RESULT:.*]] = torch.constant.bool false
+// CHECK:           return %[[RESULT]] : !torch.bool
+func @torch.aten.__is__$is_none$derefine(%arg0: !torch.vtensor) -> !torch.bool {
+  %none = torch.constant.none
+  %0 = torch.derefine %arg0 : !torch.vtensor to !torch.optional<!torch.vtensor>
+  %1 = torch.aten.__is__ %0, %none : !torch.optional<!torch.vtensor>, !torch.none -> !torch.bool
+  return %1 : !torch.bool
 }
 
 // CHECK-LABEL:   func @torch.aten.__isnot__
@@ -149,6 +181,41 @@ func @torch.aten.eq.int$same_value() -> !torch.bool {
   %int4_0 = torch.constant.int 4
   %2 = torch.aten.eq.int %int4, %int4_0 : !torch.int, !torch.int -> !torch.bool
   return %2 : !torch.bool
+}
+
+// CHECK-LABEL:   func @torch.aten.eq.int$of_size.int(
+// CHECK-SAME:                                        %[[ARG:.*]]: !torch.tensor) -> !torch.bool {
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           return %[[FALSE]] : !torch.bool
+func @torch.aten.eq.int$of_size.int(%arg0: !torch.tensor) -> !torch.bool {
+  %int-1 = torch.constant.int -1
+  %int0 = torch.constant.int 0
+  %0 = torch.aten.size.int %arg0, %int0 : !torch.tensor, !torch.int -> !torch.int
+  %1 = torch.aten.eq.int %0, %int-1 : !torch.int, !torch.int -> !torch.bool
+  return %1 : !torch.bool
+}
+
+// CHECK-LABEL:   func @torch.aten.eq.int$of_size.int_lhs_constant(
+// CHECK-SAME:                                                     %[[ARG:.*]]: !torch.tensor) -> !torch.bool {
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           return %[[FALSE]] : !torch.bool
+func @torch.aten.eq.int$of_size.int_lhs_constant(%arg0: !torch.tensor) -> !torch.bool {
+  %int-1 = torch.constant.int -1
+  %int0 = torch.constant.int 0
+  %0 = torch.aten.size.int %arg0, %int0 : !torch.tensor, !torch.int -> !torch.int
+  %1 = torch.aten.eq.int %int-1, %0  : !torch.int, !torch.int -> !torch.bool
+  return %1 : !torch.bool
+}
+
+// CHECK-LABEL:   func @torch.aten.eq.int$no_change_minus1(
+// CHECK-SAME:                                             %[[ARG:.*]]: !torch.int) -> !torch.bool {
+// CHECK:           %[[CM1:.*]] = torch.constant.int -1
+// CHECK:           %[[RESULT:.*]] = torch.aten.eq.int %[[CM1]], %[[ARG]] : !torch.int, !torch.int -> !torch.bool
+// CHECK:           return %[[RESULT]] : !torch.bool
+func @torch.aten.eq.int$no_change_minus1(%arg0: !torch.int) -> !torch.bool {
+  %int-1 = torch.constant.int -1
+  %1 = torch.aten.eq.int %int-1, %arg0  : !torch.int, !torch.int -> !torch.bool
+  return %1 : !torch.bool
 }
 
 // CHECK-LABEL:   func @torch.aten.lt.int$evaluate_to_true() -> !torch.bool {
@@ -308,6 +375,17 @@ func @torch.aten.gt.float$evaluate_to_false() -> !torch.bool {
 }
 
 
+// CHECK-LABEL:   func @torch.aten.ge.int$of_size.int(
+// CHECK-SAME:                                        %[[ARG:.*]]: !torch.tensor) -> !torch.bool {
+// CHECK:           %[[TRUE:.*]] = torch.constant.bool true
+// CHECK:           return %[[TRUE]] : !torch.bool
+func @torch.aten.ge.int$of_size.int(%arg0: !torch.tensor) -> !torch.bool {
+  %int0 = torch.constant.int 0
+  %0 = torch.aten.size.int %arg0, %int0 : !torch.tensor, !torch.int -> !torch.int
+  %1 = torch.aten.ge.int %0, %int0  : !torch.int, !torch.int -> !torch.bool
+  return %1 : !torch.bool
+}
+
 // CHECK-LABEL:   func @torch.aten.eq.float$different_value() -> !torch.bool {
 // CHECK:           %[[FALSE:.*]] = torch.constant.bool false
 // CHECK:           return %[[FALSE]] : !torch.bool
@@ -366,6 +444,46 @@ func @torch.aten.__not__() -> !torch.bool {
   return %ret: !torch.bool
 }
 
+// CHECK-LABEL:   func @torch.prim.max.int$identity(
+// CHECK-SAME:                                      %[[ARG:.*]]: !torch.int) -> !torch.int {
+// CHECK:           return %[[ARG]] : !torch.int
+func @torch.prim.max.int$identity(%arg0: !torch.int) -> !torch.int {
+  %0 = torch.prim.max.int %arg0, %arg0 : !torch.int, !torch.int -> !torch.int
+  return %0 : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.prim.max.int$constant() -> !torch.int {
+// CHECK:           %[[INT3:.*]] = torch.constant.int 3
+// CHECK:           return %[[INT3]] : !torch.int
+func @torch.prim.max.int$constant() -> !torch.int {
+  %int-1 = torch.constant.int -1
+  %int3 = torch.constant.int 3
+  %0 = torch.prim.max.int %int-1, %int3 : !torch.int, !torch.int -> !torch.int
+  return %0 : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.prim.min.self_int$basic() -> !torch.int {
+// CHECK:           %[[M1:.*]] = torch.constant.int -1
+// CHECK:           return %[[M1]] : !torch.int
+func @torch.prim.min.self_int$basic() -> !torch.int {
+  %int-1 = torch.constant.int -1
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %0 = torch.prim.ListConstruct %int-1, %int0, %int1 : (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
+  %1 = torch.prim.min.self_int %0 : !torch.list<!torch.int> -> !torch.int
+  return %1 : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.prim.min.self_int$nofold$dynamic(
+// CHECK:           torch.prim.min.self_int
+func @torch.prim.min.self_int$nofold$dynamic(%arg0: !torch.int) -> !torch.int {
+  %int-1 = torch.constant.int -1
+  %int0 = torch.constant.int 0
+  %0 = torch.prim.ListConstruct %int-1, %int0, %arg0: (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
+  %1 = torch.prim.min.self_int %0 : !torch.list<!torch.int> -> !torch.int
+  return %1 : !torch.int
+}
+
 // CHECK-LABEL:   func @torch.aten.len.t$of_size(
 // CHECK-SAME:                                   %[[ARG:.*]]: !torch.vtensor<*,f32>) -> !torch.int {
 // CHECK:           %[[DIM:.*]] = torch.aten.dim %[[ARG]] : !torch.vtensor<*,f32> -> !torch.int
@@ -393,6 +511,16 @@ func @torch.aten.len.t$of_build_list(%arg0: !torch.int) -> !torch.int {
   %0 = torch.prim.ListConstruct %arg0, %arg0, %arg0, %arg0 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
   %1 = torch.aten.len.t %0 : !torch.list<!torch.int> -> !torch.int
   return %1 : !torch.int
+}
+
+// CHECK-LABEL: func @torch.aten.len.t$no_fold_list_mutated()
+func @torch.aten.len.t$no_fold_list_mutated() -> !torch.int {
+  %int4 = torch.constant.int 4
+  %0 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+  %1 = torch.aten.append.t %0, %int4 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+  // CHECK: torch.aten.len.t
+  %2 = torch.aten.len.t %0 : !torch.list<!torch.int> -> !torch.int
+  return %2 : !torch.int
 }
 
 // CHECK-LABEL:   func @torch.aten.__getitem__.t(
@@ -431,6 +559,86 @@ func @torch.aten.__getitem__.t$no_change_test1(%arg0: !torch.list<!torch.int>) -
   %int5 = torch.constant.int 5
   %0 = torch.aten.__getitem__.t %arg0, %int5 : !torch.list<!torch.int>, !torch.int -> !torch.int
   return %0 : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.aten.__getitem__.t$getitem_of_size(
+// CHECK-SAME:                                                   %[[TENSOR:.*]]: !torch.tensor,
+// CHECK-SAME:                                                   %[[INDEX:.*]]: !torch.int) -> !torch.int {
+// CHECK:           %[[RESULT:.*]] = torch.aten.size.int %[[TENSOR]], %[[INDEX]] : !torch.tensor, !torch.int -> !torch.int
+// CHECK:           return %[[RESULT]] : !torch.int
+func @torch.aten.__getitem__.t$getitem_of_size(%arg0: !torch.tensor, %arg1: !torch.int) -> !torch.int {
+  %0 = torch.aten.size %arg0 : !torch.tensor -> !torch.list<!torch.int>
+  %1 = torch.aten.__getitem__.t %0, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+  return %1 : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.aten.__getitem__.t$negative_index() -> !torch.int {
+// CHECK:           %[[INT8:.*]] = torch.constant.int 8
+// CHECK:           return %[[INT8]] : !torch.int
+func @torch.aten.__getitem__.t$negative_index() -> !torch.int {
+  %int7 = torch.constant.int 7
+  %int8 = torch.constant.int 8
+  %int-1 = torch.constant.int -1
+  %0 = torch.prim.ListConstruct %int7, %int8 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+  %1 = torch.aten.__getitem__.t %0, %int-1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+  return %1 : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.aten.__getitem__.t$invalid_index() -> !torch.int {
+func @torch.aten.__getitem__.t$invalid_index() -> !torch.int {
+  %int7 = torch.constant.int 7
+  %int8 = torch.constant.int 8
+  %int-1 = torch.constant.int -100
+  %0 = torch.prim.ListConstruct %int7, %int8 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+  // CHECK: torch.aten.__getitem__.t
+  %1 = torch.aten.__getitem__.t %0, %int-1 : !torch.list<!torch.int>, !torch.int -> !torch.int
+  return %1 : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.aten.eq.int_list$fold$literals_of_different_sizes
+// CHECK:           %[[RET:.*]] = torch.constant.bool false
+// CHECK:           return %[[RET]] : !torch.bool
+func @torch.aten.eq.int_list$fold$literals_of_different_sizes(%arg0: !torch.int) -> !torch.bool {
+  %0 = torch.prim.ListConstruct : () -> !torch.list<!torch.int>
+  %1 = torch.prim.ListConstruct %arg0 : (!torch.int) -> !torch.list<!torch.int>
+  %2 = torch.aten.eq.int_list %0, %1 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.bool
+  return %2 : !torch.bool
+}
+
+// CHECK-LABEL:   func @torch.aten.eq.int_list$fold$same_literal
+// CHECK:           %[[RET:.*]] = torch.constant.bool true
+// CHECK:           return %[[RET]] : !torch.bool
+func @torch.aten.eq.int_list$fold$same_literal(%arg0: !torch.int) -> !torch.bool {
+  %0 = torch.prim.ListConstruct %arg0 : (!torch.int) -> !torch.list<!torch.int>
+  %1 = torch.prim.ListConstruct %arg0 : (!torch.int) -> !torch.list<!torch.int>
+  %2 = torch.aten.eq.int_list %0, %1 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.bool
+  return %2 : !torch.bool
+}
+
+// CHECK-LABEL:   func @torch.aten.eq.int_list$no_fold$different_literals(
+func @torch.aten.eq.int_list$no_fold$different_literals(%arg0: !torch.int, %arg1: !torch.int) -> !torch.bool {
+  %0 = torch.prim.ListConstruct %arg0 : (!torch.int) -> !torch.list<!torch.int>
+  %1 = torch.prim.ListConstruct %arg1 : (!torch.int) -> !torch.list<!torch.int>
+  // CHECK: torch.aten.eq.int_list
+  %2 = torch.aten.eq.int_list %0, %1 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.bool
+  return %2 : !torch.bool
+}
+
+// CHECK-LABEL:   func @torch.aten.Float.Scalar$constant_fold_int_to_float() -> !torch.float {
+// CHECK:           %[[VAL_0:.*]] = torch.constant.float 3.000000e+00
+// CHECK:           return %[[VAL_0]] : !torch.float
+func @torch.aten.Float.Scalar$constant_fold_int_to_float() -> !torch.float {
+  %0 = torch.constant.int 3
+  %1 = torch.aten.Float.Scalar %0 : !torch.int -> !torch.float
+  return %1 : !torch.float
+}
+
+// CHECK-LABEL:   func @torch.aten.Float.Scalar$identity(
+// CHECK-SAME:                                           %[[VAL_0:.*]]: !torch.float) -> !torch.float {
+// CHECK:           return %[[VAL_0]] : !torch.float
+func @torch.aten.Float.Scalar$identity(%arg0: !torch.float) -> !torch.float {
+  %0 = torch.aten.Float.Scalar %arg0 : !torch.float -> !torch.float
+  return %0 : !torch.float
 }
 
 // CHECK-LABEL:   func @torch.constant.none$constantlike() -> (!torch.none, !torch.none) {
@@ -478,6 +686,59 @@ func @torch.prim.If$erase_dead_branch(%arg0: !torch.int) -> !torch.int {
     torch.prim.If.yield %1 : !torch.int
   }
   return %0 : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.prim.If$no_fold$side_effect(
+// CHECK-SAME:                                            %[[ARG0:.*]]: !torch.bool) {
+// CHECK:           %[[STR:.*]] = torch.constant.str "str"
+// CHECK:           torch.prim.If %[[ARG0]] -> () {
+// CHECK:             torch.prim.RaiseException %[[STR]], %[[STR]] : !torch.str, !torch.str
+// CHECK:             torch.prim.If.yield
+// CHECK:           } else {
+// CHECK:             torch.prim.If.yield
+// CHECK:           }
+// CHECK:           return
+func @torch.prim.If$no_fold$side_effect(%arg0: !torch.bool) {
+  %str = torch.constant.str "str"
+  torch.prim.If %arg0 -> () {
+    torch.prim.RaiseException %str, %str : !torch.str, !torch.str
+    torch.prim.If.yield
+  } else {
+    torch.prim.If.yield
+  }
+  return
+}
+
+// CHECK-LABEL:   func @torch.prim.If$fold_same_result(
+// CHECK-SAME:                                         %[[PRED:.*]]: !torch.bool,
+// CHECK-SAME:                                         %[[ARG1:.*]]: !torch.int) -> (!torch.int, !torch.int) {
+// CHECK-NEXT:      return %[[ARG1]], %[[ARG1]] : !torch.int, !torch.int
+func @torch.prim.If$fold_same_result(%arg0: !torch.bool, %arg1: !torch.int) -> (!torch.int, !torch.int) {
+  %0, %1 = torch.prim.If %arg0 -> (!torch.int, !torch.int) {
+    torch.prim.If.yield %arg1, %arg1 : !torch.int, !torch.int
+  } else {
+    torch.prim.If.yield %arg1, %arg1 : !torch.int, !torch.int
+  }
+  return %0, %1: !torch.int, !torch.int
+}
+
+// CHECK-LABEL:   func @torch.prim.If$fold_same_result$subset_of_results(
+// CHECK-SAME:                                                           %[[PRED:.*]]: !torch.bool,
+// CHECK-SAME:                                                           %[[ARG1:.*]]: !torch.int,
+// CHECK-SAME:                                                           %[[ARG2:.*]]: !torch.int) -> (!torch.int, !torch.int) {
+// CHECK:           %[[IF_RESULT:.*]] = torch.prim.If %[[PRED]] -> (!torch.int) {
+// CHECK:             torch.prim.If.yield %[[ARG1]] : !torch.int
+// CHECK:           } else {
+// CHECK:             torch.prim.If.yield %[[ARG2]] : !torch.int
+// CHECK:           }
+// CHECK:           return %[[ARG1]], %[[IF_RESULT:.*]] : !torch.int, !torch.int
+func @torch.prim.If$fold_same_result$subset_of_results(%arg0: !torch.bool, %arg1: !torch.int, %arg2: !torch.int) -> (!torch.int, !torch.int) {
+  %0, %1 = torch.prim.If %arg0 -> (!torch.int, !torch.int) {
+    torch.prim.If.yield %arg1, %arg1: !torch.int, !torch.int
+  } else {
+    torch.prim.If.yield %arg1, %arg2: !torch.int, !torch.int
+  }
+  return %0, %1: !torch.int, !torch.int
 }
 
 // CHECK-LABEL:   func @torch.prim.TupleUnpack(
@@ -659,6 +920,24 @@ func @torch.aten.size.int$invalid_dim(%t: !torch.tensor<[2,3],f32>) -> !torch.in
   return %ret : !torch.int
 }
 
+// CHECK-LABEL:   func @torch.prim.unchecked_cast$derefine_identity(
+// CHECK-SAME:                                                      %[[ARG:.*]]: !torch.int) -> !torch.int {
+// CHECK:           return %[[ARG]] : !torch.int
+func @torch.prim.unchecked_cast$derefine_identity(%arg0: !torch.int) -> !torch.int {
+  %0 = torch.derefine %arg0 : !torch.int to !torch.optional<!torch.int>
+  %1 = torch.prim.unchecked_cast %0 : !torch.optional<!torch.int> -> !torch.int
+  return %1 : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.derefine$of_unchecked_cast(
+// CHECK-SAME:                                           %[[ARG:.*]]: !torch.optional<!torch.int>) -> !torch.optional<!torch.int> {
+// CHECK:           return %[[ARG]] : !torch.optional<!torch.int>
+func @torch.derefine$of_unchecked_cast(%arg0: !torch.optional<!torch.int>) -> !torch.optional<!torch.int> {
+  %0 = torch.prim.unchecked_cast %arg0 : !torch.optional<!torch.int> -> !torch.int
+  %1 = torch.derefine %0 : !torch.int to !torch.optional<!torch.int>
+  return %1 : !torch.optional<!torch.int>
+}
+
 // CHECK-LABEL:   func @torch.tensor_static_info_cast$downcast_first(
 // CHECK-SAME:            %[[T:.*]]: !torch.tensor) -> !torch.tensor {
 // CHECK:           return %[[T]] : !torch.tensor
@@ -675,6 +954,27 @@ func @torch.tensor_static_info_cast$upcast_first(%t: !torch.tensor<[?,?],f64>) -
   %upcast = torch.tensor_static_info_cast %t : !torch.tensor<[?,?],f64> to !torch.tensor
   %downcast = torch.tensor_static_info_cast %upcast : !torch.tensor to !torch.tensor<[?,?],f64>
   return %downcast: !torch.tensor<[?,?],f64>
+}
+
+// CHECK-LABEL:   func @torch.tensor_static_info_cast$refine(
+// CHECK-SAME:                                               %[[ARG:.*]]: !torch.vtensor<[],f32>) -> !torch.vtensor {
+// CHECK-NEXT:       %[[RESULT:.*]] = torch.aten.relu %[[ARG]] : !torch.vtensor<[],f32> -> !torch.vtensor
+// CHECK-NEXT:       return %[[RESULT]] : !torch.vtensor
+func @torch.tensor_static_info_cast$refine(%arg0: !torch.vtensor<[], f32>) -> !torch.vtensor {
+  %0 = torch.tensor_static_info_cast %arg0 : !torch.vtensor<[],f32> to !torch.vtensor
+  %1 = torch.aten.relu %0 : !torch.vtensor -> !torch.vtensor
+  return %1 : !torch.vtensor
+}
+
+// CHECK-LABEL:   func @torch.tensor_static_info_cast$no_refine(
+// CHECK-SAME:                                                  %[[ARG:.*]]: !torch.vtensor) -> !torch.vtensor {
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[ARG]] : !torch.vtensor to !torch.vtensor<[],f32>
+// CHECK:           %[[RESULT:.*]] = torch.aten.relu %[[CAST]] : !torch.vtensor<[],f32> -> !torch.vtensor
+// CHECK:           return %[[RESULT]] : !torch.vtensor
+func @torch.tensor_static_info_cast$no_refine(%arg0: !torch.vtensor) -> !torch.vtensor {
+  %0 = torch.tensor_static_info_cast %arg0 : !torch.vtensor to !torch.vtensor<[],f32>
+  %1 = torch.aten.relu %0 : !torch.vtensor<[],f32> -> !torch.vtensor
+  return %1 : !torch.vtensor
 }
 
 // CHECK-LABEL:   func @torch.prim.TupleIndex(
@@ -749,14 +1049,26 @@ func @torch.aten.squeeze.dim$zero_rank(%arg0: !torch.tensor<[],f32>) -> !torch.t
 }
 
 // CHECK-LABEL:   func @torch.aten.to.dtype$same_dtype(
-// CHECK-SAME:            %[[ARG:.*]]: !torch.tensor<[?,?],f32>) -> !torch.tensor<[?,?],f32> {
-// CHECK-NEXT:      return %[[ARG]] : !torch.tensor<[?,?],f32>
-func @torch.aten.to.dtype$same_dtype(%arg0: !torch.tensor<[?,?],f32>) -> !torch.tensor<[?,?],f32> {
+// CHECK-SAME:            %[[ARG:.*]]: !torch.tensor<*,f32>) -> !torch.tensor<*,f32> {
+// CHECK-NEXT:      return %[[ARG]] : !torch.tensor<*,f32>
+func @torch.aten.to.dtype$same_dtype(%arg0: !torch.tensor<*,f32>) -> !torch.tensor<*,f32> {
   %none = torch.constant.none
   %false = torch.constant.bool false
   %int6 = torch.constant.int 6
-  %0 = torch.aten.to.dtype %arg0, %int6, %false, %false, %none : !torch.tensor<[?,?],f32>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.tensor<[?,?],f32>
-  return %0 : !torch.tensor<[?,?],f32>
+  %0 = torch.aten.to.dtype %arg0, %int6, %false, %false, %none : !torch.tensor<*,f32>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.tensor<*,f32>
+  return %0 : !torch.tensor<*,f32>
+}
+
+// CHECK-LABEL:   func @torch.aten.to.dtype$no_fold$unk_dtype(
+// CHECK-SAME:                                        %[[ARG:.*]]: !torch.tensor) -> !torch.tensor {
+// CHECK:           %[[RESULT:.*]] = torch.aten.to.dtype %[[ARG]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !torch.tensor, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.tensor
+// CHECK:           return %[[RESULT]] : !torch.tensor
+func @torch.aten.to.dtype$no_fold$unk_dtype(%arg0: !torch.tensor) -> !torch.tensor {
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %int6 = torch.constant.int 6
+  %0 = torch.aten.to.dtype %arg0, %int6, %false, %false, %none : !torch.tensor, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.tensor
+  return %0 : !torch.tensor
 }
 
 // CHECK-LABEL:   func @torch.aten.view$1D(

--- a/test/Dialect/Torch/drop-shape-calculations.mlir
+++ b/test/Dialect/Torch/drop-shape-calculations.mlir
@@ -1,0 +1,21 @@
+// RUN: torch-mlir-opt -torch-drop-shape-calculations -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL:   func @basic(
+// CHECK-SAME:                 %[[ARG:.*]]: !torch.vtensor<[2,?],unk>) -> !torch.vtensor {
+// CHECK:           %[[TANH:.*]] = torch.aten.tanh %[[ARG]] : !torch.vtensor<[2,?],unk> -> !torch.vtensor<[2,?],unk>
+// CHECK:           %[[ERASED:.*]] = torch.tensor_static_info_cast %[[TANH]] : !torch.vtensor<[2,?],unk> to !torch.vtensor
+// CHECK:           return %[[ERASED]] : !torch.vtensor
+func @basic(%arg0: !torch.vtensor<[2,?],unk>) -> !torch.vtensor {
+  %int2 = torch.constant.int 2
+  %int1 = torch.constant.int 1
+  %0 = torch.shape.calculate  {
+    %2 = torch.aten.tanh %arg0 : !torch.vtensor<[2,?],unk> -> !torch.vtensor<[2,?],unk>
+    torch.shape.calculate.yield %2 : !torch.vtensor<[2,?],unk>
+  } shapes  {
+    %2 = torch.aten.size.int %arg0, %int1 : !torch.vtensor<[2,?],unk>, !torch.int -> !torch.int
+    %3 = torch.prim.ListConstruct %int2, %2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+    torch.shape.calculate.yield.shapes %3 : !torch.list<!torch.int>
+  } : !torch.vtensor<[2,?],unk>
+  %1 = torch.tensor_static_info_cast %0 : !torch.vtensor<[2,?],unk> to !torch.vtensor
+  return %1 : !torch.vtensor
+}

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -119,3 +119,15 @@ torch.nn_module {
   torch.slot "ob", %none : !torch.none
   torch.slot "s", %str : !torch.str
 } : !torch.nn.Module<"test">
+
+
+func @shape_calculations(%arg0: !torch.vtensor) -> !torch.vtensor {
+  %0 = torch.shape.calculate {
+    %0 = torch.aten.tanh %arg0 : !torch.vtensor -> !torch.vtensor
+    torch.shape.calculate.yield %0 : !torch.vtensor
+  } shapes {
+    %0 = torch.aten.size %arg0 : !torch.vtensor -> !torch.list<!torch.int>
+    torch.shape.calculate.yield.shapes %0 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}

--- a/test/Dialect/Torch/promote-types.mlir
+++ b/test/Dialect/Torch/promote-types.mlir
@@ -12,7 +12,7 @@
 builtin.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1],f32>,
                                             %t1: !torch.vtensor<[1],f64>,
                                             %alpha: !torch.float) {
-  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],unk>
   return
 }
 
@@ -28,7 +28,7 @@ builtin.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1
 builtin.func @tensor_tensor$different_category(%t0: !torch.vtensor<[1],si32>,
                                  %t1: !torch.vtensor<[1],f64>,
                                  %alpha: !torch.float) {
-  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],unk>
   return
 }
 
@@ -45,7 +45,7 @@ builtin.func @tensor_tensor$same_category_zero_rank_wider(
                                                   %t0: !torch.vtensor<[1],f32>,
                                                   %t1: !torch.vtensor<[],f64>,
                                                   %alpha: !torch.int) {
-  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[],f64>, !torch.int -> !torch.vtensor
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[],f64>, !torch.int -> !torch.vtensor<[1],unk>
   return
 }
 
@@ -61,7 +61,7 @@ builtin.func @tensor_tensor$same_category_zero_rank_wider(
 builtin.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si64>,
                                         %t1: !torch.vtensor<[],f32>,
                                         %alpha: !torch.int) {
-  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[1],unk>
   return
 }
 
@@ -76,7 +76,7 @@ builtin.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si
 builtin.func @tensor_tensor$alpha_wider_no_contribution(%t0: !torch.vtensor<[1],f32>,
                                %t1: !torch.vtensor<[1],f32>,
                                %alpha: !torch.float) {
-  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor
+  %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor<[1],unk>
   return
 }
 
@@ -90,7 +90,7 @@ builtin.func @tensor_tensor$alpha_wider_no_contribution(%t0: !torch.vtensor<[1],
 // CHECK-SAME:        !torch.vtensor<[1],si64>, !torch.float, !torch.int -> !torch.vtensor<[1],f32>
 // CHECK:           return
 builtin.func @tensor_scalar$scalar_higher_category(%t0: !torch.vtensor<[1],si64>, %scalar: !torch.float, %alpha: !torch.int) {
-  %1 = torch.aten.add.Scalar %t0, %scalar, %alpha: !torch.vtensor<[1], si64>, !torch.float, !torch.int -> !torch.vtensor
+  %1 = torch.aten.add.Scalar %t0, %scalar, %alpha: !torch.vtensor<[1], si64>, !torch.float, !torch.int -> !torch.vtensor<[1],unk>
   return
 }
 
@@ -104,6 +104,6 @@ builtin.func @tensor_scalar$scalar_higher_category(%t0: !torch.vtensor<[1],si64>
 // CHECK-SAME:        !torch.vtensor<[1],si32>, !torch.int, !torch.int -> !torch.vtensor<[1],si32>
 // CHECK:           return
 builtin.func @tensor_scalar$scalar_same_category_wider(%t0: !torch.vtensor<[1],si32>, %scalar: !torch.int, %alpha: !torch.int) {
-  %1 = torch.aten.add.Scalar %t0, %scalar, %alpha: !torch.vtensor<[1], si32>, !torch.int, !torch.int -> !torch.vtensor
+  %1 = torch.aten.add.Scalar %t0, %scalar, %alpha: !torch.vtensor<[1], si32>, !torch.int, !torch.int -> !torch.vtensor<[1],unk>
   return
 }

--- a/test/Dialect/Torch/refine-public-return.mlir
+++ b/test/Dialect/Torch/refine-public-return.mlir
@@ -2,13 +2,24 @@
 
 // CHECK-LABEL:   func @basic(
 // CHECK-SAME:                %[[ARG:.*]]: !torch.vtensor<[2,3,?],f32>) -> !torch.vtensor<[2,3,?],f32> {
-// CHECK:           %[[COPIED_NONVAL:.*]] = torch.copy.to_tensor %[[ARG]] : !torch.tensor<[2,3,?],f32>
-// CHECK:           %[[COPIED_VALUE:.*]] = torch.copy.to_vtensor %[[COPIED_NONVAL]] : !torch.vtensor<[2,3,?],f32>
-// CHECK:           return %[[COPIED_VALUE]] : !torch.vtensor<[2,3,?],f32>
+// CHECK:           return %[[ARG]] : !torch.vtensor<[2,3,?],f32>
 func @basic(%arg0: !torch.vtensor<[2,3,?],f32>) -> !torch.tensor {
   %1 = torch.copy.to_tensor %arg0 : !torch.tensor<[2,3,?],f32>
   %2 = torch.tensor_static_info_cast %1 : !torch.tensor<[2,3,?],f32> to !torch.tensor
   return %2 : !torch.tensor
+}
+
+// CHECK-LABEL:   func @multiple_use_non_value_tensor(
+// CHECK-SAME:                                        %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                                        %[[ARG1:.*]]: !torch.vtensor) -> !torch.vtensor {
+// CHECK:           %[[NON_VALUE_TENSOR:.*]] = torch.copy.to_tensor %[[ARG0]] : !torch.tensor
+// CHECK:           torch.overwrite.tensor.contents %[[ARG1]] overwrites %[[NON_VALUE_TENSOR]] : !torch.vtensor, !torch.tensor
+// CHECK:           %[[RESULT:.*]] = torch.copy.to_vtensor %[[NON_VALUE_TENSOR]] : !torch.vtensor
+// CHECK:           return %[[RESULT]] : !torch.vtensor
+func @multiple_use_non_value_tensor(%arg0: !torch.vtensor, %arg1: !torch.vtensor) -> !torch.tensor {
+  %0 = torch.copy.to_tensor %arg0 : !torch.tensor
+  torch.overwrite.tensor.contents %arg1 overwrites %0 : !torch.vtensor, !torch.tensor
+  return %0 : !torch.tensor
 }
 
 // No conversion on private function.

--- a/test/Dialect/Torch/refine-types-ops.mlir
+++ b/test/Dialect/Torch/refine-types-ops.mlir
@@ -1,0 +1,348 @@
+// RUN: torch-mlir-opt -torch-refine-types -split-input-file %s | FileCheck %s
+
+// This file is for tests for individual ops that require a new transfer
+// function (i.e. new code called from visitOperation).
+
+// -----
+// CHECK-LABEL:   func @aten.arange.start$int64_dtype(
+// CHECK-SAME:                    %[[START:.*]]: !torch.int,
+// CHECK-SAME:                    %[[END:.*]]: !torch.int) -> !torch.vtensor {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[T:.*]] = torch.aten.arange.start
+// CHECK-SAME:         %[[START]], %[[END]], %[[NONE]], %[[NONE]], %[[NONE]], %[[NONE]] :
+// CHECK-SAME:         !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none
+// CHECK-SAME:         -> !torch.vtensor<*,si64>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[T]] : !torch.vtensor<*,si64> to !torch.vtensor
+// CHECK:           return %[[RET]] : !torch.vtensor
+func @aten.arange.start$int64_dtype(%start: !torch.int, %end: !torch.int) -> !torch.vtensor {
+  %none = torch.constant.none
+  %ret = torch.aten.arange.start %start, %end, %none, %none, %none, %none: !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor
+  return %ret : !torch.vtensor
+}
+
+// -----
+// CHECK-LABEL:   func @aten.arange.start$float32_dtype(
+// CHECK-SAME:                    %[[START:.*]]: !torch.float,
+// CHECK-SAME:                    %[[END:.*]]: !torch.int) -> !torch.vtensor {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[T:.*]] = torch.aten.arange.start
+// CHECK-SAME:         %[[START]], %[[END]], %[[NONE]], %[[NONE]], %[[NONE]], %[[NONE]] :
+// CHECK-SAME:         !torch.float, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none
+// CHECK-SAME:         -> !torch.vtensor<*,f32>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[T]] : !torch.vtensor<*,f32> to !torch.vtensor
+// CHECK:           return %[[RET]] : !torch.vtensor
+func @aten.arange.start$float32_dtype(%start: !torch.float, %end: !torch.int) -> !torch.vtensor {
+  %none = torch.constant.none
+  %ret = torch.aten.arange.start %start, %end, %none, %none, %none, %none: !torch.float, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor
+  return %ret : !torch.vtensor
+}
+
+// -----
+// CHECK-LABEL:   func @aten.arange.start$specified_dtype(
+// CHECK-SAME:                                                    %[[END:.*]]: !torch.int) -> !torch.vtensor {
+// CHECK:           %[[CST6:.*]] = torch.constant.int 6
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[T:.*]] = torch.aten.arange
+// CHECK-SAME:         %[[END]], %[[CST6]], %[[NONE]], %[[NONE]], %[[NONE]] :
+// CHECK-SAME:         !torch.int, !torch.int, !torch.none, !torch.none, !torch.none
+// CHECK-SAME:         -> !torch.vtensor<*,f32>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[T]] : !torch.vtensor<*,f32> to !torch.vtensor
+// CHECK:           return %[[RET]] : !torch.vtensor
+func @aten.arange.start$specified_dtype(%end: !torch.int) -> !torch.vtensor {
+  %int6 = torch.constant.int 6
+  %none = torch.constant.none
+  %ret = torch.aten.arange %end, %int6, %none, %none, %none: !torch.int, !torch.int, !torch.none, !torch.none, !torch.none -> !torch.vtensor
+  return %ret : !torch.vtensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.linear(
+// CHECK-SAME:                            %[[ARG0:.*]]: !torch.vtensor<[?,3],f32>,
+// CHECK-SAME:                            %[[ARG1:.*]]: !torch.vtensor<[5,3],f32>,
+// CHECK-SAME:                            %[[ARG2:.*]]: !torch.vtensor<[5],f32>) -> !torch.vtensor {
+// CHECK:           %[[LINEAR:.*]] = torch.aten.linear %[[ARG0]], %[[ARG1]], %[[ARG2]] : !torch.vtensor<[?,3],f32>, !torch.vtensor<[5,3],f32>, !torch.vtensor<[5],f32> -> !torch.vtensor<*,f32>
+// CHECK:           %[[RESULT:.*]] = torch.tensor_static_info_cast %[[LINEAR]] : !torch.vtensor<*,f32> to !torch.vtensor
+// CHECK:           return %[[RESULT]] : !torch.vtensor
+func @torch.aten.linear(%arg0: !torch.vtensor<[?,3],f32>, %arg1: !torch.vtensor<[5,3],f32>, %arg2: !torch.vtensor<[5],f32>) -> !torch.vtensor {
+  %1 = torch.aten.linear %arg0, %arg1, %arg2 : !torch.vtensor<[?,3],f32>, !torch.vtensor<[5,3],f32>, !torch.vtensor<[5],f32> -> !torch.vtensor
+  return %1 : !torch.vtensor
+}
+
+// -----
+// CHECK-LABEL:   func @aten.sum.dim_IntList(
+// CHECK-SAME:                                       %[[T:.*]]: !torch.vtensor<*,si64>) -> !torch.vtensor {
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[INT0:.*]] = torch.constant.int 0
+// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
+// CHECK:           %[[DIMLIST:.*]] = torch.prim.ListConstruct %[[INT0]], %[[INT_NEG1]]
+// CHECK-SAME:        : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+// CHECK:           %[[RET:.*]] = torch.aten.sum.dim_IntList %[[T]], %[[DIMLIST]], %[[FALSE]], %[[NONE]]
+// CHECK-SAME:        : !torch.vtensor<*,si64>, !torch.list<!torch.int>, !torch.bool, !torch.none
+// CHECK-SAME:        -> !torch.vtensor<*,si64>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.vtensor<*,si64> to !torch.vtensor
+// CHECK:           return %[[CAST]] : !torch.vtensor
+func @aten.sum.dim_IntList(%t: !torch.vtensor<*,si64>) -> !torch.vtensor {
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  %int0 = torch.constant.int 0
+  %int-1 = torch.constant.int -1
+  %dimList = torch.prim.ListConstruct %int0, %int-1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+  %ret = torch.aten.sum.dim_IntList %t, %dimList, %false, %none : !torch.vtensor<*,si64>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.vtensor
+  return %ret : !torch.vtensor
+}
+
+// -----
+// CHECK-LABEL:   func @aten.any.dim(
+// CHECK-SAME:                               %[[T:.*]]: !torch.vtensor<*,i1>) -> !torch.vtensor {
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
+// CHECK:           %[[RET:.*]] = torch.aten.any.dim %[[T]], %[[INT_NEG1]], %[[FALSE]] : !torch.vtensor<*,i1>, !torch.int, !torch.bool -> !torch.vtensor<*,i1>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.vtensor<*,i1> to !torch.vtensor
+// CHECK:           return %[[CAST]] : !torch.vtensor
+func @aten.any.dim(%t: !torch.vtensor<*,i1>) -> !torch.vtensor {
+  %false = torch.constant.bool false
+  %int-1 = torch.constant.int -1
+  %ret = torch.aten.any.dim %t, %int-1, %false : !torch.vtensor<*,i1>, !torch.int, !torch.bool -> !torch.vtensor
+  return %ret : !torch.vtensor
+}
+
+// -----
+// CHECK-LABEL:   func @aten.any(
+// CHECK-SAME:                           %[[T:.*]]: !torch.vtensor<*,i1>) -> !torch.vtensor {
+// CHECK:           %[[RET:.*]] = torch.aten.any %[[T]] : !torch.vtensor<*,i1> -> !torch.vtensor<*,i1>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.vtensor<*,i1> to !torch.vtensor
+// CHECK:           return %[[CAST]] : !torch.vtensor
+func @aten.any(%t: !torch.vtensor<*,i1>) -> !torch.vtensor {
+  %ret = torch.aten.any %t: !torch.vtensor<*,i1> -> !torch.vtensor
+  return %ret : !torch.vtensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.zeros(
+// CHECK-SAME:        %[[DIM0:.*]]: !torch.int) -> !torch.tensor {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[INT2:.*]] = torch.constant.int 2
+// CHECK:           %[[SIZES:.*]] = torch.prim.ListConstruct %[[DIM0]], %[[INT2]] : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+// CHECK:           %[[ZEROS:.*]] = torch.aten.zeros %[[SIZES]], %[[NONE]], %[[NONE]], %[[NONE]], %[[NONE]] : !torch.list<!torch.int>, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.tensor<*,f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[ZEROS]] : !torch.tensor<*,f32> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.zeros(%dim0: !torch.int) -> !torch.tensor {
+  %none = torch.constant.none
+  %int2 = torch.constant.int 2
+  %sizesList = torch.prim.ListConstruct %dim0, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+  %ret = torch.aten.zeros %sizesList, %none, %none, %none, %none : !torch.list<!torch.int>, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.type_as(
+// CHECK-SAME:                                     %[[INPUT:.*]]: !torch.tensor<[?],si64>,
+// CHECK-SAME:                                     %[[OTHER:.*]]: !torch.tensor<[?,2],f32>) -> !torch.tensor {
+// CHECK:           %[[RET:.*]] = torch.aten.type_as %[[INPUT]], %[[OTHER]] : !torch.tensor<[?],si64>, !torch.tensor<[?,2],f32> -> !torch.tensor<*,f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,f32> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.type_as(%self: !torch.tensor<[?], si64>, %other: !torch.tensor<[?,2],f32>) -> !torch.tensor {
+  %ret = torch.aten.type_as %self, %other : !torch.tensor<[?], si64>, !torch.tensor<[?,2],f32> -> !torch.tensor
+  return %ret: !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.cat(
+// CHECK-SAME:                                 %[[T1:.*]]: !torch.tensor<[?,1,4],f32>,
+// CHECK-SAME:                                 %[[T2:.*]]: !torch.tensor<[2,3,4],f32>) -> !torch.tensor {
+// CHECK:           %[[INT1:.*]] = torch.constant.int 1
+// CHECK:           %[[TENSORS:.*]] = torch.prim.ListConstruct %[[T1]], %[[T2]] : (!torch.tensor<[?,1,4],f32>, !torch.tensor<[2,3,4],f32>) -> !torch.list<!torch.tensor>
+// CHECK:           %[[RET:.*]] = torch.aten.cat %[[TENSORS]], %[[INT1]] : !torch.list<!torch.tensor>, !torch.int -> !torch.tensor<*,f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,f32> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.cat(%t0: !torch.tensor<[?,1,4], f32>, %t1: !torch.tensor<[2,3,4], f32>) -> !torch.tensor {
+  %int1 = torch.constant.int 1
+  %tensorList = torch.prim.ListConstruct %t0, %t1: (!torch.tensor<[?,1,4], f32>, !torch.tensor<[2,3,4], f32>) -> !torch.list<!torch.tensor>
+  %ret = torch.aten.cat %tensorList, %int1 : !torch.list<!torch.tensor>, !torch.int -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten._shape_as_tensor(
+// CHECK-SAME:                                 %[[INPUT:.*]]: !torch.tensor<[?,1,4],f32>) -> !torch.tensor {
+// CHECK:           %[[RET:.*]] = torch.aten._shape_as_tensor %[[INPUT]] : !torch.tensor<[?,1,4],f32> -> !torch.tensor<*,si64>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,si64> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten._shape_as_tensor(%input: !torch.tensor<[?,1,4], f32>) -> !torch.tensor {
+  %ret= torch.aten._shape_as_tensor %input : !torch.tensor<[?,1,4], f32> -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten._shape_as_tensor$unknown_input_shape(
+// CHECK-SAME:                                 %[[INPUT:.*]]: !torch.tensor) -> !torch.tensor {
+// CHECK:           %[[RET:.*]] = torch.aten._shape_as_tensor %[[INPUT]] : !torch.tensor -> !torch.tensor<*,si64>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,si64> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten._shape_as_tensor$unknown_input_shape(%input: !torch.tensor) -> !torch.tensor {
+  %ret= torch.aten._shape_as_tensor %input : !torch.tensor -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.embedding(
+// CHECK-SAME:                                       %[[INPUT:.*]]: !torch.tensor<[104,512],f32>,
+// CHECK-SAME:                                       %[[INDEXES:.*]]: !torch.tensor<[2,3],si64>) -> !torch.tensor {
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[PADDING_IDX:.*]] = torch.constant.int 1
+// CHECK:           %[[RET:.*]] = torch.aten.embedding %[[INPUT]], %[[INDEXES]], %[[PADDING_IDX]], %[[FALSE]], %[[FALSE]] : !torch.tensor<[104,512],f32>, !torch.tensor<[2,3],si64>, !torch.int, !torch.bool, !torch.bool -> !torch.tensor<*,f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,f32> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.embedding(%weight: !torch.tensor<[104,512],f32>, %indices: !torch.tensor<[2,3], si64>) -> !torch.tensor {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %ret = torch.aten.embedding %weight, %indices, %int1, %false, %false : !torch.tensor<[104,512],f32>, !torch.tensor<[2,3], si64>, !torch.int, !torch.bool, !torch.bool -> !torch.tensor
+  return %ret: !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.tensor.float(
+// CHECK-SAME:                                          %[[t:.*]]: !torch.float) -> !torch.tensor {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[RET:.*]] = torch.aten.tensor.float %[[t]], %[[NONE]], %[[NONE]], %[[FALSE]] : !torch.float, !torch.none, !torch.none, !torch.bool -> !torch.tensor<*,f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,f32> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.tensor.float(%t: !torch.float) -> !torch.tensor {
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %ret = torch.aten.tensor.float %t, %none, %none, %false : !torch.float, !torch.none, !torch.none, !torch.bool -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.tensor.float$specified_dtype(
+// CHECK-SAME:                                          %[[t:.*]]: !torch.float) -> !torch.tensor {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[CST11:.*]] = torch.constant.int 11
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[RET:.*]] = torch.aten.tensor.float %[[t]], %[[CST11]], %[[NONE]], %[[FALSE]] : !torch.float, !torch.int, !torch.none, !torch.bool -> !torch.tensor<*,i1>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,i1> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.tensor.float$specified_dtype(%t: !torch.float) -> !torch.tensor {
+  %none = torch.constant.none
+  %int11 = torch.constant.int 11
+  %false = torch.constant.bool false
+  %ret = torch.aten.tensor.float %t, %int11, %none, %false : !torch.float, !torch.int, !torch.none, !torch.bool -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.softmax.int(
+// CHECK-SAME:                                 %[[T:.*]]: !torch.tensor<[2,3],f32>,
+// CHECK-SAME:                                 %[[DIM:.*]]: !torch.int) -> !torch.tensor {
+// CHECK:           %[[DTYPE:.*]] = torch.constant.none
+// CHECK:           %[[SOFTMAX:.*]] = torch.aten.softmax.int %[[T]], %[[DIM]], %[[DTYPE]] : !torch.tensor<[2,3],f32>, !torch.int, !torch.none -> !torch.tensor<*,f32>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<*,f32> to !torch.tensor
+// CHECK:           return %[[RET]] : !torch.tensor
+func @torch.aten.softmax.int(%t: !torch.tensor<[2,3],f32>, %dim: !torch.int) -> !torch.tensor {
+  %none = torch.constant.none
+  %ret = torch.aten.softmax.int %t, %dim, %none : !torch.tensor<[2,3],f32>, !torch.int, !torch.none -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.softmax.int$specified_dtype(
+// CHECK-SAME:                                                 %[[T:.*]]: !torch.tensor<[2,3],f32>,
+// CHECK-SAME:                                                 %[[DIM:.*]]: !torch.int) -> !torch.tensor {
+// CHECK:           %[[DTYPE:.*]] = torch.constant.int 4
+// CHECK:           %[[SOFTMAX:.*]] = torch.aten.softmax.int %[[T]], %[[DIM]], %[[DTYPE]] : !torch.tensor<[2,3],f32>, !torch.int, !torch.int -> !torch.tensor<*,si64>
+// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<*,si64> to !torch.tensor
+// CHECK:           return %[[RET]] : !torch.tensor
+func @torch.aten.softmax.int$specified_dtype(%t: !torch.tensor<[2,3],f32>, %dim: !torch.int) -> !torch.tensor {
+  %int4 = torch.constant.int 4
+  %ret = torch.aten.softmax.int %t, %dim, %int4: !torch.tensor<[2,3],f32>, !torch.int, !torch.int -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:  func @torch.aten.Matmul.Broadcast.Matrix(
+// CHECK-SAME:                                            %[[LHS:.*]]: !torch.vtensor<*,f32>,
+// CHECK-SAME:                                            %[[RHS:.*]]: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {
+// CHECK:           %[[MUL:.*]] = torch.aten.matmul %[[LHS]], %[[RHS]] : !torch.vtensor<*,f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor<*,f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[MUL]] : !torch.tensor<*,f32> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.Matmul.Broadcast.Matrix(%arg0: !torch.vtensor<*,f32>, %arg1: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<*,f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
+  return %0 : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:  func @torch.aten.Matmul.Broadcast.Vector(
+// CHECK-SAME:                                            %[[LHS:.*]]: !torch.vtensor<*,f32>,
+// CHECK-SAME:                                            %[[RHS:.*]]: !torch.vtensor<*,f32>) -> !torch.tensor {
+// CHECK:           %[[MUL:.*]] = torch.aten.matmul %[[LHS]], %[[RHS]] : !torch.vtensor<*,f32>, !torch.vtensor<*,f32> -> !torch.tensor<*,f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[MUL]] : !torch.tensor<*,f32> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.Matmul.Broadcast.Vector(%arg0: !torch.vtensor<*,f32>, %arg1: !torch.vtensor<*,f32>) -> !torch.tensor {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<*,f32>, !torch.vtensor<*,f32> -> !torch.tensor
+  return %0 : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL: func @torch.aten.to.dtype(
+// CHECK-SAME:                            %[[ARG:.*]]: !torch.tensor<[?,?],f32>) -> !torch.tensor
+// CHECK:           %[[TODTYPE:.*]] = torch.aten.to.dtype
+// CHECK-SAME:          %[[ARG]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} :
+// CHECK-SAME:          !torch.tensor<[?,?],f32>, !torch.int, !torch.bool, !torch.bool, !torch.none
+// CHECK-SAME:          -> !torch.tensor<*,si64>
+// CHECK-NEXT:      %[[RES:.*]] = torch.tensor_static_info_cast %[[TODTYPE]] : !torch.tensor<*,si64> to !torch.tensor
+// CHECK-NEXT:      return %[[RES]] : !torch.tensor
+func @torch.aten.to.dtype(%arg0: !torch.tensor<[?,?],f32>) -> !torch.tensor{
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %int4 = torch.constant.int 4
+  %0 = torch.aten.to.dtype %arg0, %int4, %false, %false, %none : !torch.tensor<[?,?],f32>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.tensor
+  return %0 : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:  func @torch.prim.NumToTensor.Scalar(
+// CHECK-SAME:                                       %[[SELF:.*]]: !torch.int) -> !torch.tensor {
+// CHECK:           %[[NTT:.*]] = torch.prim.NumToTensor.Scalar %[[SELF]] : !torch.int -> !torch.tensor<*,si64>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[NTT]] : !torch.tensor<*,si64> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.prim.NumToTensor.Scalar(%arg0: !torch.int) -> !torch.tensor {
+  %0 = torch.prim.NumToTensor.Scalar %arg0: !torch.int -> !torch.tensor
+  return %0: !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.tensor(
+// CHECK-SAME:        %[[DATA:.*]]: !torch.list<!torch.list<!torch.float>>) -> !torch.tensor {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[RET:.*]] = torch.aten.tensor %[[DATA]], %[[NONE]], %[[NONE]], %[[FALSE]]
+// CHECK-SAME:        : !torch.list<!torch.list<!torch.float>>, !torch.none, !torch.none, !torch.bool
+// CHECK-SAME:        -> !torch.tensor<*,f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,f32> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.tensor(%t: !torch.list<!torch.list<!torch.float>>) -> !torch.tensor {
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %ret = torch.aten.tensor %t, %none, %none, %false : !torch.list<!torch.list<!torch.float>>, !torch.none, !torch.none, !torch.bool -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+// CHECK-LABEL:   func @torch.aten.tensor$specified_dtype(
+// CHECK-SAME:        %[[DATA:.*]]: !torch.list<!torch.list<!torch.float>>) -> !torch.tensor {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[INT4:.*]] = torch.constant.int 4
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[RET:.*]] = torch.aten.tensor %[[DATA]], %[[INT4]], %[[NONE]], %[[FALSE]] : !torch.list<!torch.list<!torch.float>>, !torch.int, !torch.none, !torch.bool -> !torch.tensor<*,si64>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,si64> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func @torch.aten.tensor$specified_dtype(%t: !torch.list<!torch.list<!torch.float>>) -> !torch.tensor {
+  %none = torch.constant.none
+  %int4 = torch.constant.int 4
+  %false = torch.constant.bool false
+  %ret = torch.aten.tensor %t, %int4, %none, %false : !torch.list<!torch.list<!torch.float>>, !torch.int, !torch.none, !torch.bool -> !torch.tensor
+  return %ret : !torch.tensor
+}

--- a/test/Dialect/Torch/refine-types.mlir
+++ b/test/Dialect/Torch/refine-types.mlir
@@ -1,1197 +1,129 @@
 // RUN: torch-mlir-opt -torch-refine-types -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL:   func @f(
-// CHECK-SAME:            %[[ARG:.*]]: !torch.vtensor<[2,3,?],f32>) -> !torch.vtensor {
-// CHECK:           %[[SHAPED:.*]] = torch.tensor_static_info_cast %[[ARG]] : !torch.vtensor<[2,3,?],f32> to !torch.vtensor<[2,3,?],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[SHAPED]] : !torch.vtensor<[2,3,?],f32> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @f(%arg0: !torch.vtensor<[2,3,?],f32>) -> !torch.vtensor {
-  %0 = torch.tensor_static_info_cast %arg0 : !torch.vtensor<[2,3,?],f32> to !torch.vtensor
-  return %0 : !torch.vtensor
-}
+// This file tests the structural logic of the pass. This is for testing logic
+// that does not scale with the number of ops supported, such as the core
+// propagation logic, rewriting, etc.
+// Code for testing transfer functions for new ops (which is most changes)
+// should go in refine-types-ops.mlir.
 
-// -----
-
-// CHECK-LABEL:   func @f(
-// CHECK-SAME:            %[[ARG:.*]]: !torch.vtensor<[2,3,?],f32>) -> !torch.tensor {
-// CHECK:           %[[CASTED:.*]] = torch.tensor_static_info_cast %[[ARG]] : !torch.vtensor<[2,3,?],f32> to !torch.vtensor<[2,3,?],f32>
-// CHECK:           %[[NONVAL_TENSOR:.*]] = torch.copy.to_tensor %[[CASTED]] : !torch.tensor<[2,3,?],f32>
-// CHECK:           %[[ERASED:.*]] = torch.tensor_static_info_cast %[[NONVAL_TENSOR]] : !torch.tensor<[2,3,?],f32> to !torch.tensor
-// CHECK:           return %[[ERASED]] : !torch.tensor
-builtin.func @f(%arg0: !torch.vtensor<[2,3,?],f32>) -> !torch.tensor {
-  %0 = torch.tensor_static_info_cast %arg0 : !torch.vtensor<[2,3,?],f32> to !torch.vtensor
-  %1 = torch.copy.to_tensor %0 : !torch.tensor
-  return %1 : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @f(
-// CHECK-SAME:            %[[ARG:.*]]: !torch.vtensor<[2,3,?],f32>) -> !torch.vtensor {
-// CHECK:           %[[SHAPED:.*]] = torch.aten.tanh %[[ARG]] : !torch.vtensor<[2,3,?],f32> -> !torch.vtensor<[2,3,?],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[SHAPED]] : !torch.vtensor<[2,3,?],f32> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @f(%arg0: !torch.vtensor<[2,3,?],f32>) -> !torch.vtensor {
-  %1 = torch.aten.tanh %arg0 : !torch.vtensor<[2,3,?],f32> -> !torch.vtensor
+// CHECK-LABEL:   func @basic(
+// CHECK-SAME:                      %[[ARG0:.*]]: !torch.vtensor<*,f32>) -> !torch.vtensor {
+// CHECK:           %[[TANH:.*]] = torch.aten.tanh %[[ARG0]] : !torch.vtensor<*,f32> -> !torch.vtensor<*,f32>
+// CHECK:           %[[RESULT:.*]] = torch.tensor_static_info_cast %[[TANH]] : !torch.vtensor<*,f32> to !torch.vtensor
+// CHECK:           return %[[RESULT]] : !torch.vtensor
+func @basic(%arg0: !torch.vtensor<*,f32>) -> !torch.vtensor {
+  %1 = torch.aten.tanh %arg0 : !torch.vtensor<*,f32> -> !torch.vtensor
   return %1 : !torch.vtensor
 }
 
-// -----
-
-// CHECK-LABEL:   func @f(
-// CHECK-SAME:            %[[LHS:.*]]: !torch.vtensor<[2,?],f32>,
-// CHECK-SAME:            %[[RHS:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor {
-// CHECK:           %[[MM:.*]] = torch.aten.mm %[[LHS]], %[[RHS]] : !torch.vtensor<[2,?],f32>, !torch.vtensor<[?,?],f32> -> !torch.vtensor<[2,?],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[MM]] : !torch.vtensor<[2,?],f32> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @f(%arg0: !torch.vtensor<[2,?],f32>, %arg1: !torch.vtensor<[?,?],f32>) -> !torch.vtensor {
-  %1 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[2,?],f32>, !torch.vtensor<[?,?],f32> -> !torch.vtensor
-  return %1 : !torch.vtensor
+// CHECK-LABEL:   func @keep_existing_shape_information(
+// CHECK-SAME:                                          %[[ARG0:.*]]: !torch.vtensor<*,f32>) -> !torch.vtensor<[2],f32> {
+// CHECK:           %[[TANH:.*]] = torch.aten.tanh %[[ARG0]] : !torch.vtensor<*,f32> -> !torch.vtensor<[2],f32>
+// CHECK:           return %[[TANH]] : !torch.vtensor<[2],f32>
+func @keep_existing_shape_information(%arg0: !torch.vtensor<*,f32>) -> !torch.vtensor<[2],f32> {
+  %1 = torch.aten.tanh %arg0 : !torch.vtensor<*,f32> -> !torch.vtensor<[2], f32>
+  return %1 : !torch.vtensor<[2],f32>
 }
 
-// CHECK-LABEL:   func @g(
-// CHECK-SAME:            %[[LHS:.*]]: !torch.vtensor<[2,3],f32>,
-// CHECK-SAME:            %[[RHS:.*]]: !torch.vtensor<[3,4],f32>) -> !torch.vtensor {
-// CHECK:           %[[MM:.*]] = torch.aten.mm %[[LHS]], %[[RHS]] : !torch.vtensor<[2,3],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor<[2,4],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[MM]] : !torch.vtensor<[2,4],f32> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @g(%arg0: !torch.vtensor<[2,3],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor {
-  %1 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[2,3],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor
-  return %1 : !torch.vtensor
-}
-
-// CHECK-LABEL:   func @h(
-// CHECK-SAME:            %[[LHS:.*]]: !torch.vtensor<[2,?],f32>,
-// CHECK-SAME:            %[[RHS:.*]]: !torch.vtensor<[3,4],f32>) -> !torch.vtensor {
-// CHECK:           %[[MM:.*]] = torch.aten.mm %[[LHS]], %[[RHS]] : !torch.vtensor<[2,?],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor<[2,4],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[MM]] : !torch.vtensor<[2,4],f32> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @h(%arg0: !torch.vtensor<[2,?],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor {
-  %1 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[2,?],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor
-  return %1 : !torch.vtensor
-}
-
-// CHECK-LABEL:   func @i(
-// CHECK-SAME:            %[[LHS:.*]]: !torch.vtensor<[2,5],f32>,
-// CHECK-SAME:            %[[RHS:.*]]: !torch.vtensor<[3,4],f32>) -> !torch.vtensor {
-// CHECK:           %[[MM:.*]] = torch.aten.mm %[[LHS]], %[[RHS]] : !torch.vtensor<[2,5],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor
-// CHECK:           return %[[MM]] : !torch.vtensor
-builtin.func @i(%arg0: !torch.vtensor<[2,5],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor {
-  %1 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[2,5],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor
-  return %1 : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @f(
-// CHECK-SAME:            %[[LHS:.*]]: !torch.vtensor<[?,2,?],f32>,
-// CHECK-SAME:            %[[RHS:.*]]: !torch.vtensor<[3,?,?],f32>) -> !torch.vtensor {
-// CHECK:           %[[BMM:.*]] = torch.aten.bmm %[[LHS]], %[[RHS]] : !torch.vtensor<[?,2,?],f32>, !torch.vtensor<[3,?,?],f32> -> !torch.vtensor<[3,2,?],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[BMM]] : !torch.vtensor<[3,2,?],f32> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @f(%arg0: !torch.vtensor<[?,2,?],f32>, %arg1: !torch.vtensor<[3,?,?],f32>) -> !torch.vtensor {
-  %1 = torch.aten.bmm %arg0, %arg1 : !torch.vtensor<[?,2,?],f32>, !torch.vtensor<[3,?,?],f32> -> !torch.vtensor
-  return %1 : !torch.vtensor
-}
-
-// CHECK-LABEL:   func @g(
-// CHECK-SAME:            %[[LHS:.*]]: !torch.vtensor<[5,2,3],f32>,
-// CHECK-SAME:            %[[RHS:.*]]: !torch.vtensor<[5,3,4],f32>) -> !torch.vtensor {
-// CHECK:           %[[BMM:.*]] = torch.aten.bmm %[[LHS]], %[[RHS]] : !torch.vtensor<[5,2,3],f32>, !torch.vtensor<[5,3,4],f32> -> !torch.vtensor<[5,2,4],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[BMM]] : !torch.vtensor<[5,2,4],f32> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @g(%arg0: !torch.vtensor<[5,2,3],f32>, %arg1: !torch.vtensor<[5,3,4],f32>) -> !torch.vtensor {
-  %1 = torch.aten.bmm %arg0, %arg1 : !torch.vtensor<[5,2,3],f32>, !torch.vtensor<[5,3,4],f32> -> !torch.vtensor
-  return %1 : !torch.vtensor
-}
-
-// CHECK-LABEL:   func @h(
-// CHECK-SAME:            %[[LHS:.*]]: !torch.vtensor<[5,2,3],f32>,
-// CHECK-SAME:            %[[RHS:.*]]: !torch.vtensor<[7,3,4],f32>) -> !torch.vtensor {
-// CHECK:           %[[BMM:.*]] = torch.aten.bmm %[[LHS]], %[[RHS]] : !torch.vtensor<[5,2,3],f32>, !torch.vtensor<[7,3,4],f32> -> !torch.vtensor
-// CHECK:           return %[[BMM]] : !torch.vtensor
-builtin.func @h(%arg0: !torch.vtensor<[5,2,3],f32>, %arg1: !torch.vtensor<[7,3,4],f32>) -> !torch.vtensor {
-  %1 = torch.aten.bmm %arg0, %arg1 : !torch.vtensor<[5,2,3],f32>, !torch.vtensor<[7,3,4],f32> -> !torch.vtensor
-  return %1 : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @f(
-// CHECK-SAME:            %[[INPUT:.*]]: !torch.vtensor<[?,3],f32>,
-// CHECK-SAME:            %[[WEIGHT:.*]]: !torch.vtensor<[5,3],f32>,
-// CHECK-SAME:            %[[BIAS:.*]]: !torch.vtensor<[5],f32>) -> !torch.vtensor {
-// CHECK:           %[[LINEAR:.*]] = torch.aten.linear %[[INPUT]], %[[WEIGHT]], %[[BIAS]] : !torch.vtensor<[?,3],f32>, !torch.vtensor<[5,3],f32>, !torch.vtensor<[5],f32> -> !torch.vtensor<[?,5],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[LINEAR]] : !torch.vtensor<[?,5],f32> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @f(%arg0: !torch.vtensor<[?,3],f32>, %arg1: !torch.vtensor<[5,3],f32>, %arg2: !torch.vtensor<[5],f32>) -> !torch.vtensor {
-  %1 = torch.aten.linear %arg0, %arg1, %arg2 : !torch.vtensor<[?,3],f32>, !torch.vtensor<[5,3],f32>, !torch.vtensor<[5],f32> -> !torch.vtensor
-  return %1 : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL: func @f
-// CHECK:           %[[CONV2D:.*]] = torch.aten.conv2d{{.*}} -> !torch.vtensor<[?,?,?,?],unk>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[CONV2D]] : !torch.vtensor<[?,?,?,?],unk> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @f(%arg0:!torch.vtensor, %arg1:!torch.vtensor, %arg2:!torch.vtensor) ->!torch.vtensor {
-  %int0 = torch.constant.int 0
-  %int1 = torch.constant.int 1
-  %0 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %1 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %3 = torch.aten.conv2d %arg0, %arg1, %arg2, %0, %1, %2, %int1 : !torch.vtensor, !torch.vtensor, !torch.vtensor, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int ->!torch.vtensor
-  return %3 :!torch.vtensor
-}
-
-// CHECK-LABEL: func @g
-// CHECK:           %[[CONV2D:.*]] = torch.aten.conv2d{{.*}} -> !torch.vtensor<[?,?,?,?],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[CONV2D]] : !torch.vtensor<[?,?,?,?],f32> to !torch.vtensor
-// CHECK:           return %[[SHAPE_ERASED]] : !torch.vtensor
-builtin.func @g(%arg0:!torch.vtensor<*,f32>, %arg1:!torch.vtensor<*,f32>, %arg2:!torch.vtensor<*,f32>) ->!torch.vtensor {
-  %int0 = torch.constant.int 0
-  %int1 = torch.constant.int 1
-  %0 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %1 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %2 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %3 = torch.aten.conv2d %arg0, %arg1, %arg2, %0, %1, %2, %int1 : !torch.vtensor<*,f32>, !torch.vtensor<*,f32>, !torch.vtensor<*,f32>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int ->!torch.vtensor
-  return %3 :!torch.vtensor
-}
-
-// CHECK-LABEL: func @h
-// CHECK:           torch.aten.conv2d{{.*}} -> !torch.vtensor<[1,16,62,62],f32>
-builtin.func @h(%arg0:!torch.vtensor<[1,8,64,64],f32>, %arg1:!torch.vtensor<[16,8,3,3],f32>, %arg2:!torch.vtensor<*,f32>) ->!torch.vtensor {
-  %int0 = torch.constant.int 0
-  %int1 = torch.constant.int 1
-  %stride = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %padding = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %dilation = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %3 = torch.aten.conv2d %arg0, %arg1, %arg2, %stride, %padding, %dilation, %int1 : !torch.vtensor<[1,8,64,64],f32>, !torch.vtensor<[16,8,3,3],f32>, !torch.vtensor<*,f32>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int ->!torch.vtensor
-  return %3 :!torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL: func @f
-builtin.func @f(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor {
-  %int1 = torch.constant.int 1
-  %int3 = torch.constant.int 3
-  %int2 = torch.constant.int 2
-  %bool_false = torch.constant.bool false
-  %21 = torch.prim.ListConstruct %int3, %int3 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %22 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %23 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %24 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  // CHECK: torch.aten.max_pool2d{{.*}} -> !torch.vtensor<[?,?,?,?],f32>
-  %27 = torch.aten.max_pool2d %arg0, %21, %22, %23, %24, %bool_false : !torch.vtensor<[?,?,?,?],f32>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.bool -> !torch.vtensor
-  return %27 : !torch.vtensor
-}
-
-// CHECK-LABEL: func @g
-builtin.func @g(%arg0: !torch.vtensor<[1,8,64,64],f32>) -> !torch.vtensor {
-  %int0 = torch.constant.int 0
-  %int1 = torch.constant.int 1
-  %int2 = torch.constant.int 2
-  %int3 = torch.constant.int 3
-  %bool_false = torch.constant.bool false
-  %krnl = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %stride = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %padding = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %dilation = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  // CHECK: torch.aten.max_pool2d{{.*}} -> !torch.vtensor<[1,8,32,32],f32>
-  %27 = torch.aten.max_pool2d %arg0, %krnl, %stride, %padding, %dilation, %bool_false : !torch.vtensor<[1,8,64,64],f32>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.bool -> !torch.vtensor
-  return %27 : !torch.vtensor
-}
-
-// CHECK-LABEL: func @h
-builtin.func @h(%arg0: !torch.vtensor<[1,8,64,64],f32>) -> !torch.vtensor {
-  %int0 = torch.constant.int 0
-  %int1 = torch.constant.int 1
-  %int2 = torch.constant.int 2
-  %int3 = torch.constant.int 3
-  %bool_false = torch.constant.bool false
-  %krnl = torch.prim.ListConstruct %int3, %int3 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %stride = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %padding = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %dilation = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  // CHECK: torch.aten.max_pool2d{{.*}} -> !torch.vtensor<[1,8,62,62],f32>
-  %27 = torch.aten.max_pool2d %arg0, %krnl, %stride, %padding, %dilation, %bool_false : !torch.vtensor<[1,8,64,64],f32>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.bool -> !torch.vtensor
-  return %27 : !torch.vtensor
-}
-
-// CHECK-LABEL: func @i
-builtin.func @i(%arg0: !torch.vtensor<[1,8,64,64],f32>) -> !torch.vtensor {
-  %int0 = torch.constant.int 0
-  %int1 = torch.constant.int 1
-  %int2 = torch.constant.int 2
-  %int3 = torch.constant.int 3
-  %bool_false = torch.constant.bool false
-  %krnl = torch.prim.ListConstruct %int3, %int3 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %stride = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %padding = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %dilation = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  // CHECK: torch.aten.max_pool2d{{.*}} -> !torch.vtensor<[1,8,66,66],f32>
-  %27 = torch.aten.max_pool2d %arg0, %krnl, %stride, %padding, %dilation, %bool_false : !torch.vtensor<[1,8,64,64],f32>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.bool -> !torch.vtensor
-  return %27 : !torch.vtensor
-}
-
-// CHECK-LABEL: func @j
-builtin.func @j(%arg0: !torch.vtensor<[1,8,64,64],f32>) -> !torch.vtensor {
-  %int0 = torch.constant.int 0
-  %int1 = torch.constant.int 1
-  %int2 = torch.constant.int 2
-  %int3 = torch.constant.int 3
-  %bool_false = torch.constant.bool false
-  %krnl = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %stride = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %padding = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %dilation = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  // CHECK: torch.aten.max_pool2d{{.*}} -> !torch.vtensor<[1,8,32,32],f32>
-  %27 = torch.aten.max_pool2d %arg0, %krnl, %stride, %padding, %dilation, %bool_false : !torch.vtensor<[1,8,64,64],f32>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.bool -> !torch.vtensor
-  return %27 : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL: func @f
-builtin.func @f(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor {
-  %int1 = torch.constant.int 1
-  %0 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  // CHECK: torch.aten.adaptive_avg_pool2d{{.*}} -> !torch.vtensor<[?,?,1,1],f32>
-  %1 = torch.aten.adaptive_avg_pool2d %arg0, %0 : !torch.vtensor<[?,?,?,?],f32>, !torch.list<!torch.int> -> !torch.vtensor
-  return %1 : !torch.vtensor
-}
-
-// -----
-
-// Also test cast insertion for array types.
-// CHECK-LABEL:   func @flatten_all(
-// CHECK:           %[[FLATTENED:.*]] = torch.aten.flatten.using_ints{{.*}}-> !torch.tensor<[?],f32>
-// CHECK:           %[[SHAPE_ERASED:.*]] = torch.tensor_static_info_cast %[[FLATTENED]] : !torch.tensor<[?],f32> to !torch.tensor
-// CHECK:           return %[[SHAPE_ERASED]]
-builtin.func @flatten_all(%arg0: !torch.tensor<[3,2,?,5],f32>) -> !torch.tensor {
-  %end = torch.constant.int -1
-  %start = torch.constant.int 0
-  %0 = torch.aten.flatten.using_ints %arg0, %start, %end : !torch.tensor<[3,2,?,5],f32>, !torch.int, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// CHECK-LABEL:   func @flatten_some(
-// CHECK:           torch.aten.flatten.using_ints{{.*}}-> !torch.tensor<[3,?,5],f32>
-builtin.func @flatten_some(%arg0: !torch.tensor<[3,2,?,5],f32>) -> !torch.tensor {
-  %end = torch.constant.int -2
-  %start = torch.constant.int 1
-  %0 = torch.aten.flatten.using_ints %arg0, %start, %end : !torch.tensor<[3,2,?,5],f32>, !torch.int, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// CHECK-LABEL:   func @flatten_rank0(
-// CHECK:           torch.aten.flatten.using_ints{{.*}}-> !torch.tensor<[1],f32>
-builtin.func @flatten_rank0(%arg0: !torch.tensor<[],f32>) -> !torch.tensor {
-  %end = torch.constant.int -1
-  %start = torch.constant.int 0
-  %0 = torch.aten.flatten.using_ints %arg0, %start, %end : !torch.tensor<[],f32>, !torch.int, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.unsqueeze$basic(
-// CHECK:           torch.aten.unsqueeze {{.*}} -> !torch.tensor<[1],f32>
-builtin.func @torch.aten.unsqueeze$basic(%arg0: !torch.tensor<[],f32>) -> !torch.tensor {
-  %int0 = torch.constant.int 0
-  %0 = torch.aten.unsqueeze %arg0, %int0 : !torch.tensor<[],f32>, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// CHECK-LABEL:   func @torch.aten.unsqueeze$basic_negative(
-// CHECK:           torch.aten.unsqueeze {{.*}} -> !torch.tensor<[1],f32>
-builtin.func @torch.aten.unsqueeze$basic_negative(%arg0: !torch.tensor<[],f32>) -> !torch.tensor {
-  %int-1 = torch.constant.int -1
-  %0 = torch.aten.unsqueeze %arg0, %int-1 : !torch.tensor<[],f32>, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// CHECK-LABEL:   func @torch.aten.unsqueeze$invalid(
-// CHECK:           torch.aten.unsqueeze {{.*}} !torch.tensor<*,f32>
-builtin.func @torch.aten.unsqueeze$invalid(%arg0: !torch.tensor<[],f32>) -> !torch.tensor {
-  %int1 = torch.constant.int 1
-  %0 = torch.aten.unsqueeze %arg0, %int1 : !torch.tensor<[],f32>, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// CHECK-LABEL:   func @torch.aten.unsqueeze$invalid_negative(
-// CHECK:           torch.aten.unsqueeze {{.*}} -> !torch.tensor<*,f32>
-builtin.func @torch.aten.unsqueeze$invalid_negative(%arg0: !torch.tensor<[],f32>) -> !torch.tensor {
-  %int-2 = torch.constant.int -2
-  %0 = torch.aten.unsqueeze %arg0, %int-2 : !torch.tensor<[],f32>, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// CHECK-LABEL:   func @torch.aten.unsqueeze$higher_rank_front(
-// CHECK:           torch.aten.unsqueeze {{.*}} -> !torch.tensor<[1,2,3,4],f32>
-builtin.func @torch.aten.unsqueeze$higher_rank_front(%arg0: !torch.tensor<[2,3,4],f32>) -> !torch.tensor {
-  %int0 = torch.constant.int 0
-  %0 = torch.aten.unsqueeze %arg0, %int0 : !torch.tensor<[2,3,4],f32>, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// CHECK-LABEL:   func @torch.aten.unsqueeze$higher_rank_back(
-// CHECK:           torch.aten.unsqueeze {{.*}} -> !torch.tensor<[2,3,4,1],f32>
-builtin.func @torch.aten.unsqueeze$higher_rank_back(%arg0: !torch.tensor<[2,3,4],f32>) -> !torch.tensor {
-  %int-1 = torch.constant.int -1
-  %0 = torch.aten.unsqueeze %arg0, %int-1 : !torch.tensor<[2,3,4],f32>, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// CHECK-LABEL:   func @torch.aten.unsqueeze$higher_rank_middle(
-// CHECK:           torch.aten.unsqueeze {{.*}} -> !torch.tensor<[2,3,1,4],f32>
-builtin.func @torch.aten.unsqueeze$higher_rank_middle(%arg0: !torch.tensor<[2,3,4],f32>) -> !torch.tensor {
-  %int2 = torch.constant.int 2
-  %0 = torch.aten.unsqueeze %arg0, %int2 : !torch.tensor<[2,3,4],f32>, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// CHECK-LABEL:   func @torch.aten.unsqueeze$unknown_position(
-// CHECK:           torch.aten.unsqueeze {{.*}} -> !torch.tensor<*,f32>
-builtin.func @torch.aten.unsqueeze$unknown_position(%arg0: !torch.tensor<[2],f32>, %arg1: !torch.int) -> !torch.tensor {
-  %0 = torch.aten.unsqueeze %arg0, %arg1 : !torch.tensor<[2],f32>, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL: func @f
-builtin.func @f(%arg0: !torch.vtensor<[4,6,3],f32>, %arg1: !torch.vtensor<[1,1,3],f32>, %arg2: !torch.vtensor<[?,3],f32>) {
-  %int1 = torch.constant.int 1
-  // CHECK: torch.aten.add{{.*}} -> !torch.vtensor<[4,6,3],f32>
-  %0 = torch.aten.add.Tensor %arg0, %arg1, %int1 : !torch.vtensor<[4,6,3],f32>, !torch.vtensor<[1,1,3],f32>, !torch.int -> !torch.vtensor
-  // CHECK: torch.aten.add{{.*}} -> !torch.vtensor<[4,?,3],f32>
-  %1 = torch.aten.add.Tensor %arg0, %arg2, %int1 : !torch.vtensor<[4,6,3],f32>, !torch.vtensor<[?,3],f32>, !torch.int -> !torch.vtensor
-  return
-}
-
-// -----
-
-// CHECK-LABEL:   func @f
-builtin.func @f(%arg0: !torch.vtensor<[2,3,?],f32>) -> !torch.vtensor {
-  // Check propagation through multiple ops.
-  // CHECK:           torch.aten.tanh %{{.*}} : !torch.vtensor<[2,3,?],f32> -> !torch.vtensor<[2,3,?],f32>
-  // CHECK:           torch.aten.tanh %{{.*}} : !torch.vtensor<[2,3,?],f32> -> !torch.vtensor<[2,3,?],f32>
-  // CHECK:           torch.aten.tanh %{{.*}} : !torch.vtensor<[2,3,?],f32> -> !torch.vtensor<[2,3,?],f32>
-  %1 = torch.aten.tanh %arg0 : !torch.vtensor<[2,3,?],f32> -> !torch.vtensor
+// CHECK-LABEL:   func @propagate_through_multiple_ops(
+// CHECK-SAME:                                         %[[ARG0:.*]]: !torch.vtensor<*,f32>) -> !torch.vtensor {
+// CHECK:           %[[TANH0:.*]] = torch.aten.tanh %[[ARG0]] : !torch.vtensor<*,f32> -> !torch.vtensor<*,f32>
+// CHECK:           %[[TANH1:.*]] = torch.aten.tanh %[[TANH0]] : !torch.vtensor<*,f32> -> !torch.vtensor<*,f32>
+// CHECK:           %[[TANH2:.*]] = torch.aten.tanh %[[TANH1]] : !torch.vtensor<*,f32> -> !torch.vtensor<*,f32>
+// CHECK:           %[[TANH3:.*]] = torch.tensor_static_info_cast %[[TANH2]] : !torch.vtensor<*,f32> to !torch.vtensor
+// CHECK:           return %[[TANH3]] : !torch.vtensor
+func @propagate_through_multiple_ops(%arg0: !torch.vtensor<*,f32>) -> !torch.vtensor {
+  %1 = torch.aten.tanh %arg0 : !torch.vtensor<*,f32> -> !torch.vtensor
   %2 = torch.aten.tanh %1 : !torch.vtensor -> !torch.vtensor
   %3 = torch.aten.tanh %2 : !torch.vtensor -> !torch.vtensor
   return %3 : !torch.vtensor
 }
 
-// -----
-
 // Check rewriting logic in case of mixes of users that do/don't allow type
 // refinement.
-// CHECK-LABEL:   func @f
-builtin.func @f(%arg0: !torch.vtensor<[2,3,?],f32>) -> (!torch.vtensor, !torch.vtensor) {
-  // CHECK: %[[REFINED_TYPE:.*]] = torch.aten.tanh %{{.*}} : !torch.vtensor<[2,3,?],f32> -> !torch.vtensor<[2,3,?],f32>
-  %1 = torch.aten.tanh %arg0 : !torch.vtensor<[2,3,?],f32> -> !torch.vtensor
-  // CHECK: %[[ORIGINAL_TYPE:.*]] = torch.tensor_static_info_cast %[[REFINED_TYPE]] : !torch.vtensor<[2,3,?],f32> to !torch.vtensor
-  // CHECK: torch.aten.tanh %[[REFINED_TYPE]] : !torch.vtensor<[2,3,?],f32> -> !torch.vtensor<[2,3,?],f32>
+// CHECK-LABEL:   func @mixed_allowing_not_allowing_type_refinement(
+// CHECK-SAME:                                                      %[[ARG0:.*]]: !torch.vtensor<*,f32>) -> (!torch.vtensor, !torch.vtensor) {
+// CHECK:           %[[TANH0:.*]] = torch.aten.tanh %[[ARG0]] : !torch.vtensor<*,f32> -> !torch.vtensor<*,f32>
+// CHECK:           %[[ERASED:.*]] = torch.tensor_static_info_cast %[[TANH0]] : !torch.vtensor<*,f32> to !torch.vtensor
+// CHECK:           %[[TANH1:.*]] = torch.aten.tanh %[[TANH0]] : !torch.vtensor<*,f32> -> !torch.vtensor<*,f32>
+// CHECK:           return %[[ERASED]], %[[ERASED]] : !torch.vtensor, !torch.vtensor
+func @mixed_allowing_not_allowing_type_refinement(%arg0: !torch.vtensor<*,f32>) -> (!torch.vtensor, !torch.vtensor) {
+  %1 = torch.aten.tanh %arg0 : !torch.vtensor<*,f32> -> !torch.vtensor
   %3 = torch.aten.tanh %1 : !torch.vtensor -> !torch.vtensor
-  // CHECK: return %[[ORIGINAL_TYPE]], %[[ORIGINAL_TYPE]] : !torch.vtensor, !torch.vtensor
   return %1, %1 : !torch.vtensor, !torch.vtensor
 }
 
-// -----
-
-// CHECK-LABEL:   func @f
-// CHECK: %[[ATEN:.*]] = torch.aten.tanh %{{.*}} : !torch.vtensor -> !torch.vtensor<[2,3,?],f32>
-// CHECK: %[[CAST:.*]] = torch.tensor_static_info_cast %[[ATEN]] : !torch.vtensor<[2,3,?],f32> to !torch.vtensor
-// CHECK: return %[[CAST]] : !torch.vtensor
-builtin.func @f(%arg0: !torch.vtensor<[2,3,?],f32>) -> !torch.vtensor {
-  %cast = torch.tensor_static_info_cast %arg0 : !torch.vtensor<[2,3,?],f32> to !torch.vtensor
-  cf.br ^bb1(%cast: !torch.vtensor)
-^bb1(%arg1: !torch.vtensor):
-  %1 = torch.aten.tanh %arg1 : !torch.vtensor -> !torch.vtensor
-  return %1 : !torch.vtensor
+// CHECK-LABEL:   func @type_promotion$same_category_different_width(
+// CHECK-SAME:                                                       %[[ARG0:.*]]: !torch.vtensor<[?],si32>,
+// CHECK-SAME:                                                       %[[ARG1:.*]]: !torch.vtensor<[?],si64>) -> !torch.vtensor<[?],unk> {
+// CHECK:           %[[ALPHA:.*]] = torch.constant.int 3
+// CHECK:           %[[ADD:.*]] = torch.aten.add.Tensor %[[ARG0]], %[[ARG1]], %[[ALPHA]] : !torch.vtensor<[?],si32>, !torch.vtensor<[?],si64>, !torch.int -> !torch.vtensor<[?],si64>
+// CHECK:           %[[RESULT:.*]] = torch.tensor_static_info_cast %[[ADD]] : !torch.vtensor<[?],si64> to !torch.vtensor<[?],unk>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[?],unk>
+func @type_promotion$same_category_different_width(%arg0: !torch.vtensor<[?],si32>, %arg1: !torch.vtensor<[?],si64>) -> !torch.vtensor<[?],unk> {
+  %int3 = torch.constant.int 3
+  %0 = torch.aten.add.Tensor %arg0, %arg1, %int3 : !torch.vtensor<[?],si32>, !torch.vtensor<[?],si64>, !torch.int -> !torch.vtensor<[?],unk>
+  return %0 : !torch.vtensor<[?],unk>
 }
 
-// -----
-
-// CHECK-LABEL:   func @f
-// CHECK: func private @callee
-// CHECK-NEXT: torch.aten.tanh %{{.*}} : !torch.vtensor -> !torch.vtensor<[2,3,?],f32>
-builtin.func @f() {
-  builtin.module {
-    builtin.func private @callee(%arg0: !torch.vtensor) {
-      %1 = torch.aten.tanh %arg0 : !torch.vtensor -> !torch.vtensor
-      return
-    }
-    builtin.func @caller(%arg0: !torch.vtensor<[2,3,?],f32>) {
-      %cast = torch.tensor_static_info_cast %arg0 : !torch.vtensor<[2,3,?],f32> to !torch.vtensor
-      call @callee(%cast) : (!torch.vtensor) -> ()
-      return
-    }
-  }
-  return
+// CHECK-LABEL:   func @type_promotion$different_category(
+// CHECK-SAME:                                            %[[ARG0:.*]]: !torch.vtensor<[?],si64>,
+// CHECK-SAME:                                            %[[ARG1:.*]]: !torch.vtensor<[?],f32>) -> !torch.vtensor<[?],unk> {
+// CHECK:           %[[ALPHA:.*]] = torch.constant.int 3
+// CHECK:           %[[ADD:.*]] = torch.aten.add.Tensor %[[ARG0]], %[[ARG1]], %[[ALPHA]] : !torch.vtensor<[?],si64>, !torch.vtensor<[?],f32>, !torch.int -> !torch.vtensor<[?],f32>
+// CHECK:           %[[RESULT:.*]] = torch.tensor_static_info_cast %[[ADD]] : !torch.vtensor<[?],f32> to !torch.vtensor<[?],unk>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[?],unk>
+func @type_promotion$different_category(%arg0: !torch.vtensor<[?],si64>, %arg1: !torch.vtensor<[?],f32>) -> !torch.vtensor<[?],unk> {
+  %int3 = torch.constant.int 3
+  %0 = torch.aten.add.Tensor %arg0, %arg1, %int3 : !torch.vtensor<[?],si64>, !torch.vtensor<[?],f32>, !torch.int -> !torch.vtensor<[?],unk>
+  return %0 : !torch.vtensor<[?],unk>
 }
 
-// -----
-
-// CHECK-LABEL: func @f(
-// CHECK-SAME:                    %[[TENSOR:.*]]: !torch.tensor) -> !torch.bool {
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[OPTIONAL:.*]] = torch.derefine %[[TENSOR]] : !torch.tensor to !torch.optional<!torch.tensor>
-// CHECK:           %[[RET:.*]] = torch.aten.__isnot__ %[[TENSOR]], %[[NONE]] : !torch.tensor, !torch.none -> !torch.bool
-// CHECK:           return %[[RET]] : !torch.bool
-
-builtin.func @f(%arg : !torch.tensor) -> !torch.bool {
-  %none = torch.constant.none
-  %optional = "torch.derefine"(%arg) : (!torch.tensor) -> !torch.optional<!torch.tensor>
-  %ret = "torch.aten.__isnot__"(%optional, %none) : (!torch.optional<!torch.tensor>, !torch.none) -> !torch.bool
-  return %ret: !torch.bool
+// CHECK-LABEL:   func @type_promotion$same_category_zero_rank_wider(
+// CHECK-SAME:                                                       %[[ARG0:.*]]: !torch.vtensor<[?],f32>,
+// CHECK-SAME:                                                       %[[ARG1:.*]]: !torch.vtensor<[],f64>) -> !torch.vtensor<[?],unk> {
+// CHECK:           %[[ALPHA:.*]] = torch.constant.float 2.300000e+00
+// CHECK:           %[[ADD:.*]] = torch.aten.add.Tensor %[[ARG0]], %[[ARG1]], %[[ALPHA]] : !torch.vtensor<[?],f32>, !torch.vtensor<[],f64>, !torch.float -> !torch.vtensor<[?],f32>
+// CHECK:           %[[RESULT:.*]] = torch.tensor_static_info_cast %[[ADD]] : !torch.vtensor<[?],f32> to !torch.vtensor<[?],unk>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[?],unk>
+func @type_promotion$same_category_zero_rank_wider(%arg0: !torch.vtensor<[?],f32>, %arg1: !torch.vtensor<[],f64>) -> !torch.vtensor<[?],unk> {
+  %float2.300000e00 = torch.constant.float 2.300000e+00
+  %0 = torch.aten.add.Tensor %arg0, %arg1, %float2.300000e00 : !torch.vtensor<[?],f32>, !torch.vtensor<[],f64>, !torch.float -> !torch.vtensor<[?],unk>
+  return %0 : !torch.vtensor<[?],unk>
 }
 
-// -----
-
-// CHECK-LABEL:   func @aten.arange.start$int64_dtype(
-// CHECK-SAME:                    %[[START:.*]]: !torch.int,
-// CHECK-SAME:                    %[[END:.*]]: !torch.int) -> !torch.vtensor {
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[T:.*]] = torch.aten.arange.start
-// CHECK-SAME:         %[[START]], %[[END]], %[[NONE]], %[[NONE]], %[[NONE]], %[[NONE]] :
-// CHECK-SAME:         !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none
-// CHECK-SAME:         -> !torch.vtensor<[?],si64>
-// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[T]] : !torch.vtensor<[?],si64> to !torch.vtensor
-// CHECK:           return %[[RET]] : !torch.vtensor
-
-builtin.func @aten.arange.start$int64_dtype(%start: !torch.int, %end: !torch.int) -> !torch.vtensor {
-  %none = torch.constant.none
-  %ret = torch.aten.arange.start %start, %end, %none, %none, %none, %none: !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor
-  return %ret : !torch.vtensor
+// CHECK-LABEL:   func @type_promotion$zero_rank_higher_category(
+// CHECK-SAME:                                                   %[[ARG0:.*]]: !torch.vtensor<[?],si64>,
+// CHECK-SAME:                                                   %[[ARG1:.*]]: !torch.vtensor<[],f32>) -> !torch.vtensor<[?],unk> {
+// CHECK:           %[[ALPHA:.*]] = torch.constant.int 2
+// CHECK:           %[[ADD:.*]] = torch.aten.add.Tensor %[[ARG0]], %[[ARG1]], %[[ALPHA]] : !torch.vtensor<[?],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[?],f32>
+// CHECK:           %[[RESULT:.*]] = torch.tensor_static_info_cast %[[ADD]] : !torch.vtensor<[?],f32> to !torch.vtensor<[?],unk>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[?],unk>
+func @type_promotion$zero_rank_higher_category(%arg0: !torch.vtensor<[?],si64>, %arg1: !torch.vtensor<[],f32>) -> !torch.vtensor<[?],unk> {
+  %int2 = torch.constant.int 2
+  %0 = torch.aten.add.Tensor %arg0, %arg1, %int2 : !torch.vtensor<[?],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[?],unk>
+  return %0 : !torch.vtensor<[?],unk>
 }
 
-// -----
-
-// CHECK-LABEL:   func @aten.arange.start$float32_dtype(
-// CHECK-SAME:                    %[[START:.*]]: !torch.float,
-// CHECK-SAME:                    %[[END:.*]]: !torch.int) -> !torch.vtensor {
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[T:.*]] = torch.aten.arange.start
-// CHECK-SAME:         %[[START]], %[[END]], %[[NONE]], %[[NONE]], %[[NONE]], %[[NONE]] :
-// CHECK-SAME:         !torch.float, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none
-// CHECK-SAME:         -> !torch.vtensor<[?],f32>
-// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[T]] : !torch.vtensor<[?],f32> to !torch.vtensor
-// CHECK:           return %[[RET]] : !torch.vtensor
-
-builtin.func @aten.arange.start$float32_dtype(%start: !torch.float, %end: !torch.int) -> !torch.vtensor {
-  %none = torch.constant.none
-  %ret = torch.aten.arange.start %start, %end, %none, %none, %none, %none: !torch.float, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor
-  return %ret : !torch.vtensor
+// CHECK-LABEL:   func @type_promotion$alpha_wider(
+// CHECK-SAME:                                     %[[ARG0:.*]]: !torch.vtensor<[?],f32>,
+// CHECK-SAME:                                     %[[ARG1:.*]]: !torch.vtensor<[],f32>) -> !torch.vtensor<[?],unk> {
+// CHECK:           %[[ALPHA:.*]] = torch.constant.float 2.300000e+00
+// CHECK:           %[[ADD:.*]] = torch.aten.add.Tensor %[[ARG0]], %[[ARG1]], %[[ALPHA]] : !torch.vtensor<[?],f32>, !torch.vtensor<[],f32>, !torch.float -> !torch.vtensor<[?],f32>
+// CHECK:           %[[RESULT:.*]] = torch.tensor_static_info_cast %[[ADD]] : !torch.vtensor<[?],f32> to !torch.vtensor<[?],unk>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[?],unk>
+func @type_promotion$alpha_wider(%arg0: !torch.vtensor<[?],f32>, %arg1: !torch.vtensor<[],f32>) -> !torch.vtensor<[?],unk> {
+  %float2.300000e00 = torch.constant.float 2.300000e+00
+  %0 = torch.aten.add.Tensor %arg0, %arg1, %float2.300000e00 : !torch.vtensor<[?],f32>, !torch.vtensor<[],f32>, !torch.float -> !torch.vtensor<[?],unk>
+  return %0 : !torch.vtensor<[?],unk>
 }
 
-// -----
-
-// CHECK-LABEL:   func @aten.arange.start$specified_dtype(
-// CHECK-SAME:                                                    %[[END:.*]]: !torch.int) -> !torch.vtensor {
-// CHECK:           %[[CST6:.*]] = torch.constant.int 6
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[T:.*]] = torch.aten.arange
-// CHECK-SAME:         %[[END]], %[[CST6]], %[[NONE]], %[[NONE]], %[[NONE]] :
-// CHECK-SAME:         !torch.int, !torch.int, !torch.none, !torch.none, !torch.none
-// CHECK-SAME:         -> !torch.vtensor<[?],f32>
-// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[T]] : !torch.vtensor<[?],f32> to !torch.vtensor
-// CHECK:           return %[[RET]] : !torch.vtensor
-
-builtin.func @aten.arange.start$specified_dtype(%end: !torch.int) -> !torch.vtensor {
-  %int6 = torch.constant.int 6
-  %none = torch.constant.none
-  %ret = torch.aten.arange %end, %int6, %none, %none, %none: !torch.int, !torch.int, !torch.none, !torch.none, !torch.none -> !torch.vtensor
-  return %ret : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @aten.sum.dim_IntList(
-// CHECK-SAME:                                       %[[T:.*]]: !torch.vtensor<[2,3,?],si64>) -> !torch.vtensor {
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[INT0:.*]] = torch.constant.int 0
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[DIMLIST:.*]] = torch.prim.ListConstruct %[[INT0]], %[[INT_NEG1]]
-// CHECK-SAME:        : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-// CHECK:           %[[RET:.*]] = torch.aten.sum.dim_IntList %[[T]], %[[DIMLIST]], %[[FALSE]], %[[NONE]]
-// CHECK-SAME:        : !torch.vtensor<[2,3,?],si64>, !torch.list<!torch.int>, !torch.bool, !torch.none
-// CHECK-SAME:        -> !torch.vtensor<[3],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.vtensor<[3],si64> to !torch.vtensor
-// CHECK:           return %[[CAST]] : !torch.vtensor
-
-builtin.func @aten.sum.dim_IntList(%t: !torch.vtensor<[2,3,?],si64>) -> !torch.vtensor {
-  %false = torch.constant.bool false
-  %none = torch.constant.none
-  %int0 = torch.constant.int 0
-  %int-1 = torch.constant.int -1
-  %dimList = torch.prim.ListConstruct %int0, %int-1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %ret = torch.aten.sum.dim_IntList %t, %dimList, %false, %none : !torch.vtensor<[2,3,?],si64>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.vtensor
-  return %ret : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @aten.sum.dim_IntList$keepdim(
-// CHECK-SAME:                                               %[[T:.*]]: !torch.vtensor<[2,3,?],si64>) -> !torch.vtensor {
-// CHECK:           %[[KEEPDIM:.*]] = torch.constant.bool true
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[INT0:.*]] = torch.constant.int 0
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[DIMLIST:.*]] = torch.prim.ListConstruct %[[INT0]], %[[INT_NEG1]] :
-// CHECK-SAME:        (!torch.int, !torch.int) -> !torch.list<!torch.int>
-// CHECK:           %[[RET:.*]] = torch.aten.sum.dim_IntList
-// CHECK-SAME:        %[[T]], %[[DIMLIST]], %[[KEEPDIM]], %[[NONE]]
-// CHECK-SAME:        : !torch.vtensor<[2,3,?],si64>, !torch.list<!torch.int>, !torch.bool, !torch.none
-// CHECK-SAME:        -> !torch.vtensor<[1,3,1],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] :
-// CHECK-SAME:        !torch.vtensor<[1,3,1],si64> to !torch.vtensor
-// CHECK:           return %[[CAST]] : !torch.vtensor
-
-builtin.func @aten.sum.dim_IntList$keepdim(%t: !torch.vtensor<[2,3,?],si64>) -> !torch.vtensor {
-  %true = torch.constant.bool true
-  %none = torch.constant.none
-  %int0 = torch.constant.int 0
-  %int-1 = torch.constant.int -1
-  %dimList = torch.prim.ListConstruct %int0, %int-1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %ret = torch.aten.sum.dim_IntList %t, %dimList, %true, %none : !torch.vtensor<[2,3,?],si64>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.vtensor
-  return %ret : !torch.vtensor
-}
-
-// -----
-// CHECK-LABEL:   func @aten.sum.dim_IntList$unknown_position(
-// CHECK-SAME:                                       %[[T:.*]]: !torch.vtensor<[2,3,?],si64>,
-// CHECK-SAME:                                       %[[DIM:.*]]: !torch.int) -> !torch.vtensor {
-// CHECK:           %[[KEEPDIM:.*]] = torch.constant.bool false
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[DIMLIST:.*]] = torch.prim.ListConstruct %[[DIM]], %[[INT_NEG1]] : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-// CHECK:           %[[RET:.*]] = torch.aten.sum.dim_IntList %[[T]], %[[DIMLIST]], %[[KEEPDIM]], %[[NONE]] : !torch.vtensor<[2,3,?],si64>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.vtensor<[?],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.vtensor<[?],si64> to !torch.vtensor
-// CHECK:           return %[[CAST]] : !torch.vtensor
-
-builtin.func @aten.sum.dim_IntList$unknown_position(%t: !torch.vtensor<[2,3,?],si64>, %dim0: !torch.int) -> !torch.vtensor {
-  %false = torch.constant.bool false
-  %none = torch.constant.none
-  %int-1 = torch.constant.int -1
-  %dimList = torch.prim.ListConstruct %dim0, %int-1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-  %ret = torch.aten.sum.dim_IntList %t, %dimList, %false, %none : !torch.vtensor<[2,3,?],si64>, !torch.list<!torch.int>, !torch.bool, !torch.none -> !torch.vtensor
-  return %ret : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @aten.any.dim(
-// CHECK-SAME:                               %[[T:.*]]: !torch.vtensor<[2,3,?],i1>) -> !torch.vtensor {
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[RET:.*]] = torch.aten.any.dim %[[T]], %[[INT_NEG1]], %[[FALSE]] : !torch.vtensor<[2,3,?],i1>, !torch.int, !torch.bool -> !torch.vtensor<[2,3],i1>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.vtensor<[2,3],i1> to !torch.vtensor
-// CHECK:           return %[[CAST]] : !torch.vtensor
-
-builtin.func @aten.any.dim(%t: !torch.vtensor<[2,3,?],i1>) -> !torch.vtensor {
-  %false = torch.constant.bool false
-  %int-1 = torch.constant.int -1
-  %ret = torch.aten.any.dim %t, %int-1, %false : !torch.vtensor<[2,3,?],i1>, !torch.int, !torch.bool -> !torch.vtensor
-  return %ret : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @aten.any.dim$keepdim(
-// CHECK-SAME:                               %[[T:.*]]: !torch.vtensor<[2,3,?],i1>) -> !torch.vtensor {
-// CHECK:           %[[TRUE:.*]] = torch.constant.bool true
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[RET:.*]] = torch.aten.any.dim %[[T]], %[[INT_NEG1]], %[[TRUE]] : !torch.vtensor<[2,3,?],i1>, !torch.int, !torch.bool -> !torch.vtensor<[2,3,1],i1>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.vtensor<[2,3,1],i1> to !torch.vtensor
-// CHECK:           return %[[CAST]] : !torch.vtensor
-
-builtin.func @aten.any.dim$keepdim(%t: !torch.vtensor<[2,3,?],i1>) -> !torch.vtensor {
-  %true = torch.constant.bool true
-  %int-1 = torch.constant.int -1
-  %ret = torch.aten.any.dim %t, %int-1, %true : !torch.vtensor<[2,3,?],i1>, !torch.int, !torch.bool -> !torch.vtensor
-  return %ret : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @aten.any.dim$unknown_position(
-// CHECK-SAME:                               %[[T:.*]]: !torch.vtensor<[2,3,?],i1>,
-// CHECK-SAME:                               %[[DIM:.*]]: !torch.int) -> !torch.vtensor {
-// CHECK:           %[[TRUE:.*]] = torch.constant.bool true
-// CHECK:           %[[RET:.*]] = torch.aten.any.dim %[[T]], %[[DIM]], %[[TRUE]] : !torch.vtensor<[2,3,?],i1>, !torch.int, !torch.bool -> !torch.vtensor<[?,?,?],i1>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.vtensor<[?,?,?],i1> to !torch.vtensor
-// CHECK:           return %[[CAST]] : !torch.vtensor
-
-builtin.func @aten.any.dim$unknown_position(%t: !torch.vtensor<[2,3,?],i1>, %dim: !torch.int) -> !torch.vtensor {
-  %true = torch.constant.bool true
-  %ret = torch.aten.any.dim %t, %dim, %true : !torch.vtensor<[2,3,?],i1>, !torch.int, !torch.bool -> !torch.vtensor
-  return %ret : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @aten.any(
-// CHECK-SAME:                           %[[T:.*]]: !torch.vtensor<[2,3,?],i1>) -> !torch.vtensor {
-// CHECK:           %[[RET:.*]] = torch.aten.any %[[T]] : !torch.vtensor<[2,3,?],i1> -> !torch.vtensor<[1],i1>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.vtensor<[1],i1> to !torch.vtensor
-// CHECK:           return %[[CAST]] : !torch.vtensor
-
-builtin.func @aten.any(%t: !torch.vtensor<[2,3,?],i1>) -> !torch.vtensor {
-  %ret = torch.aten.any %t: !torch.vtensor<[2,3,?],i1> -> !torch.vtensor
-  return %ret : !torch.vtensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @aten.transpose.int(
-// CHECK-SAME:                                     %[[T:.*]]: !torch.tensor<[2,3,4,5],si64>) -> !torch.tensor {
-// CHECK:           %[[INT1:.*]] = torch.constant.int 1
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[RET:.*]] = torch.aten.transpose.int %[[T]], %[[INT1]], %[[INT_NEG1]] : !torch.tensor<[2,3,4,5],si64>, !torch.int, !torch.int -> !torch.tensor<[2,5,4,3],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,5,4,3],si64> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @aten.transpose.int(%t: !torch.tensor<[2,3,4,5],si64>) -> !torch.tensor {
-    %int1 = torch.constant.int 1
-    %int-1 = torch.constant.int -1
-    %ret = torch.aten.transpose.int %t, %int1, %int-1 : !torch.tensor<[2,3,4,5],si64>, !torch.int, !torch.int -> !torch.tensor
-    return %ret: !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @aten.transpose.int$unknown_position(
-// CHECK-SAME:                                     %[[T:.*]]: !torch.tensor<[2,3,4,5],si64>,
-// CHECK-SAME:                                     %[[DIM0:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[RET:.*]] = torch.aten.transpose.int %[[T]], %[[DIM0]], %[[INT_NEG1]] : !torch.tensor<[2,3,4,5],si64>, !torch.int, !torch.int -> !torch.tensor<[?,?,?,?],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[?,?,?,?],si64> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @aten.transpose.int$unknown_position(%t: !torch.tensor<[2,3,4,5],si64>, %dim0: !torch.int) -> !torch.tensor {
-    %int-1 = torch.constant.int -1
-    %ret = torch.aten.transpose.int %t, %dim0, %int-1 : !torch.tensor<[2,3,4,5],si64>, !torch.int, !torch.int -> !torch.tensor
-    return %ret: !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @aten.view(
-// CHECK-SAME:                            %[[T:.*]]: !torch.tensor<[2,3,4,5],si64>) -> !torch.tensor {
-// CHECK:           %[[INT2:.*]] = torch.constant.int 2
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[SIZES:.*]] = torch.prim.ListConstruct %[[INT2]], %[[INT_NEG1]]
-// CHECK-SAME:        : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-// CHECK:           %[[RET:.*]] = torch.aten.view %[[T]], %[[SIZES]] :
-// CHECK-SAME:        !torch.tensor<[2,3,4,5],si64>, !torch.list<!torch.int> -> !torch.tensor<[2,?],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,?],si64> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @aten.view(%t: !torch.tensor<[2,3,4,5],si64>) -> !torch.tensor {
-    %int2 = torch.constant.int 2
-    %int-1 = torch.constant.int -1
-    %sizes = torch.prim.ListConstruct %int2, %int-1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-    %ret = torch.aten.view %t, %sizes: !torch.tensor<[2,3,4,5],si64>, !torch.list<!torch.int> -> !torch.tensor
-    return %ret: !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @prim.if$refined_type_conflicting(
-// CHECK-SAME:                                                   %[[NONE:.*]]: !torch.none) -> !torch.tensor {
-// CHECK:           %[[OPTIONAL:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<!torch.tensor>
-// CHECK:           %[[NOT_NONE:.*]] = torch.aten.__isnot__ %[[NONE]], %[[NONE]] : !torch.none, !torch.none -> !torch.bool
-// CHECK:           %[[PRED:.*]] = torch.prim.If %[[NOT_NONE]] -> (!torch.tensor) {
-// CHECK:             %[[T:.*]] = torch.prim.unchecked_cast %[[OPTIONAL]] : !torch.optional<!torch.tensor> -> !torch.tensor
-// CHECK:             torch.prim.If.yield %[[T]] : !torch.tensor
-// CHECK:           } else {
-// CHECK:             %[[LITERAL:.*]] = torch.tensor.literal(dense<0.000000e+00> : tensor<3x5xf32>) : !torch.tensor
-// CHECK:             torch.prim.If.yield %[[LITERAL]] : !torch.tensor
-// CHECK:           }
-// CHECK:           return %[[PRED:.*]] : !torch.tensor
-
-builtin.func @prim.if$refined_type_conflicting(%none: !torch.none) -> !torch.tensor {
-  %optional = torch.derefine %none: !torch.none to !torch.optional<!torch.tensor>
-  %pred = torch.aten.__isnot__ %optional, %none : !torch.optional<!torch.tensor>, !torch.none -> !torch.bool
-  %res = torch.prim.If %pred -> (!torch.tensor) {
-    %t = torch.prim.unchecked_cast %optional: !torch.optional<!torch.tensor> -> !torch.tensor
-    torch.prim.If.yield %t: !torch.tensor
-  } else {
-    %t_cst = torch.tensor.literal(dense<0.0> : tensor<3x5xf32>) : !torch.tensor
-    torch.prim.If.yield %t_cst: !torch.tensor
-  }
-  return %res: !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.tensor.float(
-// CHECK-SAME:                                          %[[t:.*]]: !torch.float) -> !torch.tensor {
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[RET:.*]] = torch.aten.tensor.float %[[t]], %[[NONE]], %[[NONE]], %[[FALSE]] : !torch.float, !torch.none, !torch.none, !torch.bool -> !torch.tensor<[],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.tensor.float(%t: !torch.float) -> !torch.tensor {
-  %none = torch.constant.none
-  %false = torch.constant.bool false
-  %ret = "torch.aten.tensor.float"(%t, %none, %none, %false) : (!torch.float, !torch.none, !torch.none, !torch.bool) -> !torch.tensor
-  return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.tensor.float$specified_dtype(
-// CHECK-SAME:                                          %[[t:.*]]: !torch.float) -> !torch.tensor {
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[CST11:.*]] = torch.constant.int 11
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[RET:.*]] = torch.aten.tensor.float %[[t]], %[[CST11]], %[[NONE]], %[[FALSE]] : !torch.float, !torch.int, !torch.none, !torch.bool -> !torch.tensor<[],i1>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[],i1> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.tensor.float$specified_dtype(%t: !torch.float) -> !torch.tensor {
-  %none = torch.constant.none
-  %int11 = torch.constant.int 11
-  %false = torch.constant.bool false
-  %ret = "torch.aten.tensor.float"(%t, %int11, %none, %false) : (!torch.float, !torch.int, !torch.none, !torch.bool) -> !torch.tensor
-  return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.tensor(
-// CHECK-SAME:        %[[DATA:.*]]: !torch.list<!torch.list<!torch.float>>) -> !torch.tensor {
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[RET:.*]] = torch.aten.tensor %[[DATA]], %[[NONE]], %[[NONE]], %[[FALSE]]
-// CHECK-SAME:        : !torch.list<!torch.list<!torch.float>>, !torch.none, !torch.none, !torch.bool
-// CHECK-SAME:        -> !torch.tensor<[?,?],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[?,?],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.tensor(%t: !torch.list<!torch.list<!torch.float>>) -> !torch.tensor {
-    %none = torch.constant.none
-    %false = torch.constant.bool false
-    %ret = torch.aten.tensor %t, %none, %none, %false : !torch.list<!torch.list<!torch.float>>, !torch.none, !torch.none, !torch.bool -> !torch.tensor
-    return %ret : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten.tensor$empty_list() -> !torch.tensor {
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[DATA:.*]] = torch.prim.ListConstruct  : () -> !torch.list<!torch.float>
-// CHECK:           %[[RET:.*]] = torch.aten.tensor %[[DATA]], %[[NONE]], %[[NONE]], %[[FALSE]] : !torch.list<!torch.float>, !torch.none, !torch.none, !torch.bool -> !torch.tensor<[?],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[?],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.tensor$empty_list() -> !torch.tensor {
-    %none = torch.constant.none
-    %false = torch.constant.bool false
-    %data = torch.prim.ListConstruct : () -> !torch.list<!torch.float>
-    %ret = torch.aten.tensor %data, %none, %none, %false : !torch.list<!torch.float>, !torch.none, !torch.none, !torch.bool -> !torch.tensor
-    return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.tensor$specified_dtype(
-// CHECK-SAME:        %[[DATA:.*]]: !torch.list<!torch.list<!torch.float>>) -> !torch.tensor {
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[INT4:.*]] = torch.constant.int 4
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[RET:.*]] = torch.aten.tensor %[[DATA]], %[[INT4]], %[[NONE]], %[[FALSE]] : !torch.list<!torch.list<!torch.float>>, !torch.int, !torch.none, !torch.bool -> !torch.tensor<[?,?],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[?,?],si64> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.tensor$specified_dtype(%t: !torch.list<!torch.list<!torch.float>>) -> !torch.tensor {
-    %none = torch.constant.none
-    %int4 = torch.constant.int 4
-    %false = torch.constant.bool false
-    %ret = torch.aten.tensor %t, %int4, %none, %false : !torch.list<!torch.list<!torch.float>>, !torch.int, !torch.none, !torch.bool -> !torch.tensor
-    return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.zeros(
-// CHECK-SAME:        %[[DIM0:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[INT2:.*]] = torch.constant.int 2
-// CHECK:           %[[SIZES:.*]] = torch.prim.ListConstruct %[[DIM0]], %[[INT2]] : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-// CHECK:           %[[ZEROS:.*]] = torch.aten.zeros %[[SIZES]], %[[NONE]], %[[NONE]], %[[NONE]], %[[NONE]] : !torch.list<!torch.int>, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.tensor<[?,2],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[ZEROS]] : !torch.tensor<[?,2],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.zeros(%dim0: !torch.int) -> !torch.tensor {
-    %none = torch.constant.none
-    %int2 = torch.constant.int 2
-    %sizesList = torch.prim.ListConstruct %dim0, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
-    %ret = torch.aten.zeros %sizesList, %none, %none, %none, %none : !torch.list<!torch.int>, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.tensor
-    return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.index_select(
-// CHECK-SAME:                                          %[[INPUT:.*]]: !torch.tensor<[2,3,4],f32>,
-// CHECK-SAME:                                          %[[INDEXES:.*]]: !torch.tensor<[2],si64>) -> !torch.tensor {
-// CHECK:           %[[DIM:.*]] = torch.constant.int 1
-// CHECK:           %[[RET:.*]] = torch.aten.index_select %[[INPUT]], %[[DIM]], %[[INDEXES]] : !torch.tensor<[2,3,4],f32>, !torch.int, !torch.tensor<[2],si64> -> !torch.tensor<[2,2,4],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,2,4],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.index_select(%input: !torch.tensor<[2,3,4], f32>, %index: !torch.tensor<[2], si64>) -> !torch.tensor {
-      %dim = torch.constant.int 1
-      %ret = torch.aten.index_select %input, %dim, %index : !torch.tensor<[2,3,4], f32>, !torch.int, !torch.tensor<[2], si64> -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.index_select$unknown_indexes(
-// CHECK-SAME:                                                      %[[INPUT:.*]]: !torch.tensor<[2,3,4],f32>,
-// CHECK-SAME:                                                      %[[INDEXES:.*]]: !torch.tensor<[?],si64>) -> !torch.tensor {
-// CHECK:           %[[DIM:.*]] = torch.constant.int 1
-// CHECK:           %[[RET:.*]] = torch.aten.index_select %[[INPUT]], %[[DIM]], %[[INDEXES]] : !torch.tensor<[2,3,4],f32>, !torch.int, !torch.tensor<[?],si64> -> !torch.tensor<[2,?,4],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,?,4],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.index_select$unknown_indexes(%input: !torch.tensor<[2,3,4], f32>, %index: !torch.tensor<[?], si64>) -> !torch.tensor {
-      %dim = torch.constant.int 1
-      %ret = torch.aten.index_select %input, %dim, %index : !torch.tensor<[2,3,4], f32>, !torch.int, !torch.tensor<[?], si64> -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.index_select$unknown_dim(
-// CHECK-SAME:                                                          %[[INPUT:.*]]: !torch.tensor<[2,3,4],f32>,
-// CHECK-SAME:                                                          %[[DIM:.*]]: !torch.int,
-// CHECK-SAME:                                                          %[[INDEXES:.*]]: !torch.tensor<[?],si64>) -> !torch.tensor {
-// CHECK:           %[[RET:.*]] = torch.aten.index_select %[[INPUT]], %[[DIM]], %[[INDEXES]] : !torch.tensor<[2,3,4],f32>, !torch.int, !torch.tensor<[?],si64> -> !torch.tensor<[?,?,?],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[?,?,?],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.index_select$unknown_dim(%input: !torch.tensor<[2,3,4], f32>, %dim: !torch.int, %index: !torch.tensor<[?], si64>) -> !torch.tensor {
-      %ret = torch.aten.index_select %input, %dim, %index : !torch.tensor<[2,3,4], f32>, !torch.int, !torch.tensor<[?], si64> -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.select.int(
-// CHECK-SAME:                                        %[[INPUT:.*]]: !torch.tensor<[2,3,4],f32>,
-// CHECK-SAME:                                        %[[INDEX:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[DIM:.*]] = torch.constant.int 1
-// CHECK:           %[[RET:.*]] = torch.aten.select.int %[[INPUT]], %[[DIM]], %[[INDEX]] : !torch.tensor<[2,3,4],f32>, !torch.int, !torch.int -> !torch.tensor<[2,4],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,4],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.select.int(%input: !torch.tensor<[2,3,4], f32>, %index: !torch.int) -> !torch.tensor {
-      %dim = torch.constant.int 1
-      %ret = torch.aten.select.int %input, %dim, %index : !torch.tensor<[2,3,4], f32>, !torch.int, !torch.int -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten.type_as(
-// CHECK-SAME:                                     %[[INPUT:.*]]: !torch.tensor<[?],si64>,
-// CHECK-SAME:                                     %[[OTHER:.*]]: !torch.tensor<[?,2],f32>) -> !torch.tensor {
-// CHECK:           %[[RET:.*]] = torch.aten.type_as %[[INPUT]], %[[OTHER]] : !torch.tensor<[?],si64>, !torch.tensor<[?,2],f32> -> !torch.tensor<[?],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[?],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.type_as(%self: !torch.tensor<[?], si64>, %other: !torch.tensor<[?,2],f32>) -> !torch.tensor {
-      %ret = torch.aten.type_as %self, %other : !torch.tensor<[?], si64>, !torch.tensor<[?,2],f32> -> !torch.tensor
-      return %ret: !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.gather(
-// CHECK-SAME:                                        %[[INPUT:.*]]: !torch.tensor<[2,3,4],f32>,
-// CHECK-SAME:                                        %[[DIM:.*]]: !torch.int,
-// CHECK-SAME:                                        %[[INDEXES:.*]]: !torch.tensor<[1,2,3],si64>) -> !torch.tensor {
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[RET:.*]] = torch.aten.gather %[[INPUT]], %[[DIM]], %[[INDEXES]], %[[FALSE]] : !torch.tensor<[2,3,4],f32>, !torch.int, !torch.tensor<[1,2,3],si64>, !torch.bool -> !torch.tensor<[1,2,3],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[1,2,3],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.gather(%input: !torch.tensor<[2,3,4], f32>, %dim: !torch.int, %index: !torch.tensor<[1,2,3], si64>) -> !torch.tensor {
-      %false = torch.constant.bool false
-      %ret = torch.aten.gather %input, %dim, %index, %false : !torch.tensor<[2,3,4], f32>, !torch.int, !torch.tensor<[1,2,3], si64>, !torch.bool -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten.expand(
-// CHECK-SAME:                                    %[[INPUT:.*]]: !torch.tensor<[2,1,4],f32>) -> !torch.tensor {
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[INT5:.*]] = torch.constant.int 5
-// CHECK:           %[[INT4:.*]] = torch.constant.int 4
-// CHECK:           %[[SIZES:.*]] = torch.prim.ListConstruct %[[INT_NEG1]], %[[INT5]], %[[INT4]] : (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
-// CHECK:           %[[RET:.*]] = torch.aten.expand %[[INPUT]], %[[SIZES]], %[[FALSE]] : !torch.tensor<[2,1,4],f32>, !torch.list<!torch.int>, !torch.bool -> !torch.tensor<[2,5,4],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,5,4],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.expand(%input: !torch.tensor<[2,1,4], f32>) -> !torch.tensor {
-      %false = torch.constant.bool false
-      %int-1 = torch.constant.int -1
-      %int5 = torch.constant.int 5
-      %int4 = torch.constant.int 4
-      %size = torch.prim.ListConstruct %int-1, %int5, %int4: (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
-      %ret = torch.aten.expand %input, %size, %false : !torch.tensor<[2,1,4], f32>, !torch.list<!torch.int>, !torch.bool -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.expand$higher_rank(
-// CHECK-SAME:                                        %[[INPUT:.*]]: !torch.tensor<[2,1,4],f32>) -> !torch.tensor {
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[INT5:.*]] = torch.constant.int 5
-// CHECK:           %[[INT4:.*]] = torch.constant.int 4
-// CHECK:           %[[SIZE_LIST:.*]] = torch.prim.ListConstruct %[[INT4]], %[[INT5]], %[[INT_NEG1]], %[[INT5]], %[[INT4]] :
-// CHECK-SAME:          (!torch.int, !torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
-// CHECK:           %[[EXPAND:.*]] = torch.aten.expand %[[INPUT]], %[[SIZE_LIST]], %[[FALSE]] :
-// CHECK-SAME:          !torch.tensor<[2,1,4],f32>, !torch.list<!torch.int>, !torch.bool -> !torch.tensor<[4,5,2,5,4],f32>
-// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[EXPAND]] : !torch.tensor<[4,5,2,5,4],f32> to !torch.tensor
-// CHECK:           return %[[RET]] : !torch.tensor
-builtin.func @torch.aten.expand$higher_rank(%input: !torch.tensor<[2,1,4], f32>) -> !torch.tensor {
-      %false = torch.constant.bool false
-      %int-1 = torch.constant.int -1
-      %int5 = torch.constant.int 5
-      %int4 = torch.constant.int 4
-      %size = torch.prim.ListConstruct %int4, %int5, %int-1, %int5, %int4: (!torch.int, !torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
-      %ret = torch.aten.expand %input, %size, %false : !torch.tensor<[2,1,4], f32>, !torch.list<!torch.int>, !torch.bool -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-
-// -----
-// CHECK-LABEL:   func @torch.aten.expand$unknown_sizes(
-// CHECK-SAME:                                                  %[[INPUT:.*]]: !torch.tensor<[2,1,4],f32>,
-// CHECK-SAME:                                                  %[[SIZEX:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[INT_NEG1:.*]] = torch.constant.int -1
-// CHECK:           %[[INT4:.*]] = torch.constant.int 4
-// CHECK:           %[[SIZES:.*]] = torch.prim.ListConstruct %[[INT_NEG1]], %[[SIZEX]], %[[INT4]] : (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
-// CHECK:           %[[RET:.*]] = torch.aten.expand %[[INPUT]], %[[SIZES]], %[[FALSE]] : !torch.tensor<[2,1,4],f32>, !torch.list<!torch.int>, !torch.bool -> !torch.tensor<[2,?,4],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,?,4],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-builtin.func @torch.aten.expand$unknown_sizes(%input: !torch.tensor<[2,1,4], f32>, %index: !torch.int) -> !torch.tensor {
-      %false = torch.constant.bool false
-      %int-1 = torch.constant.int -1
-      %int4 = torch.constant.int 4
-      %size = torch.prim.ListConstruct %int-1, %index, %int4: (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
-      %ret = torch.aten.expand %input, %size, %false : !torch.tensor<[2,1,4], f32>, !torch.list<!torch.int>, !torch.bool -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten.repeat(
-// CHECK-SAME:                                    %[[INPUT:.*]]: !torch.tensor<[2,1,4],f32>,
-// CHECK-SAME:                                    %[[REPEATX:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[INT1:.*]] = torch.constant.int 1
-// CHECK:           %[[INT4:.*]] = torch.constant.int 4
-// CHECK:           %[[REPEATS:.*]] = torch.prim.ListConstruct %[[INT1]], %[[REPEATX]], %[[INT4]] : (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
-// CHECK:           %[[RET:.*]] = torch.aten.repeat %[[INPUT]], %[[REPEATS]] : !torch.tensor<[2,1,4],f32>, !torch.list<!torch.int> -> !torch.tensor<[2,?,16],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,?,16],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.repeat(%input: !torch.tensor<[2,1,4], f32>, %repeat: !torch.int) -> !torch.tensor {
-      %int1 = torch.constant.int 1
-      %int4 = torch.constant.int 4
-      %repeats = torch.prim.ListConstruct %int1, %repeat, %int4: (!torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
-      %ret = torch.aten.repeat %input, %repeats: !torch.tensor<[2,1,4], f32>, !torch.list<!torch.int> -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-
-// CHECK-LABEL:   func @torch.aten.cat(
-// CHECK-SAME:                                 %[[T1:.*]]: !torch.tensor<[?,1,4],f32>,
-// CHECK-SAME:                                 %[[T2:.*]]: !torch.tensor<[2,3,4],f32>) -> !torch.tensor {
-// CHECK:           %[[INT1:.*]] = torch.constant.int 1
-// CHECK:           %[[TENSORS:.*]] = torch.prim.ListConstruct %[[T1]], %[[T2]] : (!torch.tensor<[?,1,4],f32>, !torch.tensor<[2,3,4],f32>) -> !torch.list<!torch.tensor>
-// CHECK:           %[[RET:.*]] = torch.aten.cat %[[TENSORS]], %[[INT1]] : !torch.list<!torch.tensor>, !torch.int -> !torch.tensor<[2,?,4],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,?,4],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.cat(%t0: !torch.tensor<[?,1,4], f32>, %t1: !torch.tensor<[2,3,4], f32>) -> !torch.tensor {
-      %int1 = torch.constant.int 1
-      %tensorList = torch.prim.ListConstruct %t0, %t1: (!torch.tensor<[?,1,4], f32>, !torch.tensor<[2,3,4], f32>) -> !torch.list<!torch.tensor>
-      %ret = torch.aten.cat %tensorList, %int1 : !torch.list<!torch.tensor>, !torch.int -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten.cat$unknown_dim(
-// CHECK-SAME:                                 %[[T1:.*]]: !torch.tensor<[?,1,4],f32>,
-// CHECK-SAME:                                 %[[T2:.*]]: !torch.tensor<[2,3,4],f32>,
-// CHECK-SAME:                                 %[[DIM:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[TENSORS:.*]] = torch.prim.ListConstruct %[[T1]], %[[T2]] : (!torch.tensor<[?,1,4],f32>, !torch.tensor<[2,3,4],f32>) -> !torch.list<!torch.tensor>
-// CHECK:           %[[RET:.*]] = torch.aten.cat %[[TENSORS]], %[[DIM]] : !torch.list<!torch.tensor>, !torch.int -> !torch.tensor<[?,?,?],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[?,?,?],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-
-builtin.func @torch.aten.cat$unknown_dim(%t0: !torch.tensor<[?,1,4], f32>, %t1: !torch.tensor<[2,3,4], f32>, %dim: !torch.int) -> !torch.tensor {
-      %tensorList = torch.prim.ListConstruct %t0, %t1: (!torch.tensor<[?,1,4], f32>, !torch.tensor<[2,3,4], f32>) -> !torch.list<!torch.tensor>
-      %ret = torch.aten.cat %tensorList, %dim: !torch.list<!torch.tensor>, !torch.int -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten._shape_as_tensor(
-// CHECK-SAME:                                 %[[INPUT:.*]]: !torch.tensor<[?,1,4],f32>) -> !torch.tensor {
-// CHECK:           %[[RET:.*]] = torch.aten._shape_as_tensor %[[INPUT]] : !torch.tensor<[?,1,4],f32> -> !torch.tensor<[3],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[3],si64> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-builtin.func @torch.aten._shape_as_tensor(%input: !torch.tensor<[?,1,4], f32>) -> !torch.tensor {
-      %ret= torch.aten._shape_as_tensor %input : !torch.tensor<[?,1,4], f32> -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten._shape_as_tensor$unknown_input_shape(
-// CHECK-SAME:                                 %[[INPUT:.*]]: !torch.tensor) -> !torch.tensor {
-// CHECK:           %[[RET:.*]] = torch.aten._shape_as_tensor %[[INPUT]] : !torch.tensor -> !torch.tensor<[?],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[?],si64> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-builtin.func @torch.aten._shape_as_tensor$unknown_input_shape(%input: !torch.tensor) -> !torch.tensor {
-      %ret= torch.aten._shape_as_tensor %input : !torch.tensor -> !torch.tensor
-      return %ret : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten.embedding(
-// CHECK-SAME:                                       %[[INPUT:.*]]: !torch.tensor<[104,512],f32>,
-// CHECK-SAME:                                       %[[INDEXES:.*]]: !torch.tensor<[2,3],si64>) -> !torch.tensor {
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[PADDING_IDX:.*]] = torch.constant.int 1
-// CHECK:           %[[RET:.*]] = torch.aten.embedding %[[INPUT]], %[[INDEXES]], %[[PADDING_IDX]], %[[FALSE]], %[[FALSE]] : !torch.tensor<[104,512],f32>, !torch.tensor<[2,3],si64>, !torch.int, !torch.bool, !torch.bool -> !torch.tensor<[2,3,512],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<[2,3,512],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-builtin.func @torch.aten.embedding(%weight: !torch.tensor<[104,512],f32>, %indices: !torch.tensor<[2,3], si64>) -> !torch.tensor {
-       %false = torch.constant.bool false
-       %int1 = torch.constant.int 1
-       %ret = torch.aten.embedding %weight, %indices, %int1, %false, %false : !torch.tensor<[104,512],f32>, !torch.tensor<[2,3], si64>, !torch.int, !torch.bool, !torch.bool -> !torch.tensor
-       return %ret: !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten.softmax.int(
-// CHECK-SAME:                                 %[[T:.*]]: !torch.tensor<[2,3],f32>,
-// CHECK-SAME:                                 %[[DIM:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[DTYPE:.*]] = torch.constant.none
-// CHECK:           %[[SOFTMAX:.*]] = torch.aten.softmax.int %[[T]], %[[DIM]], %[[DTYPE]] : !torch.tensor<[2,3],f32>, !torch.int, !torch.none -> !torch.tensor<[2,3],f32>
-// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<[2,3],f32> to !torch.tensor
-// CHECK:           return %[[RET]] : !torch.tensor
-func @torch.aten.softmax.int(%t: !torch.tensor<[2,3],f32>, %dim: !torch.int) -> !torch.tensor {
-  %none = torch.constant.none
-  %ret = torch.aten.softmax.int %t, %dim, %none : !torch.tensor<[2,3],f32>, !torch.int, !torch.none -> !torch.tensor
-  return %ret : !torch.tensor
-}
-
-
-// -----
-// CHECK-LABEL:   func @torch.aten.softmax.int$specified_dtype(
-// CHECK-SAME:                                                 %[[T:.*]]: !torch.tensor<[2,3],f32>,
-// CHECK-SAME:                                                 %[[DIM:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[DTYPE:.*]] = torch.constant.int 4
-// CHECK:           %[[SOFTMAX:.*]] = torch.aten.softmax.int %[[T]], %[[DIM]], %[[DTYPE]] : !torch.tensor<[2,3],f32>, !torch.int, !torch.int -> !torch.tensor<[2,3],si64>
-// CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[SOFTMAX]] : !torch.tensor<[2,3],si64> to !torch.tensor
-// CHECK:           return %[[RET]] : !torch.tensor
-func @torch.aten.softmax.int$specified_dtype(%t: !torch.tensor<[2,3],f32>, %dim: !torch.int) -> !torch.tensor {
-  %int4 = torch.constant.int 4
-  %ret = torch.aten.softmax.int %t, %dim, %int4: !torch.tensor<[2,3],f32>, !torch.int, !torch.int -> !torch.tensor
-  return %ret : !torch.tensor
-}
-
-
-// -----
-// CHECK-LABEL:  func @torch.aten.Matmul.Broadcast.Matrix(
-// CHECK-SAME:                                            %[[LHS:.*]]: !torch.vtensor<[?,?,?,?,?],f32>,
-// CHECK-SAME:                                            %[[RHS:.*]]: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {
-// CHECK:           %[[MUL:.*]] = torch.aten.matmul %[[LHS]], %[[RHS]] : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor<[?,?,?,?,?],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[MUL]] : !torch.tensor<[?,?,?,?,?],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-func @torch.aten.Matmul.Broadcast.Matrix(%arg0: !torch.vtensor<[?,?,?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {
-  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-
-// -----
-// CHECK-LABEL:  func @torch.aten.Matmul.Broadcast.Vector(
-// CHECK-SAME:                                            %[[LHS:.*]]: !torch.vtensor<[?,?,?,?,?],f32>,
-// CHECK-SAME:                                            %[[RHS:.*]]: !torch.vtensor<[?],f32>) -> !torch.tensor {
-// CHECK:           %[[MUL:.*]] = torch.aten.matmul %[[LHS]], %[[RHS]] : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?],f32> -> !torch.tensor<[?,?,?,?],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[MUL]] : !torch.tensor<[?,?,?,?],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-func @torch.aten.Matmul.Broadcast.Vector(%arg0: !torch.vtensor<[?,?,?,?,?],f32>, %arg1: !torch.vtensor<[?],f32>) -> !torch.tensor {
-  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?],f32> -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL: func @torch.aten.to.dtype(
-// CHECK-SAME:                            %[[ARG:.*]]: !torch.tensor<[?,?],f32>) -> !torch.tensor
-// CHECK:           %[[TODTYPE:.*]] = torch.aten.to.dtype
-// CHECK-SAME:          %[[ARG]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} :
-// CHECK-SAME:          !torch.tensor<[?,?],f32>, !torch.int, !torch.bool, !torch.bool, !torch.none
-// CHECK-SAME:          -> !torch.tensor<[?,?],si64>
-// CHECK-NEXT:      %[[RES:.*]] = torch.tensor_static_info_cast %[[TODTYPE]] : !torch.tensor<[?,?],si64> to !torch.tensor
-// CHECK-NEXT:      return %[[RES]] : !torch.tensor
-func @torch.aten.to.dtype(%arg0: !torch.tensor<[?,?],f32>) -> !torch.tensor{
-    %none = torch.constant.none
-    %false = torch.constant.bool false
-    %int4 = torch.constant.int 4
-    %0 = torch.aten.to.dtype %arg0, %int4, %false, %false, %none : !torch.tensor<[?,?],f32>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.tensor
-    return %0 : !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:  func @torch.prim.NumToTensor.Scalar(
-// CHECK-SAME:                                       %[[SELF:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[NTT:.*]] = torch.prim.NumToTensor.Scalar %[[SELF]] : !torch.int -> !torch.tensor<[],si64>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[NTT]] : !torch.tensor<[],si64> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-func @torch.prim.NumToTensor.Scalar(%arg0: !torch.int) -> !torch.tensor {
-  %0 = torch.prim.NumToTensor.Scalar %arg0: !torch.int -> !torch.tensor
-  return %0: !torch.tensor
-}
-
-// -----
-// CHECK-LABEL:   func @torch.aten.BinaryBroadcasting(
-// CHECK-SAME:                                        %[[T0:.*]]: !torch.vtensor<[5,4,3,3,1],f32>,
-// CHECK-SAME:                                        %[[T1:.*]]: !torch.vtensor<[?,3,1,2],f32>,
-// CHECK-SAME:                                        %[[SCALAR:.*]]: !torch.int) -> !torch.tensor {
-// CHECK:           %[[ADD:.*]] = torch.aten.add.Tensor %[[T0]], %[[T1]], %[[SCALAR]] : !torch.vtensor<[5,4,3,3,1],f32>, !torch.vtensor<[?,3,1,2],f32>, !torch.int -> !torch.tensor<[5,?,3,3,2],f32>
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[ADD]] : !torch.tensor<[5,?,3,3,2],f32> to !torch.tensor
-// CHECK:           return %[[CAST]] : !torch.tensor
-func @torch.aten.BinaryBroadcasting(%arg0: !torch.vtensor<[5,4,3,3,1],f32>, %arg1: !torch.vtensor<[?,3,1,2],f32>, %arg2: !torch.int) -> !torch.tensor {
-  %0 = torch.aten.add.Tensor %arg0, %arg1, %arg2: !torch.vtensor<[5,4,3,3,1],f32>, !torch.vtensor<[?,3,1,2],f32>, !torch.int -> !torch.tensor
-  return %0 : !torch.tensor
-}
-
-// -----
 // CHECK-LABEL:   func @torch.overwrite.tensor.contents$dynamic_overwrites_static(
 // CHECK-SAME:                                                           %[[STATIC:.*]]: !torch.vtensor<[2],f32>,
 // CHECK-SAME:                                                           %[[DYNAMIC:.*]]: !torch.vtensor<[?],f32>) -> !torch.vtensor<[2],f32> {
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[DYNAMIC_COPY:.*]] : !torch.vtensor<[?],f32> to !torch.vtensor<[2],f32>
-// CHECK:           torch.overwrite.tensor.contents %[[CAST]] overwrites %[[STATIC_COPY:.*]] : !torch.vtensor<[2],f32>, !torch.tensor<[2],f32>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[DYNAMIC_COPY:.*]] : !torch.vtensor<[?],f32> to !torch.vtensor<*,f32>
+// CHECK:           %[[CAST2:.*]] = torch.tensor_static_info_cast %[[CAST:.*]] : !torch.vtensor<*,f32> to !torch.vtensor<*,f32>
+// CHECK:           torch.overwrite.tensor.contents %[[CAST2]] overwrites %[[STATIC_COPY:.*]] : !torch.vtensor<*,f32>, !torch.tensor<*,f32>
 func @torch.overwrite.tensor.contents$dynamic_overwrites_static(%static: !torch.vtensor<[2],f32>, %dynamic: !torch.vtensor<[?],f32>) -> !torch.vtensor<[2],f32> {
   %static_no_type = torch.tensor_static_info_cast %static : !torch.vtensor<[2],f32> to !torch.vtensor
   %static_copy = torch.copy.to_tensor %static_no_type : !torch.tensor
@@ -1202,12 +134,13 @@ func @torch.overwrite.tensor.contents$dynamic_overwrites_static(%static: !torch.
   return %result : !torch.vtensor<[2],f32>
 }
 
-// -----
 // CHECK-LABEL:   func @torch.overwrite.tensor.contents$static_overwrites_dynamic(
-// CHECK-SAME:                                                           %[[STATIC:.*]]: !torch.vtensor<[2],f32>,
-// CHECK-SAME:                                                           %[[DYNAMIC:.*]]: !torch.vtensor<[?],f32>) -> !torch.vtensor<[?],f32> {
-// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[STATIC_COPY:.*]] : !torch.vtensor<[2],f32> to !torch.vtensor<[?],f32>
-// CHECK:           torch.overwrite.tensor.contents %[[CAST]] overwrites %[[DYNAMIC_COPY:.*]] : !torch.vtensor<[?],f32>, !torch.tensor<[?],f32>
+// CHECK-SAME:                                                                    %[[ARG0:.*]]: !torch.vtensor<[2],f32>,
+// CHECK-SAME:                                                                    %[[ARG1:.*]]: !torch.vtensor<[?],f32>) -> !torch.vtensor<[?],f32> {
+// CHECK:           %[[ARG0_ERASED:.*]] = torch.tensor_static_info_cast %[[ARG0]] : !torch.vtensor<[2],f32> to !torch.vtensor<*,f32>
+// CHECK:           %[[ARG1_ERASED:.*]] = torch.tensor_static_info_cast %[[ARG1]] : !torch.vtensor<[?],f32> to !torch.vtensor<*,f32>
+// CHECK:           %[[MUTABLE_COPY:.*]] = torch.copy.to_tensor %[[ARG1_ERASED]] : !torch.tensor<*,f32>
+// CHECK:           torch.overwrite.tensor.contents %[[ARG0_ERASED]] overwrites %[[MUTABLE_COPY]] : !torch.vtensor<*,f32>, !torch.tensor<*,f32>
 func @torch.overwrite.tensor.contents$static_overwrites_dynamic(%static: !torch.vtensor<[2],f32>, %dynamic: !torch.vtensor<[?],f32>) -> !torch.vtensor<[?],f32> {
   %static_no_type = torch.tensor_static_info_cast %static : !torch.vtensor<[2],f32> to !torch.vtensor
   %dynamic_no_type = torch.tensor_static_info_cast %dynamic : !torch.vtensor<[?],f32> to !torch.vtensor

--- a/test/Dialect/Torch/reify-shape-calculations.mlir
+++ b/test/Dialect/Torch/reify-shape-calculations.mlir
@@ -1,0 +1,232 @@
+// RUN: torch-mlir-opt -torch-reify-shape-calculations -split-input-file %s | FileCheck %s
+
+// CHECK: module {
+// CHECK: func private @__torch_mlir_shape_fn.aten.tanh(
+
+// CHECK-LABEL:   func @basic(
+// CHECK-SAME:                %[[ARG:.*]]: !torch.vtensor) -> !torch.vtensor {
+// CHECK:           %[[RESULT:.*]] = torch.shape.calculate  {
+// CHECK:             %[[TANH:.*]] = torch.aten.tanh %[[ARG]] : !torch.vtensor -> !torch.vtensor
+// CHECK:             torch.shape.calculate.yield %[[TANH]] : !torch.vtensor
+// CHECK:           } shapes  {
+// CHECK:             %[[SHAPE:.*]] = torch.aten.size %[[ARG]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:             %[[RESULT_SHAPE:.*]] = call @__torch_mlir_shape_fn.aten.tanh(%[[SHAPE]]) : (!torch.list<!torch.int>) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[RESULT_SHAPE]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor
+// CHECK:           return %[[RESULT:.*]] : !torch.vtensor
+func @basic(%arg0: !torch.vtensor) -> !torch.vtensor {
+  %0 = torch.aten.tanh %arg0 : !torch.vtensor -> !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// -----
+
+// CHECK: module {
+// CHECK:   func private @__torch_mlir_shape_fn.aten.fill.Scalar(
+
+// CHECK-LABEL:   func @pseudo_ops(
+// CHECK-SAME:                     %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                     %[[ARG1:.*]]: !torch.int) -> !torch.vtensor {
+// CHECK:           %[[RESULT:.*]] = torch.shape.calculate {
+// CHECK:             %[[VALUE:.*]] = torch.pseudo.aten.fill.Scalar %[[ARG0]], %[[ARG1]] : !torch.vtensor, !torch.int -> !torch.vtensor
+// CHECK:             torch.shape.calculate.yield %[[VALUE]] : !torch.vtensor
+// CHECK:           } shapes {
+// CHECK:             %[[SHAPE:.*]] = torch.aten.size %[[ARG0]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:             %[[RESULT_SHAPE:.*]] = call @__torch_mlir_shape_fn.aten.fill.Scalar(%[[SHAPE]], %{{.*}}) : (!torch.list<!torch.int>, !torch.float) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[RESULT_SHAPE]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor
+// CHECK:           return %[[RESULT:.*]] : !torch.vtensor
+func @pseudo_ops(%arg0: !torch.vtensor, %arg1: !torch.int) -> !torch.vtensor {
+  %0 = torch.pseudo.aten.fill.Scalar %arg0, %arg1 : !torch.vtensor, !torch.int -> !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// -----
+
+// CHECK: module {
+// CHECK-LABEL:   func private @__torch_mlir_shape_fn.aten.uniform(
+// CHECK-SAME:                                                     {{.*}}!torch.any)
+
+// CHECK-LABEL:   func @adjust_shape_function_arg$torch.any(
+// CHECK-SAME:                     %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                     %[[ARG1:.*]]: !torch.float) -> !torch.vtensor {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[RESULT:.*]] = torch.shape.calculate {
+// CHECK:             %[[UNIFORM:.*]] = torch.pseudo.aten.uniform %[[ARG0]], %[[ARG1]], %[[ARG1]], %[[NONE]] : !torch.vtensor, !torch.float, !torch.float, !torch.none -> !torch.vtensor
+// CHECK:             torch.shape.calculate.yield %[[UNIFORM]] : !torch.vtensor
+// CHECK:           } shapes {
+// CHECK:             %[[ARG0_SHAPE:.*]] = torch.aten.size %[[ARG0]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:             %[[ANY:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.any
+// CHECK:             %[[SHAPE:.*]] = call @__torch_mlir_shape_fn.aten.uniform(%[[ARG0_SHAPE]], %[[ARG1]], %[[ARG1]], %[[ANY]]) : (!torch.list<!torch.int>, !torch.float, !torch.float, !torch.any) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[SHAPE]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor
+// CHECK:           return %[[RESULT:.*]] : !torch.vtensor
+func @adjust_shape_function_arg$torch.any(%arg0: !torch.vtensor, %arg1: !torch.float) -> !torch.vtensor {
+  %none = torch.constant.none
+  %0 = torch.pseudo.aten.uniform %arg0, %arg1, %arg1, %none : !torch.vtensor, !torch.float, !torch.float, !torch.none -> !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// -----
+
+// torch.aten.add.Tensor also has a shape function that calls a "broadcast"
+// helper, so this test also checks our logic for transitively pulling in
+// callees of the shape functions.
+
+// CHECK: module {
+// CHECK: func private @__torch_mlir_shape_fn.aten.add.Tensor(
+
+// CHECK-LABEL:   func @adjust_shape_function_arg$scalar(
+// CHECK-SAME:                      %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                      %[[ARG1:.*]]: !torch.vtensor) -> !torch.vtensor {
+// CHECK:           %[[INT1:.*]] = torch.constant.int 1
+// CHECK:           %[[RESULT:.*]] = torch.shape.calculate  {
+// CHECK:             %[[ADD:.*]] = torch.aten.add.Tensor %[[ARG0]], %[[ARG1]], %[[INT1]] : !torch.vtensor, !torch.vtensor, !torch.int -> !torch.vtensor
+// CHECK:             torch.shape.calculate.yield %[[ADD]] : !torch.vtensor
+// CHECK:           } shapes  {
+// CHECK:             %[[ARG0_SHAPE:.*]] = torch.aten.size %[[ARG0]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:             %[[ARG1_SHAPE:.*]] = torch.aten.size %[[ARG1]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:             %[[SCALAR_CONVERTED:.*]] = torch.aten.Float.Scalar %[[INT1]] : !torch.int -> !torch.float
+// CHECK:             %[[RESULT_SHAPE:.*]] = call @__torch_mlir_shape_fn.aten.add.Tensor(%[[ARG0_SHAPE]], %[[ARG1_SHAPE]], %[[SCALAR_CONVERTED]]) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.float) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[RESULT_SHAPE]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor
+// CHECK:           return %[[RESULT:.*]] : !torch.vtensor
+func @adjust_shape_function_arg$scalar(%arg0: !torch.vtensor, %arg1: !torch.vtensor) -> !torch.vtensor {
+  %int1 = torch.constant.int 1
+  %0 = torch.aten.add.Tensor %arg0, %arg1, %int1 : !torch.vtensor, !torch.vtensor, !torch.int -> !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// -----
+
+// CHECK: module {
+// CHECK: func private @__torch_mlir_shape_fn.aten.topk(
+
+// CHECK-LABEL:   func @multiple_results(
+// CHECK-SAME:                           %[[ARG:.*]]: !torch.tensor) -> (!torch.tensor, !torch.tensor) {
+// CHECK:           %[[TRUE:.*]] = torch.constant.bool true
+// CHECK:           %[[INT3:.*]] = torch.constant.int 3
+// CHECK:           %[[INT1:.*]] = torch.constant.int 1
+// CHECK:           %[[RESULTS:.*]]:2 = torch.shape.calculate  {
+// CHECK:             %[[TOP_VALUES:.*]], %[[TOPK_INDICES:.*]] = torch.aten.topk %[[ARG]], %[[INT3]], %[[INT1]], %[[TRUE]], %[[TRUE]] : !torch.tensor, !torch.int, !torch.int, !torch.bool, !torch.bool -> !torch.tensor, !torch.tensor
+// CHECK:             torch.shape.calculate.yield %[[TOP_VALUES]], %[[TOPK_INDICES]] : !torch.tensor, !torch.tensor
+// CHECK:           } shapes  {
+// CHECK:             %[[ARG_SHAPE:.*]] = torch.aten.size %[[ARG]] : !torch.tensor -> !torch.list<!torch.int>
+// CHECK:             %[[TOPK_SHAPE_TUPLE:.*]] = call @__torch_mlir_shape_fn.aten.topk(%[[ARG_SHAPE]], %[[INT3]], %[[INT1]], %[[TRUE]], %[[TRUE]]) : (!torch.list<!torch.int>, !torch.int, !torch.int, !torch.bool, !torch.bool) -> !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>>
+// CHECK:             %[[TOPK_SHAPE:.*]]:2 = torch.prim.TupleUnpack %[[TOPK_SHAPE_TUPLE]] : !torch.tuple<!torch.list<!torch.int>, !torch.list<!torch.int>> -> !torch.list<!torch.int>, !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[TOPK_SHAPE]]#0, %[[TOPK_SHAPE]]#1 : !torch.list<!torch.int>, !torch.list<!torch.int>
+// CHECK:           } : !torch.tensor, !torch.tensor
+// CHECK:           return %[[RESULTS:.*]]#0, %[[RESULTS]]#1 : !torch.tensor, !torch.tensor
+
+func @multiple_results(%arg0: !torch.tensor) -> (!torch.tensor, !torch.tensor) {
+  %true = torch.constant.bool true
+  %int3 = torch.constant.int 3
+  %int1 = torch.constant.int 1
+  %values, %indices = torch.aten.topk %arg0, %int3, %int1, %true, %true : !torch.tensor, !torch.int, !torch.int, !torch.bool, !torch.bool -> !torch.tensor, !torch.tensor
+  return %values, %indices : !torch.tensor, !torch.tensor
+}
+
+// -----
+
+// CHECK-LABEL:   func @adjust_shape_function_arg$optional(
+// CHECK-SAME:                  %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                  %[[ARG1:.*]]: !torch.vtensor) -> !torch.vtensor {
+// CHECK:           %[[RESULT:.*]] = torch.shape.calculate  {
+// CHECK:             %[[CONV:.*]] = torch.aten.conv2d %[[ARG0]], %[[ARG1]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !torch.vtensor, !torch.vtensor, !torch.none, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int -> !torch.vtensor
+// CHECK:             torch.shape.calculate.yield %[[CONV]] : !torch.vtensor
+// CHECK:           } shapes  {
+// CHECK:             %[[SHAPE0:.*]] = torch.aten.size %[[ARG0]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:             %[[SHAPE1:.*]] = torch.aten.size %[[ARG1]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:             %[[DEREFINED:.*]] = torch.derefine %{{.*}} : !torch.none to !torch.optional<!torch.list<!torch.int>>
+// CHECK:             %[[SHAPE:.*]] = call @__torch_mlir_shape_fn.aten.conv2d(%[[SHAPE0]], %[[SHAPE1]], %[[DEREFINED]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!torch.list<!torch.int>, !torch.list<!torch.int>, !torch.optional<!torch.list<!torch.int>>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[SHAPE]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor
+// CHECK:           return %[[RESULT:.*]] : !torch.vtensor
+func @adjust_shape_function_arg$optional(%arg0: !torch.vtensor, %arg1: !torch.vtensor) -> !torch.vtensor {
+  %int3 = torch.constant.int 3
+  %int4 = torch.constant.int 4
+  %int2 = torch.constant.int 2
+  %int1 = torch.constant.int 1
+  %none = torch.constant.none
+  %24 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+  %25 = torch.prim.ListConstruct %int3, %int3 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+  %26 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+  %29 = torch.aten.conv2d %arg0, %arg1, %none, %24, %25, %26, %int1 : !torch.vtensor, !torch.vtensor, !torch.none, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.list<!torch.int>, !torch.int -> !torch.vtensor
+  return %29 : !torch.vtensor
+}
+
+// -----
+
+// CHECK-LABEL:   func @adjust_shape_function_arg$optional_tensor(
+// CHECK-SAME:                          %[[ARG:.*]]: !torch.vtensor) -> !torch.vtensor {
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[TRUE:.*]] = torch.constant.bool true
+// CHECK:           %[[C1EM5:.*]] = torch.constant.float 1.000000e-05
+// CHECK:           %[[C1EM1:.*]] = torch.constant.float 1.000000e-01
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[DEREFINED:.*]] = torch.derefine %[[ARG]] : !torch.vtensor to !torch.optional<!torch.vtensor>
+// CHECK:           %[[RESULT:.*]] = torch.shape.calculate  {
+// CHECK:             %[[BN:.*]] = torch.aten.batch_norm %[[ARG]], %[[DEREFINED]], %[[NONE]], %[[NONE]], %[[NONE]], %[[FALSE]], %[[C1EM1]], %[[C1EM5]], %[[TRUE]] : !torch.vtensor, !torch.optional<!torch.vtensor>, !torch.none, !torch.none, !torch.none, !torch.bool, !torch.float, !torch.float, !torch.bool -> !torch.vtensor
+// CHECK:             torch.shape.calculate.yield %[[BN]] : !torch.vtensor
+// CHECK:           } shapes  {
+// CHECK:             %[[ARG_SIZE:.*]] = torch.aten.size %[[ARG]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:             %[[NONE2:.*]] = torch.constant.none
+// CHECK:             %[[IS:.*]] = torch.aten.__is__ %[[DEREFINED]], %[[NONE2]] : !torch.optional<!torch.vtensor>, !torch.none -> !torch.bool
+// CHECK:             %[[DEREFINED_OPTIONAL_SIZE:.*]] = torch.prim.If %[[IS]] -> (!torch.optional<!torch.list<!torch.int>>) {
+// CHECK:               %[[DEREFINE_NONE:.*]] = torch.derefine %[[NONE2]] : !torch.none to !torch.optional<!torch.list<!torch.int>>
+// CHECK:               torch.prim.If.yield %[[DEREFINE_NONE]] : !torch.optional<!torch.list<!torch.int>>
+// CHECK:             } else {
+// CHECK:               %[[DOWNCASTED:.*]] = torch.prim.unchecked_cast %[[DEREFINED]] : !torch.optional<!torch.vtensor> -> !torch.vtensor
+// CHECK:               %[[DOWNCASTED_SIZE:.*]] = torch.aten.size %[[DOWNCASTED]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:               %[[DEREFINE_DOWNCASTED_SIZE:.*]] = torch.derefine %[[DOWNCASTED_SIZE]] : !torch.list<!torch.int> to !torch.optional<!torch.list<!torch.int>>
+// CHECK:               torch.prim.If.yield %[[DEREFINE_DOWNCASTED_SIZE]] : !torch.optional<!torch.list<!torch.int>>
+// CHECK:             }
+// CHECK:             %[[DEREFINED_NONE1:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<!torch.list<!torch.int>>
+// CHECK:             %[[DEREFINED_NONE2:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<!torch.list<!torch.int>>
+// CHECK:             %[[DEREFINED_NONE3:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<!torch.list<!torch.int>>
+// CHECK:             %[[BN_SHAPE:.*]] = call @__torch_mlir_shape_fn.aten.batch_norm(%[[ARG_SIZE]], %[[DEREFINED_OPTIONAL_SIZE:.*]], %[[DEREFINED_NONE1]], %[[DEREFINED_NONE2]], %[[DEREFINED_NONE3]], %[[FALSE]], %[[C1EM1]], %[[C1EM5]], %[[TRUE]]) : (!torch.list<!torch.int>, !torch.optional<!torch.list<!torch.int>>, !torch.optional<!torch.list<!torch.int>>, !torch.optional<!torch.list<!torch.int>>, !torch.optional<!torch.list<!torch.int>>, !torch.bool, !torch.float, !torch.float, !torch.bool) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[BN_SHAPE]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor
+// CHECK:           return %[[RESULT:.*]] : !torch.vtensor
+func @adjust_shape_function_arg$optional_tensor(%arg0: !torch.vtensor) -> !torch.vtensor {
+  %false = torch.constant.bool false
+  %true = torch.constant.bool true
+  %float1.000000e-05 = torch.constant.float 1.000000e-05
+  %float1.000000e-01 = torch.constant.float 1.000000e-01
+  %none = torch.constant.none
+  %derefined_tensor = torch.derefine %arg0 : !torch.vtensor to !torch.optional<!torch.vtensor>
+  %0 = torch.aten.batch_norm %arg0, %derefined_tensor, %none, %none, %none, %false, %float1.000000e-01, %float1.000000e-05, %true : !torch.vtensor, !torch.optional<!torch.vtensor>, !torch.none, !torch.none, !torch.none, !torch.bool, !torch.float, !torch.float, !torch.bool -> !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// -----
+
+// CHECK-LABEL:   func @adjust_shape_function_arg$list(
+// CHECK-SAME:                                       %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                                       %[[ARG1:.*]]: !torch.vtensor) -> !torch.vtensor {
+// CHECK:           %[[LIST:.*]] = torch.prim.ListConstruct %[[ARG1]] : (!torch.vtensor) -> !torch.list<!torch.vtensor>
+// CHECK:           %[[VAL_3:.*]] = torch.shape.calculate  {
+// CHECK:             %[[VAL_4:.*]] = torch.aten.index.Tensor %[[ARG0]], %[[LIST]] : !torch.vtensor, !torch.list<!torch.vtensor> -> !torch.vtensor
+// CHECK:             torch.shape.calculate.yield %[[VAL_4]] : !torch.vtensor
+// CHECK:           } shapes  {
+// CHECK:             %[[ARG0_SHAPE:.*]] = torch.aten.size %[[ARG0]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:             %[[ADJUSTED_LIST:.*]] = torch.prim.ListConstruct  : () -> !torch.list<!torch.optional<!torch.list<!torch.int>>>
+// CHECK:             %[[LIST_SIZE:.*]] = torch.aten.len.t %[[LIST]] : !torch.list<!torch.vtensor> -> !torch.int
+// CHECK:             %[[CTRUE:.*]] = torch.constant.bool true
+// CHECK:             torch.prim.Loop %[[LIST_SIZE]], %[[CTRUE]], init()  {
+// CHECK:             ^bb0(%[[ITER_NUM:.*]]: !torch.int):
+// CHECK:               %[[UNADJUSTED_ELEMENT:.*]] = torch.aten.__getitem__.t %[[LIST]], %[[ITER_NUM]] : !torch.list<!torch.vtensor>, !torch.int -> !torch.vtensor
+// CHECK:               %[[UNADJUSTED_ELEMENT_SHAPE:.*]] = torch.aten.size %[[UNADJUSTED_ELEMENT]] : !torch.vtensor -> !torch.list<!torch.int>
+// CHECK:               %[[ADJUSTED_ELEMENT:.*]] = torch.derefine %[[UNADJUSTED_ELEMENT_SHAPE]] : !torch.list<!torch.int> to !torch.optional<!torch.list<!torch.int>>
+// CHECK:               %{{.*}} = torch.aten.append.t %[[ADJUSTED_LIST]], %[[ADJUSTED_ELEMENT]] : !torch.list<!torch.optional<!torch.list<!torch.int>>>, !torch.optional<!torch.list<!torch.int>> -> !torch.list<!torch.optional<!torch.list<!torch.int>>>
+// CHECK:               torch.prim.Loop.condition %[[CTRUE]], iter()
+// CHECK:             } : (!torch.int, !torch.bool) -> ()
+// CHECK:             %[[RESULT_SHAPE:.*]] = call @__torch_mlir_shape_fn.aten.index.Tensor(%[[ARG0_SHAPE]], %[[ADJUSTED_LIST]]) : (!torch.list<!torch.int>, !torch.list<!torch.optional<!torch.list<!torch.int>>>) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[RESULT_SHAPE]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor
+// CHECK:           return %[[VAL_15:.*]] : !torch.vtensor
+func @adjust_shape_function_arg$list(%arg0: !torch.vtensor, %arg1: !torch.vtensor) -> !torch.vtensor {
+  %0 = torch.prim.ListConstruct %arg1 : (!torch.vtensor) -> !torch.list<!torch.vtensor>
+  %1 = torch.aten.index.Tensor %arg0, %0 : !torch.vtensor, !torch.list<!torch.vtensor> -> !torch.vtensor
+  return %1 : !torch.vtensor
+}

--- a/test/Dialect/Torch/simplify-shape-calculations.mlir
+++ b/test/Dialect/Torch/simplify-shape-calculations.mlir
@@ -1,0 +1,370 @@
+// RUN: torch-mlir-opt -torch-simplify-shape-calculations -split-input-file %s | FileCheck %s
+
+
+// CHECK-LABEL:   func @refine_shape_calculate_result$basic(
+// CHECK-SAME:                                              %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                                              %[[ARG1:.*]]: !torch.int) -> !torch.vtensor {
+// CHECK:           %[[INT2:.*]] = torch.constant.int 2
+// CHECK:           %[[RESULT:.*]] = torch.shape.calculate {
+// CHECK:             %[[REFINED:.*]] = torch.tensor_static_info_cast %[[ARG0]] : !torch.vtensor to !torch.vtensor<[2,?],unk>
+// CHECK:             torch.shape.calculate.yield %[[REFINED]] : !torch.vtensor<[2,?],unk>
+// CHECK:           } shapes {
+// CHECK:             %[[SHAPE:.*]] = torch.prim.ListConstruct %[[INT2]], %[[ARG1]] : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[SHAPE]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor<[2,?],unk>
+// CHECK:           %[[RESULT_ERASED:.*]] = torch.tensor_static_info_cast %[[RESULT:.*]] : !torch.vtensor<[2,?],unk> to !torch.vtensor
+// CHECK:           return %[[RESULT_ERASED]] : !torch.vtensor
+func @refine_shape_calculate_result$basic(%arg0: !torch.vtensor, %arg1: !torch.int) -> !torch.vtensor {
+  %int2 = torch.constant.int 2
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct %int2, %arg1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// CHECK-LABEL:   func @refine_shape_calculate_result$clobber_one_element(
+// CHECK:           %[[RESULT_ERASED:.*]] = torch.tensor_static_info_cast %{{.*}} : !torch.vtensor<[?,2],unk> to !torch.vtensor
+// CHECK:           return %[[RESULT_ERASED]] : !torch.vtensor
+func @refine_shape_calculate_result$clobber_one_element(%arg0: !torch.vtensor, %arg1: !torch.int, %arg2: !torch.bool) -> !torch.vtensor {
+  %int0 = torch.constant.int 0
+  %int2 = torch.constant.int 2
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+    torch.prim.If %arg2 -> () {
+      // Clobber element 0 of the list. So we can only know that the result is [?,2] instead of [2,2].
+      %2 = torch.aten._set_item.t %1, %int0, %arg1 : !torch.list<!torch.int>, !torch.int, !torch.int -> !torch.list<!torch.int>
+      torch.prim.If.yield
+    } else {
+      torch.prim.If.yield
+    }
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// CHECK-LABEL:   func @refine_shape_calculate_result$clobber_all_elements(
+// CHECK:           %[[RESULT_ERASED:.*]] = torch.tensor_static_info_cast %{{.*}} : !torch.vtensor<[?,?],unk> to !torch.vtensor
+// CHECK:           return %[[RESULT_ERASED]] : !torch.vtensor
+func @refine_shape_calculate_result$clobber_all_elements(%arg0: !torch.vtensor, %arg1: !torch.int, %arg2: !torch.bool) -> !torch.vtensor {
+  %int0 = torch.constant.int 0
+  %int2 = torch.constant.int 2
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+    torch.prim.If %arg2 -> () {
+      // Set an unknown element of the list. This clobbers our knowledge of the whole contents of the list.
+      // So we can only know that the result is [?,?] instead of [2,2].
+      %2 = torch.aten._set_item.t %1, %arg1, %int0 : !torch.list<!torch.int>, !torch.int, !torch.int -> !torch.list<!torch.int>
+      torch.prim.If.yield
+    } else {
+      torch.prim.If.yield
+    }
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// Make sure that information previously in the IR is not lost.
+// CHECK-LABEL:   func @refine_shape_calculate_result$meet_with_existing_information(
+// CHECK:           %[[RESULT_ERASED:.*]] = torch.tensor_static_info_cast %{{.*}} : !torch.vtensor<[2,3],f32> to !torch.vtensor<[?,3],f32>
+// CHECK:           return %[[RESULT_ERASED]] : !torch.vtensor<[?,3],f32>
+func @refine_shape_calculate_result$meet_with_existing_information(%arg0: !torch.vtensor<[?,3],f32>, %arg1: !torch.int) -> !torch.vtensor<[?,3],f32> {
+  %int0 = torch.constant.int 0
+  %int2 = torch.constant.int 2
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor<[?,3],f32>
+  } shapes {
+    %1 = torch.prim.ListConstruct %int2, %arg1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor<[?,3],f32>
+  return %0 : !torch.vtensor<[?,3],f32>
+}
+
+// Don't insert static info casts if not needed.
+// CHECK-LABEL:   func @refine_shape_calculate_result$user_allows_type_refinement(
+// CHECK-NOT:       torch.tensor_static_info_cast
+func @refine_shape_calculate_result$user_allows_type_refinement(%arg0: !torch.vtensor) -> !torch.vtensor {
+  %int2 = torch.constant.int 2
+  %0 = torch.aten.tanh %arg0 : !torch.vtensor -> !torch.vtensor
+  %1 = torch.shape.calculate {
+    torch.shape.calculate.yield %0 : !torch.vtensor
+  } shapes {
+    %2 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+    torch.shape.calculate.yield.shapes %2 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  %2 = torch.aten.tanh %1 : !torch.vtensor -> !torch.vtensor
+  return %2 : !torch.vtensor
+}
+
+// CHECK-LABEL:   func @fully_unroll_prim_loop$unroll(
+// CHECK-SAME:                                 %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                                 %[[ARG1:.*]]: !torch.list<!torch.int>) -> !torch.vtensor {
+// CHECK:           %[[INT1:.*]] = torch.constant.int 1
+// CHECK:           %[[INT2:.*]] = torch.constant.int 2
+// CHECK:           %[[INT0:.*]] = torch.constant.int 0
+// CHECK:           %[[RESULT:.*]] = torch.shape.calculate {
+// CHECK:             torch.shape.calculate.yield %[[ARG0]] : !torch.vtensor
+// CHECK:           } shapes {
+// CHECK:             torch.prim.Print(%[[INT0]], %[[INT0]]) : !torch.int, !torch.int
+// CHECK:             torch.prim.Print(%[[INT1]], %[[INT0]]) : !torch.int, !torch.int
+// CHECK:             torch.prim.Print(%[[INT2]], %[[INT0]]) : !torch.int, !torch.int
+// CHECK:             torch.shape.calculate.yield.shapes %[[ARG1]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor
+// CHECK:           return %[[RESULT:.*]] : !torch.vtensor
+func @fully_unroll_prim_loop$unroll(%arg0: !torch.vtensor, %arg1: !torch.list<!torch.int>) -> !torch.vtensor {
+  %true = torch.constant.bool true
+  %int0 = torch.constant.int 0
+  %int3 = torch.constant.int 3
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    torch.prim.Loop %int3, %true, init(%int0) {
+    ^bb0(%arg2: !torch.int, %arg3: !torch.int):
+      torch.prim.Print(%arg2, %arg3) : !torch.int, !torch.int
+      torch.prim.Loop.condition %true, iter(%arg3: !torch.int)
+    } : (!torch.int, !torch.bool, !torch.int) -> (!torch.int)
+    torch.shape.calculate.yield.shapes %arg1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// CHECK-LABEL:   func @fully_unroll_prim_loop$no_unroll(
+// CHECK:           torch.prim.Loop
+func @fully_unroll_prim_loop$no_unroll(%arg0: !torch.vtensor, %arg1: !torch.list<!torch.int>, %arg2: !torch.int) -> !torch.vtensor {
+  %true = torch.constant.bool true
+  %int3 = torch.constant.int 3
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    torch.prim.Loop %arg2, %true, init() {
+    ^bb0(%arg3: !torch.int):
+      torch.prim.Print(%arg2) : !torch.int
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    torch.shape.calculate.yield.shapes %arg1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// CHECK-LABEL:   func @abstractly_interpret_list_ops$basic(
+// CHECK-SAME:                                              %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                                              %[[ARG1:.*]]: !torch.int,
+// CHECK-SAME:                                              %[[ARG2:.*]]: !torch.int) -> !torch.vtensor {
+// CHECK:             %[[SHAPE:.*]] = torch.prim.ListConstruct %[[ARG1]], %[[ARG2]] : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[SHAPE]] : !torch.list<!torch.int>
+func @abstractly_interpret_list_ops$basic(%arg0: !torch.vtensor, %arg1: !torch.int, %arg2: !torch.int) -> !torch.vtensor {
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct : () -> !torch.list<!torch.int>
+    %2 = torch.aten.append.t %1, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    %3 = torch.aten.append.t %1, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// Test the different supported mutation ops.
+// CHECK-LABEL:   func @abstractly_interpret_list_ops$mutation_ops(
+// CHECK:             %[[SHAPE:.*]] = torch.prim.ListConstruct %int1, %arg1, %arg2, %arg3 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[SHAPE]] : !torch.list<!torch.int>
+func @abstractly_interpret_list_ops$mutation_ops(%arg0: !torch.vtensor, %arg1: !torch.int, %arg2: !torch.int, %arg3: !torch.int) -> !torch.vtensor {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+    %2 = torch.aten._set_item.t %1, %int1, %arg1 : !torch.list<!torch.int>, !torch.int, !torch.int -> !torch.list<!torch.int>
+    %3 = torch.aten.append.t %1, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    torch.aten.insert.t %1, %int3, %arg3 : !torch.list<!torch.int>, !torch.int, !torch.int
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+
+// CHECK-LABEL:   func @abstractly_interpret_list_ops$use_of_alias$not_yet_handled(
+// CHECK:           torch.aten.append.t
+// CHECK:           torch.aten.append.t
+func @abstractly_interpret_list_ops$use_of_alias$not_yet_handled(%arg0: !torch.vtensor, %arg1: !torch.int, %arg2: !torch.int) -> !torch.vtensor {
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct : () -> !torch.list<!torch.int>
+    %2 = torch.aten.append.t %1, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    // The value of the alias %2 is printed, but we don't handle that yet.
+    torch.prim.Print(%2) : !torch.list<!torch.int>
+    %3 = torch.aten.append.t %1, %arg2 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// CHECK-LABEL:   func @abstractly_interpret_list_ops$readonly_op_in_child_region(
+// CHECK-SAME:                                                                    %[[VAL_0:.*]]: !torch.vtensor,
+// CHECK-SAME:                                                                    %[[VAL_1:.*]]: !torch.int) -> !torch.vtensor {
+// CHECK:           %[[INT3:.*]] = torch.constant.int 3
+// CHECK:             %[[SHAPE:.*]] = torch.prim.ListConstruct %[[INT3]] : (!torch.int) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[SHAPE]] : !torch.list<!torch.int>
+func @abstractly_interpret_list_ops$readonly_op_in_child_region(%arg0: !torch.vtensor, %arg1: !torch.int) -> !torch.vtensor {
+  %true = torch.constant.bool true
+  %int3 = torch.constant.int 3
+  %int0 = torch.constant.int 0
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct : () -> !torch.list<!torch.int>
+    // This readonly op in a loop doesn't block us from abstractly interpreting
+    // the whole block.
+    torch.prim.Loop %arg1, %true, init() {
+    ^bb0(%arg3: !torch.int):
+      %2 = torch.aten.__getitem__.t %1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Print(%2) : !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    %2 = torch.aten.append.t %1, %int3 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// The mutation in the child region prevents us from abstractly interpreting.
+// CHECK-LABEL:   func @abstractly_interpret_list_ops$mutation_in_child_region(
+// CHECK:             torch.aten.append.t
+func @abstractly_interpret_list_ops$mutation_in_child_region(%arg0: !torch.vtensor, %arg1: !torch.int) -> !torch.vtensor {
+  %true = torch.constant.bool true
+  %int3 = torch.constant.int 3
+  %int0 = torch.constant.int 0
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct : () -> !torch.list<!torch.int>
+    torch.prim.Loop %arg1, %true, init() {
+    ^bb0(%arg3: !torch.int):
+      %2 = torch.aten.__getitem__.t %1, %int0 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Print(%2) : !torch.list<!torch.int>
+      // This mutation prevents us from abstractly interpreting.
+      %3 = torch.aten.append.t %1, %arg1 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    %2 = torch.aten.append.t %1, %int3 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+// CHECK-LABEL:   func @abstractly_interpret_list_ops$miscompile$list_identity(
+// CHECK-SAME:                                                                 %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                                                                 %[[ARG1:.*]]: !torch.list<!torch.int>,
+// CHECK-SAME:                                                                 %[[ARG2:.*]]: !torch.bool) -> !torch.vtensor {
+// CHECK:           %[[INT3:.*]] = torch.constant.int 3
+// CHECK:           %[[VAL_4:.*]] = torch.shape.calculate {
+// CHECK:             %[[VAL_5:.*]] = torch.tensor_static_info_cast %[[ARG0]] : !torch.vtensor to !torch.vtensor<[3,3],unk>
+// CHECK:             torch.shape.calculate.yield %[[VAL_5]] : !torch.vtensor<[3,3],unk>
+// CHECK:           } shapes {
+                      // Notice this torch.prim.ListConstruct....
+// CHECK:             %[[VAL_6:.*]] = torch.prim.ListConstruct %[[INT3]] : (!torch.int) -> !torch.list<!torch.int>
+// CHECK:             %[[VAL_7:.*]] = torch.prim.If %[[ARG2]] -> (!torch.list<!torch.int>) {
+// CHECK:               torch.prim.If.yield %[[VAL_6]] : !torch.list<!torch.int>
+// CHECK:             } else {
+// CHECK:               torch.prim.If.yield %[[ARG1]] : !torch.list<!torch.int>
+// CHECK:             }
+                      // .... and this one don't have the same object identity, but should! 
+// CHECK:             %[[VAL_8:.*]] = torch.prim.ListConstruct %[[INT3]], %[[INT3]] : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+// CHECK:             %[[VAL_9:.*]] = torch.prim.If %[[ARG2]] -> (!torch.list<!torch.int>) {
+// CHECK:               torch.prim.If.yield %[[VAL_8]] : !torch.list<!torch.int>
+// CHECK:             } else {
+// CHECK:               torch.prim.If.yield %[[ARG1]] : !torch.list<!torch.int>
+// CHECK:             }
+// CHECK:             %[[VAL_10:.*]] = torch.aten.__is__ %[[VAL_11:.*]], %[[VAL_12:.*]] : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.bool
+// CHECK:             torch.prim.Print(%[[VAL_10]]) : !torch.bool
+// CHECK:             torch.shape.calculate.yield.shapes %[[VAL_8]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor<[3,3],unk>
+// CHECK:           %[[VAL_13:.*]] = torch.tensor_static_info_cast %[[VAL_14:.*]] : !torch.vtensor<[3,3],unk> to !torch.vtensor
+// CHECK:           return %[[VAL_13]] : !torch.vtensor
+func @abstractly_interpret_list_ops$miscompile$list_identity(%arg0: !torch.vtensor, %arg1: !torch.list<!torch.int>, %arg2: !torch.bool) -> !torch.vtensor {
+  %true = torch.constant.bool true
+  %int3 = torch.constant.int 3
+  %int0 = torch.constant.int 0
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct : () -> !torch.list<!torch.int>
+    %2 = torch.aten.append.t %1, %int3 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    // TODO: Fix this miscompile!
+    // For the case where %arg2 is true, the resulting IR will miscompile
+    // because the abstract interpretation of the list ops will create two list
+    // literals.
+    // One possible solution would be to know that torch.prim.If.yield creates
+    // a new SSA name for the same dynamic value (it's not the only thing that
+    // can do this -- pushing and popping the list onto another list could
+    // create the same situation). Another possible solution would be to only
+    // replace a single list literal at a time, and bail out if there are any
+    // uses of the original list value that are not replaced by the created
+    // literal.
+    %3 = torch.prim.If %arg2 -> (!torch.list<!torch.int>) {
+      torch.prim.If.yield %1 : !torch.list<!torch.int>
+    } else {
+      torch.prim.If.yield %arg1 : !torch.list<!torch.int>
+    }
+    %4 = torch.aten.append.t %1, %int3 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+    %5 = torch.prim.If %arg2 -> (!torch.list<!torch.int>) {
+      torch.prim.If.yield %1 : !torch.list<!torch.int>
+    } else {
+      torch.prim.If.yield %arg1 : !torch.list<!torch.int>
+    }
+    %6 = torch.aten.__is__ %3, %5 : !torch.list<!torch.int>, !torch.list<!torch.int> -> !torch.bool
+    torch.prim.Print(%6) : !torch.bool
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
+
+
+
+// "Integration test" for basic case of all the patterns working together.
+// This test should usually not be the one to catch an issue.
+// If it does catch an issue then it indicates a more precise unit test that is
+// missing.
+// CHECK-LABEL:   func @basic_integration(
+// CHECK-SAME:                %[[ARG0:.*]]: !torch.vtensor<[?,?],unk>) -> !torch.vtensor {
+// CHECK:           %[[INT0:.*]] = torch.constant.int 0
+// CHECK:           %[[INT1:.*]] = torch.constant.int 1
+// CHECK:           %[[RESULT:.*]] = torch.shape.calculate {
+// CHECK:             %[[TANH:.*]] = torch.aten.tanh %[[ARG0]] : !torch.vtensor<[?,?],unk> -> !torch.vtensor<[?,?],unk>
+// CHECK:             torch.shape.calculate.yield %[[TANH]] : !torch.vtensor<[?,?],unk>
+// CHECK:           } shapes {
+// CHECK:             %[[SIZE0:.*]] = torch.aten.size.int %[[ARG0]], %[[INT0]] : !torch.vtensor<[?,?],unk>, !torch.int -> !torch.int
+// CHECK:             %[[SIZE1:.*]] = torch.aten.size.int %[[ARG0]], %[[INT1]] : !torch.vtensor<[?,?],unk>, !torch.int -> !torch.int
+// CHECK:             %[[SHAPE:.*]] = torch.prim.ListConstruct %[[SIZE0]], %[[SIZE1]] : (!torch.int, !torch.int) -> !torch.list<!torch.int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[SHAPE]] : !torch.list<!torch.int>
+// CHECK:           } : !torch.vtensor<[?,?],unk>
+// CHECK:           %[[RESULT_ERASED:.*]] = torch.tensor_static_info_cast %[[RESULT:.*]] : !torch.vtensor<[?,?],unk> to !torch.vtensor
+// CHECK:           return %[[RESULT_ERASED]] : !torch.vtensor
+func @basic_integration(%arg0: !torch.vtensor<[?,?],unk>) -> !torch.vtensor {
+  %true = torch.constant.bool true
+  %0 = torch.shape.calculate {
+    %1 = torch.aten.tanh %arg0 : !torch.vtensor<[?,?],unk> -> !torch.vtensor
+    torch.shape.calculate.yield %1 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct  : () -> !torch.list<!torch.int>
+    %2 = torch.aten.dim %arg0 : !torch.vtensor<[?,?],unk> -> !torch.int
+    torch.prim.Loop %2, %true, init() {
+    ^bb0(%arg1: !torch.int):
+      %3 = torch.aten.size.int %arg0, %arg1 : !torch.vtensor<[?,?],unk>, !torch.int -> !torch.int
+      %4 = torch.aten.append.t %1, %3 : !torch.list<!torch.int>, !torch.int -> !torch.list<!torch.int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    torch.shape.calculate.yield.shapes %1 : !torch.list<!torch.int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}

--- a/test/python/importer/jit_ir/node_import/classes.py
+++ b/test/python/importer/jit_ir/node_import/classes.py
@@ -1,0 +1,32 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See LICENSE.pytorch for license information.
+
+import typing
+
+import torch
+from torch._C import CompilationUnit
+from torch_mlir.dialects.torch.importer.jit_ir import ModuleBuilder
+
+import typing
+
+# RUN: %PYTHON %s | torch-mlir-opt | FileCheck %s
+
+mb = ModuleBuilder()
+
+class BasicClass:
+    def __init__(self, x: int):
+        self.x = x
+
+# CHECK-LABEL:   func @__torch__.prim_CreateObject(
+# CHECK-SAME:                                      %[[ARG0:.*]]: !torch.int) -> !torch.nn.Module<"__torch__.BasicClass"> {
+# CHECK:           %[[OBJECT:.*]] = torch.prim.CreateObject !torch.nn.Module<"__torch__.BasicClass">
+# CHECK:           %[[NONE:.*]] = torch.prim.CallMethod %[[OBJECT]]["__init__"] (%[[ARG0]]) : !torch.nn.Module<"__torch__.BasicClass">, (!torch.int) -> !torch.none
+# CHECK:           return %[[OBJECT]] : !torch.nn.Module<"__torch__.BasicClass">
+@mb.import_function
+@torch.jit.script
+def prim_CreateObject(i: int):
+    return BasicClass(i)
+
+mb.module.operation.print()
+print()


### PR DESCRIPTION
See the documentation in `docs/shape_lib.md` and
`docs/adding_a_shape_function.md` for an overview of the system.

This completely overhauls how we represent shape functions. In
particular, RefineTypes does not infer shapes anymore (only dtypes).
Shape functions are now written in (TorchScript'able) Python.

Recommended review order:

1. Read `docs/shape_lib.md` and `docs/adding_a_shape_function.md`.
1. Code and tests for ReifyShapeCalculations, DropShapeCalculations.
1. Code and tests for SimplifyShapeCalculations.
1. shape_lib_gen.py
1. Code and tests for new RefineTypes pass.
1. Random folders/canonicalizers in TorchOps.cpp and associated test in
   `canonicalize.mlir`.
1. New ReadOnly trait inferred from the registry.
1. Any miscellaneous remaining stuff.

Example `-print-ir-after-all` for ElementwiseUnaryModule:
[IR lowering dump](https://gist.github.com/silvasean/e4dc8cbc8d00aac7819602e3cbd8e212).

Example `-print-ir-after-all` for ElementwiseBinaryModule:
[IR lowering dump](https://gist.github.com/silvasean/daf6860ecced732af3568af6b1899113).