### PR TITLE
Enable support for LTC Input/Output Mapping

### DIFF
--- a/build_tools/autogen_ltc_backend.py
+++ b/build_tools/autogen_ltc_backend.py
@@ -232,7 +232,6 @@ def generate_backend(
     shape_inference_defs = extract_signatures(
         backend_path.joinpath("LazyShapeInference.cpp")
     )
-    assert len(shape_inference_defs) > 0
     assert len(shape_inference_decls) > len(shape_inference_defs)
 
     missing_defs = (

--- a/build_tools/autogen_ltc_backend.yaml
+++ b/build_tools/autogen_ltc_backend.yaml
@@ -19,6 +19,7 @@ blacklist:
 - zeros_like  # Error: TODO add support for type BaseType(name=<BaseTy.MemoryFormat: 12>)
 
 # Additional ops which autogen is supported for but don't compile yet
+- detach
 - item
 - size
 - where

--- a/python/torch_mlir/csrc/base_lazy_backend/LazyShapeInference.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/LazyShapeInference.cpp
@@ -13,9 +13,5 @@
 namespace torch {
 namespace lazy {
 
-std::vector<Shape> compute_shape_detach(const at::Tensor& self) {
-  return {Shape(self.scalar_type(), self.sizes().vec())};
-}
-
 } // namespace lazy
 } // namespace torch

--- a/python/torch_mlir/csrc/base_lazy_backend/LazyShapeInference.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/LazyShapeInference.h
@@ -38,7 +38,6 @@ TORCH_API std::vector<Shape> compute_shape_broadcast_to(const at::Tensor & self,
 TORCH_API std::vector<Shape> compute_shape_bucketize(const at::Tensor & self, const at::Tensor & boundaries, bool out_int32, bool right);
 TORCH_API std::vector<Shape> compute_shape_constant_pad_nd(const at::Tensor & self, at::IntArrayRef pad, const at::Scalar & value);
 TORCH_API std::vector<Shape> compute_shape_conv2d(const at::Tensor & input, const at::Tensor & weight, const c10::optional<at::Tensor> & bias, at::IntArrayRef stride, at::IntArrayRef padding, at::IntArrayRef dilation, int64_t groups);
-TORCH_API std::vector<Shape> compute_shape_detach(const at::Tensor & self);
 TORCH_API std::vector<Shape> compute_shape_div(const at::Tensor & self, const at::Scalar & other);
 TORCH_API std::vector<Shape> compute_shape_div_(at::Tensor & self, const at::Scalar & other);
 TORCH_API std::vector<Shape> compute_shape_dropout(const at::Tensor & input, double p, bool train);

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -65,8 +65,13 @@ void TorchMlirLoweringContext::SetUpAlias(
       {output_index, param_number, param_index, must_alias});
 }
 
+bool TorchMlirLoweringContext::CheckResultShape(
+    const BackendDataPtr& parameter_data, int64_t result_idx) {
+  return Shape(parameter_data->shape()) == GetResultShape(result_idx);
+}
+
 // Get the shape of the result tuple component, given by index.
-c10::optional<torch::lazy::Shape>
+torch::lazy::Shape
 TorchMlirLoweringContext::GetResultShape(size_t index) const {
   TORCH_CHECK(
       index < root_tuple_.size(), "Tried getting result shape at index ", index,
@@ -86,7 +91,7 @@ TorchMlirLoweringContext::GetResultShape(size_t index) const {
   }
 
   // No shape information.
-  return c10::nullopt;
+  return Shape();
 }
 
 size_t TorchMlirLoweringContext::AddResult(const Output& output) {

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -128,7 +128,7 @@ TorchMlirLoweringContext::TorchMlirLoweringContext(
 }
 
 // Get the shape of the result tuple component, given by index.
-torch::lazy::Shape
+c10::optional<torch::lazy::Shape>
 TorchMlirLoweringContext::GetResultShape(size_t index) const {
   TORCH_CHECK(
       index < root_tuple_.size(), "Tried getting result shape at index ", index,
@@ -148,7 +148,7 @@ TorchMlirLoweringContext::GetResultShape(size_t index) const {
   }
 
   // No shape information.
-  return Shape{};
+  return c10::nullopt;
 }
 
 size_t TorchMlirLoweringContext::AddResult(const Output& output) {

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -85,6 +85,7 @@ std::string TorchMlirComputation::to_string() const {
   // MLIR
   ss << "MLIR: \n";
   mlirOperationPrint(func_op_, print_callback, &ss);
+  ss << "\n";
 
   // Input/Output Mapping
   ss << "Input/Output Alias Mapping: \n";

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -91,7 +91,7 @@ std::string TorchMlirComputation::to_string() const {
   ss << "Input/Output Alias Mapping: \n";
   for (InputOutputAlias input_output_alias : input_output_aliases_) {
     ss << "Output: " << input_output_alias.output_index
-       << " -> Input: " << input_output_alias.param_number << std::endl;
+       << " -> Input param: " << input_output_alias.param_number << std::endl;
   }
 
   return ss.str();

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
@@ -41,9 +41,13 @@ public:
 
 class TORCH_API TorchMlirComputation : public torch::lazy::Computation {
 public:
+  using InputOutputAliases = LoweringContext::InputOutputAliases;
+  using InputOutputAlias = LoweringContext::InputOutputAlias;
+
   TorchMlirComputation(
       MlirOperation func_op, MlirContext mlir_context,
-      const std::shared_ptr<torch::jit::Graph>& graph);
+      const std::shared_ptr<torch::jit::Graph>& graph,
+      InputOutputAliases input_output_aliases);
 
   int parameters_size() const override;
 
@@ -67,6 +71,7 @@ private:
   MlirOperation func_op_;
   MlirContext mlir_context_;
   std::shared_ptr<torch::jit::Graph> graph_;
+  InputOutputAliases input_output_aliases_;
   unsigned num_results_;
 };
 

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
@@ -85,7 +85,7 @@ public:
       torch::lazy::Util::EmissionMap emit_status);
 
   // Get the shape of the result tuple component, given by index.
-  torch::lazy::Shape GetResultShape(size_t index) const override;
+  c10::optional<torch::lazy::Shape> GetResultShape(size_t index) const override;
 
   // Adds the given output as a component of the result tuple and returns its
   // assigned position within the tuple.

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
@@ -69,10 +69,7 @@ public:
 
   // Check if parameter shape matches result at index.
   bool CheckResultShape(
-      const BackendDataPtr& parameter_data, int64_t result_idx) override;
-
-  // Get the shape of the result tuple component, given by index.
-  torch::lazy::Shape GetResultShape(size_t index) const override;
+      const BackendDataPtr& parameter_data, size_t result_idx) override;
 
   // Adds the given output as a component of the result tuple and returns its
   // assigned position within the tuple.

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
@@ -39,50 +39,33 @@ public:
   Create(LoweringContext* loctx);
 };
 
-class TORCH_API TorchMlirComputation : public torch::lazy::Computation {
-public:
-  using InputOutputAliases = LoweringContext::InputOutputAliases;
-  using InputOutputAlias = LoweringContext::InputOutputAlias;
-
-  TorchMlirComputation(
-      MlirOperation func_op, MlirContext mlir_context,
-      const std::shared_ptr<torch::jit::Graph>& graph,
-      InputOutputAliases input_output_aliases);
-
-  int parameters_size() const override;
-
-  const std::vector<torch::lazy::Shape>& parameter_shapes() const override;
-
-  const std::vector<std::string>& parameter_names() const override;
-
-  const torch::lazy::Shape& result_shape() const override;
-
-  unsigned num_results() const;
-
-  MlirOperation func_op() const;
-
-  std::string to_string() const;
-
-private:
-  std::vector<std::string> parameter_names_;
-  std::vector<Shape> parameter_shapes_;
-  Shape result_shape_;
-
-  MlirOperation func_op_;
-  MlirContext mlir_context_;
-  std::shared_ptr<torch::jit::Graph> graph_;
-  InputOutputAliases input_output_aliases_;
-  unsigned num_results_;
-};
-
 class TORCH_API TorchMlirLoweringContext : public torch::lazy::LoweringContext {
 public:
+  // Describes an input/output alias as inserted by the SetUpAlias() API.
+  struct InputOutputAlias {
+    // Specifies the index of the aliased buffer in the result tuple.
+    std::vector<int64_t> output_index;
+    // Specifies the parameter containing the buffer to be aliased.
+    int64_t param_number;
+    // Specifies the index of the aliased buffer in the parameter
+    std::vector<int64_t> param_index;
+    // Specifies if the alias is a must alias or may alias.
+    bool must_alias;
+  };
+  using InputOutputAliases = std::vector<InputOutputAlias>;
+
   TorchMlirLoweringContext(
       const std::string& name, torch::lazy::BackendDevice device);
   TorchMlirLoweringContext(
       const std::string& name, torch::lazy::BackendDevice device,
       c10::ArrayRef<torch::lazy::Node*> post_order,
       torch::lazy::Util::EmissionMap emit_status);
+
+  // Adds a new input/output alias.
+  void SetUpAlias(
+      const std::vector<int64_t>& output_index, int64_t param_number,
+      const std::vector<int64_t>& param_index,
+      bool must_alias = false) override;
 
   // Get the shape of the result tuple component, given by index.
   c10::optional<torch::lazy::Shape> GetResultShape(size_t index) const override;
@@ -133,12 +116,50 @@ private:
 
   void RegisterMlirDialects();
 
+  // Holds the input/output alias information populated by the SetUpAlias() API.
+  InputOutputAliases input_output_aliases_;
   std::shared_ptr<torch::jit::Graph> graph_;
   MlirContext mlir_context_;
   std::unordered_map<BackendData::Handle, Parameter> parameters_map_;
   std::vector<torch::jit::Value*> root_tuple_;
   OutputMap<torch::jit::Value*> emitted_outputs_;
   std::unique_ptr<TorchMlirNodeLoweringInterface> lowering_;
+};
+
+class TORCH_API TorchMlirComputation : public torch::lazy::Computation {
+public:
+  using InputOutputAliases = TorchMlirLoweringContext::InputOutputAliases;
+  using InputOutputAlias = TorchMlirLoweringContext::InputOutputAlias;
+
+  TorchMlirComputation(
+      MlirOperation func_op, MlirContext mlir_context,
+      const std::shared_ptr<torch::jit::Graph>& graph,
+      InputOutputAliases input_output_aliases);
+
+  int parameters_size() const override;
+
+  const std::vector<torch::lazy::Shape>& parameter_shapes() const override;
+
+  const std::vector<std::string>& parameter_names() const override;
+
+  const torch::lazy::Shape& result_shape() const override;
+
+  unsigned num_results() const;
+
+  MlirOperation func_op() const;
+
+  std::string to_string() const;
+
+private:
+  std::vector<std::string> parameter_names_;
+  std::vector<Shape> parameter_shapes_;
+  Shape result_shape_;
+
+  MlirOperation func_op_;
+  MlirContext mlir_context_;
+  std::shared_ptr<torch::jit::Graph> graph_;
+  InputOutputAliases input_output_aliases_;
+  unsigned num_results_;
 };
 
 } // namespace lazy

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
@@ -67,8 +67,12 @@ public:
       const std::vector<int64_t>& param_index,
       bool must_alias = false) override;
 
+  // Check if parameter shape matches result at index.
+  bool CheckResultShape(
+      const BackendDataPtr& parameter_data, int64_t result_idx) override;
+
   // Get the shape of the result tuple component, given by index.
-  c10::optional<torch::lazy::Shape> GetResultShape(size_t index) const override;
+  torch::lazy::Shape GetResultShape(size_t index) const override;
 
   // Adds the given output as a component of the result tuple and returns its
   // assigned position within the tuple.


### PR DESCRIPTION
Complements this upstream PyTorch PR: https://github.com/pytorch/pytorch/pull/75828

This PR adds support for mapping input and output tensors which alias each other. (e.g. maps input weight tensor in parameter to the same tensor in output after a training iteration)
```
MLIR: 
func @graph(%arg0: !torch.vtensor<[1,5],f32>, %arg1: !torch.vtensor<[1],si64>, ..., %arg6: !torch.vtensor<[10,5],f32>, %arg7: !torch.vtensor<[10],f32>, ...) {
  ...
  return %arg0, %arg1, %17, %23, ... : !torch.vtensor<[1,5],f32>, !torch.vtensor<[1],si64>, !torch.vtensor<[10,5],f32>, !torch.vtensor<[10],f32>, ...
}

Input/Output Alias Mapping: 
Output: 0 -> Input: 0
Output: 1 -> Input: 1
Output: 2 -> Input: 6
Output: 3 -> Input: 7
```

The `aten::detach` op has also been disabled in this PR to fix the issue of tensors not aliasing properly due to copying.

cc: @antoniojkim @ke1337 