### PR TITLE
Make TorchOps.cpp faster to iterate on.

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -62,7 +62,7 @@ def Torch_NnModuleOp : Torch_Op<"nn_module", [
   let arguments = (ins);
   let results = (outs Torch_NnModuleType:$result);
   let regions = (region SizedRegion<1>:$region);
-  let verifier = "return ::verify(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat = "$region attr-dict `:` qualified(type($result))";
 
@@ -146,7 +146,7 @@ def Torch_ClassTypeOp : Torch_Op<"class_type", [
   let arguments = (ins SymbolNameAttr:$sym_name);
   let results = (outs);
   let regions = (region SizedRegion<1>:$region);
-  let verifier = "return ::verify(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat = "$sym_name $region attr-dict";
 }
@@ -360,7 +360,7 @@ def Torch_PrimListConstructOp: Torch_Op<"prim.ListConstruct", [
     AnyTorchListType:$result
   );
 
-  let verifier = "return ::verify(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     $elements attr-dict `:` functional-type(operands, results)
@@ -382,7 +382,7 @@ def Torch_PrimDictConstructOp: Torch_Op<"prim.DictConstruct", [
     Torch_DictType:$result
   );
 
-  let verifier = "return ::verify(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     `keys` `(` ($keys^ `:` qualified(type($keys)))? `)` `values` `(` ($values^ `:` qualified(type($values)))? `)` attr-dict `->` qualified(type($result))
@@ -474,7 +474,7 @@ def Torch_PrimLoopOp : Torch_Op<"prim.Loop", [
     $maxTripCount `,` $initialCondition `,` `init` `(` $iterArgsInit `)` $region
     attr-dict `:` functional-type(operands, results)
   }];
-  let verifier = [{ return RegionBranchOpInterface::verifyTypes(*this); }];
+  let hasVerifier = 1;
   let extraClassDeclaration = [{
     /// Returns true if this loop is "for-like". Otherwise it is "while-like"
     /// and this function returns false.
@@ -528,7 +528,7 @@ def Torch_PrimIfOp : Torch_Op<"prim.If", [
   let regions = (region SizedRegion<1>:$thenRegion, SizedRegion<1>:$elseRegion);
   // Indicate that the operation has a custom parser and printer method.
   let hasCustomAssemblyFormat = 1;
-  let verifier = [{ return RegionBranchOpInterface::verifyTypes(*this); }];
+  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -877,7 +877,7 @@ def Torch_CopyToNonValueTensorOp : Torch_Op<"copy.to_tensor", [
   let assemblyFormat = [{
     $operand attr-dict `:` qualified(type($result))
   }];
-  let verifier = "return ::verify(*this);";
+  let hasVerifier = 1;
 }
 
 def Torch_CopyToValueTensorOp : Torch_Op<"copy.to_vtensor", [
@@ -907,7 +907,7 @@ def Torch_CopyToValueTensorOp : Torch_Op<"copy.to_vtensor", [
   let assemblyFormat = [{
     $operand attr-dict `:` qualified(type($result))
   }];
-  let verifier = "return ::verify(*this);";
+  let hasVerifier = 1;
 }
 
 def Torch_OverwriteTensorContentsOp : Torch_Op<"overwrite.tensor.contents", [
@@ -1083,7 +1083,7 @@ def Torch_ShapeCalculateOp : Torch_Op<"shape.calculate", [
   let assemblyFormat = [{
     $body `shapes` $shapeCalculation attr-dict `:` type($results)
   }];
-  let verifier = [{ return RegionBranchOpInterface::verifyTypes(*this); }];
+  let hasVerifier = 1;
 }
 
 def Torch_ShapeCalculateYieldOp : Torch_Op<"shape.calculate.yield", [
@@ -1126,7 +1126,7 @@ def Torch_ShapeCalculateYieldShapesOp : Torch_Op<"shape.calculate.yield.shapes",
     attr-dict ($results^ `:` type($results))?
   }];
 
-  let verifier = "return ::verify(*this);";
+  let hasVerifier = 1;
 }
 
 #endif // TORCH_OPS

--- a/include/torch-mlir/Dialect/Torch/IR/TorchTypes.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchTypes.h
@@ -16,6 +16,16 @@ namespace mlir {
 namespace torch {
 namespace Torch {
 
+/// PyTorch has a well-developed notion of subtyping.
+///
+/// This is a restricted subset of it that only handles a few special cases
+/// that we need to model.
+///
+/// TODO: Flesh this out.
+/// TODO: Decide / properly model the distinction between PEP 483 / Python
+/// subtyping vs "more static information".
+bool isValidSubtype(Type subtype, Type type);
+
 class NonValueTensorType;
 class ValueTensorType;
 

--- a/lib/Dialect/Torch/IR/CMakeLists.txt
+++ b/lib/Dialect/Torch/IR/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(TorchMLIRTorchDialect
   TorchDialect.cpp
   TorchOps.cpp
+  TorchOpsODSGenerated.cpp
   TorchTypes.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/Torch/IR/TorchOpsODSGenerated.cpp
+++ b/lib/Dialect/Torch/IR/TorchOpsODSGenerated.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is meant to include the `TorchOps.cpp.inc` file and compile it
+// separately from the main TorchOps.cpp file. The .inc file takes a very long
+// time to compile, and slows down the iteration time on folders,
+// canonicalizations, parser/printers, etc. in the actual TorchOps.cpp file, so
+// it makes sense to isolate it and let the build system cache it.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Support/LLVM.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Casting.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+#define GET_OP_CLASSES
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.cpp.inc"


### PR DESCRIPTION
The ODS-generated code included via the `TorchOps.cpp.inc` file takes a
very long time to compile. This PR isolates it into its own file so that
the build system can cache it.

This PR creates a new file `TorchOpsODSGenerated.cpp` just to include
the `TorchOps.cpp.inc` file. Doing so required moving to the "new" way
to define verifiers, since the static `verify` free functions in
TorchOps.cpp weren't accessible from the .inc file after it was moved to
`TorchOpsODSGenerated.cpp`.

On my machine, this drops the build time of TorchOps.cpp (such as when
iterating on a canonicalizer) from >40 seconds to <10 seconds.
10 seconds still isn't great though, but at least it isn't "go get a
coffee" type of waiting.