### PR TITLE
Avoid `using` the `torch_upstream` namespace.

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
@@ -21,6 +21,10 @@
 // original PyTorch license and the code here should not be mixed with "code
 // that we [Torch-MLIR] write".
 
+// Note: As a coding convention, we should never `using` the `torch_upstream`
+// namespace. This is to ensure that at a glance from the code, it is clear
+// that we are referencing upstream types.
+
 namespace mlir {
 namespace torch {
 namespace torch_upstream {

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -20,7 +20,6 @@
 using namespace mlir;
 using namespace mlir::torch;
 using namespace mlir::torch::Torch;
-using namespace mlir::torch::torch_upstream; // For ScalarType and type
 
 // Helper funtion to get rank of `Base tensor type`.
 // -1 is returned if the tensorRank can't be determined.


### PR DESCRIPTION
This is code that we always want to treat as "foreign" and not get too
comfortable using in many functions. One way to accomplish that is to
make it a bit clunkier to use.

Also, fix Utils.cpp to match the LLVM/MLIR coding conventions (don't
define functions inside namespaces -- prefer `using` and explicit
qualification).