### PR TITLE
Move COMMON_TORCH_MLIR_LOWERING_XFAILS into test_suite

### DIFF
--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -10,19 +10,8 @@
 # (this includes down into lower parts of the stack, where a side table
 # might be used to keep more elaborate sets of testing configurations).
 
-# Lists of tests that fail to even reach the backends.
-# These represent further work needed in torch-mlir to lower them properly
-# to the backend contract.
-COMMON_TORCH_MLIR_LOWERING_XFAILS = {
-    "QuantizedMLP_basic",
-    "TableBatchEmbeddingModule_basic",
-    "MobilenetV2Module_basic",
-    "MobilenetV3Module_basic",
-    "ConvolutionModule3D_basic",
-    "ConvolutionModule1D_basic",
-    "MaxPool2dWith3dInputModule_basic",
-    "MaxPool2dWithIndicesWith3dInputModule_basic",
-}
+from torch_mlir_e2e_test.test_suite import COMMON_TORCH_MLIR_LOWERING_XFAILS
+
 REFBACKEND_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS
 
 EAGER_MODE_XFAIL_SET = REFBACKEND_XFAIL_SET.union({

--- a/python/torch_mlir_e2e_test/test_suite/__init__.py
+++ b/python/torch_mlir_e2e_test/test_suite/__init__.py
@@ -3,6 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
 
+# Lists of tests that fail to even reach the backends.
+# These represent further work needed in torch-mlir to lower them properly
+# to the backend contract.
+COMMON_TORCH_MLIR_LOWERING_XFAILS = {
+    "QuantizedMLP_basic",
+    "TableBatchEmbeddingModule_basic",
+    "MobilenetV2Module_basic",
+    "MobilenetV3Module_basic",
+    "ConvolutionModule3D_basic",
+    "ConvolutionModule1D_basic",
+    "MaxPool2dWith3dInputModule_basic",
+    "MaxPool2dWithIndicesWith3dInputModule_basic",
+}
+
 def register_all_tests():
     """Registers all the built-in E2E tests that Torch-MLIR provides."""
     # Side-effecting import statements.


### PR DESCRIPTION
That way, downstreams don't have to duplicate this list.

Also, remove "external config" feature, since it is subsumed by just
importing the test suite.