### PR TITLE
Add shape transfer function and lowering to linalg for aten.neg

### DIFF
--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -258,6 +258,10 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
     return createCalculationForMathOpWithDtypeConversion<math::RsqrtOp>(
         b, converter, payloadArgs[0], op);
   }
+  if (isa<AtenNegOp>(op)) {
+    return createCalculationForMathOpWithDtypeConversion<arith::NegFOp>(
+        b, converter, payloadArgs[0], op);
+  }
   if (isa<AtenSinOp>(op)) {
     return createCalculationForMathOpWithDtypeConversion<math::SinOp>(
         b, converter, payloadArgs[0], op);
@@ -935,7 +939,7 @@ public:
              AtenWhereSelfOp, AtenCeilOp, AtenGtTensorOp, AtenEqTensorOp,
              AtenLtTensorOp, AtenSubScalarOp, AtenAddScalarOp, AtenThresholdOp,
              AtenThresholdBackwardOp, AtenCloneOp, AtenSinOp, AtenCosOp,
-             AtenNeScalarOp>(op))
+             AtenNeScalarOp, AtenNegOp>(op))
       return rewriter.notifyMatchFailure(op, "not a supported elementwise op");
 
     if (failed(verifyLinalgCompatibleTypes(op, rewriter)))

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -92,6 +92,10 @@ module {
     %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
     return %0 : !torch.list<int>
   }
+  func @"__torch_mlir_shape_fn.aten.neg"(%arg0: !torch.list<int>) -> !torch.list<int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
+    return %0 : !torch.list<int>
+  }
   func @"__torch_mlir_shape_fn.aten.floor"(%arg0: !torch.list<int>) -> !torch.list<int> {
     %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
     return %0 : !torch.list<int>

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -318,6 +318,9 @@ def aten〇hardtanh(self: List[int], min_val: float = -1, max_val: float = 1) ->
 def aten〇sqrt(self: List[int]) -> List[int]:
     return upstream_shape_helpers.unary(self)
 
+def aten〇neg(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
 def aten〇floor(self: List[int]) -> List[int]:
     return upstream_shape_helpers.unary(self)
 

--- a/test/Conversion/TorchToLinalg/basic.mlir
+++ b/test/Conversion/TorchToLinalg/basic.mlir
@@ -194,3 +194,16 @@ func @torch.tensor_static_info_cast$basic(%t: !torch.vtensor<[?],f32>) -> !torch
   %t_cast = torch.tensor_static_info_cast %t : !torch.vtensor<[?],f32> to !torch.vtensor<[4],f32>
   return %t_cast : !torch.vtensor<[4],f32>
 }
+
+// -----
+
+// CHECK-LABEL:     func @torch.aten.neg
+// CHECK: linalg.generic {{.*}} {
+// CHECK-NEXT:    ^bb0(%[[LHS:.*]]: f32, %{{.*}}: f32):
+// CHECK-NEXT:      %[[NEG:.*]] = arith.negf %[[LHS]] : f32
+// CHECK-NEXT:      linalg.yield %[[NEG]] : f32
+// CHECK-NEXT:    } -> tensor<?x?xf32>
+func @torch.aten.neg(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.neg %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}


### PR DESCRIPTION
This PR contains two commits for `aten.neg`, one for adding the shape transfer function and another for translating the torch operation to the linalg dialect.