### PR TITLE
Add non-default dtype support for a few elementwise math ops.

### DIFF
--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -37,6 +37,25 @@ def ElementwiseUnaryModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class ElementwiseUnaryIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+    def forward(self, a):
+        return torch.tanh(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseUnaryIntModule())
+def ElementwiseUnaryIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 4), dtype=torch.int32))
+
+# ==============================================================================
+
 class ElementwiseBinaryModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -279,6 +298,25 @@ class ElementwiseSigmoidModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseSigmoidModule())
 def ElementwiseSigmoidModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 5))
+
+# ==============================================================================
+
+class ElementwiseSigmoidIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+    def forward(self, x):
+        return torch.sigmoid(x)
+
+
+@register_test_case(module_factory=lambda: ElementwiseSigmoidIntModule())
+def ElementwiseSigmoidIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 5), dtype=torch.int32))
 
 # ==============================================================================
 
@@ -545,6 +583,25 @@ def ElementwiseLogModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class ElementwiseLogIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+    def forward(self, a):
+        return torch.log(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseLogIntModule())
+def ElementwiseLogIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 4), dtype=torch.int32))
+
+# ==============================================================================
+
 class ElementwiseErfModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -561,6 +618,25 @@ class ElementwiseErfModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseErfModule())
 def ElementwiseErfModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+
+class ElementwiseErfIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.erf(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseErfIntModule())
+def ElementwiseErfIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 4), dtype=torch.int32))
 
 # ==============================================================================
 
@@ -582,6 +658,26 @@ class ElementwiseSqrtModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseSqrtModule())
 def ElementwiseSqrtModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+
+class ElementwiseSqrtIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+
+    def forward(self, a):
+        return torch.sqrt(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseSqrtIntModule())
+def ElementwiseSqrtIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 4), dtype=torch.int32))
 
 # ==============================================================================
 
@@ -699,6 +795,25 @@ def ElementwiseLog2Module_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class ElementwiseLog2IntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+    def forward(self, a):
+        return torch.log2(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseLog2IntModule())
+def ElementwiseLog2IntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 4), dtype=torch.int32))
+
+# ==============================================================================
+
 class ElementwiseRsqrtModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -716,6 +831,26 @@ class ElementwiseRsqrtModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseRsqrtModule())
 def ElementwiseRsqrtModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+
+class ElementwiseRsqrtIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+
+    def forward(self, a):
+        return torch.rsqrt(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseRsqrtIntModule())
+def ElementwiseRsqrtIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 4), dtype=torch.int32))
 
 # ==============================================================================
 
@@ -754,6 +889,25 @@ class ElementwiseReciprocalModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseReciprocalModule())
 def ElementwiseReciprocalModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(4))
+
+# ==============================================================================
+
+class ElementwiseReciprocalIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int32, True),
+    ])
+
+    def forward(self, a):
+        return torch.reciprocal(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseReciprocalIntModule())
+def ElementwiseReciprocalIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (4,), dtype=torch.int32))
 
 # ==============================================================================
 
@@ -949,3 +1103,123 @@ class ElementwiseCloneContiguousModule(torch.nn.Module):
 def ElementwiseCloneContiguousModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 3, 4))
 
+# ==============================================================================
+
+class ElementwiseExpModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return torch.exp(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseExpModule())
+def ElementwiseExpModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+
+class ElementwiseExpIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+
+    def forward(self, a):
+        return torch.exp(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseExpIntModule())
+def ElementwiseExpIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 4), dtype=torch.int32))
+
+
+# ==============================================================================
+
+class ElementwiseSinModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return torch.sin(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseSinModule())
+def ElementwiseSinModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+
+class ElementwiseSinIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+
+    def forward(self, a):
+        return torch.sin(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseSinIntModule())
+def ElementwiseSinIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 4), dtype=torch.int32))
+
+# ==============================================================================
+
+class ElementwiseCosModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return torch.cos(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseCosModule())
+def ElementwiseCosModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+
+# ==============================================================================
+
+class ElementwiseCosIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int32, True),
+    ])
+
+    def forward(self, a):
+        return torch.cos(a)
+
+
+@register_test_case(module_factory=lambda: ElementwiseCosIntModule())
+def ElementwiseCosIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1, 10, (3, 4), dtype=torch.int32))

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -34,6 +34,7 @@ TOSA_PASS_SET = {
     "ElementwiseUnaryModule_basic",
     "ElementwiseBinaryModule_basic",
     "ElementwiseSigmoidModule_basic",
+    "ElementwiseExpModule_basic",
     "ElementwiseReluModule_basic",
     "ElementwiseFloorModule_basic",
     "ElementwiseLogModule_basic",

--- a/lib/Dialect/Torch/IR/UtilsForODSGenerated.cpp
+++ b/lib/Dialect/Torch/IR/UtilsForODSGenerated.cpp
@@ -62,19 +62,16 @@ ParseResult Torch::parseDefaultTorchOp(OpAsmParser &parser,
 
 void Torch::printDefaultTorchOp(OpAsmPrinter &p, Operation *op, int numOperands,
                                 int numResults) {
-  p << ' ';
-  llvm::interleaveComma(op->getOperands(), p);
-  p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{});
-  p << " : ";
   if (numOperands > 0) {
     p << ' ';
+    llvm::interleaveComma(op->getOperands(), p);
+  }
+  p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{});
+  p << " : ";
+  if (numOperands > 0)
     llvm::interleaveComma(op->getOperandTypes(), p);
-  }
-  if (numOperands > 0 && numResults > 0) {
+  if (numOperands > 0 && numResults > 0)
     p << " -> ";
-  }
-  if (numResults > 0) {
-    p << ' ';
+  if (numResults > 0)
     llvm::interleaveComma(op->getResultTypes(), p);
-  }
 }

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -72,6 +72,18 @@ module {
     %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
     return %0 : !torch.list<int>
   }
+  func @"__torch_mlir_shape_fn.aten.exp"(%arg0: !torch.list<int>) -> !torch.list<int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
+    return %0 : !torch.list<int>
+  }
+  func @"__torch_mlir_shape_fn.aten.sin"(%arg0: !torch.list<int>) -> !torch.list<int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
+    return %0 : !torch.list<int>
+  }
+  func @"__torch_mlir_shape_fn.aten.cos"(%arg0: !torch.list<int>) -> !torch.list<int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
+    return %0 : !torch.list<int>
+  }
   func @"__torch_mlir_shape_fn.aten.hardtanh"(%arg0: !torch.list<int>, %arg1: !torch.float, %arg2: !torch.float) -> !torch.list<int> {
     %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
     return %0 : !torch.list<int>
@@ -1859,7 +1871,7 @@ module {
       }
       torch.prim.If.yield
     }
-    %2 = torch.operator "aten.sub.float"(%arg1, %arg0) : (!torch.float, !torch.float) -> !torch.float
+    %2 = torch.aten.sub.float %arg1, %arg0 : !torch.float, !torch.float -> !torch.float
     %3 = torch.operator "aten.div.float"(%2, %arg2) : (!torch.float, !torch.float) -> !torch.float
     %4 = torch.operator "aten.ceil.float"(%3) : (!torch.float) -> !torch.int
     %5 = torch.prim.ListConstruct %4 : (!torch.int) -> !torch.list<int>
@@ -1891,7 +1903,7 @@ module {
       torch.prim.RaiseException %str, %none : !torch.str, !torch.none
       torch.prim.If.yield
     }
-    %2 = torch.operator "aten.sub.float"(%arg1, %arg0) : (!torch.float, !torch.float) -> !torch.float
+    %2 = torch.aten.sub.float %arg1, %arg0 : !torch.float, !torch.float -> !torch.float
     %3 = torch.operator "aten.ceil.float"(%2) : (!torch.float) -> !torch.int
     %4 = torch.prim.ListConstruct %3 : (!torch.int) -> !torch.list<int>
     return %4 : !torch.list<int>

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -303,6 +303,15 @@ def aten〇hardswish(self: List[int]) -> List[int]:
 def aten〇silu(self: List[int]) -> List[int]:
     return upstream_shape_helpers.unary(self)
 
+def aten〇exp(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇sin(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
+def aten〇cos(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
 def aten〇hardtanh(self: List[int], min_val: float = -1, max_val: float = 1) -> List[int]:
     return upstream_shape_helpers.unary(self)
 


### PR DESCRIPTION
This PR adds non-default dtype support for elementwise math ops:

- AtenTanhOp
- AtenExpOp 
- AtenSinOp
- AtenCosOp
- AtenSigmoidOp
- AtenReciprocalOp 
- AtenLogOp
- AtenSqrtOp
- AtenLog2Op 
- AtenRsqrtOp 
- AtenErfOp

Changes:

- Fix type inference: set the output dtype to `float32`, except for `float64` and `null` input. 
- Fix Torch2Linalg conversion: add dtype conversion over input value before math op.
- Add test cases with `int32` input.

@ramiro050 @cathyzhyi