### PR TITLE
Add support for multi-dim input to `index_put_impl`

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -35,6 +35,9 @@ Value getDtypeIntValueForType(PatternRewriter &rewriter, Location loc,
 // Helper to convert a tensor to a specific scalar type.
 Value convertTensorToDtype(PatternRewriter &rewriter, Location loc, Value input,
                            Type dtype);
+// Helper funtion to get rank of `Base tensor type`.
+// -1 is returned if the tensorRank can't be determined.
+int getTensorRank(Value tensor);
 
 } // namespace Torch
 } // namespace torch

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -21,19 +21,6 @@ using namespace mlir;
 using namespace mlir::torch;
 using namespace mlir::torch::Torch;
 
-// Helper funtion to get rank of `Base tensor type`.
-// -1 is returned if the tensorRank can't be determined.
-static int getTensorRank(Value tensor) {
-  int tensorRank = -1;
-  BaseTensorType tensorType = tensor.getType().cast<BaseTensorType>();
-
-  if (tensorType.hasSizes()) {
-    ArrayRef<int64_t> tensorShape = tensorType.getSizes();
-    tensorRank = tensorShape.size();
-  }
-  return tensorRank;
-}
-
 // Helper function to compute the return type of the reduction function.
 // `dim` specifies the dimension to reduce and `keepDim` preserves the rank of
 // the input tensor.

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -95,3 +95,14 @@ Value Torch::convertTensorToDtype(PatternRewriter &rewriter, Location loc,
       loc, newType, input, convertIntVal, falseVal, falseVal, noneVal);
   return converted;
 }
+
+int Torch::getTensorRank(Value tensor) {
+  int tensorRank = -1;
+  BaseTensorType tensorType = tensor.getType().cast<BaseTensorType>();
+
+  if (tensorType.hasSizes()) {
+    ArrayRef<int64_t> tensorShape = tensorType.getSizes();
+    tensorRank = tensorShape.size();
+  }
+  return tensorRank;
+}

--- a/python/torch_mlir_e2e_test/test_suite/index_put.py
+++ b/python/torch_mlir_e2e_test/test_suite/index_put.py
@@ -11,7 +11,7 @@ from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
 
 # ==============================================================================
 
-class IndexPutImplOneDimFloatNonAccumulateModule(torch.nn.Module):
+class IndexPutImpl1DFloatNonAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -29,13 +29,61 @@ class IndexPutImplOneDimFloatNonAccumulateModule(torch.nn.Module):
                                           unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImplOneDimFloatNonAccumulateModule())
-def IndexPutImplOneDimFloatNonAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPutImpl1DFloatNonAccumulateModule())
+def IndexPutImpl1DFloatNonAccumulateModule_basic(module, tu: TestUtils):
   module.forward(tu.rand(100), torch.randint(100, (250,)),
                  tu.rand(250))
 
 
-class IndexPutImplOneDimIntNonAccumulateModule(torch.nn.Module):
+class IndexPutImpl2DFloatNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten._index_put_impl_(input, (index,), value,
+                                          accumulate=False,
+                                          unsafe=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutImpl2DFloatNonAccumulateModule())
+def IndexPutImpl2DFloatNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
+                 tu.rand(5, 8))
+
+
+class IndexPutImpl3DFloatNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten._index_put_impl_(input, (index,), value,
+                                          accumulate=False,
+                                          unsafe=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutImpl3DFloatNonAccumulateModule())
+def IndexPutImpl3DFloatNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
+                 tu.rand(5, 8, 6))
+
+
+class IndexPutImpl1DIntNonAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -53,13 +101,13 @@ class IndexPutImplOneDimIntNonAccumulateModule(torch.nn.Module):
                                           unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImplOneDimIntNonAccumulateModule())
-def IndexPutImplOneDimIntNonAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPutImpl1DIntNonAccumulateModule())
+def IndexPutImpl1DIntNonAccumulateModule_basic(module, tu: TestUtils):
   module.forward(torch.randint(1000, (200,)), torch.randint(100, (300,)),
                  torch.randint(10000, (300,)))
 
 
-class IndexPutImplOneDimFloatAccumulateModule(torch.nn.Module):
+class IndexPutImpl1DFloatAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -79,13 +127,61 @@ class IndexPutImplOneDimFloatAccumulateModule(torch.nn.Module):
                                           unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImplOneDimFloatAccumulateModule())
-def IndexPutImplOneDimFloatAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPutImpl1DFloatAccumulateModule())
+def IndexPutImpl1DFloatAccumulateModule_basic(module, tu: TestUtils):
   module.forward(tu.rand(1000), torch.randint(10, (500,)),
                  tu.rand(500))
 
 
-class IndexPutImplOneDimIntAccumulateModule(torch.nn.Module):
+class IndexPutImpl2DFloatAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten._index_put_impl_(input.clone(), (index,), value,
+                                          accumulate=True,
+                                          unsafe=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutImpl2DFloatAccumulateModule())
+def IndexPutImpl2DFloatAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
+                 tu.rand(5, 8))
+
+
+class IndexPutImpl3DFloatAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten._index_put_impl_(input.clone(), (index,), value,
+                                          accumulate=True,
+                                          unsafe=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutImpl3DFloatAccumulateModule())
+def IndexPutImpl3DFloatAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
+                 tu.rand(5, 8, 6))
+
+
+class IndexPutImpl1DIntAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -105,14 +201,14 @@ class IndexPutImplOneDimIntAccumulateModule(torch.nn.Module):
                                           unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImplOneDimIntAccumulateModule())
-def IndexPutImplOneDimIntAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPutImpl1DIntAccumulateModule())
+def IndexPutImpl1DIntAccumulateModule_basic(module, tu: TestUtils):
   module.forward(torch.randint(100, (10,)), torch.randint(10, (10,)),
                  torch.randint(1000, (10,)))
 
 # ==============================================================================
 
-class IndexPutOneDimFloatNonAccumulateModule(torch.nn.Module):
+class IndexPut1DFloatNonAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -128,13 +224,13 @@ class IndexPutOneDimFloatNonAccumulateModule(torch.nn.Module):
     return torch.ops.aten.index_put(input, (index,), value, accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutOneDimFloatNonAccumulateModule())
-def IndexPutOneDimFloatNonAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPut1DFloatNonAccumulateModule())
+def IndexPut1DFloatNonAccumulateModule_basic(module, tu: TestUtils):
   module.forward(tu.rand(100), torch.randint(100, (250,)),
                  tu.rand(250))
 
 
-class IndexPutOneDimIntNonAccumulateModule(torch.nn.Module):
+class IndexPut1DIntNonAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -150,13 +246,13 @@ class IndexPutOneDimIntNonAccumulateModule(torch.nn.Module):
     return torch.ops.aten.index_put(input, (index,), value, accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutOneDimIntNonAccumulateModule())
-def IndexPutOneDimIntNonAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPut1DIntNonAccumulateModule())
+def IndexPut1DIntNonAccumulateModule_basic(module, tu: TestUtils):
   module.forward(torch.randint(1000, (200,)), torch.randint(100, (300,)),
                  torch.randint(10000, (300,)))
 
 
-class IndexPutOneDimFloatAccumulateModule(torch.nn.Module):
+class IndexPut1DFloatAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -172,13 +268,13 @@ class IndexPutOneDimFloatAccumulateModule(torch.nn.Module):
     return torch.ops.aten.index_put(input, (index,), value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutOneDimFloatAccumulateModule())
-def IndexPutOneDimFloatAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPut1DFloatAccumulateModule())
+def IndexPut1DFloatAccumulateModule_basic(module, tu: TestUtils):
   module.forward(tu.rand(1000), torch.randint(10, (500,)),
                  tu.rand(500))
 
 
-class IndexPutOneDimIntAccumulateModule(torch.nn.Module):
+class IndexPut1DIntAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -194,7 +290,7 @@ class IndexPutOneDimIntAccumulateModule(torch.nn.Module):
     return torch.ops.aten.index_put(input, (index,), value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutOneDimIntAccumulateModule())
-def IndexPutOneDimIntAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPut1DIntAccumulateModule())
+def IndexPut1DIntAccumulateModule_basic(module, tu: TestUtils):
   module.forward(torch.randint(100, (10,)), torch.randint(10, (10,)),
                  torch.randint(1000, (10,)))


### PR DESCRIPTION
This commit adds support for multi-dimensional tensors as input to the
`_index_put_impl_` op. The support was to some degree already there,
since `ScatterOp` already supports multi-dimensional tensors. This
commit also adds a bit more error checking to `index_put` and
refactors the code for creating `ScatterOp`s to mimic the way one
would make a `Linalg::GenericOp`.