### PR TITLE
Add minimal support for Union types.

### DIFF
--- a/include/torch-mlir-c/TorchTypes.h
+++ b/include/torch-mlir-c/TorchTypes.h
@@ -53,6 +53,18 @@ torchMlirTorchTupleTypeGet(MlirContext context, intptr_t numContainedTypes,
                            MlirType const *containedTypes);
 
 //===----------------------------------------------------------------------===//
+// torch.union<T1, T2, T3> type.
+//===----------------------------------------------------------------------===//
+
+/// Checks whether the given type is a !torch.union type
+MLIR_CAPI_EXPORTED bool torchMlirTypeIsATorchUnion(MlirType t);
+
+/// Gets the !torch.union type with contained types `containedTypes`.
+MLIR_CAPI_EXPORTED MlirType
+torchMlirTorchUnionTypeGet(MlirContext context, intptr_t numContainedTypes,
+                           MlirType const *containedTypes);
+
+//===----------------------------------------------------------------------===//
 // torch.list<T> type.
 //===----------------------------------------------------------------------===//
 

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -686,6 +686,7 @@ def Torch_DerefineOp : Torch_Op<"derefine", [
   }];
 
   let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Torch_OperatorOp : Torch_Op<"operator", [

--- a/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
@@ -245,6 +245,24 @@ def Torch_TupleType : Torch_Type<"Tuple", "tuple"> {
   );
 }
 
+def Torch_UnionType : Torch_Type<"Union", "union"> {
+  let summary = "!torch.union<T1, T2, T3>";
+  let description = [{
+    Union type with 0-N alternative types.
+
+    NOTE: We use the terminology "contained types" for consistency with
+    PyTorch. Strictly speaking, the types aren't "contained" though.
+
+    TODO: Canonicalize unions based on subtype relations, to allow
+    using pointer equality to compare two unions for being the same.
+    For now, `!torch.union<T1, T2>` is different from `!torch.union<T2, T1>`,
+    and same for `!torch.union<T1, SubtypeOfT1>` vs `!torch.union<T1>`.
+  }];
+  let parameters = (ins
+    ArrayRefParameter<"::mlir::Type", "contained types">:$containedTypes
+  );
+}
+
 def Torch_DeviceType : Torch_Type<"Device", "Device"> {
   let summary = "Torch device";
 }
@@ -417,11 +435,9 @@ def AnyTorchOptionalTensorListType :
              "Any optional tensor list type (Tensor?[])">;
 
 // Note: TorchScript does not consider !torch.bool to be a Scalar.
-def AnyTorchScalarType : AnyTypeOf<[
-  Torch_IntType,
-  Torch_FloatType,
-  Torch_NumberType,
-], "Any Python numeric type compatible with being the scalar type of a tensor (`Scalar`)">;
+def AnyTorchScalarType :
+    Type<CPred<"isValidSubtype($_self, ::mlir::torch::Torch::NumberType::get($_self.getContext()))">,
+         "Any Python numeric type compatible with being the scalar type of a tensor">;
 def AnyTorchOptionalScalarType:
       OptionalOf<AnyTorchScalarType, "Optional torch scalar type">;
 
@@ -454,6 +470,7 @@ def AnyTorchType : AnyTypeOf<[
   Torch_OptionalType,
   Torch_StringType,
   Torch_TupleType,
+  Torch_UnionType,
 ], "Any type that is legal to pass to a Torch kernel">;
 
 def AnyTorchListType : ListOf<[AnyType], "Any Torch list Type">;

--- a/lib/CAPI/TorchTypes.cpp
+++ b/lib/CAPI/TorchTypes.cpp
@@ -61,6 +61,24 @@ MlirType torchMlirTorchTupleTypeGet(MlirContext context,
 }
 
 //===----------------------------------------------------------------------===//
+// torch.union<T1, T2, T3> type.
+//===----------------------------------------------------------------------===//
+
+bool torchMlirTypeIsATorchUnion(MlirType t) {
+  return unwrap(t).isa<Torch::UnionType>();
+}
+
+MlirType torchMlirTorchUnionTypeGet(MlirContext context,
+                                    intptr_t numContainedTypes,
+                                    MlirType const *containedTypes) {
+  return wrap(Torch::UnionType::get(
+      unwrap(context),
+      llvm::to_vector<6>(
+          llvm::map_range(llvm::makeArrayRef(containedTypes, numContainedTypes),
+                          [](MlirType t) { return unwrap(t); }))));
+}
+
+//===----------------------------------------------------------------------===//
 // torch.list<T> type.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -452,6 +452,20 @@ OpFoldResult DerefineOp::fold(ArrayRef<Attribute> operands) {
   return nullptr;
 }
 
+void DerefineOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add(+[](DerefineOp op, PatternRewriter &rewriter) {
+    bool madeChange = false;
+    for (OpOperand &use : llvm::make_early_inc_range(op->getUses())) {
+      if (use.getOwner()->hasTrait<OpTrait::AllowsTypeRefinement>()) {
+        use.set(op.getOperand());
+        madeChange = true;
+      }
+    }
+    return success(madeChange);
+  });
+}
+
 static OpFoldResult atenIsOrIsNotFoldHelper(Operation *op, bool equalIsTrue) {
   Value lhs = op->getOperand(0);
   Value rhs = op->getOperand(1);

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
@@ -181,6 +181,15 @@ MlirType torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
     return torchMlirTorchTupleTypeGet(context, containedTypes.size(),
                                       containedTypes.data());
   }
+  case TypeKind::UnionType: {
+    std::vector<MlirType> containedTypes;
+    for (const c10::TypePtr &type :
+         torchType->cast<c10::UnionType>()->containedTypes()) {
+      containedTypes.push_back(getMlirTypeFromTorchType(loc, type));
+    }
+    return torchMlirTorchUnionTypeGet(context, containedTypes.size(),
+                                      containedTypes.data());
+  }
   case TypeKind::ListType: {
     return torchMlirTorchListTypeGet(getMlirTypeFromTorchType(
         loc, torchType->cast<c10::ListType>()->getElementType()));

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,8 @@
 --pre
 
 numpy
-# TODO: Fix for latest PyTorch.
-torch==1.12.0.dev20220328+cpu
-torchvision==0.13.0.dev20220328+cpu
+torch
+torchvision
 
 # Build requirements.
 pybind11

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -35,6 +35,13 @@ func private @tuple.one_element() -> !torch.tuple<tensor>
 // CHECK: @tuple.two_elements() -> !torch.tuple<tensor, tensor>
 func private @tuple.two_elements() -> !torch.tuple<tensor, tensor>
 
+// CHECK: @union.empty() -> !torch.union<>
+func private @union.empty() -> !torch.union<>
+// CHECK: @union.one_element() -> !torch.union<tensor>
+func private @union.one_element() -> !torch.union<tensor>
+// CHECK: @union.two_elements() -> !torch.union<tensor, tensor>
+func private @union.two_elements() -> !torch.union<tensor, tensor>
+
 // CHECK: @dict() -> !torch.dict<str, tensor>
 func private @dict() -> !torch.dict<str, tensor>
 
@@ -133,4 +140,9 @@ func @shape_calculations(%arg0: !torch.vtensor) -> !torch.vtensor {
     torch.shape.calculate.yield.shapes %0 : !torch.list<int>
   } : !torch.vtensor
   return %0 : !torch.vtensor
+}
+
+func @number_type_subtypes(%arg0: !torch.tensor, %arg1: !torch.list<int>, %arg2: !torch.union<float, int>) {
+  %0 = torch.aten.constant_pad_nd %arg0, %arg1, %arg2 : !torch.tensor, !torch.list<int>, !torch.union<float, int> -> !torch.tensor
+  return
 }

--- a/test/python/importer/jit_ir/node_import/union.py
+++ b/test/python/importer/jit_ir/node_import/union.py
@@ -1,0 +1,24 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See LICENSE.pytorch for license information.
+
+from typing import Union
+
+import torch
+from torch_mlir.dialects.torch.importer.jit_ir import ModuleBuilder
+
+# RUN: %PYTHON %s | torch-mlir-opt | FileCheck %s
+
+mb = ModuleBuilder()
+
+# CHECK-LABEL:   func @__torch__.f(
+# CHECK-SAME:                      %{{.*}}: !torch.union<float, int>) -> !torch.none {
+
+@mb.import_function
+@torch.jit.script
+def f(x: Union[int, float]):
+  return
+ 
+assert isinstance(f, torch.jit.ScriptFunction)
+mb.module.operation.print()
+print()


### PR DESCRIPTION
A recent PyTorch commit made ConstantPad2d call a helper function with a
`Union[int, float]` type annotated. This commit adds minimal support for
representing and dealing with that.
https://github.com/pytorch/pytorch/pull/73287

Changes:
- Adding support for `!torch.union<T1, T2, T3>`/`Torch::UnionType`,
  along with the importer and CAPI code.
- Add support in isValidSubtype for union types.
- Adding a canonicalizer for `torch.derefine` to help simplify some code
  that derefines to a UnionType (this also fixes #664).

There is still more work to do for really supporting UnionType well,
such as canonicalizing UnionType's so that they can be compared with
pointer equality.