### PR TITLE
[MLIR][TORCH] Add E2E support for aten.index_put.hacked_twin op

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -2599,6 +2599,57 @@ def Torch_AtenIndexPut_Op : Torch_Op<"aten.index_put_", [
   }];
 }
 
+def Torch_AtenIndexPutHackedTwinOp : Torch_Op<"aten.index_put.hacked_twin", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::index_put.hacked_twin : (Tensor, Tensor[], Tensor, bool) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchListOfTensorType:$indices,
+    AnyTorchTensorType:$values,
+    Torch_BoolType:$accumulate
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenIndexPutHackedTwinOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 4, 1);
+    }
+    void AtenIndexPutHackedTwinOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 4, 1);
+    }
+  }];
+}
+
+def Torch_AtenIndexPut_HackedTwinOp : Torch_Op<"aten.index_put_.hacked_twin", [
+    IsTrailingUnderscoreInplaceVariant,
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::index_put_.hacked_twin : (Tensor, Tensor[], Tensor, bool) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchListOfTensorType:$indices,
+    AnyTorchTensorType:$values,
+    Torch_BoolType:$accumulate
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenIndexPut_HackedTwinOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 4, 1);
+    }
+    void AtenIndexPut_HackedTwinOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 4, 1);
+    }
+  }];
+}
+
 def Torch_AtenLinearOp : Torch_Op<"aten.linear", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -498,7 +498,8 @@ ChangeResult TypeAnalyzer::visitOperation(
           AtenExpandOp, AtenExpandAsOp, AtenBroadcastToOp, AtenRepeatOp,
           AtenConstantPadNdOp, AtenZero_Op,
           AtenIndexTensorOp, ValsemVariantAtenIndexPutImplOp, AtenIndexPutOp,
-          ValsemVariantAtenCopyOp, ValsemVariantAtenZeroOp>(op)) {
+          ValsemVariantAtenCopyOp, ValsemVariantAtenZeroOp,
+          AtenIndexPutHackedTwinOp>(op)) {
     ValueKnowledge knowledge =
         ValueKnowledge::getNotNonePessimisticValueState(op->getContext());
     knowledge.dtype = operands[0]->getValue().dtype;

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -2475,6 +2475,10 @@ module {
     %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
     return %0 : !torch.list<int>
   }
+  func @"__torch_mlir_shape_fn.aten.index_put.hacked_twin"(%arg0: !torch.list<int>, %arg1: !torch.list<list<int>>, %arg2: !torch.list<int>, %arg3: !torch.bool) -> !torch.list<int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
+    return %0 : !torch.list<int>
+  }
   func @"__torch_mlir_shape_fn.aten.nll_loss_forward"(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.optional<list<int>>, %arg3: !torch.int, %arg4: !torch.int) -> !torch.tuple<list<int>, list<int>> {
     %int1 = torch.constant.int 1
     %int2 = torch.constant.int 2

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -796,6 +796,9 @@ def aten〇index_select(self: List[int], dim: int, index: List[int]) -> List[int
 def aten〇index_put(self: List[int], indices: List[Optional[List[int]]], values: List[int], accumulate: bool = False) -> List[int]:
     return upstream_shape_helpers.unary(self)
 
+def aten〇index_put〇hacked_twin(self: List[int], indices: List[List[int]], values: List[int], accumulate: bool = False) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
 def aten〇embedding(weight: List[int], indices: List[int], padding_idx: int = -1, scale_grad_by_freq: bool = False, sparse: bool = False) -> List[int]:
     return upstream_shape_helpers.embedding(weight, indices, padding_idx, scale_grad_by_freq, sparse)
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -299,6 +299,8 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit_with_mutating_variants("aten::triu : (Tensor, int) -> (Tensor)")
     emit_with_mutating_variants(
         "aten::index_put : (Tensor, Tensor?[], Tensor, bool) -> (Tensor)")
+    emit_with_mutating_variants(
+        "aten::index_put.hacked_twin : (Tensor, Tensor[], Tensor, bool) -> (Tensor)")
 
     # Non-elementwise tensor compute ops
     emit("aten::linear : (Tensor, Tensor, Tensor?) -> (Tensor)")

--- a/python/torch_mlir_e2e_test/test_suite/index_put.py
+++ b/python/torch_mlir_e2e_test/test_suite/index_put.py
@@ -11,552 +11,814 @@ from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
 
 # ==============================================================================
 
+
 class IndexPutImpl1DFloatNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten._index_put_impl_(input, (index,), value,
-                                          accumulate=False,
-                                          unsafe=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten._index_put_impl_(input, (index, ),
+                                               value,
+                                               accumulate=False,
+                                               unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImpl1DFloatNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutImpl1DFloatNonAccumulateModule())
 def IndexPutImpl1DFloatNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(100), torch.randint(100, (250,)),
-                 tu.rand(250))
+    module.forward(tu.rand(100), torch.randint(100, (250, )), tu.rand(250))
 
 
 class IndexPutImpl2DFloatNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1, -1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten._index_put_impl_(input, (index,), value,
-                                          accumulate=False,
-                                          unsafe=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten._index_put_impl_(input, (index, ),
+                                               value,
+                                               accumulate=False,
+                                               unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImpl2DFloatNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutImpl2DFloatNonAccumulateModule())
 def IndexPutImpl2DFloatNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
-                 tu.rand(5, 8))
+    module.forward(tu.rand(10, 8), torch.randint(4, (5, )), tu.rand(5, 8))
 
 
 class IndexPutImpl3DFloatNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1, -1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1, -1, -1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten._index_put_impl_(input, (index,), value,
-                                          accumulate=False,
-                                          unsafe=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten._index_put_impl_(input, (index, ),
+                                               value,
+                                               accumulate=False,
+                                               unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImpl3DFloatNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutImpl3DFloatNonAccumulateModule())
 def IndexPutImpl3DFloatNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
-                 tu.rand(5, 8, 6))
+    module.forward(tu.rand(10, 8, 6), torch.randint(4, (5, )),
+                   tu.rand(5, 8, 6))
+
+
+# ==============================================================================
 
 
 class IndexPutImpl1DIntNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten._index_put_impl_(input, (index,), value,
-                                          accumulate=False,
-                                          unsafe=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten._index_put_impl_(input, (index, ),
+                                               value,
+                                               accumulate=False,
+                                               unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImpl1DIntNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutImpl1DIntNonAccumulateModule())
 def IndexPutImpl1DIntNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(1000, (200,)), torch.randint(100, (300,)),
-                 torch.randint(10000, (300,)))
+    module.forward(torch.randint(1000, (200, )), torch.randint(100, (300, )),
+                   torch.randint(10000, (300, )))
+
+
+# ==============================================================================
 
 
 class IndexPutImpl1DFloatAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    # Since the input is updated in-place, we pass input.clone() in place
-    # of input to avoid wrong results.
-    return torch.ops.aten._index_put_impl_(input.clone(), (index,), value,
-                                          accumulate=True,
-                                          unsafe=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        # Since the input is updated in-place, we pass input.clone() in place
+        # of input to avoid wrong results.
+        return torch.ops.aten._index_put_impl_(input.clone(), (index, ),
+                                               value,
+                                               accumulate=True,
+                                               unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImpl1DFloatAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutImpl1DFloatAccumulateModule())
 def IndexPutImpl1DFloatAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(1000), torch.randint(10, (500,)),
-                 tu.rand(500))
+    module.forward(tu.rand(1000), torch.randint(10, (500, )), tu.rand(500))
 
 
 class IndexPutImpl2DFloatAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1, -1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten._index_put_impl_(input.clone(), (index,), value,
-                                          accumulate=True,
-                                          unsafe=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten._index_put_impl_(input.clone(), (index, ),
+                                               value,
+                                               accumulate=True,
+                                               unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImpl2DFloatAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutImpl2DFloatAccumulateModule())
 def IndexPutImpl2DFloatAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
-                 tu.rand(5, 8))
+    module.forward(tu.rand(10, 8), torch.randint(4, (5, )), tu.rand(5, 8))
 
 
 class IndexPutImpl3DFloatAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1, -1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1, -1, -1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten._index_put_impl_(input.clone(), (index,), value,
-                                          accumulate=True,
-                                          unsafe=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten._index_put_impl_(input.clone(), (index, ),
+                                               value,
+                                               accumulate=True,
+                                               unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImpl3DFloatAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutImpl3DFloatAccumulateModule())
 def IndexPutImpl3DFloatAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
-                 tu.rand(5, 8, 6))
+    module.forward(tu.rand(10, 8, 6), torch.randint(4, (5, )),
+                   tu.rand(5, 8, 6))
+
+
+# ==============================================================================
 
 
 class IndexPutImpl1DIntAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    # Since the input is updated in-place, we pass input.clone() in place
-    # of input to avoid wrong results.
-    return torch.ops.aten._index_put_impl_(input.clone(), (index,), value,
-                                          accumulate=True,
-                                          unsafe=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        # Since the input is updated in-place, we pass input.clone() in place
+        # of input to avoid wrong results.
+        return torch.ops.aten._index_put_impl_(input.clone(), (index, ),
+                                               value,
+                                               accumulate=True,
+                                               unsafe=False)
 
 
 @register_test_case(module_factory=lambda: IndexPutImpl1DIntAccumulateModule())
 def IndexPutImpl1DIntAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(100, (10,)), torch.randint(10, (10,)),
-                 torch.randint(1000, (10,)))
+    module.forward(torch.randint(100, (10, )), torch.randint(10, (10, )),
+                   torch.randint(1000, (10, )))
+
 
 # ==============================================================================
 
+
 class IndexPut1DFloatNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, (index,), value, accumulate=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPut1DFloatNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPut1DFloatNonAccumulateModule())
 def IndexPut1DFloatNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(100), torch.randint(100, (250,)),
-                 tu.rand(250))
+    module.forward(tu.rand(100), torch.randint(100, (250, )), tu.rand(250))
+
+
+class IndexPut2DFloatNonAccumulateModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=False)
+
+
+@register_test_case(
+    module_factory=lambda: IndexPut2DFloatNonAccumulateModule())
+def IndexPut2DFloatNonAccumulateModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(10, 8), torch.randint(4, (5, )), tu.rand(5, 8))
+
+
+class IndexPut3DFloatNonAccumulateModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=False)
+
+
+@register_test_case(
+    module_factory=lambda: IndexPut3DFloatNonAccumulateModule())
+def IndexPut3DFloatNonAccumulateModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(10, 8, 6), torch.randint(4, (5, )),
+                   tu.rand(5, 8, 6))
+
+
+# ==============================================================================
 
 
 class IndexPut1DIntNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, (index,), value, accumulate=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=False)
 
 
 @register_test_case(module_factory=lambda: IndexPut1DIntNonAccumulateModule())
 def IndexPut1DIntNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(1000, (200,)), torch.randint(100, (300,)),
-                 torch.randint(10000, (300,)))
+    module.forward(torch.randint(1000, (200, )), torch.randint(100, (300, )),
+                   torch.randint(10000, (300, )))
+
+
+class IndexPut2DIntNonAccumulateModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=False)
+
+
+@register_test_case(module_factory=lambda: IndexPut2DIntNonAccumulateModule())
+def IndexPut2DIntNonAccumulateModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1000, (10, 8)), torch.randint(4, (5, )),
+                   torch.randint(1000, (5, 8)))
+
+
+class IndexPut3DIntNonAccumulateModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=False)
+
+
+@register_test_case(module_factory=lambda: IndexPut3DIntNonAccumulateModule())
+def IndexPut3DIntNonAccumulateModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1000, (10, 8, 6)), torch.randint(4, (5, )),
+                   torch.randint(1000, (5, 8, 6)))
+
+
+# ==============================================================================
 
 
 class IndexPut1DFloatAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, (index,), value, accumulate=True)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=True)
 
 
 @register_test_case(module_factory=lambda: IndexPut1DFloatAccumulateModule())
 def IndexPut1DFloatAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(1000), torch.randint(10, (500,)),
-                 tu.rand(500))
+    module.forward(tu.rand(1000), torch.randint(10, (500, )), tu.rand(500))
+
+
+class IndexPut2DFloatAccumulateModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPut2DFloatAccumulateModule())
+def IndexPut2DFloatAccumulateModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(10, 8), torch.randint(4, (5, )), tu.rand(5, 8))
+
+
+class IndexPut3DFloatAccumulateModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPut3DFloatAccumulateModule())
+def IndexPut3DFloatAccumulateModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(10, 8, 6), torch.randint(4, (5, )),
+                   tu.rand(5, 8, 6))
+
+
+# ==============================================================================
 
 
 class IndexPut1DIntAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, (index,), value, accumulate=True)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=True)
 
 
 @register_test_case(module_factory=lambda: IndexPut1DIntAccumulateModule())
 def IndexPut1DIntAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(100, (10,)), torch.randint(10, (10,)),
-                 torch.randint(1000, (10,)))
+    module.forward(torch.randint(100, (10, )), torch.randint(10, (10, )),
+                   torch.randint(1000, (10, )))
+
+
+class IndexPut2DIntAccumulateModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPut2DIntAccumulateModule())
+def IndexPut2DIntAccumulateModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1000, (10, 8)), torch.randint(4, (5, )),
+                   torch.randint(1000, (5, 8)))
+
+
+class IndexPut3DIntAccumulateModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, (index, ),
+                                        value,
+                                        accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPut3DIntAccumulateModule())
+def IndexPut3DIntAccumulateModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(1000, (10, 8, 6)), torch.randint(4, (5, )),
+                   torch.randint(1000, (5, 8, 6)))
+
 
 # ==============================================================================
 # IndexPutHackedTwin tests are using the aten.index_put.hacked_twin operator.
 
+
 class IndexPutHackedTwin1DFloatNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index],
+                                        value,
+                                        accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin1DFloatNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin1DFloatNonAccumulateModule())
 def IndexPutHackedTwin1DFloatNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(100), torch.randint(100, (250,)),
-                 tu.rand(250))
+    module.forward(tu.rand(100), torch.randint(100, (250, )), tu.rand(250))
 
 
 class IndexPutHackedTwin2DFloatNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1, -1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index],
+                                        value,
+                                        accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin2DFloatNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin2DFloatNonAccumulateModule())
 def IndexPutHackedTwin2DFloatNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
-                 tu.rand(5, 8))
+    module.forward(tu.rand(10, 8), torch.randint(4, (5, )), tu.rand(5, 8))
 
 
 class IndexPutHackedTwin3DFloatNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1, -1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1, -1, -1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index],
+                                        value,
+                                        accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin3DFloatNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin3DFloatNonAccumulateModule())
 def IndexPutHackedTwin3DFloatNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
-                 tu.rand(5, 8, 6))
+    module.forward(tu.rand(10, 8, 6), torch.randint(4, (5, )),
+                   tu.rand(5, 8, 6))
+
+
+# ==============================================================================
 
 
 class IndexPutHackedTwin1DIntNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index],
+                                        value,
+                                        accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin1DIntNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin1DIntNonAccumulateModule())
 def IndexPutHackedTwin1DIntNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(1000, (200,)), torch.randint(100, (300,)),
-                 torch.randint(10000, (300,)))
+    module.forward(torch.randint(1000, (200, )), torch.randint(100, (300, )),
+                   torch.randint(10000, (300, )))
 
 
 class IndexPutHackedTwin2DIntNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1, -1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index],
+                                        value,
+                                        accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin2DIntNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin2DIntNonAccumulateModule())
 def IndexPutHackedTwin2DIntNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(1000, (10, 8)), torch.randint(4, (5,)),
-                 torch.randint(1000, (5, 8)))
+    module.forward(torch.randint(1000, (10, 8)), torch.randint(4, (5, )),
+                   torch.randint(1000, (5, 8)))
 
 
 class IndexPutHackedTwin3DIntNonAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1, -1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1, -1, -1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index],
+                                        value,
+                                        accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin3DIntNonAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin3DIntNonAccumulateModule())
 def IndexPutHackedTwin3DIntNonAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(1000, (10, 8, 6)), torch.randint(4, (5,)),
-                 torch.randint(1000, (5, 8, 6)))
+    module.forward(torch.randint(1000, (10, 8, 6)), torch.randint(4, (5, )),
+                   torch.randint(1000, (5, 8, 6)))
+
+
+# ==============================================================================
 
 
 class IndexPutHackedTwin1DFloatAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index], value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin1DFloatAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin1DFloatAccumulateModule())
 def IndexPutHackedTwin1DFloatAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(1000), torch.randint(10, (500,)),
-                 tu.rand(500))
+    module.forward(tu.rand(1000), torch.randint(10, (500, )), tu.rand(500))
 
 
 class IndexPutHackedTwin2DFloatAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1, -1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index], value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin2DFloatAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin2DFloatAccumulateModule())
 def IndexPutHackedTwin2DFloatAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
-                 tu.rand(5, 8))
+    module.forward(tu.rand(10, 8), torch.randint(4, (5, )), tu.rand(5, 8))
 
 
 class IndexPutHackedTwin3DFloatAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1, -1], torch.float32, True),
-      ([-1], torch.int64, True),
-      ([-1, -1, -1], torch.float32, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index], value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin3DFloatAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin3DFloatAccumulateModule())
 def IndexPutHackedTwin3DFloatAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
-                 tu.rand(5, 8, 6))
+    module.forward(tu.rand(10, 8, 6), torch.randint(4, (5, )),
+                   tu.rand(5, 8, 6))
+
+
+# ==============================================================================
 
 
 class IndexPutHackedTwin1DIntAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index], value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin1DIntAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin1DIntAccumulateModule())
 def IndexPutHackedTwin1DIntAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(100, (10,)), torch.randint(10, (10,)),
-                 torch.randint(1000, (10,)))
+    module.forward(torch.randint(100, (10, )), torch.randint(10, (10, )),
+                   torch.randint(1000, (10, )))
 
 
 class IndexPutHackedTwin2DIntAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1, -1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index], value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin2DIntAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin2DIntAccumulateModule())
 def IndexPutHackedTwin2DIntAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(1000, (10, 8)), torch.randint(4, (5,)),
-                 torch.randint(1000, (5, 8)))
+    module.forward(torch.randint(1000, (10, 8)), torch.randint(4, (5, )),
+                   torch.randint(1000, (5, 8)))
 
 
 class IndexPutHackedTwin3DIntAccumulateModule(torch.nn.Module):
 
-  def __init__(self):
-    super().__init__()
+    def __init__(self):
+        super().__init__()
 
-  @export
-  @annotate_args([
-      None,
-      ([-1, -1, -1], torch.int64, True),
-      ([-1], torch.int64, True),
-      ([-1, -1, -1], torch.int64, True),
-  ])
-  def forward(self, input, index, value):
-    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+        ([-1], torch.int64, True),
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, input, index, value):
+        return torch.ops.aten.index_put(input, [index], value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutHackedTwin3DIntAccumulateModule())
+@register_test_case(
+    module_factory=lambda: IndexPutHackedTwin3DIntAccumulateModule())
 def IndexPutHackedTwin3DIntAccumulateModule_basic(module, tu: TestUtils):
-  module.forward(torch.randint(1000, (10, 8, 6)), torch.randint(4, (5,)),
-                 torch.randint(1000, (5, 8, 6)))
+    module.forward(torch.randint(1000, (10, 8, 6)), torch.randint(4, (5, )),
+                   torch.randint(1000, (5, 8, 6)))

--- a/python/torch_mlir_e2e_test/test_suite/index_put.py
+++ b/python/torch_mlir_e2e_test/test_suite/index_put.py
@@ -294,3 +294,269 @@ class IndexPut1DIntAccumulateModule(torch.nn.Module):
 def IndexPut1DIntAccumulateModule_basic(module, tu: TestUtils):
   module.forward(torch.randint(100, (10,)), torch.randint(10, (10,)),
                  torch.randint(1000, (10,)))
+
+# ==============================================================================
+# IndexPutHackedTwin tests are using the aten.index_put.hacked_twin operator.
+
+class IndexPutHackedTwin1DFloatNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin1DFloatNonAccumulateModule())
+def IndexPutHackedTwin1DFloatNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(100), torch.randint(100, (250,)),
+                 tu.rand(250))
+
+
+class IndexPutHackedTwin2DFloatNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin2DFloatNonAccumulateModule())
+def IndexPutHackedTwin2DFloatNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
+                 tu.rand(5, 8))
+
+
+class IndexPutHackedTwin3DFloatNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin3DFloatNonAccumulateModule())
+def IndexPutHackedTwin3DFloatNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
+                 tu.rand(5, 8, 6))
+
+
+class IndexPutHackedTwin1DIntNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.int64, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.int64, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin1DIntNonAccumulateModule())
+def IndexPutHackedTwin1DIntNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(torch.randint(1000, (200,)), torch.randint(100, (300,)),
+                 torch.randint(10000, (300,)))
+
+
+class IndexPutHackedTwin2DIntNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1], torch.int64, True),
+      ([-1], torch.int64, True),
+      ([-1, -1], torch.int64, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin2DIntNonAccumulateModule())
+def IndexPutHackedTwin2DIntNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(torch.randint(1000, (10, 8)), torch.randint(4, (5,)),
+                 torch.randint(1000, (5, 8)))
+
+
+class IndexPutHackedTwin3DIntNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.int64, True),
+      ([-1], torch.int64, True),
+      ([-1, -1, -1], torch.int64, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin3DIntNonAccumulateModule())
+def IndexPutHackedTwin3DIntNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(torch.randint(1000, (10, 8, 6)), torch.randint(4, (5,)),
+                 torch.randint(1000, (5, 8, 6)))
+
+
+class IndexPutHackedTwin1DFloatAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin1DFloatAccumulateModule())
+def IndexPutHackedTwin1DFloatAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1000), torch.randint(10, (500,)),
+                 tu.rand(500))
+
+
+class IndexPutHackedTwin2DFloatAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin2DFloatAccumulateModule())
+def IndexPutHackedTwin2DFloatAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
+                 tu.rand(5, 8))
+
+
+class IndexPutHackedTwin3DFloatAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin3DFloatAccumulateModule())
+def IndexPutHackedTwin3DFloatAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
+                 tu.rand(5, 8, 6))
+
+
+class IndexPutHackedTwin1DIntAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.int64, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.int64, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin1DIntAccumulateModule())
+def IndexPutHackedTwin1DIntAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(torch.randint(100, (10,)), torch.randint(10, (10,)),
+                 torch.randint(1000, (10,)))
+
+
+class IndexPutHackedTwin2DIntAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1], torch.int64, True),
+      ([-1], torch.int64, True),
+      ([-1, -1], torch.int64, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin2DIntAccumulateModule())
+def IndexPutHackedTwin2DIntAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(torch.randint(1000, (10, 8)), torch.randint(4, (5,)),
+                 torch.randint(1000, (5, 8)))
+
+
+class IndexPutHackedTwin3DIntAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.int64, True),
+      ([-1], torch.int64, True),
+      ([-1, -1, -1], torch.int64, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten.index_put(input, [index], value, accumulate=True)
+
+
+@register_test_case(module_factory=lambda: IndexPutHackedTwin3DIntAccumulateModule())
+def IndexPutHackedTwin3DIntAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(torch.randint(1000, (10, 8, 6)), torch.randint(4, (5,)),
+                 torch.randint(1000, (5, 8, 6)))


### PR DESCRIPTION
This commit decomposes `aten.index_put.hacked_twin` op into
`valsem.aten.index_put_impl` op.

Signed-Off By: Vivek Khandelwal <vivek@nod-labs.com>