### PR TITLE
Make e2e testing parallel

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/index_put.py
+++ b/python/torch_mlir_e2e_test/test_suite/index_put.py
@@ -133,9 +133,10 @@ class IndexPutImpl1DFloatAccumulateModule(torch.nn.Module):
         ([-1], torch.float32, True),
     ])
     def forward(self, input, index, value):
-      return torch.ops.aten._index_put_impl_(input, (index,), value,
-                                            accumulate=True,
-                                            unsafe=False)
+        return torch.ops.aten._index_put_impl_(input, (index, ),
+                                               value,
+                                               accumulate=True,
+                                               unsafe=False)
 
 
 @register_test_case(
@@ -211,9 +212,10 @@ class IndexPutImpl1DIntAccumulateModule(torch.nn.Module):
         ([-1], torch.int64, True),
     ])
     def forward(self, input, index, value):
-      return torch.ops.aten._index_put_impl_(input, (index,), value,
-                                          accumulate=True,
-                                          unsafe=False)
+        return torch.ops.aten._index_put_impl_(input, (index, ),
+                                               value,
+                                               accumulate=True,
+                                               unsafe=False)
 
 
 @register_test_case(module_factory=lambda: IndexPutImpl1DIntAccumulateModule())


### PR DESCRIPTION
This change makes the e2e testing parallel using the multiprocessing
python module.

This also fixes the inplace update tensor issue we had
where the torchscript execution would update the input value inplace
resulting the actual test not being able to see the original input
value.