### PR TITLE
Add convolution_backward and convolution_backward_overrideable

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -2728,6 +2728,75 @@ def Torch_AtenConv2dOp : Torch_Op<"aten.conv2d", [
   }];
 }
 
+def Torch_AtenConvolutionBackwardOp : Torch_Op<"aten.convolution_backward", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::convolution_backward : (Tensor, Tensor, Tensor, int[]?, int[], int[], int[], bool, int[], int, bool[]) -> (Tensor, Tensor, Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$grad_output,
+    AnyTorchTensorType:$input,
+    AnyTorchTensorType:$weight,
+    TorchOptionalIntListType:$bias_sizes,
+    TorchIntListType:$stride,
+    TorchIntListType:$padding,
+    TorchIntListType:$dilation,
+    Torch_BoolType:$transposed,
+    TorchIntListType:$output_padding,
+    Torch_IntType:$groups,
+    TorchBoolListType:$output_mask
+  );
+  let results = (outs
+    AnyTorchTensorType:$result0,
+    AnyTorchTensorType:$result1,
+    AnyTorchTensorType:$result2
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenConvolutionBackwardOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 11, 3);
+    }
+    void AtenConvolutionBackwardOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 11, 3);
+    }
+  }];
+}
+
+def Torch_AtenConvolutionBackwardOverrideableOp : Torch_Op<"aten.convolution_backward_overrideable", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::convolution_backward_overrideable : (Tensor, Tensor, Tensor, int[], int[], int[], bool, int[], int, bool[]) -> (Tensor, Tensor, Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$grad_output,
+    AnyTorchTensorType:$input,
+    AnyTorchTensorType:$weight,
+    TorchIntListType:$stride,
+    TorchIntListType:$padding,
+    TorchIntListType:$dilation,
+    Torch_BoolType:$transposed,
+    TorchIntListType:$output_padding,
+    Torch_IntType:$groups,
+    TorchBoolListType:$output_mask
+  );
+  let results = (outs
+    AnyTorchTensorType:$grad_input,
+    AnyTorchTensorType:$grad_weight,
+    AnyTorchTensorType:$grad_bias
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenConvolutionBackwardOverrideableOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 10, 3);
+    }
+    void AtenConvolutionBackwardOverrideableOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 10, 3);
+    }
+  }];
+}
+
 def Torch_AtenNativeBatchNormOp : Torch_Op<"aten.native_batch_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
@@ -433,6 +433,7 @@ def AnyTorchTensorListType:
 def AnyTorchOptionalTensorListType :
       ListOf<[AnyTorchOptionalTensorType],
              "Any optional tensor list type (Tensor?[])">;
+def TorchOptionalIntListType : OptionalOf<TorchIntListType, "Optional torch int list type (int[]?)">;
 
 // Note: TorchScript does not consider !torch.bool to be a Scalar.
 def AnyTorchScalarType :

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -492,6 +492,9 @@ public:
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
 
+    for(size_t i = 0; i < paddingInts.size(); i++)
+      paddingInts[i] += 1;
+
     SmallVector<Value> paddingIntValues =
         getAsConstantIntValues(rewriter, loc, paddingInts);
     SmallVector<Value> dilationIntValues =
@@ -506,6 +509,8 @@ public:
         rewriter.create<arith::ConstantOp>(loc, IntegerAttr::get(intType, 1));
     Value c0 =
         rewriter.create<arith::ConstantOp>(loc, FloatAttr::get(elementType, 0));
+    Value ci0 =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getI64IntegerAttr(0));
     Value groupEqual1 = rewriter.create<arith::CmpIOp>(
         loc, arith::CmpIPredicate::eq, groups, c1);
     rewriter.create<cf::AssertOp>(
@@ -526,7 +531,7 @@ public:
     auto getConvOutputDim = [&](Value lhDim, Value rhDim, Value padding, Value stride, Value dilation, bool valid) -> Value {
       if(valid) {
         return torch_to_linalg::getOutputDimForConvOps(
-                rewriter, loc, lhDim, padding, dilation,
+                rewriter, loc, lhDim, ci0, dilation,
                 castIndexToInt(rhDim), stride);
       }
       // TODO: dilation, stride

--- a/lib/Conversion/TorchToLinalg/Utils.cpp
+++ b/lib/Conversion/TorchToLinalg/Utils.cpp
@@ -67,6 +67,22 @@ Value torch_to_linalg::getPaddedTensor(Operation *op, OpBuilder &b,
   return getPaddedTensor(op, b, input, paddingInts, paddingInts, c0);
 }
 
+Value torch_to_linalg::getPaddedTensor(
+    Operation *op, OpBuilder &b, Value &input,
+    SmallVectorImpl<int64_t> &lowPaddingInts,
+    SmallVectorImpl<int64_t> &highPaddingInts,
+    Value pad, Type outType) {
+  Location loc = op->getLoc();
+  SmallVector<OpFoldResult> lowPaddings =
+      getIndexIntsAsOpFoldResult(b, lowPaddingInts);
+  SmallVector<OpFoldResult> highPaddings =
+      getIndexIntsAsOpFoldResult(b, highPaddingInts);
+  Value paddedInput = tensor::createPadScalarOp(
+      outType, input, pad, /*low=*/lowPaddings, /*high=*/highPaddings,
+      /*packing=*/false, loc, b);
+  return paddedInput;
+}
+
 Value torch_to_linalg::getOutputDimForConvOps(OpBuilder &b, Location loc,
                                               Value in, Value paddingInt,
                                               Value dilationInt,

--- a/lib/Conversion/TorchToLinalg/Utils.h
+++ b/lib/Conversion/TorchToLinalg/Utils.h
@@ -24,6 +24,11 @@ Value getPaddedTensor(Operation *op, OpBuilder &b, Value &input,
 Value getPaddedTensor(Operation *op, OpBuilder &b, Value &input,
                       SmallVectorImpl<int64_t> &paddingInts);
 
+Value getPaddedTensor(Operation *op, OpBuilder &b, Value &input,
+                      SmallVectorImpl<int64_t> &lowPaddingInts,
+                      SmallVectorImpl<int64_t> &highPaddingInts,
+                      Value pad, Type outType);
+
 // Helper function to caculate the output tensor dims for convolution-like ops.
 // Along each dim:
 // dim_out =

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -737,6 +737,22 @@ public:
 };
 } // namespace
 
+// Decompose aten.convolution_backward_overrideable to aten.convolution_backward
+namespace {
+class DecomposeAtenConvolutionBackwardOverrideableOp : public OpRewritePattern<AtenConvolutionBackwardOverrideableOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AtenConvolutionBackwardOverrideableOp op,
+                                PatternRewriter &rewriter) const override {
+    
+    Value none = rewriter.create<ConstantNoneOp>(op->getLoc());
+    rewriter.replaceOpWithNewOp<AtenConvolutionBackwardOp>(op, op.getResultTypes(), op.grad_output(), op.input(), op.weight(), none, op.stride(), op.padding(), op.dilation(), op.transposed(), op.output_padding(), op.groups(), op.output_mask());
+
+    return success();
+  }
+};
+} // namespace
+
 // Decompose aten.addmm into aten.mm and aten.add.Tensor op.
 namespace {
 class DecomposeAtenAddmmOp : public OpRewritePattern<AtenAddmmOp> {
@@ -1638,6 +1654,8 @@ class DecomposeComplexOpsPass
     target.addIllegalOp<AtenWhereScalarOtherOp>();
     patterns.add<DecomposeAtenWhereScalarSelfOp>(context);
     target.addIllegalOp<AtenWhereScalarSelfOp>();
+    patterns.add<DecomposeAtenConvolutionBackwardOverrideableOp>(context);
+    target.addIllegalOp<AtenConvolutionBackwardOverrideableOp>();
     patterns.add<DecomposeAtenSizeOp>(context);
     target.addIllegalOp<AtenSizeOp>();
     patterns.add<DecomposeAtenReshapeOp>(context);
@@ -1740,3 +1758,4 @@ std::unique_ptr<OperationPass<FuncOp>>
 mlir::torch::Torch::createDecomposeComplexOpsPass() {
   return std::make_unique<DecomposeComplexOpsPass>();
 }
+

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -651,7 +651,7 @@ ChangeResult TypeAnalyzer::visitOperation(
   }
 
   // 3 results take dtype from first operand.
-  if (isa<AtenNativeLayerNormOp, AtenNativeBatchNormOp>(op)) {
+  if (isa<AtenNativeLayerNormOp, AtenNativeBatchNormOp, AtenConvolutionBackwardOp, AtenConvolutionBackwardOverrideableOp>(op)) {
     auto self = operands[0]->getValue();
     auto result0Knowledge =
         ValueKnowledge::getNotNonePessimisticValueState(op->getContext());

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -2295,6 +2295,70 @@ module {
     } : (!torch.int, !torch.bool, !torch.bool) -> !torch.bool
     return %1 : !torch.bool
   }
+  func @"__torch_mlir_shape_fn.aten.convolution_backward"(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.list<int>, %arg3: !torch.optional<list<int>>, %arg4: !torch.list<int>, %arg5: !torch.list<int>, %arg6: !torch.list<int>, %arg7: !torch.bool, %arg8: !torch.list<int>, %arg9: !torch.int, %arg10: !torch.list<bool>) -> !torch.tuple<list<int>, list<int>, list<int>> {
+    %int1 = torch.constant.int 1
+    %none = torch.constant.none
+    %0 = torch.derefine %none : !torch.none to !torch.optional<list<int>>
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.conv_output_size(%arg0, %arg2, %0, %arg4, %arg5, %arg6, %arg9) : (!torch.list<int>, !torch.list<int>, !torch.optional<list<int>>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.list<int>
+    %2 = torch.derefine %none : !torch.none to !torch.optional<list<int>>
+    %3 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.conv_output_valid(%arg1, %arg0, %2, %arg4, %arg5, %arg6, %arg9) : (!torch.list<int>, !torch.list<int>, !torch.optional<list<int>>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.list<int>
+    %4 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<int>, !torch.int -> !torch.int
+    %5 = torch.prim.ListConstruct %4 : (!torch.int) -> !torch.list<int>
+    %6 = torch.prim.TupleConstruct %1, %3, %5 : !torch.list<int>, !torch.list<int>, !torch.list<int> -> !torch.tuple<list<int>, list<int>, list<int>>
+    return %6 : !torch.tuple<list<int>, list<int>, list<int>>
+  }
+  func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.conv_output_valid(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.optional<list<int>>, %arg3: !torch.list<int>, %arg4: !torch.list<int>, %arg5: !torch.list<int>, %arg6: !torch.int) -> !torch.list<int> {
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %int0 = torch.constant.int 0
+    %true = torch.constant.bool true
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.check_shape_forward(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6) : (!torch.list<int>, !torch.list<int>, !torch.optional<list<int>>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.none
+    %1 = torch.aten.len.t %arg5 : !torch.list<int> -> !torch.int
+    %2 = torch.aten.gt.int %1, %int0 : !torch.int, !torch.int -> !torch.bool
+    %3 = torch.aten.len.t %arg0 : !torch.list<int> -> !torch.int
+    %4 = torch.prim.ListConstruct  : () -> !torch.list<int>
+    %5 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<int>, !torch.int -> !torch.int
+    %6 = torch.aten.append.t %4, %5 : !torch.list<int>, !torch.int -> !torch.list<int>
+    %7 = torch.aten.__getitem__.t %arg1, %int0 : !torch.list<int>, !torch.int -> !torch.int
+    %8 = torch.aten.append.t %4, %7 : !torch.list<int>, !torch.int -> !torch.list<int>
+    %9 = torch.aten.__range_length %int2, %3, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %9, %true, init() {
+    ^bb0(%arg7: !torch.int):
+      %10 = torch.aten.__derive_index %arg7, %int2, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+      %11 = torch.prim.If %2 -> (!torch.int) {
+        %23 = torch.aten.sub.int %10, %int2 : !torch.int, !torch.int -> !torch.int
+        %24 = torch.aten.__getitem__.t %arg5, %23 : !torch.list<int>, !torch.int -> !torch.int
+        torch.prim.If.yield %24 : !torch.int
+      } else {
+        torch.prim.If.yield %int1 : !torch.int
+      }
+      %12 = torch.aten.__getitem__.t %arg1, %10 : !torch.list<int>, !torch.int -> !torch.int
+      %13 = torch.aten.sub.int %12, %int1 : !torch.int, !torch.int -> !torch.int
+      %14 = torch.aten.mul.int %11, %13 : !torch.int, !torch.int -> !torch.int
+      %15 = torch.aten.add.int %14, %int1 : !torch.int, !torch.int -> !torch.int
+      %16 = torch.aten.__getitem__.t %arg0, %10 : !torch.list<int>, !torch.int -> !torch.int
+      %17 = torch.aten.sub.int %16, %15 : !torch.int, !torch.int -> !torch.int
+      %18 = torch.aten.sub.int %10, %int2 : !torch.int, !torch.int -> !torch.int
+      %19 = torch.aten.__getitem__.t %arg3, %18 : !torch.list<int>, !torch.int -> !torch.int
+      %20 = torch.aten.floordiv.int %17, %19 : !torch.int, !torch.int -> !torch.int
+      %21 = torch.aten.add.int %int1, %20 : !torch.int, !torch.int -> !torch.int
+      %22 = torch.aten.append.t %4, %21 : !torch.list<int>, !torch.int -> !torch.list<int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    return %4 : !torch.list<int>
+  }
+  func @"__torch_mlir_shape_fn.aten.convolution_backward_overrideable"(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.list<int>, %arg3: !torch.list<int>, %arg4: !torch.list<int>, %arg5: !torch.list<int>, %arg6: !torch.bool, %arg7: !torch.list<int>, %arg8: !torch.int, %arg9: !torch.list<bool>) -> !torch.tuple<list<int>, list<int>, list<int>> {
+    %int1 = torch.constant.int 1
+    %none = torch.constant.none
+    %0 = torch.derefine %none : !torch.none to !torch.optional<list<int>>
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.conv_output_size(%arg1, %arg2, %0, %arg3, %arg4, %arg5, %arg8) : (!torch.list<int>, !torch.list<int>, !torch.optional<list<int>>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.list<int>
+    %2 = torch.derefine %none : !torch.none to !torch.optional<list<int>>
+    %3 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.conv_output_valid(%arg0, %arg1, %2, %arg3, %arg4, %arg5, %arg8) : (!torch.list<int>, !torch.list<int>, !torch.optional<list<int>>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int) -> !torch.list<int>
+    %4 = torch.aten.__getitem__.t %arg0, %int1 : !torch.list<int>, !torch.int -> !torch.int
+    %5 = torch.prim.ListConstruct %4 : (!torch.int) -> !torch.list<int>
+    %6 = torch.prim.TupleConstruct %1, %3, %5 : !torch.list<int>, !torch.list<int>, !torch.list<int> -> !torch.tuple<list<int>, list<int>, list<int>>
+    return %6 : !torch.tuple<list<int>, list<int>, list<int>>
+  }
   func @"__torch_mlir_shape_fn.aten.batch_norm"(%arg0: !torch.list<int>, %arg1: !torch.optional<list<int>>, %arg2: !torch.optional<list<int>>, %arg3: !torch.optional<list<int>>, %arg4: !torch.optional<list<int>>, %arg5: !torch.bool, %arg6: !torch.float, %arg7: !torch.float, %arg8: !torch.bool) -> !torch.list<int> {
     return %arg0 : !torch.list<int>
   }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -762,6 +762,16 @@ def aten〇topk(self: List[int], k: int, dim: int = -1, largest: bool = True, so
 def aten〇conv2d(input: List[int], weight: List[int], bias: Optional[List[int]] = None, stride: List[int] = (1, 1), padding: List[int] = (0, 0), dilation: List[int] = (1, 1), groups: int = 1) -> List[int]:
     return upstream_shape_helpers.conv2d(input, weight, bias, stride, padding, dilation, groups)
 
+def aten〇convolution_backward(grad_output: List[int], input: List[int], weight: List[int], bias_sizes: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], transposed: bool, output_padding: List[int], groups: int, output_mask: List[bool]) -> Tuple[List[int], List[int], List[int]]:
+    inGrad = upstream_shape_helpers.conv_output_size(grad_output, weight, None, stride, padding, dilation, groups)
+    weightGrad = upstream_shape_helpers.conv_output_valid(input, grad_output, None, stride, padding, dilation, groups)
+    return inGrad, weightGrad, [grad_output[1]]
+
+def aten〇convolution_backward_overrideable(grad_output: List[int], input: List[int], weight: List[int], stride: List[int], padding: List[int], dilation: List[int], transposed: bool, output_padding: List[int], groups: int, output_mask: List[bool]) -> Tuple[List[int], List[int], List[int]]:
+    inGrad = upstream_shape_helpers.conv_output_size(input, weight, None, stride, padding, dilation, groups)
+    weightGrad = upstream_shape_helpers.conv_output_valid(grad_output, input, None, stride, padding, dilation, groups)
+    return inGrad, weightGrad, [grad_output[1]]
+
 def aten〇batch_norm(input: List[int], weight: Optional[List[int]], bias: Optional[List[int]], running_mean: Optional[List[int]], running_var: Optional[List[int]], training: bool, momentum: float, eps: float, cudnn_enabled: bool) -> List[int]:
     # Torch's symbolic shape analysis is a bit looser about optional
     # arguments than we are, so their batch_norm helper function works

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -27,6 +27,7 @@ TORCH_TYPE_TO_ODS_TYPE = {
     "int": "Torch_IntType",
     "int[]": "TorchIntListType",
     "int?": "TorchOptionalIntType",
+    "int[]?": "TorchOptionalIntListType",
     "bool": "Torch_BoolType",
     "bool[]": "TorchBoolListType",
     "bool?": "TorchOptionalBoolType",
@@ -307,6 +308,8 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit(
         "aten::conv2d : (Tensor, Tensor, Tensor?, int[], int[], int[], int) -> (Tensor)"
     )
+    emit("aten::convolution_backward : (Tensor, Tensor, Tensor, int[]?, int[], int[], int[], bool, int[], int, bool[]) -> (Tensor, Tensor, Tensor)")
+    emit("aten::convolution_backward_overrideable : (Tensor, Tensor, Tensor, int[], int[], int[], bool, int[], int, bool[]) -> (Tensor, Tensor, Tensor)")
     emit(
         "aten::native_batch_norm : (Tensor, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, float) -> (Tensor, Tensor, Tensor)"
     )

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/upstream_shape_helpers.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/upstream_shape_helpers.py
@@ -515,6 +515,23 @@ def conv_output_size(input_size: List[int], weight_size: List[int], bias: Option
     output_size.append((input_size[d] + (2 * padding[d - 2]) - kernel) // stride[d - 2] + 1)
   return output_size
 
+def conv_output_valid(input_size: List[int], weight_size: List[int], bias: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], groups: int):
+  check_shape_forward(input_size, weight_size, bias, stride, padding, dilation, groups)
+
+  has_dilation = len(dilation) > 0
+  dim = len(input_size)
+  output_size: List[int] = []
+  input_batch_size_dim = 0
+  weight_output_channels_dim = 0
+  output_size.append(input_size[input_batch_size_dim])
+  output_size.append(weight_size[weight_output_channels_dim])
+
+  for d in range(2, dim):
+    dilation_ = dilation[d - 2] if has_dilation else 1
+    kernel = dilation_ * (weight_size[d] - 1) + 1
+    output_size.append(1 + ((input_size[d] - kernel) // stride[d-2]))
+  return output_size
+
 def conv1d(input: List[int], weight: List[int], bias: Optional[List[int]], stride: List[int], padding: List[int], dilation: List[int], groups: int):
   assert len(weight) == 3
   assert len(input) == 3

--- a/python/torch_mlir_e2e_test/test_suite/backprop.py
+++ b/python/torch_mlir_e2e_test/test_suite/backprop.py
@@ -92,8 +92,7 @@ class ConvolutionBackwardModule2D(torch.nn.Module):
 @register_test_case(module_factory=lambda: ConvolutionBackwardModule2D())
 def ConvolutionBackwardModule2D_basic(module, tu: TestUtils):
     with torch.backends.mkldnn.flags(enabled=False):
-        grad = torch.stack([torch.tensor([float(x)]*2*2).reshape(2, 2) for x in list(range(3*3))]).reshape(2, 2, 3, 3)
-        module.forward(grad, torch.ones(2, 2, 4, 4), torch.ones(2, 2, 2, 2))
+        module.forward(torch.ones(2, 2, 3, 3), torch.ones(2, 2, 4, 4), torch.ones(2, 2, 2, 2))
 
 #class ConvolutionBackwardModule3D(torch.nn.Module):
 #    def __init__(self):

--- a/python/torch_mlir_e2e_test/test_suite/backprop.py
+++ b/python/torch_mlir_e2e_test/test_suite/backprop.py
@@ -56,6 +56,66 @@ def TanhBackward_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+#class ConvolutionBackwardModule1D(torch.nn.Module):
+#    def __init__(self):
+#        super().__init__()
+#
+#    @export
+#    @annotate_args([
+#        None,
+#        ([-1, -1, -1], torch.float32, True),
+#        ([-1, -1, -1], torch.float32, True),
+#        ([-1, -1, -1], torch.float32, True),
+#    ])
+#    def forward(self, grad_out, input_vec, weight):
+#        return torch.ops.aten.convolution_backward(grad_out, input_vec, weight, bias_sizes=None, stride=[1], padding=[0], dilation=[1], transposed=False, output_padding=[0], groups=1, output_mask=[True, True, True])
+
+#@register_test_case(module_factory=lambda: ConvolutionBackwardModule1D())
+#def ConvolutionBackwardModule1D_basic(module, tu: TestUtils):
+#    with torch.backends.mkldnn.flags(enabled=False):
+#        module.forward(torch.randn(3, 3, 3), torch.randn(3, 3, 3), torch.randn(3, 3, 1))
+
+class ConvolutionBackwardModule2D(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.float32, True),
+        ([-1, -1, -1, -1], torch.float32, True),
+        ([-1, -1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, grad_out, input_vec, weight):
+        return torch.ops.aten.convolution_backward(grad_out, input_vec, weight, bias_sizes=None, stride=[1, 1], padding=[0, 0], dilation=[1, 1], transposed=False, output_padding=[0], groups=1, output_mask=[True, True, True])
+
+@register_test_case(module_factory=lambda: ConvolutionBackwardModule2D())
+def ConvolutionBackwardModule2D_basic(module, tu: TestUtils):
+    with torch.backends.mkldnn.flags(enabled=False):
+        grad = torch.stack([torch.tensor([float(x)]*2*2).reshape(2, 2) for x in list(range(3*3))]).reshape(2, 2, 3, 3)
+        module.forward(grad, torch.ones(2, 2, 4, 4), torch.ones(2, 2, 2, 2))
+
+#class ConvolutionBackwardModule3D(torch.nn.Module):
+#    def __init__(self):
+#        super().__init__()
+
+#    @export
+#    @annotate_args([
+#        None,
+#        ([-1, -1, -1, -1, -1], torch.float32, True),
+#        ([-1, -1, -1, -1, -1], torch.float32, True),
+#        ([-1, -1, -1, -1, -1], torch.float32, True),
+#    ])
+#    def forward(self, grad_out, input_vec, weight):
+#        return torch.ops.aten.convolution_backward(grad_out, input_vec, weight, bias_sizes=None, stride=[1, 1, 1], padding=[0], dilation=[1, 1, 1], transposed=False, output_padding=[0], groups=1, output_mask=[True, True, True])
+
+#@register_test_case(module_factory=lambda: ConvolutionBackwardModule3D())
+#def ConvolutionBackwardModule3D_basic(module, tu: TestUtils):
+#    with torch.backends.mkldnn.flags(enabled=False):
+#        module.forward(torch.randn(3, 3, 3, 3, 3), torch.randn(3, 3, 3, 3, 3), torch.randn(3, 3, 1, 1, 1))
+
+# ==============================================================================
+
 class GeluBackwardModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/python/torch_mlir_e2e_test/torchscript/reporting.py
+++ b/python/torch_mlir_e2e_test/torchscript/reporting.py
@@ -158,6 +158,11 @@ class ValueReport:
                     f'dtype ({value.dtype}) is not equal to golden dtype ({golden.dtype})'
                 )
             if not torch.allclose(value, golden, rtol=1e-03, atol=1e-07, equal_nan=True):
+                torch.set_printoptions(sci_mode=False)
+                print("==Value==")
+                print(value)
+                print("==Golden==")
+                print(golden)
                 return self._record_failure(
                     f'value ({TensorSummary(value)}) is not close to golden value ({TensorSummary(golden)})'
                 )

--- a/python/torch_mlir_e2e_test/utils.py
+++ b/python/torch_mlir_e2e_test/utils.py
@@ -19,11 +19,18 @@ def get_module_name_for_debug_dump(module):
         return "UnnammedModule"
     return StringAttr(module.operation.attributes["torch.debug_module_name"]).value
 
+mlircount = 0
 def run_pipeline_with_repro_report(module,
                                    pipeline: str,
                                    description: str):
     """Runs `pipeline` on `module`, with a nice repro report if it fails."""
+    global mlircount
     module_name = get_module_name_for_debug_dump(module)
+    filename = os.path.join(os.getcwd(), module_name + "_" + str(mlircount) + ".mlir")
+    mlircount += 1
+    print(pipeline)
+    with open(filename, 'w') as f:
+        f.write(str(module))
     try:
         original_stderr = sys.stderr 
         sys.stderr = StringIO()


### PR DESCRIPTION
I've been working on an implementation for `convolution_backward` and I'm running into a roadblock that I hope some fresh eyes will help me figure out. I've got the 1D case almost finished (except the bias gradient) but I'm not getting the expected results for the input and weight gradients. The weight gradient in particular is orders of magnitude off.