### PR TITLE
Add bazel build support (1/N)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ __pycache__
 *.egg-info
 *.whl
 /wheelhouse
+
+# Bazel
+bazel-*

--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -1,0 +1,13 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+build --action_env=CC=clang
+build --action_env=CXX=clang++
+build --cxxopt=-std=c++14 
+build --host_cxxopt=-std=c++14 
+build --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=0
+build --cxxopt=-U__GXX_ABI_VERSION
+build --cxxopt=-D__GXX_ABI_VERSION=1011
+build --cxxopt=-DPYBIND11_COMPILER_TYPE=\"_gcc\"
+build --cxxopt=-DMLIR_PYTHON_PACKAGE_PREFIX=torch_mlir.

--- a/utils/bazel/BUILD.bazel
+++ b/utils/bazel/BUILD.bazel
@@ -1,0 +1,5 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Required to reference .bzl files in this package

--- a/utils/bazel/WORKSPACE.bazel
+++ b/utils/bazel/WORKSPACE.bazel
@@ -1,0 +1,46 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+    ],
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+new_local_repository(
+    name = "llvm-raw",
+    build_file_content = "# empty",
+    path = "../../externals/llvm-project",
+)
+
+load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure", "llvm_disable_optional_support_deps")
+
+llvm_configure(
+  name = "llvm-project",
+  repo_mapping = {
+    "@python_runtime": "@local_config_python",
+  },
+)
+llvm_disable_optional_support_deps()
+
+new_local_repository(
+    name = "torch-mlir-raw",
+    build_file_content = "# empty",
+    path = "../../"
+)
+
+load("@torch-mlir-raw//utils/bazel:configure.bzl", "torch_mlir_configure")
+
+torch_mlir_configure(
+  name = "torch-mlir"
+)

--- a/utils/bazel/configure.bzl
+++ b/utils/bazel/configure.bzl
@@ -1,0 +1,56 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Helper macros to configure torch-mlir overlay project."""
+
+# This is adapted from llvm-project's utils/bazel/configure.bzl
+
+DEFAULT_OVERLAY_PATH = "torch-mlir-overlay"
+
+def _overlay_directories(repository_ctx):
+    src_path = repository_ctx.path(Label("//:WORKSPACE")).dirname
+    bazel_path = src_path.get_child("utils").get_child("bazel")
+    overlay_path = bazel_path.get_child("torch-mlir-overlay")
+    script_path = bazel_path.get_child("overlay_directories.py")
+
+    python_bin = repository_ctx.which("python3")
+    if not python_bin:
+        # Windows typically just defines "python" as python3. The script itself
+        # contains a check to ensure python3.
+        python_bin = repository_ctx.which("python")
+
+    if not python_bin:
+        fail("Failed to find python3 binary")
+
+    cmd = [
+        python_bin,
+        script_path,
+        "--src",
+        src_path,
+        "--overlay",
+        overlay_path,
+        "--target",
+        ".",
+    ]
+    exec_result = repository_ctx.execute(cmd, timeout = 20)
+
+    if exec_result.return_code != 0:
+        fail(("Failed to execute overlay script: '{cmd}'\n" +
+              "Exited with code {return_code}\n" +
+              "stdout:\n{stdout}\n" +
+              "stderr:\n{stderr}\n").format(
+            cmd = " ".join([str(arg) for arg in cmd]),
+            return_code = exec_result.return_code,
+            stdout = exec_result.stdout,
+            stderr = exec_result.stderr,
+        ))
+
+def _torch_mlir_configure_impl(repository_ctx):
+    _overlay_directories(repository_ctx)
+
+torch_mlir_configure = repository_rule(
+    implementation = _torch_mlir_configure_impl,
+    local = True,
+    configure = True
+)

--- a/utils/bazel/overlay_directories.py
+++ b/utils/bazel/overlay_directories.py
@@ -1,0 +1,96 @@
+#!/bin/python3
+
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is copied from llvm-project's utils/bazel/overlay_directories.py
+
+"""Overlays two directories into a target directory using symlinks.
+
+Tries to minimize the number of symlinks created (that is, does not symlink
+every single file). Symlinks every file in the overlay directory. Only symlinks
+individual files in the source directory if their parent directory is also
+contained in the overlay directory tree.
+"""
+
+import argparse
+import errno
+import os
+import sys
+
+
+def _check_python_version():
+  if sys.version_info[0] < 3:
+    raise RuntimeError(
+        "Must be invoked with a python 3 interpreter but was %s" %
+        sys.executable)
+
+
+def _check_dir_exists(path):
+  if not os.path.isdir(path):
+    raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), path)
+
+
+def parse_arguments():
+  parser = argparse.ArgumentParser(description="""
+    Overlays two directories into a target directory using symlinks.
+
+    Tries to minimize the number of symlinks created (that is, does not symlink
+    every single file). Symlinks every file in the overlay directory. Only
+    symlinks individual files in the source directory if their parent directory
+    is also contained in the overlay directory tree.
+    """)
+  parser.add_argument(
+      "--src",
+      required=True,
+      help="Directory that contains most of the content to symlink.")
+  parser.add_argument(
+      "--overlay",
+      required=True,
+      help="Directory to overlay on top of the source directory.")
+  parser.add_argument(
+      "--target",
+      required=True,
+      help="Directory in which to place the fused symlink directories.")
+
+  args = parser.parse_args()
+
+  _check_dir_exists(args.target)
+  _check_dir_exists(args.overlay)
+  _check_dir_exists(args.src)
+
+  return args
+
+
+def _symlink_abs(from_path, to_path):
+  if not os.path.exists(to_path):
+    os.symlink(os.path.abspath(from_path), os.path.abspath(to_path))
+
+
+def main(args):
+  for root, dirs, files in os.walk(args.overlay):
+    # We could do something more intelligent here and only symlink individual
+    # files if the directory is present in both overlay and src. This could also
+    # be generalized to an arbitrary number of directories without any
+    # "src/overlay" distinction. In the current use case we only have two and
+    # the overlay directory is always small, so putting that off for now.
+    rel_root = os.path.relpath(root, start=args.overlay)
+    if rel_root != ".":
+      os.mkdir(os.path.join(args.target, rel_root))
+
+    for file in files:
+      relpath = os.path.join(rel_root, file)
+      _symlink_abs(os.path.join(args.overlay, relpath),
+                   os.path.join(args.target, relpath))
+
+    for src_entry in os.listdir(os.path.join(args.src, rel_root)):
+      if src_entry not in dirs:
+        relpath = os.path.join(rel_root, src_entry)
+        _symlink_abs(os.path.join(args.src, relpath),
+                     os.path.join(args.target, relpath))
+
+
+if __name__ == "__main__":
+  _check_python_version()
+  main(parse_arguments())

--- a/utils/bazel/torch-mlir-overlay/.bazelignore
+++ b/utils/bazel/torch-mlir-overlay/.bazelignore
@@ -1,0 +1,7 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Skip the following directories when overlaying 
+utils/bazel
+externals

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -1,0 +1,822 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "gentbl_filegroup", "td_library")
+
+package(
+    default_visibility = [
+    "//visibility:public",
+    ],
+)
+
+# Torch Dialect/IR
+td_library(
+    name = "MLIRTorchOpsIncGenTdFiles",
+    srcs = [
+        "include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td",
+        "include/torch-mlir/Dialect/Torch/IR/TorchBase.td",
+        "include/torch-mlir/Dialect/Torch/IR/TorchOps.td",
+        "include/torch-mlir/Dialect/Torch/IR/TorchTypes.td"
+    ],
+    includes = ["include"],
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:CastInterfacesTdFiles",
+        "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles"
+    ]
+)
+
+gentbl_cc_library(
+    name = "MLIRTorchOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "include/torch-mlir/Dialect/Torch/IR/TorchOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "include/torch-mlir/Dialect/Torch/IR/TorchOps.cpp.inc"
+        ),
+        (
+            [
+                "-gen-dialect-decls",
+                "-dialect=torch",
+            ],
+            "include/torch-mlir/Dialect/Torch/IR/TorchDialect.h.inc"
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+                "-dialect=torch",
+            ],
+            "include/torch-mlir/Dialect/Torch/IR/TorchDialect.cpp.inc"
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "include/torch-mlir/Dialect/Torch/IR/TorchOps.td",
+    deps = [
+        ":MLIRTorchOpsIncGenTdFiles"
+    ]
+)
+
+gentbl_cc_library(
+    name = "MLIRTorchTypesIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            ["-gen-typedef-decls"],
+            "include/torch-mlir/Dialect/Torch/IR/TorchTypes.h.inc"
+        ),
+        (
+            ["-gen-typedef-defs"],
+            "include/torch-mlir/Dialect/Torch/IR/TorchTypes.cpp.inc"
+        )
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "include/torch-mlir/Dialect/Torch/IR/TorchTypes.td",
+    deps = [
+        ":MLIRTorchOpsIncGenTdFiles"
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRTorchDialectUtils",
+    srcs = [
+        "lib/Dialect/Torch/Utils/Utils.cpp",
+        "lib/Dialect/Torch/Utils/TorchUpstream.cpp"
+    ],
+    strip_include_prefix = "include",
+    hdrs = [
+        "include/torch-mlir/Dialect/Torch/Utils/Utils.h",
+        "include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h",
+        "include/torch-mlir/Dialect/Torch/IR/TorchOps.h",
+        "include/torch-mlir/Dialect/Torch/IR/TorchTraits.h",
+        "include/torch-mlir/Dialect/Torch/IR/TorchTypes.h"
+    ],
+    deps = [
+        ":MLIRTorchOpsIncGen",
+        ":MLIRTorchTypesIncGen",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:ControlFlowInterfaces",
+        "@llvm-project//mlir:InferTypeOpInterface",
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRTorchDialect",
+    srcs = [
+        "lib/Dialect/Torch/IR/TorchDialect.cpp",
+        "lib/Dialect/Torch/IR/TorchOps.cpp",
+        "lib/Dialect/Torch/IR/TorchTypes.cpp",
+        "lib/Dialect/Torch/IR/TorchOpsODSGenerated.cpp",
+        "lib/Dialect/Torch/IR/UtilsForODSGenerated.cpp",
+        "lib/Dialect/Torch/IR/UtilsForODSGenerated.h"
+    ],
+    hdrs = glob([
+        "include/torch-mlir/Dialect/Torch/IR/*.h",
+    ]),
+    includes = ["include"],
+    deps = [
+        ":MLIRTorchOpsIncGen",
+        ":MLIRTorchTypesIncGen",
+        ":TorchMLIRTorchDialectUtils",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:ControlFlowInterfaces",
+        "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:TransformUtils",
+    ]
+)
+
+# Torch Dialect/Transforms
+td_library(
+    name = "TorchMLIRTorchPassesTdFiles",
+    srcs = [
+        "include/torch-mlir/Dialect/Torch/Transforms/Passes.td"
+    ],
+    includes = ["include"],
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ]
+)
+
+gentbl_cc_library(
+    name = "TorchMLIRTorchPassesIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            ["-gen-pass-decls"],
+            "include/torch-mlir/Dialect/Torch/Transforms/Passes.h.inc",
+        )
+    ],
+    td_file = "include/torch-mlir/Dialect/Torch/Transforms/Passes.td",
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    deps = [
+        ":TorchMLIRTorchPassesTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ]
+)
+
+
+
+cc_library(
+    name = "TorchMLIRTorchPasses",
+    srcs = [
+        "lib/Dialect/Torch/Transforms/AdjustCallingConventions.cpp",
+        "lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp",
+        "lib/Dialect/Torch/Transforms/DropShapeCalculations.cpp",
+        "lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp",
+        "lib/Dialect/Torch/Transforms/InlineGlobalSlots.cpp",
+        "lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp",
+        "lib/Dialect/Torch/Transforms/Passes.cpp",
+        "lib/Dialect/Torch/Transforms/PrepareForGlobalizeObjectGraph.cpp",
+        "lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp",
+        "lib/Dialect/Torch/Transforms/RefinePublicReturn.cpp",
+        "lib/Dialect/Torch/Transforms/RefineTypes.cpp",
+        "lib/Dialect/Torch/Transforms/ReifyShapeCalculations.cpp",
+        "lib/Dialect/Torch/Transforms/ShapeLibrary.cpp",
+        "lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp",
+        "lib/Dialect/Torch/Transforms/PassDetail.h",
+    ],
+    hdrs = [
+        "include/torch-mlir/Dialect/Torch/Transforms/Passes.h",
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchDialect",
+        ":TorchMLIRTorchPassesIncGen",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:Parser"
+    ]
+)
+
+# TorchConversion diaelct
+td_library(
+    name = "MLIRTorchConversionOpsTdFiles",
+    srcs = [
+        "include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionBase.td",
+        "include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.td",
+    ],
+    includes = ["include"],
+    deps = [
+        ":MLIRTorchOpsIncGenTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:CastInterfacesTdFiles",
+        "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles"
+    ]
+)
+
+gentbl_cc_library(
+    name = "MLIRTorchConversionOpsIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.cpp.inc"
+        ),
+        (
+            [
+                "-gen-dialect-decls",
+                "-dialect=torch_c",
+            ],
+            "include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h.inc"
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+                "-dialect=torch_c",
+            ],
+            "include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.cpp.inc"
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.td",
+    deps = [
+        ":MLIRTorchConversionOpsTdFiles"
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRTorchConversionDialect",
+    srcs = [
+        "lib/Dialect/TorchConversion/IR/TorchConversionDialect.cpp",
+        "lib/Dialect/TorchConversion/IR/TorchConversionOps.cpp",
+    ],
+    hdrs = [
+        "include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h",
+        "include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h",
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":MLIRTorchConversionOpsIncGen",
+        ":TorchMLIRTorchDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface"
+    ]
+)
+
+# Conversion
+td_library(
+    name = "TorchMLIRConversionPassesTdFiles",
+    includes = ["include"],
+    srcs = [
+        "include/torch-mlir/Conversion/Passes.td"
+    ]
+)
+
+gentbl_cc_library(
+    name = "TorchMLIRConversionPassesIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            ["-gen-pass-decls"],
+            "include/torch-mlir/Conversion/Passes.h.inc",
+        )
+    ],
+    td_file = "include/torch-mlir/Conversion/Passes.td",
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    deps = [
+        ":TorchMLIRConversionPassesTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ]
+)
+
+# TorchConversion transforms
+td_library(
+    name = "TorchMLIRTorchConversionPassesTdFiles",
+    srcs = [
+        "include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td"
+    ],
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ]
+)
+gentbl_cc_library(
+    name = "TorchMLIRTorchConversionPassesIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            ["-gen-pass-decls"],
+            "include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h.inc",
+        )
+    ],
+    td_file = "include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td",
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    deps = [
+        ":TorchMLIRTorchConversionPassesTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRConversionUtils",
+    srcs = [
+        "lib/Conversion/Utils/Utils.cpp"
+    ],
+    hdrs = [
+        "include/torch-mlir/Conversion/Utils/Utils.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:ArithmeticDialect",
+        "@llvm-project//mlir:ControlFlowOps",
+        "@llvm-project//mlir:LinalgOps"
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRTorchToLinalg",
+    srcs = [
+        "lib/Conversion/TorchToLinalg/DataMovement.cpp",
+        "lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp",
+        "lib/Conversion/TorchToLinalg/Linear.cpp",
+        "lib/Conversion/TorchToLinalg/Pooling.cpp",
+        "lib/Conversion/TorchToLinalg/Random.cpp",
+        "lib/Conversion/TorchToLinalg/Reduction.cpp",
+        "lib/Conversion/TorchToLinalg/TensorConstructors.cpp",
+        "lib/Conversion/TorchToLinalg/TensorScalarInterop.cpp",
+        "lib/Conversion/TorchToLinalg/TorchToLinalg.cpp",
+        "lib/Conversion/TorchToLinalg/Uncategorized.cpp",
+        "lib/Conversion/TorchToLinalg/Utils.cpp",
+        "lib/Conversion/TorchToLinalg/Utils.h",
+        "lib/Conversion/TorchToLinalg/PopulatePatterns.h",
+        "lib/Conversion/PassDetail.h",
+    ],
+    hdrs = [
+        "include/torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRConversionUtils",
+        ":TorchMLIRTorchBackendTypeConversion",
+        ":TorchMLIRTorchDialect",
+        ":TorchMLIRConversionPassesIncGen",
+        ":TorchMLIRTorchConversionDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:ArithmeticDialect",
+        "@llvm-project//mlir:ControlFlowOps",
+        "@llvm-project//mlir:LinalgOps",
+        "@llvm-project//mlir:Dialect",
+        "@llvm-project//mlir:TensorUtils",
+        "@llvm-project//mlir:TransformUtils"
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRTorchToSCF",
+    srcs = [
+        "lib/Conversion/TorchToSCF/TorchToSCF.cpp",
+        "lib/Conversion/PassDetail.h",
+    ],
+    hdrs = [
+        "include/torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchBackendTypeConversion",
+        ":TorchMLIRTorchConversionDialect",
+        ":TorchMLIRConversionPassesIncGen",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:ArithmeticDialect",
+        "@llvm-project//mlir:ControlFlowOps",
+        "@llvm-project//mlir:LinalgOps",
+        "@llvm-project//mlir:Dialect",
+        "@llvm-project//mlir:TensorUtils",
+        "@llvm-project//mlir:TransformUtils"
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRTorchToStd",
+    srcs = [
+        "lib/Conversion/TorchToStd/TorchToStd.cpp",
+        "lib/Conversion/PassDetail.h"
+    ],
+    hdrs = [
+        "include/torch-mlir/Conversion/TorchToStd/TorchToStd.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchBackendTypeConversion",
+        ":TorchMLIRTorchConversionDialect",
+        ":TorchMLIRConversionPassesIncGen",
+        "@llvm-project//mlir:Dialect"
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRTorchToTMTensor",
+    srcs = [
+        "lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp",
+        "lib/Conversion/PassDetail.h",
+    ],
+    hdrs = [
+        "include/torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchBackendTypeConversion",
+        ":TorchMLIRTorchConversionDialect",
+        ":TorchMLIRConversionPassesIncGen",
+        ":TorchMLIRTMTensorDialect",
+        ":TorchMLIRConversionUtils",
+        "@llvm-project//mlir:LinalgOps"
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRConversionPasses",
+    srcs = [
+        "lib/Conversion/Passes.cpp"
+    ],
+    hdrs = [
+        "include/torch-mlir/Conversion/Passes.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchToLinalg",
+        ":TorchMLIRTorchToSCF",
+        ":TorchMLIRTorchToStd",
+        ":TorchMLIRTorchToTosa",
+        ":TorchMLIRTorchToTMTensor"
+    ]
+)
+
+
+cc_library(
+    name = "TorchMLIRTorchConversionPasses",
+    srcs = [
+        "lib/Dialect/TorchConversion/Transforms/Passes.cpp",
+        "lib/Dialect/TorchConversion/Transforms/BackendTypeConversionPasses.cpp",
+        "lib/Dialect/TorchConversion/Transforms/VerifyInvariantsBeforeBackendLowering.cpp",
+        "lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp",
+        "lib/Dialect/TorchConversion/Transforms/VerifyTosaBackendContract.cpp",
+        "lib/Dialect/TorchConversion/Transforms/PassDetail.h"
+    ],
+    hdrs = [
+        "include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h",
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchConversionPassesIncGen",
+        ":TorchMLIRTorchBackendTypeConversion",
+        ":TorchMLIRTorchDialect",
+        ":TorchMLIRTorchPasses",
+        ":TorchMLIRTorchConversionDialect",
+        ":TorchMLIRTorchToLinalg",
+        ":TorchMLIRTorchToSCF",
+        ":TorchMLIRTorchToStd",
+        ":TorchMLIRTorchToTosa",
+        ":TorchMLIRTorchToTMTensor",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:LinalgOps",
+        "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:TosaDialect",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:MemRefTransforms",
+        "@llvm-project//mlir:ConversionPasses",
+    ]
+)
+
+
+cc_library(
+    name = "TorchMLIRTorchToTosa",
+    srcs = [
+        "lib/Conversion/TorchToTosa/TorchToTosa.cpp",
+        "lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp",
+        "lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp",
+        "lib/Conversion/PassDetail.h",
+    ] ,
+    hdrs = [
+        "include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h",
+        "include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h",
+        "include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchBackendTypeConversion",
+        ":TorchMLIRTorchConversionDialect",
+        ":TorchMLIRConversionPassesIncGen",
+        "@llvm-project//mlir:Dialect",
+        "@llvm-project//mlir:QuantOps",
+        "@llvm-project//mlir:TosaDialect"
+    ]
+)
+
+# Dialects.TorchConversion
+cc_library(
+    name = "TorchMLIRTorchBackendTypeConversion",
+    srcs = [
+        "lib/Dialect/TorchConversion/Transforms/BackendTypeConversion.cpp"
+    ],
+    hdrs = [
+        "include/torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchConversionDialect",
+        "@llvm-project//mlir:FuncTransforms"
+    ]
+)
+
+# External dialects
+td_library(
+    name = "TorchMLIRTMTensorOpsTdFiles",
+    srcs = [
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorInterfaces.td",
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/ScalarLoopOpInterface.td",
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.td",
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorBase.td"
+    ],
+    includes = ["externals/llvm-external-projects/torch-mlir-dialects/include"],
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+        "@llvm-project//mlir:ControlFlowInterfacesTdFiles"
+    ]
+)
+
+gentbl_cc_library(
+    name = "TorchMLIRTMTensorInterfacesIncGen",
+    strip_include_prefix = "externals/llvm-external-projects/torch-mlir-dialects/include",
+    tbl_outs = [
+        (
+            ["-gen-op-interface-decls"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOpInterfaces.h.inc",
+        ),
+        (
+            ["-gen-op-interface-defs"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOpInterfaces.cpp.inc",
+        ),
+        (
+            ["-gen-type-interface-decls"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorTypeInterfaces.h.inc",
+        ),
+        (
+            ["-gen-type-interface-defs"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorTypeInterfaces.cpp.inc",    
+        )
+    ],
+    td_file = "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorInterfaces.td",    
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    deps = [
+        ":TorchMLIRTMTensorOpsTdFiles",
+    ]
+)
+
+gentbl_cc_library(
+    name = "TorchMLIRTMTensorScalarLoopOpInterfaceIncGen",
+    strip_include_prefix = "externals/llvm-external-projects/torch-mlir-dialects/include",
+    tbl_outs = [
+        (
+            ["-gen-op-interface-decls"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/ScalarLoopOpInterface.h.inc"
+        ),
+        (
+            ["-gen-op-interface-defs"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/ScalarLoopOpInterface.cpp.inc"
+        )
+    ],
+    td_file = "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/ScalarLoopOpInterface.td",    
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    deps = [
+        ":TorchMLIRTMTensorOpsTdFiles",
+    ]
+)
+
+gentbl_cc_library(
+    name = "TorchMLIRTMTensorOpsIncGen",
+    strip_include_prefix = "externals/llvm-external-projects/torch-mlir-dialects/include",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.h.inc"
+        ),
+        (
+            ["-gen-op-defs"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.cpp.inc"
+        ),
+        (
+            ["-gen-typedef-decls"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorTypes.h.inc"
+        ),
+        (
+            [
+                "-gen-dialect-decls",
+                "-dialect=tm_tensor"
+            ],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h.inc"
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+                "-dialect=tm_tensor"
+            ],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.cpp.inc"
+        ),
+    ],
+    td_file = "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.td",
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    deps = [
+        ":TorchMLIRTMTensorOpsTdFiles"
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRTMTensorDialect",
+    srcs = [
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorDialect.cpp",
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorInterfaces.cpp",
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorOps.cpp",
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/ScalarLoopOpInterface.cpp"
+    ],
+    hdrs = [
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorInterfaces.h",
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/ScalarLoopOpInterface.h",
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h",
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.h"
+    ],
+    strip_include_prefix = "externals/llvm-external-projects/torch-mlir-dialects/include",
+    deps = [
+        ":TorchMLIRTMTensorOpsIncGen",
+        ":TorchMLIRTMTensorScalarLoopOpInterfaceIncGen",
+        ":TorchMLIRTMTensorInterfacesIncGen",
+        "@llvm-project//mlir:Dialect",
+        "@llvm-project//mlir:DialectUtils",
+        "@llvm-project//mlir:ViewLikeInterface",
+        "@llvm-project//mlir:ControlFlowInterfaces",
+        "@llvm-project//mlir:Affine",
+        "@llvm-project//mlir:LinalgOps",
+    ]
+)
+
+td_library(
+    name = "TorchMLIRTMTensorTransformsPassesTdFiles",
+    srcs = [
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.td",
+    ],
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles"
+    ]
+)
+
+gentbl_cc_library(
+    name = "TorchMLIRTMTensorTransformsPassesIncGen",
+    strip_include_prefix = "externals/llvm-external-projects/torch-mlir-dialects/include",
+    tbl_outs = [
+        (
+            ["-gen-pass-decls"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.h.inc"
+        ),
+        (
+            ["-gen-pass-capi-header"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.h.cpi.inc"
+        ),
+        (
+            ["-gen-pass-capi-impl"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.cpi.cpp.inc"
+        )
+    ],
+    td_file = "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.td",
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    deps = [
+        ":TorchMLIRTMTensorTransformsPassesTdFiles"
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRTMTensorPasses",
+    strip_include_prefix = "externals/llvm-external-projects/torch-mlir-dialects/include",
+    srcs = [
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/Transforms/Bufferize.cpp",
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/Transforms/ConvertToLoops.cpp",
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/Transforms/Passes.cpp",
+    ],
+    hdrs = [
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.h",
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/PassDetail.h"
+    ],
+    deps = [
+        ":TorchMLIRTMTensorTransformsPassesIncGen",
+        ":TorchMLIRTMTensorDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:LinalgOps",
+        "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:BufferizationTransforms",
+        "@llvm-project//mlir:FuncTransforms",
+        "@llvm-project//mlir:LinalgTransforms"
+    ]
+)
+
+# RefBackend
+filegroup(
+    name = "TorchMLIRRefBackendPassesDetails",
+    srcs = [
+        "lib/RefBackend/PassDetail.h"
+    ]
+)
+
+td_library(
+    name = "TorchMLIRRefBackendPassTdFiles",
+    srcs = [
+        "include/torch-mlir/RefBackend/Passes.td"
+    ],
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ]
+)
+
+gentbl_cc_library(
+    name = "TorchMLIRRefBackendPassIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            ["-gen-pass-decls"],
+            "include/torch-mlir/RefBackend/Passes.h.inc",
+        )
+    ],
+    td_file = "include/torch-mlir/RefBackend/Passes.td",
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    deps = [
+        ":TorchMLIRRefBackendPassTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRRefBackendPass",
+    srcs = [
+        "lib/RefBackend/RefBackend.cpp"
+    ] + [":TorchMLIRRefBackendPassesDetails"],
+    hdrs = [
+        "include/torch-mlir/RefBackend/Passes.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRRefBackendPassIncGen",
+        ":TorchMLIRTorchConversionDialect",
+        ":TorchMLIRTorchBackendTypeConversion",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:ArithmeticTransforms",
+        "@llvm-project//mlir:LinalgOps",
+        "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:MathTransforms",
+    ]
+)
+
+cc_library(
+    name = "TorchMLIRInitAll",
+    srcs = [
+        "lib/InitAll.cpp"
+    ],
+    hdrs = [
+        "include/torch-mlir/InitAll.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchPasses",
+        ":TorchMLIRTorchConversionDialect",
+        ":TorchMLIRTorchDialect",
+        ":TorchMLIRTorchConversionPasses",
+        ":TorchMLIRTMTensorDialect",
+        ":TorchMLIRTMTensorPasses",
+        ":TorchMLIRConversionPasses",
+        ":TorchMLIRRefBackendPass",
+        "@llvm-project//mlir:Dialect",
+        "@llvm-project//mlir:DialectUtils",
+        "@llvm-project//mlir:IR"
+    ]
+)
+
+# tools
+cc_binary(
+    name = "torch-mlir-opt",
+    srcs = [
+        "tools/torch-mlir-opt/torch-mlir-opt.cpp"
+    ],
+    deps = [
+        ":TorchMLIRInitAll",
+        ":TorchMLIRTorchDialect",
+        ":TorchMLIRTorchPasses",
+        "@llvm-project//mlir:AllPassesAndDialects",
+        "@llvm-project//mlir:MlirOptLib"
+    ]
+)


### PR DESCRIPTION
This PR adds rules for building the compiler part with bazel, 
a followup PRs will include rules for building the python bindings.

Towards fixing #660 