### PR TITLE
Add README instructions for OOT build

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -2,7 +2,7 @@ name: "Setup build environment"
 description: "Setup the build environment. An action so that it can be shared between in-tree/out-of-tree jobs"
 
 inputs:
-  cache-key:
+  cache-suffix:
     description: |
       Additional string that is used to compute the ccache hash.
       Different jobs running the action need distinct values for this key,
@@ -33,4 +33,4 @@ runs:
   - name: Ccache for C++ compilation
     uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
     with:
-      key: ${{ runner.os }}-clangreleaseasserts-${{ steps.get-submodule-hash.outputs.hash }}-${{ inputs.cache-key }}
+      key: ${{ runner.os }}-clangreleaseasserts-${{ steps.get-submodule-hash.outputs.hash }}${{ inputs.cache-suffix }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,28 @@
+name: "Setup build environment"
+description: "Setup the build environment. An action so that it can be shared between in-tree/out-of-tree jobs"
+
+runs:
+  using: "composite"
+  steps:
+  - name: Set up Python
+    uses: actions/setup-python@v2
+    with:
+      python-version: 3.9
+  - name: Install MLIR Python depends
+    run: |
+      python -m pip install -r $GITHUB_WORKSPACE/externals/llvm-project/mlir/python/requirements.txt
+    shell: bash
+  - name: Install PyTorch nightly depends
+    run: |
+      python -m pip install -r requirements.txt
+    shell: bash
+  - name: Install Ninja
+    uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
+  - name: Get Submodule Hash
+    id: get-submodule-hash
+    run: echo "::set-output name=hash::$(md5sum $(git submodule status))"
+    shell: bash
+  - name: Ccache for C++ compilation
+    uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
+    with:
+      key: ${{ runner.os }}-clangreleaseasserts-${{ steps.get-submodule-hash.outputs.hash }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,6 +1,14 @@
 name: "Setup build environment"
 description: "Setup the build environment. An action so that it can be shared between in-tree/out-of-tree jobs"
 
+inputs:
+  cache-key:
+    description: |
+      Additional string that is used to compute the ccache hash.
+      Different jobs running the action need distinct values for this key,
+      but the content is irrelevant.
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -25,4 +33,4 @@ runs:
   - name: Ccache for C++ compilation
     uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
     with:
-      key: ${{ runner.os }}-clangreleaseasserts-${{ steps.get-submodule-hash.outputs.hash }}
+      key: ${{ runner.os }}-clangreleaseasserts-${{ steps.get-submodule-hash.outputs.hash }}-${{ inputs.cache-key }}

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -16,7 +16,8 @@ on:
 
 jobs:
   build:
-    name: Build and Test and maybe Publish (Release Asserts)
+    name: Build and Test (Release Asserts)
+    # Changes to the name of this job needs to be synced with releaseSnapshotPackage.yml.
     runs-on: ubuntu-20.04
     steps:
     - name: Get torch-mlir
@@ -91,7 +92,7 @@ jobs:
         release_id: ${{ github.event.inputs.release_id }}
 
   build-out-of-tree:
-    name: Build and Test out-of-tree (Release Asserts)
+    name: Build out-of-tree (Release Asserts)
     runs-on: ubuntu-20.04
     steps:
     - name: Get torch-mlir
@@ -102,6 +103,8 @@ jobs:
       with:
         cache-suffix: '-out-of-tree'
     - name: Build LLVM (standalone)
+      # This build takes a while but is expected to almost always be cached.
+      # A cache invalidation occurs when the committed LLVM version is changed.
       run: |
         cd $GITHUB_WORKSPACE
         cmake -Bllvm-build -GNinja \
@@ -131,13 +134,5 @@ jobs:
           .
         ninja -Cbuild check-torch-mlir-all
 
-    - name: RefBackend - TorchScript end-to-end tests
-      run: |
-        cd $GITHUB_WORKSPACE
-        export PYTHONPATH="$GITHUB_WORKSPACE/build/python_packages/torch_mlir"
-        python -m e2e_testing.torchscript.main --config=refbackend -v
-    - name: TOSA backend - TorchScript end-to-end tests
-      run: |
-        cd $GITHUB_WORKSPACE
-        export PYTHONPATH="$GITHUB_WORKSPACE/build/python_packages/torch_mlir"
-        python -m e2e_testing.torchscript.main --config=tosa -v
+    # Don't run python tests, as check-torch-mlir-all already checks
+    # what we want.

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: Build and Test (Release Asserts)
+    name: Build and Test and maybe Publish (Release Asserts)
     runs-on: ubuntu-20.04
     steps:
     - name: Get torch-mlir
@@ -86,3 +86,53 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
       with:
         release_id: ${{ github.event.inputs.release_id }}
+
+  build-out-of-tree:
+    name: Build and Test out-of-tree (Release Asserts)
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Get torch-mlir
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    - uses: ./.github/actions/setup-build
+    - name: Build LLVM (standalone)
+      run: |
+        cd $GITHUB_WORKSPACE
+        cmake -Bllvm-build -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_LINKER=lld \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+          -DPython3_EXECUTABLE=$(which python) \
+          -DLLVM_ENABLE_ASSERTIONS=ON \
+          -DLLVM_ENABLE_PROJECTS=mlir \
+          -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+          -DLLVM_TARGETS_TO_BUILD=host \
+          externals/llvm-project/llvm
+        ninja -Cllvm-build
+
+    - name: Build and test torch-mlir (out-of-tree)
+      run: |
+        cd $GITHUB_WORKSPACE
+        cmake -GNinja -Bbuild \
+          -DCMAKE_LINKER=lld \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+          -DMLIR_DIR="$(pwd)/llvm-build/lib/cmake/mlir/" \
+          -DLLVM_DIR="$(pwd)/llvm-build/lib/cmake/llvm/" \
+          -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+          -DPython3_EXECUTABLE=$(which python) \
+          .
+        ninja -Cbuild check-torch-mlir-all
+
+    - name: RefBackend - TorchScript end-to-end tests
+      run: |
+        cd $GITHUB_WORKSPACE
+        export PYTHONPATH="$GITHUB_WORKSPACE/build/python_packages/torch_mlir"
+        python -m e2e_testing.torchscript.main --config=refbackend -v
+    - name: TOSA backend - TorchScript end-to-end tests
+      run: |
+        cd $GITHUB_WORKSPACE
+        export PYTHONPATH="$GITHUB_WORKSPACE/build/python_packages/torch_mlir"
+        python -m e2e_testing.torchscript.main --config=tosa -v

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -19,30 +19,11 @@ jobs:
     name: Build and Test (Release Asserts)
     runs-on: ubuntu-20.04
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
     - name: Get torch-mlir
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-    - name: Install MLIR Python depends
-      run: |
-        python -m pip install -r $GITHUB_WORKSPACE/externals/llvm-project/mlir/python/requirements.txt
-    - name: Install PyTorch nightly depends
-      run: |
-        python -m pip install -r requirements.txt
-    - name: Install Ninja
-      uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
-    - name: Get Submodule Hash
-      id: get-submodule-hash
-      run: echo "::set-output name=hash::$(md5sum $(git submodule status))"
-      shell: bash
-    - name: Ccache for C++ compilation
-      uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
-      with:
-        key: ${{ runner.os }}-clangreleaseasserts-${{ steps.get-submodule-hash.outputs.hash }}
+    - uses: ./.github/actions/setup-build
     - name: Build and Test torch-mlir (Assert)
       run: |
         cd $GITHUB_WORKSPACE
@@ -85,11 +66,10 @@ jobs:
           TORCH_MLIR_PYTHON_PACKAGE_VERSION="${{ github.event.inputs.python_package_version }}" \
           ./build_tools/build_python_wheels.sh
 
-    # If we were given a release_id, then upload the package we just built
-    # to the github releases page.
+    # upload the package we just built to the github releases page.
     - name: Upload Release Assets (if requested)
-      if: github.event.inputs.release_id != ''
       id: upload-release-assets
+      if: github.event.inputs.release_id != ''
       uses: dwenegar/upload-release-assets@v1
       env:
         GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
@@ -99,8 +79,8 @@ jobs:
     # Publishing is necessary to make the release visible to `pip`
     # on the github releases page.
     - name: Publish Release (if requested)
-      if: github.event.inputs.release_id != ''
       id: publish_release
+      if: github.event.inputs.release_id != ''
       uses: eregon/publish-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -25,7 +25,7 @@ jobs:
         submodules: 'true'
     - uses: ./.github/actions/setup-build
       with:
-        cache-key: 'in-tree'
+        cache-suffix: ''
     - name: Build and Test torch-mlir (Assert)
       run: |
         cd $GITHUB_WORKSPACE
@@ -100,7 +100,7 @@ jobs:
         submodules: 'true'
     - uses: ./.github/actions/setup-build
       with:
-        cache-key: 'out-of-tree'
+        cache-suffix: '-out-of-tree'
     - name: Build LLVM (standalone)
       run: |
         cd $GITHUB_WORKSPACE

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -24,6 +24,8 @@ jobs:
       with:
         submodules: 'true'
     - uses: ./.github/actions/setup-build
+      with:
+        cache-key: 'in-tree'
     - name: Build and Test torch-mlir (Assert)
       run: |
         cd $GITHUB_WORKSPACE
@@ -97,6 +99,8 @@ jobs:
       with:
         submodules: 'true'
     - uses: ./.github/actions/setup-build
+      with:
+        cache-key: 'out-of-tree'
     - name: Build LLVM (standalone)
       run: |
         cd $GITHUB_WORKSPACE

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -66,10 +66,11 @@ jobs:
           TORCH_MLIR_PYTHON_PACKAGE_VERSION="${{ github.event.inputs.python_package_version }}" \
           ./build_tools/build_python_wheels.sh
 
-    # upload the package we just built to the github releases page.
+    # If we were given a release_id, then upload the package we just built
+    # to the github releases page.
     - name: Upload Release Assets (if requested)
-      id: upload-release-assets
       if: github.event.inputs.release_id != ''
+      id: upload-release-assets
       uses: dwenegar/upload-release-assets@v1
       env:
         GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
@@ -79,8 +80,8 @@ jobs:
     # Publishing is necessary to make the release visible to `pip`
     # on the github releases page.
     - name: Publish Release (if requested)
-      id: publish_release
       if: github.event.inputs.release_id != ''
+      id: publish_release
       uses: eregon/publish-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ python -m pip install -r requirements.txt
 
 ## Build
 
-The following command generates configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build.
+Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is the most straightforward, as it will build LLVM dependencies as well.
+
+### Building torch-mlir in-tree
+
+The following command generates configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build. This will build LLVM as well as torch-mlir and its subprojects.
 
 ```shell
 cmake -GNinja -Bbuild \
@@ -80,6 +84,8 @@ The following additional quality of life flags can be used to reduce build time:
 # Use --ld-path= instead of -fuse-ld=lld for clang > 13
 ```
 
+### Building against a pre-built LLVM
+
 If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following command as template:
 ```shell
 cmake -GNinja -Bbuild \
@@ -93,6 +99,11 @@ cmake -GNinja -Bbuild \
   .
 ```
 The same QoL CMake flags can be used to enable ccache and lld. Be sure to have built LLVM with `-DLLVM_ENABLE_PROJECTS=mlir`.
+
+Be aware that the installed version of LLVM needs in general to match the committed version in `externals/llvm-project`. Using a different version may or may not work.
+
+
+### Build commands
 
 After either cmake run (in-tree/out-of-tree), use one of the following commands to build the project:
 ```shell

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ python -m pip install -r requirements.txt
 ```
 
 ## Build
+
+The following command generates configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build.
+
 ```shell
 cmake -GNinja -Bbuild \
   -DCMAKE_C_COMPILER=clang \
@@ -65,23 +68,44 @@ cmake -GNinja -Bbuild \
   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
   -DLLVM_TARGETS_TO_BUILD=host \
   externals/llvm-project/llvm
-
-# Additional quality of life CMake flags:
-# Enable ccache:
-#  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-# Enable LLD (links in seconds compared to minutes)
-# -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld"
+```
+The following additional quality of life flags can be used to reduce build time:
+* Enabling ccache:
+```shell
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+```
+* Enabling LLD (links in seconds compared to minutes)
+```shell
+  -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld"
 # Use --ld-path= instead of -fuse-ld=lld for clang > 13
+```
 
+If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following command as template:
+```shell
+cmake -GNinja -Bbuild \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DPython3_FIND_VIRTUALENV=ONLY \
+  -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir/" \
+  -DLLVM_DIR="$LLVM_INSTALL_DIR/lib/cmake/llvm/" \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DLLVM_TARGETS_TO_BUILD=host \
+  .
+```
+The same QoL CMake flags can be used to enable ccache and lld. Be sure to have built LLVM with `-DLLVM_ENABLE_PROJECTS=mlir`.
+
+After either cmake run (in-tree/out-of-tree), use one of the following commands to build the project:
+```shell
 # Build just torch-mlir (not all of LLVM)
 cmake --build build --target tools/torch-mlir/all
 
 # Run unit tests.
 cmake --build build --target check-torch-mlir
 
-# Build everything (including LLVM)
+# Build everything (including LLVM if in-tree)
 cmake --build build
 ```
+
 ## Demos
 
 ## Setup Python Environment


### PR DESCRIPTION
(OOT = out-of-tree)

Followup on #726 (#733 was the draft)

* Add instructions in the README to show how to build the project OOT
* Add a ci job that performs an OOT build with tests
  * Part of the existing job (setup logic) has been extracted into a custom [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) in order to share it between the two jobs.

Both jobs run in parallel, on separate git clones of the project. I found no way to make them work on the same clone without making them entirely sequential.


