### PR TITLE
importer: add initial support for loading BFloat16 tensors

### DIFF
--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -52,6 +52,8 @@ torch_upstream::ScalarType Torch::getScalarTypeForType(Type type) {
     return torch_upstream::ScalarType::Int;
   if (type.isSignlessInteger(1))
     return torch_upstream::ScalarType::Bool;
+  if (type.isBF16())
+    return torch_upstream::ScalarType::BFloat16;
   llvm::report_fatal_error("unhandled type for getScalarTypeForType");
 }
 
@@ -69,6 +71,8 @@ Type Torch::getTypeForScalarType(
     return IntegerType::get(context, 32, signedness);
   case torch_upstream::ScalarType::Bool:
     return IntegerType::get(context, 1);
+  case torch_upstream::ScalarType::BFloat16:
+    return mlir::FloatType::getBF16(context);
   default:
     return Type();
   }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
@@ -319,6 +319,9 @@ MlirAttribute torch_mlir::convertTensorToMlirElementsAttr(at::Tensor tensor,
   case ScalarType::QInt8:
     return mlirDenseElementsAttrInt8Get(
         shapedType, numElements, static_cast<const int8_t *>(tensorData));
+  case ScalarType::BFloat16:
+    return mlirDenseElementsAttrBFloat16Get(
+        shapedType, numElements, static_cast<const uint16_t *>(tensorData));
   default:
     throwUnsupportedTensorError();
   }

--- a/test/Conversion/TorchToLinalg/basic.mlir
+++ b/test/Conversion/TorchToLinalg/basic.mlir
@@ -207,3 +207,16 @@ func @torch.aten.neg(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f
   %0 = torch.aten.neg %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
   return %0 : !torch.vtensor<[?,?],f32>
 }
+
+// -----
+
+// CHECK-LABEL:     func @torch.aten.neg.bf16
+// CHECK: linalg.generic {{.*}} {
+// CHECK-NEXT:    ^bb0(%[[LHS:.*]]: bf16, %{{.*}}: bf16):
+// CHECK-NEXT:      %[[NEG:.*]] = arith.negf %[[LHS]] : bf16
+// CHECK-NEXT:      linalg.yield %[[NEG]] : bf16
+// CHECK-NEXT:    } -> tensor<?x?xbf16>
+func @torch.aten.neg.bf16(%arg0: !torch.vtensor<[?,?],bf16>) -> !torch.vtensor<[?,?],bf16> {
+  %0 = torch.aten.neg %arg0 : !torch.vtensor<[?,?],bf16> -> !torch.vtensor<[?,?],bf16>
+  return %0 : !torch.vtensor<[?,?],bf16>
+}

--- a/test/python/importer/jit_ir/ivalue_import/tensors.py
+++ b/test/python/importer/jit_ir/ivalue_import/tensors.py
@@ -16,13 +16,31 @@ class TestModule(torch.nn.Module):
         super().__init__()
         # TODO: Test (and make work) tensors that alias each other.
         self.ones = torch.ones(1)
+        self.ones_i32 = torch.ones(1, dtype=torch.int32)
+        self.ones_i64 = torch.ones(1, dtype=torch.int64)
+        self.ones_f32 = torch.ones(1, dtype=torch.float32)
+        self.ones_f64 = torch.ones(1, dtype=torch.float64)
+        self.ones_bool = torch.ones(1, dtype=torch.bool)
+        self.ones_bf16 = torch.ones(1, dtype=torch.bfloat16)
         self.arange = torch.nn.Parameter(torch.arange(3.0))
 
 # CHECK: %[[ARANGE:.*]] = torch.tensor.literal(dense<[0.000000e+00, 1.000000e+00, 2.000000e+00]> : tensor<3xf32>) : !torch.tensor<[3],f32>
 # CHECK: %[[ONES:.*]] = torch.tensor.literal(dense<1.000000e+00> : tensor<1xf32>) : !torch.tensor<[1],f32>
+# CHECK: %[[ONES_I32:.*]] = torch.tensor.literal(dense<1> : tensor<1xsi32>) : !torch.tensor<[1],si32>
+# CHECK: %[[ONES_I64:.*]] = torch.tensor.literal(dense<1> : tensor<1xsi64>) : !torch.tensor<[1],si64>
+# CHECK: %[[ONES_F32:.*]] = torch.tensor.literal(dense<1.000000e+00> : tensor<1xf32>) : !torch.tensor<[1],f32>
+# CHECK: %[[ONES_F64:.*]] = torch.tensor.literal(dense<1.000000e+00> : tensor<1xf64>) : !torch.tensor<[1],f64>
+# CHECK: %[[ONES_BOOL:.*]] = torch.tensor.literal(dense<true> : tensor<1xi1>) : !torch.tensor<[1],i1>
+# CHECK: %[[ONES_BF16:.*]] = torch.tensor.literal(dense<1.000000e+00> : tensor<1xbf16>) : !torch.tensor<[1],bf16>
 # CHECK: %[[ROOT:.*]] = torch.nn_module  {
 # CHECK:   torch.slot "arange", %[[ARANGE]] : !torch.tensor<[3],f32>
 # CHECK:   torch.slot "ones", %[[ONES]] : !torch.tensor<[1],f32>
+# CHECK:   torch.slot "ones_i32", %[[ONES_I32]] : !torch.tensor<[1],si32>
+# CHECK:   torch.slot "ones_i64", %[[ONES_I64]] : !torch.tensor<[1],si64>
+# CHECK:   torch.slot "ones_f32", %[[ONES_F32]] : !torch.tensor<[1],f32>
+# CHECK:   torch.slot "ones_f64", %[[ONES_F64]] : !torch.tensor<[1],f64>
+# CHECK:   torch.slot "ones_bool", %[[ONES_BOOL]] : !torch.tensor<[1],i1>
+# CHECK:   torch.slot "ones_bf16", %[[ONES_BF16]] : !torch.tensor<[1],bf16>
 # CHECK: }
 
 


### PR DESCRIPTION
This patch updates the `torch_mlir::convertTensorToMlirElementsAttr()`
method to enable the creation of tensors whose base type is BFloat16.
This patch also adds a test to validate the IR generation.

I admit that this patch is possibly contentious and/or incomplete.  Let me know if y'all would like to see any additions or changes.  Thanks!