### PR TITLE
Add 1D, weight, and reduction support to nll_loss_backward

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/nll_loss.py
+++ b/python/torch_mlir_e2e_test/test_suite/nll_loss.py
@@ -1,4 +1,4 @@
-# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
@@ -162,6 +162,37 @@ def NllLossModuleBackward_basic(module, tu: TestUtils):
                  torch.tensor(3.))
 
 
+class NllLossModule_backwardWeight(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.float32, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, weight, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=weight,
+                                            reduction=0,
+                                            ignore_index=10,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backwardWeight())
+def NllLossModuleBackwardWeight_basic(module, tu: TestUtils):
+  module.forward(tu.rand(3), tu.rand(3, 4), torch.tensor([2, 3, 0]),
+                 torch.rand(4), torch.tensor(3.))
+
+
+
 class NllLossModule_backward_ignore_index(torch.nn.Module):
 
   def __init__(self):
@@ -190,3 +221,298 @@ class NllLossModule_backward_ignore_index(torch.nn.Module):
 def NllLossModuleBackward_ignore_index(module, tu: TestUtils):
   module.forward(tu.rand(3), tu.rand(3, 4), torch.tensor([2, 3, 0]),
                  torch.tensor(3.))
+
+
+class NllLossModule_backwardMean(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=None,
+                                            reduction=1,
+                                            ignore_index=1,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backwardMean())
+def NllLossModuleBackwardMean_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3, 4), torch.tensor([2, 3, 0]),
+                 torch.tensor(3.))
+
+
+class NllLossModule_backwardMeanWeight(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.float32, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, weight, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=weight,
+                                            reduction=1,
+                                            ignore_index=1,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backwardMeanWeight())
+def NllLossModuleBackwardMeanWeight_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3, 4), torch.tensor([2, 3, 0]),
+                 torch.rand(4), torch.tensor(3.))
+
+
+class NllLossModule_backwardSum(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=None,
+                                            reduction=2,
+                                            ignore_index=1,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backwardSum())
+def NllLossModuleBackwardSum_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3, 4), torch.tensor([2, 3, 0]),
+                 torch.tensor(3.))
+
+
+class NllLossModule_backwardSumWeight(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.float32, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, weight, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=weight,
+                                            reduction=2,
+                                            ignore_index=1,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backwardSumWeight())
+def NllLossModuleBackwardSumWeight_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3, 4), torch.tensor([2, 3, 0]),
+                 torch.rand(4), torch.tensor(3.))
+
+
+class NllLossModule_backward1D(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=None,
+                                            reduction=0,
+                                            ignore_index=10,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backward1D())
+def NllLossModuleBackward1D_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3), torch.tensor([2, 3, 0]),
+                 torch.tensor(3.))
+
+
+class NllLossModule_backward1DWeight(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.float32, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, weight, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=weight,
+                                            reduction=0,
+                                            ignore_index=10,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backward1DWeight())
+def NllLossModuleBackward1DWeight_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3), torch.tensor([2, 3, 0]),
+                 torch.rand(3), torch.tensor(3.))
+
+
+class NllLossModule_backward1DMean(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=None,
+                                            reduction=1,
+                                            ignore_index=1,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backward1DMean())
+def NllLossModuleBackward1DMean_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3), torch.tensor([2, 3, 0]),
+                 torch.tensor(3.))
+
+
+class NllLossModule_backward1DMeanWeight(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.float32, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, weight, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=weight,
+                                            reduction=1,
+                                            ignore_index=1,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backward1DMeanWeight())
+def NllLossModuleBackward1DMeanWeight_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3), torch.tensor([2, 3, 0]),
+                 torch.rand(3), torch.tensor(3.))
+
+
+class NllLossModule_backward1DSum(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=None,
+                                            reduction=2,
+                                            ignore_index=1,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backward1DSum())
+def NllLossModuleBackward1DSum_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3), torch.tensor([2, 3, 0]),
+                 torch.tensor(3.))
+
+
+class NllLossModule_backward1DSumWeight(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1], torch.float32, True),
+      ([-1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1], torch.float32, True),
+      ([], torch.float32, True),
+  ])
+  def forward(self, grad_output, input, target, weight, total_weight):
+    return torch.ops.aten.nll_loss_backward(grad_output,
+                                            input,
+                                            target=target,
+                                            weight=weight,
+                                            reduction=2,
+                                            ignore_index=1,
+                                            total_weight=total_weight)
+
+
+@register_test_case(module_factory=lambda: NllLossModule_backward1DSumWeight())
+def NllLossModuleBackward1DSumWeight_basic(module, tu: TestUtils):
+  module.forward(tu.rand(1), tu.rand(3), torch.tensor([2, 3, 0]),
+                 torch.rand(3), torch.tensor(3.))


### PR DESCRIPTION
This commit adds the following support to the op `nll_loss_backward`:
- `input` tensor can be rank-1
- `weight` parameter
- `reduction` parameter
- `target`, `grad_output`, `total_weight` can be rank-0
- Checks that input tensors are of the expected type