### PR TITLE
Generate MLIR with shape information via LTC frontend

### DIFF
--- a/build_tools/autogen_ltc_backend.py
+++ b/build_tools/autogen_ltc_backend.py
@@ -158,7 +158,7 @@ class MlirLazyIr(codegen.gen_lazy_tensor.dest.LazyIR):
     size_t i = 0;
     {emplace_arguments_str}
     {emplace_kwarguments}
-    torch::lazy::TorchMlirOpVector {schema.aten_name}_out = torch::lazy::LowerTorchMlirBuiltin(function, op().op, arguments, kwarguments);
+    torch::lazy::TorchMlirOpVector {schema.aten_name}_out = torch::lazy::LowerTorchMlirBuiltin(function, op().op, shapes(), arguments, kwarguments);
     CHECK_EQ({schema.aten_name}_out.size(), {len(func.returns)});
   
     return {schema.aten_name}_out;

--- a/examples/ltc_backend_mnist.py
+++ b/examples/ltc_backend_mnist.py
@@ -42,7 +42,7 @@ def main(device):
     class Model(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.fc1 = torch.nn.Linear(5, 5)
+            self.fc1 = torch.nn.Linear(5, 10)
 
         def forward(self, x):
             out = self.fc1(x)

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -36,9 +36,6 @@ TorchMlirComputation::TorchMlirComputation(
     const std::shared_ptr<torch::jit::Graph>& graph)
     : func_op_(std::move(func_op)), mlir_context_(std::move(mlir_context)),
       graph_(graph), num_results_(graph_->outputs().size()) {
-
-  // TODO(henrytu): Save parameter shape information.
-
   for (torch::jit::Value* input : graph_->inputs()) {
     parameter_names_.push_back(input->debugName());
   }
@@ -144,22 +141,15 @@ void TorchMlirLoweringContext::AddParameter(
 ComputationPtr TorchMlirLoweringContext::Build() {
   PRINT_FUNCTION();
 
+  // Insert return values into graph.
   for (torch::jit::Value* output : root_tuple_) {
     graph_->block()->registerOutput(output);
   }
 
-  // Create jit::Function from jit::Graph.
-  c10::QualifiedName name("graph");
-  auto cu = std::make_shared<torch::jit::CompilationUnit>();
-  // IMPORTANT: We pass in a COPY of the graph into create_function, since it
-  //            may get mutated in the process.
-  auto jit_fn = cu->create_function(std::move(name), std::move(graph_->copy()));
-
   // Generate MLIR.
-  MlirOperation func_op =
-      torch_mlir::importJitFunctionAsFuncOp(mlir_context_, jit_fn);
+  MlirOperation func_op = torch_mlir::importJitFunctionAsFuncOp(
+      mlir_context_, generate_jit_fn().get());
 
-  // TODO(henrytu): Inject tensor shapes into func_op
   return std::make_shared<TorchMlirComputation>(func_op, mlir_context_, graph_);
 }
 
@@ -224,6 +214,14 @@ torch::jit::Value* TorchMlirLoweringContext::GetParameter(BackendDataPtr data) {
         TORCH_CHECK(
             false, "Unhandled scalar type: ", c10::toString(scalar.type()));
       }
+    } else {
+      // Save parameter shape information.
+      param->setType(torch::jit::TensorType::create(
+          /*scalar_type=*/data->shape().scalar_type(),
+          /*device=*/c10::nullopt,
+          /*sizes=*/c10::VaryingShape<int64_t>(data->shape().sizes()),
+          /*strides=*/c10::VaryingShape<int64_t>(),
+          /*requires_grad=*/c10::nullopt));
     }
 
     it = parameters_map_.emplace(handle, Parameter{param, parameters_.size()})
@@ -243,6 +241,46 @@ size_t TorchMlirLoweringContext::AddResult(torch::jit::Value* op) {
   PRINT_FUNCTION();
   root_tuple_.push_back(std::move(op));
   return root_tuple_.size() - 1;
+}
+
+// Sync vector of c10::Argument with type specified from parallel list of
+// jit::Value. There must be a 1:1 map between elements of args and values.
+std::vector<c10::Argument> sync_argument_types(
+    const std::vector<c10::Argument>& args,
+    c10::ArrayRef<torch::jit::Value*> values) {
+  TORCH_CHECK(
+      args.size() == values.size(),
+      "Expected 1:1 mapping between list of c10::Argument and jit::Value! Got ",
+      args.size(), ":", values.size(), " instead!");
+
+  std::vector<c10::Argument> updated_args;
+  for (unsigned i = 0; i < args.size(); i++) {
+    updated_args.push_back(args[i].cloneWithType(values[i]->type()));
+  }
+
+  return updated_args;
+}
+
+std::unique_ptr<torch::jit::Function>
+TorchMlirLoweringContext::generate_jit_fn() const {
+  // IMPORTANT: We pass in a COPY of the graph into create_function, since it
+  //            may get mutated in the process.
+  auto fn = std::make_unique<torch::jit::GraphFunction>(
+      c10::QualifiedName("graph"), graph_->copy(), nullptr);
+
+  c10::FunctionSchema schema = fn->getSchema();
+
+  // When constructing the default schema of a jit::GraphFunction, input and
+  // output shapes are stripped (via call to unshapedType(...)); however,
+  // since we want to have shape information in our MLIR, we'll add it back.
+  std::vector<c10::Argument> arguments =
+      sync_argument_types(schema.arguments(), graph_->inputs());
+  std::vector<c10::Argument> returns =
+      sync_argument_types(schema.returns(), graph_->outputs());
+
+  fn->setSchema(schema.cloneWithArguments(arguments).cloneWithReturns(returns));
+
+  return fn;
 }
 
 void TorchMlirLoweringContext::RegisterMlirDialects() {

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -148,7 +148,10 @@ ComputationPtr TorchMlirLoweringContext::Build() {
 
   // Generate MLIR.
   MlirOperation func_op = torch_mlir::importJitFunctionAsFuncOp(
-      mlir_context_, generate_jit_fn().get());
+      /*context=*/mlir_context_,
+      /*function=*/generate_jit_fn().get(),
+      /*getArgAttribute=*/[](int) -> MlirAttribute { return {nullptr}; },
+      /*importOptions=*/{/*assumeTensorsHaveValueSemantics=*/true});
 
   return std::make_shared<TorchMlirComputation>(func_op, mlir_context_, graph_);
 }

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
@@ -122,6 +122,10 @@ private:
 
   size_t AddResult(torch::jit::Value* op);
 
+  // Creates a jit::Function from the current jit::Graph. Input and output
+  // type information is patched to include shape.
+  std::unique_ptr<torch::jit::Function> generate_jit_fn() const;
+
   void RegisterMlirDialects();
 
   std::shared_ptr<torch::jit::Graph> graph_;

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_node_lowering.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_node_lowering.h
@@ -23,6 +23,7 @@ typedef std::shared_ptr<torch::jit::GraphFunction> TorchMlirFunction;
 
 TORCH_API TorchMlirOpVector LowerTorchMlirBuiltin(
     TorchMlirFunction function, c10::Symbol sym,
+    const c10::ArrayRef<Shape> result_shapes,
     const std::vector<torch::jit::NamedValue>& arguments,
     const std::vector<torch::jit::NamedValue>& kwarguments = {});
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.cpp
@@ -23,12 +23,13 @@ using namespace torch_mlir;
 
 MlirOperation torch_mlir::importJitFunctionAsFuncOp(
     MlirContext context, torch::jit::Function *function,
-    std::function<MlirAttribute(int)> getArgAttribute) {
+    std::function<MlirAttribute(int)> getArgAttribute,
+    const ImportOptions &importOptions) {
   // Useful for debugging:
   // graph->dump();
   MlirLocation loc = mlirLocationUnknownGet(context);
   MlirType functionType =
-      getFunctionTypeFromSchema(context, function->getSchema());
+      getFunctionTypeFromSchema(context, function->getSchema(), importOptions);
   // Use the function's qualified name from the compilation unit.
   // This is a stable linkage name that matches Python module lookup
   // conventions (see compilation unit import in IValueImporter for more details
@@ -65,7 +66,7 @@ MlirOperation torch_mlir::importJitFunctionAsFuncOp(
   };
   MlirBlock block = importBlock(
       context, torch::jit::toGraphFunction(*function).graph()->block(),
-      createTerminator);
+      createTerminator, importOptions);
   mlirRegionAppendOwnedBlock(bodyRegion, block);
   return func;
 }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 
+#include "import_options.h"
 #include "node_importer.h"
 #include "pybind.h"
 
@@ -42,7 +43,8 @@ namespace torch_mlir {
 TORCH_API MlirOperation importJitFunctionAsFuncOp(
     MlirContext context, torch::jit::Function *function,
     std::function<MlirAttribute(int)> getArgAttribute =
-        [](int) -> MlirAttribute { return {nullptr}; });
+        [](int) -> MlirAttribute { return {nullptr}; },
+    const ImportOptions &importOptions = {});
 
 } // namespace torch_mlir
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
@@ -1,0 +1,29 @@
+//===- import_options.h -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIRJITIRIMPORTER_CSRC_IMPORT_OPTIONS_H
+#define TORCHMLIRJITIRIMPORTER_CSRC_IMPORT_OPTIONS_H
+
+namespace torch_mlir {
+// Common import options across importers. We define this as a struct to avoid
+// an unstructured proliferation of different kinds of ways to control different
+// parts of the import process.
+struct ImportOptions {
+  // If this is set to true, then all tensors in the program can be assumed to
+  // have value semantics. This can happen, for example, when coming from
+  // LazyTensorCore since conversion to value semantics has already happened at
+  // a higher level there before we see the program. For
+  // calling-convention-impacting decisions, this flag should be interpreted as
+  // a requirement to use a value-semantic tensor type (!torch.vtensor) in
+  // signatures.
+  bool assumeTensorsHaveValueSemantics = false;
+};
+} // namespace torch_mlir
+
+#endif // TORCHMLIRJITIRIMPORTER_CSRC_IMPORT_OPTIONS_H

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.h
@@ -10,6 +10,8 @@
 #ifndef TORCHMLIRJITIRIMPORTER_CSRC_NODE_IMPORTER_H
 #define TORCHMLIRJITIRIMPORTER_CSRC_NODE_IMPORTER_H
 
+#include "import_options.h"
+
 #include <memory>
 
 #include "pybind.h"
@@ -25,7 +27,8 @@ using CreateTerminatorFn =
     std::function<void(c10::ArrayRef<MlirValue>, MlirBlock)>;
 
 MlirBlock importBlock(MlirContext context, torch::jit::Block *jitBlock,
-                      CreateTerminatorFn createTerminator);
+                      CreateTerminatorFn createTerminator,
+                      const ImportOptions &importOptions = {});
 
 } // namespace torch_mlir
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.h
@@ -10,6 +10,8 @@
 #ifndef TORCHMLIRJITIRIMPORTER_CSRC_TORCH_TO_MLIR_UTILS_H
 #define TORCHMLIRJITIRIMPORTER_CSRC_TORCH_TO_MLIR_UTILS_H
 
+#include "import_options.h"
+
 #include <memory>
 
 #include "pybind.h"
@@ -37,14 +39,16 @@ MlirType getMlirTypeForTorchScalarType(MlirLocation loc,
 /// Maps a torch type to a corresponding MlirType. Returns a null type
 /// on failure and emits a diagnostic.
 MlirType getMlirTypeFromTorchType(MlirLocation loc,
-                                  const c10::TypePtr &torchType);
+                                  const c10::TypePtr &torchType,
+                                  const ImportOptions &importOptions = {});
 
 /// Creates a FunctionType suitable for expressing the signature of `schema`.
 ///
 /// This can differ from the type inferred from the block of a
 /// torch::jit::Function due to derefinement.
 MlirType getFunctionTypeFromSchema(MlirContext context,
-                                   const c10::FunctionSchema &schema);
+                                   const c10::FunctionSchema &schema,
+                                   const ImportOptions &importOptions = {});
 
 /// Creates an appropriate MlirAttribute that holds the same values as `tensor`.
 MlirAttribute convertTensorToMlirElementsAttr(at::Tensor tensor,
@@ -58,7 +62,8 @@ MlirLocation getMlirLocationFromNode(MlirContext context,
 
 std::vector<MlirType>
 getMlirTypesFromValues(MlirLocation loc,
-                       c10::ArrayRef<torch::jit::Value *> values);
+                       c10::ArrayRef<torch::jit::Value *> values,
+                       const ImportOptions &importOptions = {});
 
 std::vector<MlirValue> derefineValues(c10::ArrayRef<MlirValue> values,
                                       c10::ArrayRef<MlirType> expectedTypes,


### PR DESCRIPTION
Previously, the intermediate JIT graph was generated without shape information, which caused generic `!torch.tensor` types to be scattered throughout the final MLIR. This PR improves the lowering by injecting each `jit::Value` of tensor type with its corresponding shape from the origin `lazy::Node`. Additionally, the MLIR parameter and return values are also generated with their respective shapes.

Example output for an FC MNIST model:
```
func @graph(%arg0: !torch.vtensor<[1,5],f32>, %arg1: !torch.vtensor<[1],si64>, %arg2: !torch.float, %arg3: !torch.int, %arg4: !torch.int, %arg5: !torch.int, %arg6: !torch.vtensor<[10,5],f32>, %arg7: !torch.vtensor<[10],f32>, %arg8: !torch.vtensor<*,f32>, %arg9: !torch.float) -> (!torch.vtensor<[1,5],f32>, !torch.vtensor<[1],si64>, !torch.vtensor<[10,5],f32>, !torch.vtensor<[10],f32>, !torch.vtensor<[1,10],f32>, !torch.vtensor<*,f32>, !torch.vtensor<[10],f32>, !torch.vtensor<[10,5],f32>) {
  %0 = torch.aten.detach %arg6 :  !torch.vtensor<[10,5],f32> ->  !torch.vtensor<[10,5],f32>
  %int1 = torch.constant.int 1
  %int0 = torch.constant.int 0
  %1 = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
  %int1_0 = torch.constant.int 1
  %int0_1 = torch.constant.int 0
  %2 = torch.prim.ListConstruct %int1_0, %int0_1 : (!torch.int, !torch.int) -> !torch.list<int>
  %3 = torch.aten.permute %0, %2 :  !torch.vtensor<[10,5],f32>, !torch.list<int> ->  !torch.vtensor<[5,10],f32>
  %4 = torch.aten.detach %arg7 :  !torch.vtensor<[10],f32> ->  !torch.vtensor<[10],f32>
  %5 = torch.aten.addmm %4, %arg0, %3, %arg5, %arg4 :  !torch.vtensor<[10],f32>, !torch.vtensor<[1,5],f32>, !torch.vtensor<[5,10],f32>, !torch.int, !torch.int ->  !torch.vtensor<[1,10],f32>
  %6 = torch.aten.relu %5 :  !torch.vtensor<[1,10],f32> ->  !torch.vtensor<[1,10],f32>
  %int1_2 = torch.constant.int 1
  %false = torch.constant.bool false
  %7 = torch.aten._log_softmax %6, %int1_2, %false :  !torch.vtensor<[1,10],f32>, !torch.int, !torch.bool ->  !torch.vtensor<[1,10],f32>
  %none = torch.constant.none
  %int1_3 = torch.constant.int 1
  %int-100 = torch.constant.int -100
  %output, %total_weight = torch.aten.nll_loss_forward %7, %arg1, %none, %int1_3, %int-100 :  !torch.vtensor<[1,10],f32>, !torch.vtensor<[1],si64>, !torch.none, !torch.int, !torch.int ->  !torch.vtensor<*,f32>, !torch.vtensor<*,f32>
  %8 = torch.prim.TupleConstruct %output, %total_weight : !torch.vtensor<*,f32>, !torch.vtensor<*,f32> -> !torch.tuple<vtensor, vtensor>
  %none_4 = torch.constant.none
  %int1_5 = torch.constant.int 1
  %int-100_6 = torch.constant.int -100
  %9 = torch.aten.nll_loss_backward %arg8, %7, %arg1, %none_4, %int1_5, %int-100_6, %total_weight :  !torch.vtensor<*,f32>, !torch.vtensor<[1,10],f32>, !torch.vtensor<[1],si64>, !torch.none, !torch.int, !torch.int, !torch.vtensor<*,f32> ->  !torch.vtensor<[1,10],f32>
  %int1_7 = torch.constant.int 1
  %int6 = torch.constant.int 6
  %10 = torch.aten._log_softmax_backward_data %9, %7, %int1_7, %int6 :  !torch.vtensor<[1,10],f32>, !torch.vtensor<[1,10],f32>, !torch.int, !torch.int ->  !torch.vtensor<[1,10],f32>
  %11 = torch.aten.threshold_backward %10, %6, %arg3 :  !torch.vtensor<[1,10],f32>, !torch.vtensor<[1,10],f32>, !torch.int ->  !torch.vtensor<[1,10],f32>
  %int1_8 = torch.constant.int 1
  %int0_9 = torch.constant.int 0
  %12 = torch.prim.ListConstruct %int1_8, %int0_9 : (!torch.int, !torch.int) -> !torch.list<int>
  %int1_10 = torch.constant.int 1
  %int0_11 = torch.constant.int 0
  %13 = torch.prim.ListConstruct %int1_10, %int0_11 : (!torch.int, !torch.int) -> !torch.list<int>
  %14 = torch.aten.permute %arg0, %13 :  !torch.vtensor<[1,5],f32>, !torch.list<int> ->  !torch.vtensor<[5,1],f32>
  %15 = torch.aten.mm %14, %11 :  !torch.vtensor<[5,1],f32>, !torch.vtensor<[1,10],f32> ->  !torch.vtensor<[5,10],f32>
  %int1_12 = torch.constant.int 1
  %int0_13 = torch.constant.int 0
  %16 = torch.prim.ListConstruct %int1_12, %int0_13 : (!torch.int, !torch.int) -> !torch.list<int>
  %int1_14 = torch.constant.int 1
  %int0_15 = torch.constant.int 0
  %17 = torch.prim.ListConstruct %int1_14, %int0_15 : (!torch.int, !torch.int) -> !torch.list<int>
  %18 = torch.aten.permute %15, %17 :  !torch.vtensor<[5,10],f32>, !torch.list<int> ->  !torch.vtensor<[10,5],f32>
  %19 = torch.aten.detach %18 :  !torch.vtensor<[10,5],f32> ->  !torch.vtensor<[10,5],f32>
  %20 = torch.aten.add.Tensor %0, %19, %arg2 :  !torch.vtensor<[10,5],f32>, !torch.vtensor<[10,5],f32>, !torch.float ->  !torch.vtensor<[10,5],f32>
  %int0_16 = torch.constant.int 0
  %21 = torch.prim.ListConstruct %int0_16 : (!torch.int) -> !torch.list<int>
  %true = torch.constant.bool true
  %none_17 = torch.constant.none
  %22 = torch.aten.sum.dim_IntList %11, %21, %true, %none_17 :  !torch.vtensor<[1,10],f32>, !torch.list<int>, !torch.bool, !torch.none ->  !torch.vtensor<[1,10],f32>
  %int10 = torch.constant.int 10
  %23 = torch.prim.ListConstruct %int10 : (!torch.int) -> !torch.list<int>
  %int10_18 = torch.constant.int 10
  %24 = torch.prim.ListConstruct %int10_18 : (!torch.int) -> !torch.list<int>
  %25 = torch.aten.reshape %22, %24 :  !torch.vtensor<[1,10],f32>, !torch.list<int> ->  !torch.vtensor<[10],f32>
  %26 = torch.aten.detach %25 :  !torch.vtensor<[10],f32> ->  !torch.vtensor<[10],f32>
  %27 = torch.aten.add.Tensor %4, %26, %arg9 :  !torch.vtensor<[10],f32>, !torch.vtensor<[10],f32>, !torch.float ->  !torch.vtensor<[10],f32>
  return %arg0, %arg1, %20, %27, %6, %output, %26, %19 : !torch.vtensor<[1,5],f32>, !torch.vtensor<[1],si64>, !torch.vtensor<[10,5],f32>, !torch.vtensor<[10],f32>, !torch.vtensor<[1,10],f32>, !torch.vtensor<*,f32>, !torch.vtensor<[10],f32>, !torch.vtensor<[10,5],f32>
}
```

Note: This PR is based on https://github.com/llvm/torch-mlir/pull/725, but GitHub does not allow for setting the base to a fork while keeping this PR in the upstream repo, so there are several shared commits. Only the last one is specifically part of this PR.

Marked as draft while waiting for a dependency PR to land: https://github.com/llvm/torch-mlir/pull/725

Resolves: https://github.com/llvm/torch-mlir/issues/727

cc: @antoniojkim @ke1337