### PR TITLE
[SimplifyShapeCalculations] Fix AbstractlyInterpretListOpsWithinABlock

### DIFF
--- a/lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp
+++ b/lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp
@@ -199,7 +199,8 @@ public:
       return failure();
 
     // Rewrite all users to use the appropriate list literals.
-    Value latestLiteral = op;
+    Value latestLiteral = rewriter.create<PrimListConstructOp>(
+        op->getLoc(), op.getType(), op->getOperands());
     int nextLiteral = 0;
     for (Operation *user : usersToInterpret) {
       if (auto append = dyn_cast<AtenAppendTOp>(user)) {

--- a/test/Dialect/Torch/simplify-shape-calculations.mlir
+++ b/test/Dialect/Torch/simplify-shape-calculations.mlir
@@ -191,6 +191,25 @@ func @abstractly_interpret_list_ops$mutation_ops(%arg0: !torch.vtensor, %arg1: !
   return %0 : !torch.vtensor
 }
 
+// Test interspersed mutation and evaluation ops.
+// CHECK-LABEL:   func @abstractly_interpret_list_ops$mix_mutation_and_evaluation_ops(
+// CHECK:             %[[SHAPE:.*]] = torch.prim.ListConstruct %int0, %int1, %int2 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK:             torch.shape.calculate.yield.shapes %[[SHAPE]] : !torch.list<int>
+func @abstractly_interpret_list_ops$mix_mutation_and_evaluation_ops(%arg0: !torch.vtensor) -> !torch.vtensor {
+  %0 = torch.shape.calculate {
+    torch.shape.calculate.yield %arg0 : !torch.vtensor
+  } shapes {
+    %1 = torch.prim.ListConstruct : () -> !torch.list<int>
+    %2 = torch.aten.len.t %1 : !torch.list<int> -> !torch.int
+    %3 = torch.aten.append.t %1, %2 : !torch.list<int>, !torch.int -> !torch.list<int>
+    %4 = torch.aten.len.t %1 : !torch.list<int> -> !torch.int
+    %5 = torch.aten.append.t %1, %4 : !torch.list<int>, !torch.int -> !torch.list<int>
+    %6 = torch.aten.len.t %1 : !torch.list<int> -> !torch.int
+    %7 = torch.aten.append.t %1, %6 : !torch.list<int>, !torch.int -> !torch.list<int>
+    torch.shape.calculate.yield.shapes %1 : !torch.list<int>
+  } : !torch.vtensor
+  return %0 : !torch.vtensor
+}
 
 // CHECK-LABEL:   func @abstractly_interpret_list_ops$use_of_alias$not_yet_handled(
 // CHECK:           torch.aten.append.t


### PR DESCRIPTION
The logic in the rewriting phase had a bug in case of a read-only op
coming before mutation ops. The logic would use the op itself as the
"latest literal", but that is not correct, because later on we replace
the op itself with the *final* "latest literal", assuming that all uses
of the op have been rewritten -- that was working in general, except for
any read-only ops at the beginning.

Big thanks to @ljfitz for the tiny reproducer!

Fixes #704