### PR TITLE
Add maximize-value-semantics support for ops with two tensor inputs

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -2859,6 +2859,20 @@ def Torch_AtenExpandOp : Torch_Op<"aten.expand", [
   let assemblyFormat = "$self `,` $size `,` $implicit attr-dict `:` qualified(type($self)) `,` qualified(type($size)) `,` qualified(type($implicit)) `->` qualified(type($result))";
 }
 
+def Torch_AtenExpandAsOp : Torch_Op<"aten.expand_as", [
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::expand_as : (Tensor, Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchTensorType:$other
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $other attr-dict `:` qualified(type($self)) `,` qualified(type($other)) `->` qualified(type($result))";
+}
+
 def Torch_AtenBroadcastToOp : Torch_Op<"aten.broadcast_to", [
     AllowsTypeRefinement,
     ReadOnly

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -397,6 +397,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::ones_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)")
         emit("aten::empty.memory_format : (int[], int?, int?, Device?, bool?, int?) -> (Tensor)")
         emit("aten::expand : (Tensor, int[], bool) -> (Tensor)")
+        emit("aten::expand_as : (Tensor, Tensor) -> (Tensor)")
         emit("aten::broadcast_to : (Tensor, int[]) -> (Tensor)")
         emit("aten::index.Tensor : (Tensor, Tensor?[]) -> (Tensor)")
         emit("aten::index_select : (Tensor, int, Tensor) -> (Tensor)")

--- a/test/Dialect/Torch/maximize-value-semantics.mlir
+++ b/test/Dialect/Torch/maximize-value-semantics.mlir
@@ -220,3 +220,27 @@ func @viewlike$unmodeled_op(%arg0: !torch.vtensor) -> !torch.vtensor {
   %2 = torch.copy.to_vtensor %1 : !torch.vtensor
   return %2 : !torch.vtensor
 }
+
+// CHECK-LABEL:   func @viewlike$two_inputs_one_copy(
+// CHECK-SAME:                                       %[[ARG:.*]]: !torch.vtensor) -> !torch.vtensor {
+// CHECK:           %[[EXPAND_AS:.*]] = torch.aten.expand_as %[[ARG]], %[[ARG]] : !torch.vtensor, !torch.vtensor -> !torch.vtensor
+// CHECK:           return %[[EXPAND_AS]] : !torch.vtensor
+func @viewlike$two_inputs_one_copy(%arg0: !torch.vtensor) -> !torch.vtensor {
+  %0 = torch.copy.to_tensor %arg0 : !torch.tensor
+  %1 = torch.aten.expand_as %0, %0 : !torch.tensor, !torch.tensor -> !torch.tensor
+  %2 = torch.copy.to_vtensor %1 : !torch.vtensor
+  return %2 : !torch.vtensor
+}
+
+// CHECK-LABEL:   func @viewlike$two_inputs_two_copies(
+// CHECK-SAME:                                         %[[ARG0:.*]]: !torch.vtensor,
+// CHECK-SAME:                                         %[[ARG1:.*]]: !torch.vtensor) -> !torch.vtensor {
+// CHECK:           %[[EXPAND_AS:.*]] = torch.aten.expand_as %[[ARG0]], %[[ARG1]] : !torch.vtensor, !torch.vtensor -> !torch.vtensor
+// CHECK:           return %[[EXPAND_AS]] : !torch.vtensor
+func @viewlike$two_inputs_two_copies(%arg0: !torch.vtensor, %arg1: !torch.vtensor) -> !torch.vtensor {
+  %0 = torch.copy.to_tensor %arg0 : !torch.tensor
+  %1 = torch.copy.to_tensor %arg1 : !torch.tensor
+  %2 = torch.aten.expand_as %0, %1 : !torch.tensor, !torch.tensor -> !torch.tensor
+  %3 = torch.copy.to_vtensor %2 : !torch.vtensor
+  return %3 : !torch.vtensor
+}


### PR DESCRIPTION
This commit adds value semantics support for ops such as
`aten.view_as` and `aten.expand_as` that take two tensors as input.

This is needed for the implementation of `aten.expand_as` that 
@vivekkhandelwal1 is currently working on.

I also simplified a few things in the implementation.