### PR TITLE
[TORCH][MLIR] Fix the return types of `aten.native_layer_norm`.

### DIFF
--- a/e2e_testing/torchscript/norm_like.py
+++ b/e2e_testing/torchscript/norm_like.py
@@ -204,13 +204,33 @@ class NativeLayerNormModule(torch.nn.Module):
     ])
     def forward(self, x, weight, bias):
         list = [2, 2, 3]
-        # TODO: Fix the case of the other return values.
         return torch.ops.aten.native_layer_norm(
-            x, list, weight, bias, eps=0.5)[0]
+            x, list, weight, bias, eps=0.5)
 
 
 @register_test_case(module_factory=lambda: NativeLayerNormModule())
 def NativeLayerNormModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 5, 2, 2, 3), tu.rand(2, 2, 3), tu.rand(2, 2, 3))
+
+class NativeLayerNormDynamicModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x, weight, bias):
+        list = [2, 2, 3]
+        return torch.ops.aten.native_layer_norm(
+            x, list, weight, bias, eps=0.5)
+
+
+@register_test_case(module_factory=lambda: NativeLayerNormDynamicModule())
+def NativeLayerNormDynamicModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 5, 2, 2, 3), tu.rand(2, 2, 3), tu.rand(2, 2, 3))
 
 # ==============================================================================

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -1118,9 +1118,10 @@ class DecomposeAtenLayerNormOp : public OpRewritePattern<AtenLayerNormOp> {
     Value normalizedShape = op.normalized_shape();
     SmallVector<Value> normalizedShapeSizesTorchInt;
     getListConstructElements(normalizedShape, normalizedShapeSizesTorchInt);
-    std::vector<int64_t> meanVarSizes;
-    for (int i = normalizedShapeSizesTorchInt.size(); i < inputRank; i++)
-      meanVarSizes.push_back(input.getSizes()[i]);
+    int64_t axis = inputRank - normalizedShapeSizesTorchInt.size();
+    std::vector<int64_t> meanVarSizes(inputRank, 1);
+    for (int i = 0; i < axis; i++)
+      meanVarSizes[i] = input.getSizes()[i];
     auto meanVarType = input.getWithSizesAndDtype(
         llvm::makeArrayRef(meanVarSizes), input.getDtype());
     auto nativeLayerNorm = rewriter.create<AtenNativeLayerNormOp>(

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -2505,20 +2505,36 @@ module {
   }
   func @"__torch_mlir_shape_fn.aten.native_layer_norm"(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.optional<list<int>>, %arg3: !torch.optional<list<int>>, %arg4: !torch.float) -> !torch.tuple<list<int>, list<int>, list<int>> {
     %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %str = torch.constant.str "AssertionError: "
+    %none = torch.constant.none
     %true = torch.constant.bool true
     %0 = torch.prim.ListConstruct  : () -> !torch.list<int>
-    %1 = torch.aten.len.t %arg1 : !torch.list<int> -> !torch.int
-    %2 = torch.aten.len.t %arg0 : !torch.list<int> -> !torch.int
-    %3 = torch.aten.__range_length %1, %2, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    %1 = torch.aten.len.t %arg0 : !torch.list<int> -> !torch.int
+    %2 = torch.aten.len.t %arg1 : !torch.list<int> -> !torch.int
+    %3 = torch.aten.sub.int %1, %2 : !torch.int, !torch.int -> !torch.int
+    %4 = torch.aten.ge.int %3, %int0 : !torch.int, !torch.int -> !torch.bool
+    torch.prim.If %4 -> () {
+      torch.prim.If.yield
+    } else {
+      torch.prim.RaiseException %str, %none : !torch.str, !torch.none
+      torch.prim.If.yield
+    }
     torch.prim.Loop %3, %true, init() {
     ^bb0(%arg5: !torch.int):
-      %5 = torch.aten.__derive_index %arg5, %1, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
-      %6 = torch.aten.__getitem__.t %arg0, %5 : !torch.list<int>, !torch.int -> !torch.int
-      %7 = torch.aten.append.t %0, %6 : !torch.list<int>, !torch.int -> !torch.list<int>
+      %8 = torch.aten.__getitem__.t %arg0, %arg5 : !torch.list<int>, !torch.int -> !torch.int
+      %9 = torch.aten.append.t %0, %8 : !torch.list<int>, !torch.int -> !torch.list<int>
       torch.prim.Loop.condition %true, iter()
     } : (!torch.int, !torch.bool) -> ()
-    %4 = torch.prim.TupleConstruct %arg0, %0, %0 : !torch.list<int>, !torch.list<int>, !torch.list<int> -> !torch.tuple<list<int>, list<int>, list<int>>
-    return %4 : !torch.tuple<list<int>, list<int>, list<int>>
+    %5 = torch.aten.len.t %arg0 : !torch.list<int> -> !torch.int
+    %6 = torch.aten.__range_length %3, %5, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+    torch.prim.Loop %6, %true, init() {
+    ^bb0(%arg5: !torch.int):
+      %8 = torch.aten.append.t %0, %int1 : !torch.list<int>, !torch.int -> !torch.list<int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    %7 = torch.prim.TupleConstruct %arg0, %0, %0 : !torch.list<int>, !torch.list<int>, !torch.list<int> -> !torch.tuple<list<int>, list<int>, list<int>>
+    return %7 : !torch.tuple<list<int>, list<int>, list<int>>
   }
   func @"__torch_mlir_shape_fn.aten.native_batch_norm"(%arg0: !torch.list<int>, %arg1: !torch.optional<list<int>>, %arg2: !torch.optional<list<int>>, %arg3: !torch.optional<list<int>>, %arg4: !torch.optional<list<int>>, %arg5: !torch.bool, %arg6: !torch.float, %arg7: !torch.float) -> !torch.tuple<list<int>, list<int>, list<int>> {
     %int0 = torch.constant.int 0

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -766,25 +766,17 @@ def aten〇nll_loss_forward(self: List[int], target: List[int], weight: Optional
 def aten〇nll_loss_backward(grad_output: List[int], self: List[int], target: List[int], weight: Optional[List[int]], reduction: int, ignore_index: int, total_weight: List[int]) -> List[int]:
     return upstream_shape_helpers.unary(self)
 
-# TODO: Fix shape function (see body).
-# @check_shape_function([
-#     Invocation(TensorOfShape(2, 5, 2, 2, 3), [2, 2, 3], None, None, 1e-6), # Basic case.
-# ])
+@check_shape_function([
+    Invocation(TensorOfShape(2, 5, 2, 2, 3), [2, 2, 3], None, None, 1e-6), # Basic case.
+])
 def aten〇native_layer_norm(input: List[int], normalized_shape: List[int], weight: Optional[List[int]], bias: Optional[List[int]], eps: float) -> Tuple[List[int], List[int], List[int]]:
     reduction_shape: List[int] = []
-    # TODO: Fix buggy behavior. TorchToLinalg needs to properly handle the
-    # correctly inferred shapes.
-    # With input=[2, 5, 2, 2, 3] and normalized_shape=[2, 2, 3], we should get
-    # [[2, 5, 2, 2, 3], [2, 5, 1, 1, 1], [2, 5, 1, 1, 1]]
-    for i in range(len(normalized_shape), len(input)):
+    num_unreduced_dimensions = len(input) - len(normalized_shape)
+    assert num_unreduced_dimensions >= 0
+    for i in range(num_unreduced_dimensions):
         reduction_shape.append(input[i])
-    # Correct code:
-    # num_unreduced_dimensions = len(input) - len(normalized_shape)
-    # assert num_unreduced_dimensions >= 0
-    # for i in range(num_unreduced_dimensions):
-    #     reduction_shape.append(input[i])
-    # for i in range(num_unreduced_dimensions, len(input)):
-    #     reduction_shape.append(1)
+    for i in range(num_unreduced_dimensions, len(input)):
+        reduction_shape.append(1)
     return input, reduction_shape, reduction_shape
 
 @check_shape_function([


### PR DESCRIPTION
This commit fixes the 2nd and 3rd return types of the `aten.native_layer_norm`.
Previously the mean and rSTD were returned with reduction dims removed.
This commit fixes this and keeps the reduction dims of the results.

Signed-Off-By: Prateek Gupta <prateek@nord-labs.com>

fixes: #665 