### PR TITLE
llvm: bump tag to e1318078

### DIFF
--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorInterfaces.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorInterfaces.td
@@ -463,7 +463,7 @@ def TMTensorInterface : OpInterface<"TMTensorOp"> {
           $_op->getAttrs());
         for (Region &r : $_op->getRegions())
           r.cloneInto(state.addRegion(), bvm);
-        return b.createOperation(state);
+        return b.create(state);
       }]
     >
   ];

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.td
@@ -31,9 +31,7 @@ class TMTensor_Op<string mnemonic, list<Trait> traits = []> :
          TMTensorInterface,
          SingleBlockImplicitTerminator<"::mlir::torch::TMTensor::YieldOp">
   ])> {
-  let verifier = [{ return verify$cppClass(*this); }];
-  let printer = [{ return print$cppClass(p, *this); }];
-  let parser = [{ return parse$cppClass(parser, result); }];
+  let hasVerifier = 1;
   code extraTMTensorOpClassDeclaration = [{
     SmallVector<Value> getDestinationOperands(OpBuilder &b) {
       SmallVector<Value> dest(outputs().begin(), outputs().end());

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/PassDetail.h
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/PassDetail.h
@@ -10,6 +10,7 @@
 #ifndef TORCH_MLIR_DIALECTS_DIALECT_TMTENSOR_TRANSFORMS_PASS_DETAIL_H_
 #define TORCH_MLIR_DIALECTS_DIALECT_TMTENSOR_TRANSFORMS_PASS_DETAIL_H_
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.h
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.h
@@ -10,14 +10,15 @@
 #ifndef TORCH_MLIR_DIALECTS_DIALECT_TMTENSOR_TRANSFORMS_PASSES_H_
 #define TORCH_MLIR_DIALECTS_DIALECT_TMTENSOR_TRANSFORMS_PASSES_H_
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
 namespace torch {
 namespace TMTensor {
 
-std::unique_ptr<OperationPass<FuncOp>> createTMTensorToLoopsPass();
-std::unique_ptr<OperationPass<FuncOp>> createTMTensorBufferizePass();
+std::unique_ptr<OperationPass<func::FuncOp>> createTMTensorToLoopsPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createTMTensorBufferizePass();
 
 void registerPasses();
 

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.td
@@ -13,12 +13,12 @@
 include "mlir/Pass/PassBase.td"
 
 def TMTensorToLoops :
-    Pass<"tm-tensor-to-loops", "FuncOp"> {
+    Pass<"tm-tensor-to-loops", "func::FuncOp"> {
   let summary = "Convert TMTensor ops to loops and Linalg ops.";
   let constructor = "mlir::torch::TMTensor::createTMTensorToLoopsPass()";
 }
 
-def TMTensorBufferize : Pass<"tm-tensor-bufferize", "FuncOp"> {
+def TMTensorBufferize : Pass<"tm-tensor-bufferize", "func::FuncOp"> {
   let summary = "Bufferize the TMTensor dialect";
   let constructor = "mlir::torch::TMTensor::createTMTensorBufferizePass()";
 }

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/Transforms/Bufferize.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/Transforms/Bufferize.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/Func/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinDialect.h"
@@ -150,7 +151,7 @@ struct TMTensorBufferizePass
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 torch::TMTensor::createTMTensorBufferizePass() {
   return std::make_unique<TMTensorBufferizePass>();
 }

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/Transforms/ConvertToLoops.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/Transforms/ConvertToLoops.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
@@ -111,7 +112,7 @@ struct TMTensorToLoopsPass : public TMTensorToLoopsBase<TMTensorToLoopsPass> {
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 torch::TMTensor::createTMTensorToLoopsPass() {
   return std::make_unique<TMTensorToLoopsPass>();
 }

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -16,17 +16,17 @@ include "mlir/Pass/PassBase.td"
 // Torch conversions
 //===----------------------------------------------------------------------===//
 
-def ConvertTorchToStd : Pass<"convert-torch-to-std", "FuncOp"> {
+def ConvertTorchToStd : Pass<"convert-torch-to-std", "func::FuncOp"> {
   let summary = "Convert recognized Torch ops to Std ops";
   let constructor = "mlir::torch::createConvertTorchToStdPass()";
 }
 
-def ConvertTorchToSCF: Pass<"convert-torch-to-scf", "FuncOp"> {
+def ConvertTorchToSCF: Pass<"convert-torch-to-scf", "func::FuncOp"> {
   let summary = "Convert recognized Torch ops to SCF ops";
   let constructor = "mlir::torch::createConvertTorchToSCFPass()";
 }
 
-def ConvertTorchToLinalg : Pass<"convert-torch-to-linalg", "FuncOp"> {
+def ConvertTorchToLinalg : Pass<"convert-torch-to-linalg", "func::FuncOp"> {
   let summary = "Convert recognized Torch ops to Linalg ops";
   let description = [{
     Convert ATen ops to linalg ops.
@@ -105,7 +105,7 @@ def ConvertTorchToLinalg : Pass<"convert-torch-to-linalg", "FuncOp"> {
   let constructor = "mlir::torch::createConvertTorchToLinalgPass()";
 }
 
-def ConvertTorchToTosa : Pass<"convert-torch-to-tosa", "FuncOp"> {
+def ConvertTorchToTosa : Pass<"convert-torch-to-tosa", "func::FuncOp"> {
   let summary = "Convert Torch ops to TOSA ops";
   let description = [{
     This pass assumes that TOSA ops are responsible for emitting error
@@ -114,7 +114,7 @@ def ConvertTorchToTosa : Pass<"convert-torch-to-tosa", "FuncOp"> {
   let constructor = "mlir::torch::createConvertTorchToTosaPass()";
 }
 
-def ConvertTorchToTMTensor : Pass<"convert-torch-to-tmtensor", "FuncOp"> {
+def ConvertTorchToTMTensor : Pass<"convert-torch-to-tmtensor", "func::FuncOp"> {
   let summary = "Convert recognized Torch ops to TMTensor/Linalg ops";
   let description = [{
     Convert ATen ops to tmtensor/linalg ops.

--- a/include/torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h
+++ b/include/torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h
@@ -10,12 +10,13 @@
 #ifndef TORCHMLIR_CONVERSION_ATENTOLINALG_ATENTOLINALG_H
 #define TORCHMLIR_CONVERSION_ATENTOLINALG_ATENTOLINALG_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include <memory>
 
 namespace mlir {
 namespace torch {
-std::unique_ptr<OperationPass<FuncOp>> createConvertTorchToLinalgPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToLinalgPass();
 }
 } // namespace mlir
 

--- a/include/torch-mlir/Conversion/TorchToSCF/TorchToSCF.h
+++ b/include/torch-mlir/Conversion/TorchToSCF/TorchToSCF.h
@@ -10,11 +10,12 @@
 #ifndef TORCHMLIR_CONVERSION_TORCHTOSCF_TORCHTOSCF_H
 #define TORCHMLIR_CONVERSION_TORCHTOSCF_TORCHTOSCF_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
 namespace torch {
-std::unique_ptr<OperationPass<FuncOp>> createConvertTorchToSCFPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToSCFPass();
 }
 } // namespace mlir
 

--- a/include/torch-mlir/Conversion/TorchToStd/TorchToStd.h
+++ b/include/torch-mlir/Conversion/TorchToStd/TorchToStd.h
@@ -10,12 +10,13 @@
 #ifndef TORCHMLIR_CONVERSION_ATENTOSTD_ATENTOSTD_H
 #define TORCHMLIR_CONVERSION_ATENTOSTD_ATENTOSTD_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include <memory>
 
 namespace mlir {
 namespace torch {
-std::unique_ptr<OperationPass<FuncOp>> createConvertTorchToStdPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToStdPass();
 }
 } // namespace mlir
 

--- a/include/torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h
+++ b/include/torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h
@@ -10,11 +10,12 @@
 #ifndef TORCHMLIR_CONVERSION_TORCHTOTMTENSOR_TORCHTOTMTENSOR_H
 #define TORCHMLIR_CONVERSION_TORCHTOTMTENSOR_TORCHTOTMTENSOR_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
 namespace torch {
-std::unique_ptr<OperationPass<FuncOp>> createConvertTorchToTMTensorPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTMTensorPass();
 }
 } // namespace mlir
 

--- a/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
@@ -10,12 +10,13 @@
 #ifndef TORCHMLIR_CONVERSION_TORCHTOTOSA_TORCHTOTOSA_H
 #define TORCHMLIR_CONVERSION_TORCHTOTOSA_TORCHTOTOSA_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include <memory>
 
 namespace mlir {
 namespace torch {
-std::unique_ptr<OperationPass<FuncOp>> createConvertTorchToTosaPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTosaPass();
 }
 } // namespace mlir
 

--- a/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
@@ -10,6 +10,8 @@
 #ifndef TORCH_TYPES
 #define TORCH_TYPES
 
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/DialectBase.td"
 include "torch-mlir/Dialect/Torch/IR/TorchBase.td"
 
 //===----------------------------------------------------------------------===//
@@ -24,28 +26,8 @@ class Torch_Type<string name, string typeMnemonic,
 
 class Torch_TypeWithContainedType<string name, string typeMnemonic> : Torch_Type<name, typeMnemonic> {
   let parameters = (ins "::mlir::Type":$containedType);
+  let hasCustomAssemblyFormat = 1;
 
-  let printer = [{
-    $_printer << "<";
-    // Print the contained type without the `!torch.` prefix.
-    printTorchDialectType(getImpl()->containedType, $_printer);
-    $_printer << ">";
-  }];
-
-  let parser = [{
-    if ($_parser.parseLess())
-      return Type();
-
-    // Parse the contained type, but forward directly to our internal parsing
-    // of `torch` dialect types, so that we can parse nested types without
-    // the `!torch.` prefix.
-    Type containedType = parseTorchDialectType($_parser);
-    if (!containedType)
-      return Type();
-    if ($_parser.parseGreater())
-      return Type();
-    return get($_ctxt, containedType);
-  }];
   let builders = [
     TypeBuilderWithInferredContext<(ins "::mlir::Type":$containedType), [{
       return Base::get(containedType.getContext(), containedType);
@@ -59,23 +41,7 @@ def Torch_NnModuleType : Torch_Type<"NnModule", "nn.Module"> {
     Represents an instance of a `torch.nn.Module` with the given `className`.
   }];
   let parameters = (ins StringRefParameter<"class name">:$className);
-
-  let printer = [{
-    $_printer << "<\"";
-    llvm::printEscapedString(getImpl()->className, $_printer.getStream());
-    $_printer << "\">";
-  }];
-
-  let parser = [{
-    if ($_parser.parseLess())
-      return Type();
-   std::string className;
-    if ($_parser.parseOptionalString(&className))
-      return Type();
-    if ($_parser.parseGreater())
-      return Type();
-    return get($_ctxt, className);
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 // For standard ArrayRefs, which require allocation.
@@ -186,6 +152,7 @@ class AnyTorchTensorType<string name, string typeMnemonic>
     "::mlir::Type":$optionalDtype
   );
   let genVerifyDecl = 1;
+  let hasCustomAssemblyFormat = 1;
   string extraBaseClassDeclaration = [{
   }];
 }
@@ -243,6 +210,7 @@ def Torch_TupleType : Torch_Type<"Tuple", "tuple"> {
   let parameters = (ins
     ArrayRefParameter<"::mlir::Type", "contained types">:$containedTypes
   );
+  let hasCustomAssemblyFormat = 1;
 }
 
 def Torch_UnionType : Torch_Type<"Union", "union"> {
@@ -261,6 +229,7 @@ def Torch_UnionType : Torch_Type<"Union", "union"> {
   let parameters = (ins
     ArrayRefParameter<"::mlir::Type", "contained types">:$containedTypes
   );
+  let hasCustomAssemblyFormat = 1;
 }
 
 def Torch_DeviceType : Torch_Type<"Device", "Device"> {
@@ -367,30 +336,7 @@ def Torch_DictType : Torch_Type<"Dict", "dict"> {
   let description = [{
     Torch Dict type with key and value type.
   }];
-
-  let printer = [{
-    $_printer << "<";
-    printTorchDialectType(getImpl()->keyType, $_printer);
-    $_printer << ", ";
-    printTorchDialectType(getImpl()->valueType, $_printer);
-    $_printer<< ">";
-  }];
-
-  let parser = [{
-    if ($_parser.parseLess())
-      return Type();
-    Type keyType = parseTorchDialectType($_parser);
-    if (!keyType)
-      return Type();
-    if ($_parser.parseComma())
-      return Type();
-    Type valueType = parseTorchDialectType($_parser);
-    if (!valueType)
-      return Type();
-    if ($_parser.parseGreater())
-      return Type();
-    return get($_ctxt, keyType, valueType);
-  }];
+  let hasCustomAssemblyFormat = 1;
   let builders = [
     TypeBuilderWithInferredContext<(ins "::mlir::Type":$keyType,
                                         "::mlir::Type":$valueType), [{

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
@@ -10,11 +10,14 @@
 #ifndef TORCHMLIR_DIALECT_TORCH_TRANSFORMS_PASSES_H
 #define TORCHMLIR_DIALECT_TORCH_TRANSFORMS_PASSES_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 
 #include <memory>
 
 namespace mlir {
+class ModuleOp;
+
 namespace torch {
 namespace Torch {
 
@@ -48,25 +51,26 @@ void createTorchShapeRefinementPipeline(
 
 std::unique_ptr<OperationPass<ModuleOp>> createAdjustCallingConventionsPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createRefineTypesPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createRefineTypesPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createInlineGlobalSlotsPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createReduceOpVariantsPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createReduceOpVariantsPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createMaximizeValueSemanticsPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createMaximizeValueSemanticsPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createRefinePublicReturnPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createDecomposeComplexOpsPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createDecomposeComplexOpsPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createPreprocessShapeLibraryPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createReifyShapeCalculationsPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createSimplifyShapeCalculationsPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSimplifyShapeCalculationsPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createDropShapeCalculationsPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createDropShapeCalculationsPass();
 
 StringRef getShapeLibrary();
 

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -126,7 +126,7 @@ def AdjustCallingConventions
   }];
 }
 
-def RefineTypes : Pass<"torch-refine-types", "FuncOp"> {
+def RefineTypes : Pass<"torch-refine-types", "func::FuncOp"> {
   let summary = "Refine types";
   let constructor = "mlir::torch::Torch::createRefineTypesPass()";
   let description = [{
@@ -149,7 +149,7 @@ def InlineGlobalSlots : Pass<"torch-inline-global-slots", "ModuleOp"> {
   }];
 }
 
-def ReduceOpVariants : Pass<"torch-reduce-op-variants", "FuncOp"> {
+def ReduceOpVariants : Pass<"torch-reduce-op-variants", "func::FuncOp"> {
   let summary = "Reduces variants of ops to a smaller set of ops.";
   let constructor = "mlir::torch::Torch::createReduceOpVariantsPass()";
   let description = [{
@@ -165,7 +165,7 @@ def ReduceOpVariants : Pass<"torch-reduce-op-variants", "FuncOp"> {
   }];
 }
 
-def MaximizeValueSemantics : Pass<"torch-maximize-value-semantics", "FuncOp"> {
+def MaximizeValueSemantics : Pass<"torch-maximize-value-semantics", "func::FuncOp"> {
   let summary = "Use value-semantic tensors where possible.";
   let description = [{
     Use value-semantic tensors where possible to make the program more
@@ -215,7 +215,7 @@ def RefinePublicReturn : Pass<"torch-refine-public-return", "ModuleOp"> {
   }];
 }
 
-def DecomposeComplexOps : Pass<"torch-decompose-complex-ops", "FuncOp"> {
+def DecomposeComplexOps : Pass<"torch-decompose-complex-ops", "func::FuncOp"> {
   let summary = "Decompose complicated torch operations";
   let constructor = "mlir::torch::Torch::createDecomposeComplexOpsPass()";
   let description = [{
@@ -238,7 +238,7 @@ def ReifyShapeCalculations : Pass<"torch-reify-shape-calculations", "ModuleOp"> 
   }];
 }
 
-def SimplifyShapeCalculations : Pass<"torch-simplify-shape-calculations", "FuncOp"> {
+def SimplifyShapeCalculations : Pass<"torch-simplify-shape-calculations", "func::FuncOp"> {
   let summary = "Simplify reified shape calculations.";
   let constructor = "mlir::torch::Torch::createSimplifyShapeCalculationsPass()";
   let description = [{
@@ -246,7 +246,7 @@ def SimplifyShapeCalculations : Pass<"torch-simplify-shape-calculations", "FuncO
   }];
 }
 
-def DropShapeCalculations : Pass<"torch-drop-shape-calculations", "FuncOp"> {
+def DropShapeCalculations : Pass<"torch-drop-shape-calculations", "func::FuncOp"> {
   let summary = "Drop reified shape calculations.";
   let constructor = "mlir::torch::Torch::createDropShapeCalculationsPass()";
   let description = [{

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
@@ -10,12 +10,15 @@
 #ifndef TORCHMLIR_DIALECT_TORCHCONVERSION_TRANSFORMS_PASSES_H
 #define TORCHMLIR_DIALECT_TORCHCONVERSION_TRANSFORMS_PASSES_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
 
 #include <memory>
 
 namespace mlir {
+class ModuleOp;
+
 namespace torch {
 namespace TorchConversion {
 
@@ -36,7 +39,7 @@ createVerifyInvariantsBeforeBackendLoweringPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createFuncBackendTypeConversionPass();
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 createFinalizingBackendTypeConversionPass();
 
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
@@ -43,7 +43,7 @@ def FuncBackendTypeConversion : Pass<"torch-func-backend-type-conversion", "Modu
 }
 
 def FinalizingBackendTypeConversion
-    : Pass<"torch-finalizing-backend-type-conversion", "FuncOp"> {
+    : Pass<"torch-finalizing-backend-type-conversion", "func::FuncOp"> {
   let summary = "Finalizes a partial conversion to builtin tensors";
   let constructor =
     "mlir::torch::TorchConversion::createFinalizingBackendTypeConversionPass()";

--- a/include/torch-mlir/RefBackend/Passes.h
+++ b/include/torch-mlir/RefBackend/Passes.h
@@ -10,10 +10,13 @@
 #ifndef TORCHMLIR_REFBACKEND_PASSES_H
 #define TORCHMLIR_REFBACKEND_PASSES_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 
 namespace mlir {
+class ModuleOp;
+
 namespace torch {
 namespace RefBackend {
 
@@ -22,13 +25,13 @@ void registerRefBackendPasses();
 
 std::unique_ptr<OperationPass<ModuleOp>> createMungeCallingConventionsPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createExpandOpsForLLVMPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createExpandOpsForLLVMPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createInsertRngGlobalsPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createMungeMemrefCopyPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createMungeMemrefCopyPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createGeneralizeTensorPadPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createGeneralizeTensorPadPass();
 } // namespace RefBackend
 } // namespace torch
 } // namespace mlir

--- a/include/torch-mlir/RefBackend/Passes.td
+++ b/include/torch-mlir/RefBackend/Passes.td
@@ -24,18 +24,18 @@ def InsertRngGlobals: Pass<"refback-insert-rng-globals", "ModuleOp"> {
   let dependentDialects = ["memref::MemRefDialect"];
 }
 
-def ExpandOpsForLLVM : Pass<"refback-expand-ops-for-llvm", "FuncOp"> {
+def ExpandOpsForLLVM : Pass<"refback-expand-ops-for-llvm", "func::FuncOp"> {
   let summary = "Expand ops into more primitive ops before LLVM lowering.";
   let constructor = "mlir::torch::RefBackend::createExpandOpsForLLVMPass();";
 }
 
-def MungeMemrefCopy : Pass<"refback-munge-memref-copy", "FuncOp"> {
+def MungeMemrefCopy : Pass<"refback-munge-memref-copy", "func::FuncOp"> {
   let summary = "Munge memref.copy to linalg.copy";
   let constructor = "mlir::torch::RefBackend::createMungeMemrefCopyPass();";
   let dependentDialects = ["memref::MemRefDialect"];
 }
 
-def GeneralizeTensorPad : Pass<"refback-generalize-tensor-pad", "FuncOp"> {
+def GeneralizeTensorPad : Pass<"refback-generalize-tensor-pad", "func::FuncOp"> {
   let summary = "Convert tensor.pad to linalg ops";
   let constructor = "mlir::torch::RefBackend::createGeneralizeTensorPadPass()";
 }

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -10,6 +10,7 @@
 #ifndef TORCHMLIR_CONVERSION_PASSDETAIL_H
 #define TORCHMLIR_CONVERSION_PASSDETAIL_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -88,7 +88,7 @@ public:
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::createConvertTorchToLinalgPass() {
   return std::make_unique<ConvertTorchToLinalg>();
 }

--- a/lib/Conversion/TorchToSCF/TorchToSCF.cpp
+++ b/lib/Conversion/TorchToSCF/TorchToSCF.cpp
@@ -91,7 +91,7 @@ public:
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::createConvertTorchToSCFPass() {
   return std::make_unique<ConvertTorchToSCF>();
 }

--- a/lib/Conversion/TorchToStd/TorchToStd.cpp
+++ b/lib/Conversion/TorchToStd/TorchToStd.cpp
@@ -10,6 +10,7 @@
 #include "torch-mlir/Conversion/TorchToStd/TorchToStd.h"
 
 #include "../PassDetail.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -221,7 +222,7 @@ public:
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::createConvertTorchToStdPass() {
   return std::make_unique<ConvertTorchToStd>();
 }

--- a/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
+++ b/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
@@ -10,8 +10,10 @@
 #include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 
 #include "../PassDetail.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/MLIRContext.h"
 #include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"
 #include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.h"
@@ -566,7 +568,7 @@ public:
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::createConvertTorchToTMTensorPass() {
   return std::make_unique<ConvertTorchToTMTensor>();
 }

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -3170,7 +3170,7 @@ public:
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::createConvertTorchToTosaPass() {
   return std::make_unique<ConvertTorchToTosa>();
 }

--- a/lib/Conversion/Utils/Utils.cpp
+++ b/lib/Conversion/Utils/Utils.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 

--- a/lib/Dialect/Torch/IR/UtilsForODSGenerated.cpp
+++ b/lib/Dialect/Torch/IR/UtilsForODSGenerated.cpp
@@ -35,7 +35,7 @@ ParseResult Torch::parseDefaultTorchOp(OpAsmParser &parser,
                                        OperationState &result, int numOperands,
                                        int numResults) {
   llvm::SMLoc loc = parser.getCurrentLocation();
-  SmallVector<OpAsmParser::OperandType> operands;
+  SmallVector<OpAsmParser::UnresolvedOperand> operands;
   if (parser.parseOperandList(operands, /*requiredOperandCount=*/numOperands))
     return failure();
   if (parser.parseOptionalAttrDict(result.attributes))

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -1781,7 +1781,7 @@ class DecomposeComplexOpsPass
   }
 };
 } // namespace
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::Torch::createDecomposeComplexOpsPass() {
   return std::make_unique<DecomposeComplexOpsPass>();
 }

--- a/lib/Dialect/Torch/Transforms/DropShapeCalculations.cpp
+++ b/lib/Dialect/Torch/Transforms/DropShapeCalculations.cpp
@@ -54,7 +54,7 @@ class DropShapeCalculationsPass
     patterns.insert<DropShapeCalculateOp>(context);
     ConversionTarget target(*context);
     target.addIllegalOp<ShapeCalculateOp>();
-    target.addLegalOp<FuncOp>();
+    target.addLegalOp<func::FuncOp>();
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {
@@ -64,7 +64,7 @@ class DropShapeCalculationsPass
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::Torch::createDropShapeCalculationsPass() {
   return std::make_unique<DropShapeCalculationsPass>();
 }

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -355,7 +355,7 @@ class MaximizeValueSemanticsPass
 
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::Torch::createMaximizeValueSemanticsPass() {
   return std::make_unique<MaximizeValueSemanticsPass>();
 }

--- a/lib/Dialect/Torch/Transforms/PassDetail.h
+++ b/lib/Dialect/Torch/Transforms/PassDetail.h
@@ -10,9 +10,11 @@
 #ifndef TORCHMLIR_DIALECT_TORCH_TRANSFORMS_PASSDETAIL_H
 #define TORCHMLIR_DIALECT_TORCH_TRANSFORMS_PASSDETAIL_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
+class ModuleOp;
 namespace torch {
 namespace Torch {
 

--- a/lib/Dialect/Torch/Transforms/PrepareForGlobalizeObjectGraph.cpp
+++ b/lib/Dialect/Torch/Transforms/PrepareForGlobalizeObjectGraph.cpp
@@ -33,10 +33,10 @@ public:
     auto classType = symbolTable.lookup<ClassTypeOp>(
         op.receiver().getType().cast<NnModuleType>().getClassName());
     assert(classType && "malformed module -- missing ClassTypeOp");
-    FuncOp func;
+    func::FuncOp func;
     for (auto method : classType.getOps<MethodOp>()) {
       if (method.name() == op.name()) {
-        func = symbolTable.lookup<FuncOp>(method.function());
+        func = symbolTable.lookup<func::FuncOp>(method.function());
         break;
       }
     }

--- a/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
+++ b/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
@@ -207,7 +207,7 @@ public:
     assert(op->getNumRegions() == 0 && op->getNumSuccessors() == 0 &&
            "Torch JIT operators shouldn't have regions or successors");
 
-    Operation *newOp = rewriter.createOperation(state);
+    Operation *newOp = rewriter.create(state);
     auto tensor =
         rewriter.create<CopyToValueTensorOp>(op->getLoc(), newOp->getResult(0));
     createOverwriteTensorContents(rewriter, op->getLoc(), tensor,
@@ -276,7 +276,7 @@ class ReduceOpVariantsPass : public ReduceOpVariantsBase<ReduceOpVariantsPass> {
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::Torch::createReduceOpVariantsPass() {
   return std::make_unique<ReduceOpVariantsPass>();
 }

--- a/lib/Dialect/Torch/Transforms/RefinePublicReturn.cpp
+++ b/lib/Dialect/Torch/Transforms/RefinePublicReturn.cpp
@@ -25,7 +25,7 @@ class RefinePublicReturnPass
     : public RefinePublicReturnBase<RefinePublicReturnPass> {
   void runOnOperation() override {
     auto module = getOperation();
-    module.walk([&](FuncOp func) {
+    module.walk([&](func::FuncOp func) {
       if (func.getVisibility() != SymbolTable::Visibility::Public)
         return;
       if (func.isExternal())
@@ -40,7 +40,7 @@ class RefinePublicReturnPass
     });
   }
 
-  void rewriteSignature(FuncOp func) {
+  void rewriteSignature(func::FuncOp func) {
     // Find the unique return op.
     func::ReturnOp returnOp;
     WalkResult walkResult = func.walk([&](func::ReturnOp op) {
@@ -90,7 +90,7 @@ class RefinePublicReturnPass
     returnOp->setOperands(newOperands);
 
     // Update the function type.
-    auto funcType = func.getType();
+    auto funcType = func.getFunctionType();
     func.setType(FunctionType::get(funcType.getContext(), funcType.getInputs(),
                                    ValueRange(newOperands).getTypes()));
   }

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -1191,7 +1191,7 @@ static bool isSafeToRefineOperandInPlace(OpOperand *use, Type newOperandType) {
   return operationIsValidWithRefinedType(use, newOperandType);
 }
 
-void optimize(FuncOp func, TypeAnalyzer &analyzer) {
+void optimize(func::FuncOp func, TypeAnalyzer &analyzer) {
   func.walk([&](Operation *op) {
     auto convertValuesToMostRefinedType = [&](ValueRange values, OpBuilder &b) {
       for (Value v : values) {
@@ -1336,7 +1336,7 @@ class RefineTypesPass : public RefineTypesBase<RefineTypesPass> {
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::Torch::createRefineTypesPass() {
   return std::make_unique<RefineTypesPass>();
 }

--- a/lib/Dialect/Torch/Transforms/ReifyShapeCalculations.cpp
+++ b/lib/Dialect/Torch/Transforms/ReifyShapeCalculations.cpp
@@ -169,7 +169,7 @@ static Value adjustShapeFunctionArg(Value operand, Type desiredType,
 // from the shape library.
 static LogicalResult
 populateShapeCalculationRegion(ShapeCalculateOp op, ValueRange originalOperands,
-                               mlir::FuncOp shapeFunction) {
+                               mlir::func::FuncOp shapeFunction) {
   // Create a call to the shape function in the `shapeCalculation` region.
   // We will import the callee from the shape library later.
   OpBuilder b(op.getContext());
@@ -241,7 +241,7 @@ class ReifyShapeCalculationsPass
         name = name.drop_front(strlen("valsem."));
       auto shapeFunctionName = ("__torch_mlir_shape_fn." + Twine(name)).str();
       auto shapeFunction =
-          shapeLibrary->lookupSymbol<FuncOp>(shapeFunctionName);
+          shapeLibrary->lookupSymbol<func::FuncOp>(shapeFunctionName);
       if (!shapeFunction)
         return;
       neededShapeFunctions.push_back(shapeFunctionName);
@@ -276,7 +276,7 @@ class ReifyShapeCalculationsPass
       auto symName = worklist.pop_back_val();
       if (importedFunctions.count(symName))
         continue;
-      auto func = shapeLibrary->lookupSymbol<mlir::FuncOp>(symName);
+      auto func = shapeLibrary->lookupSymbol<mlir::func::FuncOp>(symName);
       assert(func && "broken shape library");
       // Move the shape function from the library to the module this pass
       // is running on. (this mutates the library, but we re-parse it each time

--- a/lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp
+++ b/lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp
@@ -415,7 +415,7 @@ class SimplifyShapeCalculationsPass
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::Torch::createSimplifyShapeCalculationsPass() {
   return std::make_unique<SimplifyShapeCalculationsPass>();
 }

--- a/lib/Dialect/TorchConversion/Transforms/BackendTypeConversionPasses.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/BackendTypeConversionPasses.cpp
@@ -45,9 +45,10 @@ struct FuncBackendTypeConversionPass
     typeConverter.addConversion([](Type type) { return type; });
     TorchConversion::setupBackendTypeConversion(target, typeConverter);
 
-    populateFunctionOpInterfaceTypeConversionPattern<FuncOp>(patterns, typeConverter);
-    target.addDynamicallyLegalOp<FuncOp>([&](FuncOp op) {
-      return typeConverter.isSignatureLegal(op.getType()) &&
+    populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+        patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+      return typeConverter.isSignatureLegal(op.getFunctionType()) &&
              typeConverter.isLegal(&op.getBody());
     });
     populateCallOpTypeConversionPattern(patterns, typeConverter);
@@ -155,7 +156,7 @@ struct FinalizingBackendTypeConversionPass
 };
 } // namespace
 
-std::unique_ptr<OperationPass<FuncOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::torch::TorchConversion::createFinalizingBackendTypeConversionPass() {
   return std::make_unique<FinalizingBackendTypeConversionPass>();
 }

--- a/lib/Dialect/TorchConversion/Transforms/PassDetail.h
+++ b/lib/Dialect/TorchConversion/Transforms/PassDetail.h
@@ -10,9 +10,12 @@
 #ifndef TORCHMLIR_DIALECT_TORCHCONVERSION_TRANSFORMS_PASSDETAIL_H
 #define TORCHMLIR_DIALECT_TORCHCONVERSION_TRANSFORMS_PASSDETAIL_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
+class ModuleOp;
+
 namespace torch {
 namespace TorchConversion {
 

--- a/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
@@ -9,6 +9,8 @@
 
 #include "PassDetail.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -60,7 +62,7 @@ class VerifyLinalgOnTensorsBackendContractPass
     ConversionTarget target(*context);
 
     // Structural operations.
-    target.addDynamicallyLegalOp<ModuleOp, FuncOp, func::ReturnOp>(
+    target.addDynamicallyLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>(
         opHasLegalTypes);
 
     target.addDynamicallyLegalOp<GetNextSeedOp>(opHasLegalTypes);

--- a/lib/Dialect/TorchConversion/Transforms/VerifyTosaBackendContract.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyTosaBackendContract.cpp
@@ -9,6 +9,7 @@
 
 #include "PassDetail.h"
 
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
@@ -39,7 +40,7 @@ class VerifyTosaBackendContractPass
     ConversionTarget target(*context);
 
     // Structural operations.
-    target.addDynamicallyLegalOp<ModuleOp, FuncOp, func::ReturnOp>(
+    target.addDynamicallyLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>(
         opHasLegalTypes);
     // Basic scalar operations.
     target.addLegalDialect<tosa::TosaDialect>();

--- a/lib/RefBackend/PassDetail.h
+++ b/lib/RefBackend/PassDetail.h
@@ -10,6 +10,7 @@
 #ifndef REFBACKEND_PASSDETAIL_H
 #define REFBACKEND_PASSDETAIL_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Pass/Pass.h"
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.cpp
@@ -36,8 +36,8 @@ MlirOperation torch_mlir::importJitFunctionAsFuncOp(
   MlirAttribute symNameAttr = mlirStringAttrGet(
       context, toMlirStringRef(function->qualname().qualifiedName()));
   MlirOperation func = createMlirOperation(
-      "builtin.func", loc, mlirRegionCreate(),
-      toMlirNamedAttribute("type", mlirTypeAttrGet(functionType)),
+      "func.func", loc, mlirRegionCreate(),
+      toMlirNamedAttribute("function_type", mlirTypeAttrGet(functionType)),
       toMlirNamedAttribute("sym_name", symNameAttr));
   std::vector<MlirAttribute> argAttrDicts;
   for (int i = 0, e = mlirFunctionTypeGetNumInputs(functionType); i != e; i++) {

--- a/python/torch_mlir/eager_mode/ir_building.py
+++ b/python/torch_mlir/eager_mode/ir_building.py
@@ -29,7 +29,7 @@ import torch
 from torch.jit import ScriptFunction
 
 from torch_mlir import ir
-from torch_mlir.dialects.builtin import FuncOp
+from torch_mlir.dialects.func import FuncOp
 from torch_mlir.dialects.torch.importer.jit_ir import ModuleBuilder
 
 

--- a/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -115,15 +115,15 @@ class RefBackendInvoker:
 
 
 LOWERING_PIPELINE = ",".join([
-    "builtin.func(refback-generalize-tensor-pad)",
+    "func.func(refback-generalize-tensor-pad)",
     # Bufferize.
-    "builtin.func(scf-bufferize)",
-    "builtin.func(tm-tensor-bufferize)",
-    "builtin.func(linalg-bufferize)",
+    "func.func(scf-bufferize)",
+    "func.func(tm-tensor-bufferize)",
+    "func.func(linalg-bufferize)",
     "func-bufferize",
     "arith-bufferize",
-    "builtin.func(tensor-bufferize)",
-    "builtin.func(finalizing-bufferize)",
+    "func.func(tensor-bufferize)",
+    "func.func(finalizing-bufferize)",
     # Munge to make it ExecutionEngine compatible.
     # Specifically, we rewrite calling convention boundaries to be in terms
     # of unranked memref, and we rewrite the return to actually be a
@@ -135,17 +135,17 @@ LOWERING_PIPELINE = ",".join([
     # global seed used in stateful rng.
     "refback-insert-rng-globals",
     # Lower to LLVM
-    "builtin.func(tm-tensor-to-loops)",
-    "builtin.func(refback-munge-memref-copy)",
-    "builtin.func(convert-linalg-to-loops)",
-    "builtin.func(lower-affine)",
+    "func.func(tm-tensor-to-loops)",
+    "func.func(refback-munge-memref-copy)",
+    "func.func(convert-linalg-to-loops)",
+    "func.func(lower-affine)",
     "convert-scf-to-cf",
-    "builtin.func(refback-expand-ops-for-llvm)",
-    "builtin.func(arith-expand)",
-    "builtin.func(convert-math-to-llvm)",
+    "func.func(refback-expand-ops-for-llvm)",
+    "func.func(arith-expand)",
+    "func.func(convert-math-to-llvm)",
     "convert-linalg-to-llvm",
     "convert-memref-to-llvm",
-    "builtin.func(convert-arith-to-llvm)",
+    "func.func(convert-arith-to-llvm)",
     "convert-func-to-llvm",
     "convert-cf-to-llvm",
     "reconcile-unrealized-casts",

--- a/python/torch_mlir_e2e_test/tosa_backends/linalg_on_tensors.py
+++ b/python/torch_mlir_e2e_test/tosa_backends/linalg_on_tensors.py
@@ -38,25 +38,25 @@ class LinalgOnTensorsTosaBackend(TosaBackend):
         """
 
         # TOSA legalization may emit tosa.const() ops. These are legalized
-        # by tosa-to-standard to arith.constants. This mechanical transformation 
+        # by tosa-to-arith to arith.constants. This mechanical transformation 
         # must be done prior to TOSA-to-LinAlg so that the latter does not fail. 
         # This is an artifact of legalizations spread across a collection of simple
         # ones in TOSA-to-Standard and the main conversions TOSA-to-LinAlg, 
         # that depend on TOSA as well as TOSA-to-Standard.  
         run_pipeline_with_repro_report(
             imported_module,
-            "builtin.func(tosa-to-standard)",
-            "Lowering TOSA to Standard")
+            "func.func(tosa-to-arith)",
+            "Lowering TOSA to Arith")
 
         # Named ops must be legalized prior to general tosa-to-linalg
         run_pipeline_with_repro_report(
             imported_module,
-            "builtin.func(tosa-to-linalg-named)",
+            "func.func(tosa-to-linalg-named)",
             "Lowering TOSA to Linalg-on-Tensors for Named Ops")
 
         run_pipeline_with_repro_report(
             imported_module,
-            "builtin.func(tosa-to-linalg)",
+            "func.func(tosa-to-linalg)",
             "Lowering TOSA to Linalg-on-Tensors")
         return self.refbackend.compile(imported_module)
 

--- a/test/Conversion/TorchToLinalg/pooling.mlir
+++ b/test/Conversion/TorchToLinalg/pooling.mlir
@@ -1,7 +1,7 @@
 // RUN: torch-mlir-opt <%s -convert-torch-to-linalg -split-input-file -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: func @forward
-builtin.func @forward(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
+func.func @forward(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
   %int1 = torch.constant.int 1
   %int2 = torch.constant.int 2
   %int3 = torch.constant.int 3

--- a/test/Dialect/Torch/GlobalizeObjectGraph/error.mlir
+++ b/test/Dialect/Torch/GlobalizeObjectGraph/error.mlir
@@ -42,7 +42,7 @@ torch.nn_module {
   torch.slot "t1", %t : !torch.tensor
   torch.slot "t2", %t : !torch.tensor
 } : !torch.nn.Module<"c">
-builtin.func private @use_slot(%arg0 : !torch.nn.Module<"c">) -> !torch.tensor {
+func.func private @use_slot(%arg0 : !torch.nn.Module<"c">) -> !torch.tensor {
   %t1 = torch.prim.GetAttr %arg0["t1"] : !torch.nn.Module<"c"> -> !torch.tensor
   %t2 = torch.prim.GetAttr %arg0["t2"] : !torch.nn.Module<"c"> -> !torch.tensor
   %cst = torch.constant.int 1
@@ -63,7 +63,7 @@ torch.nn_module {
   torch.slot "t1", %t : !torch.tensor
   torch.slot "t2", %t : !torch.tensor
 } : !torch.nn.Module<"c">
-builtin.func private @set_slot(%arg0 : !torch.nn.Module<"c">, %arg1 : !torch.tensor) {
+func.func private @set_slot(%arg0 : !torch.nn.Module<"c">, %arg1 : !torch.tensor) {
   torch.prim.SetAttr %arg0["t1"] = %arg1: !torch.nn.Module<"c">, !torch.tensor
   torch.prim.SetAttr %arg0["t2"] = %arg1: !torch.nn.Module<"c">, !torch.tensor
   return

--- a/test/Dialect/Torch/invalid.mlir
+++ b/test/Dialect/Torch/invalid.mlir
@@ -4,8 +4,8 @@
 
 torch.class_type @c {}
 %0 = torch.nn_module {
-  // expected-error @+1 {{'builtin.func' op is not allowed inside 'torch.nn_module'}}
-  builtin.func @f()
+  // expected-error @+1 {{'func.func' op is not allowed inside 'torch.nn_module'}}
+  func.func @f()
 } : !torch.nn.Module<"c">
 
 // -----
@@ -32,8 +32,8 @@ torch.class_type @c {
 // -----
 
 torch.class_type @c {
-  // expected-error @+1 {{'builtin.func' op is not allowed inside `torch.class_type`}}
-  builtin.func @f()
+  // expected-error @+1 {{'func.func' op is not allowed inside `torch.class_type`}}
+  func.func @f()
 }
 
 // -----
@@ -60,7 +60,7 @@ torch.class_type @c {
   torch.method "f", @f
 }
 
-builtin.func @f(%arg0: !torch.nn.Module<"c">) {
+func.func @f(%arg0: !torch.nn.Module<"c">) {
   return
 }
 
@@ -71,11 +71,11 @@ torch.class_type @c {
   torch.method "f", @f
 }
 
-builtin.func private @f(%arg0: !torch.nn.Module<"c">)
+func.func private @f(%arg0: !torch.nn.Module<"c">)
 
 // -----
 
-builtin.func private @f() {
+func.func private @f() {
   return
 }
 torch.class_type @c {
@@ -85,7 +85,7 @@ torch.class_type @c {
 
 // -----
 
-builtin.func private @f(!torch.nn.Module<"other_c">) {
+func.func private @f(%arg0: !torch.nn.Module<"other_c">) {
   return
 }
 torch.class_type @c {
@@ -101,21 +101,21 @@ torch.class_type @c {
 // -----
 
 // expected-error @+1 {{'torch.type_bound' must be attached to an argument of !torch.tensor/!torch.vtensor type}}
-builtin.func @f(%arg0: i32 {torch.type_bound = !torch.tensor<*,f32>})
+func.func @f(%arg0: i32 {torch.type_bound = !torch.tensor<*,f32>})
 
 // -----
 
 // expected-error @+1 {{'torch.type_bound' must be TypeAttr}}
-builtin.func @f(%arg0: i32 {torch.type_bound = 1})
+func.func @f(%arg0: i32 {torch.type_bound = 1})
 
 // -----
 
 // expected-error @+1 {{'torch.type_bound' must be of !torch.tensor/!torch.vtensor type}}
-builtin.func @f(%arg0: i32 {torch.type_bound = i32})
+func.func @f(%arg0: i32 {torch.type_bound = i32})
 
 // -----
 
-builtin.func @derefine(%arg0: !torch.optional<tensor>) -> !torch.tensor {
+func.func @derefine(%arg0: !torch.optional<tensor>) -> !torch.tensor {
   // expected-error @+1 {{operand type '!torch.optional<tensor>' and result type '!torch.tensor' are cast incompatible}}
   %0 = torch.derefine %arg0 : !torch.optional<tensor> to !torch.tensor
   return %0 : !torch.tensor
@@ -123,7 +123,7 @@ builtin.func @derefine(%arg0: !torch.optional<tensor>) -> !torch.tensor {
 
 // -----
 
-builtin.func @torch.prim.unchecked_cast$invalid_types(%arg0: !torch.tensor) -> !torch.optional<tensor> {
+func.func @torch.prim.unchecked_cast$invalid_types(%arg0: !torch.tensor) -> !torch.optional<tensor> {
   // expected-error @+1 {{operand type '!torch.tensor' and result type '!torch.optional<tensor>' are cast incompatible}}
   %0 = torch.prim.unchecked_cast %arg0 : !torch.tensor -> !torch.optional<tensor>
   return %0 : !torch.optional<tensor>
@@ -132,11 +132,11 @@ builtin.func @torch.prim.unchecked_cast$invalid_types(%arg0: !torch.tensor) -> !
 // -----
 
 // expected-error @+1 {{invalid dtype 'tuple<>' for !torch.tensor type}}
-builtin.func private @tensor.invalid_dtype() -> !torch.tensor<*,tuple<>>
+func.func private @tensor.invalid_dtype() -> !torch.tensor<*,tuple<>>
 
 // -----
 
-builtin.func @torch.tensor() {
+func.func @torch.tensor() {
   // Incompatible shape.
   // expected-error@+1 {{must be Multi-dimensional array modeling Torch's Tensor type, but got}}
   %0 = torch.tensor.literal(dense<42.0> : tensor<3x2xf32>) : !torch.vtensor<[],f32>
@@ -145,7 +145,7 @@ builtin.func @torch.tensor() {
 
 // -----
 
-builtin.func @torch.tensor() {
+func.func @torch.tensor() {
   // Incompatible dtype.
   // expected-error@+1 {{must be Multi-dimensional array modeling Torch's Tensor type, but got}}
   %0 = torch.tensor.literal(dense<42.0> : tensor<f32>) : !torch.vtensor<[],f64>
@@ -154,7 +154,7 @@ builtin.func @torch.tensor() {
 
 // -----
 
-builtin.func @torch.tensor() {
+func.func @torch.tensor() {
   // Incompatible type.
   // expected-error@+1 {{must be Multi-dimensional array modeling Torch's Tensor type, but got}}
   %0 = torch.tensor.literal(dense<42.0> : tensor<f32>) : i1
@@ -163,7 +163,7 @@ builtin.func @torch.tensor() {
 
 // -----
 
-builtin.func @torch.prim.ListConstruct() {
+func.func @torch.prim.ListConstruct() {
   %int2 = torch.constant.int 2
   // expected-error@+1 {{operand types should have the same type as the list contained type}}
   torch.prim.ListConstruct %int2 : (!torch.int) -> !torch.list<tensor>
@@ -172,7 +172,7 @@ builtin.func @torch.prim.ListConstruct() {
 
 // -----
 
-builtin.func @torch.overwrite.tensor.contents(%arg0: !torch.vtensor<[1],f32>, %arg1: !torch.vtensor<[?],f32>) -> !torch.vtensor<[1],f32> {
+func.func @torch.overwrite.tensor.contents(%arg0: !torch.vtensor<[1],f32>, %arg1: !torch.vtensor<[?],f32>) -> !torch.vtensor<[1],f32> {
   %0 = torch.copy.to_tensor %arg0 : !torch.tensor<[1],f32>
   // expected-error@+1 {{'torch.overwrite.tensor.contents' op failed to verify that overwritten tensor type is corresponding !torch.tensor of value tensor type}}
   torch.overwrite.tensor.contents %arg1 overwrites %0 : !torch.vtensor<[?],f32>, !torch.tensor<[1],f32>

--- a/test/Dialect/Torch/promote-types.mlir
+++ b/test/Dialect/Torch/promote-types.mlir
@@ -9,7 +9,7 @@
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
 // CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],f64>
 // CHECK:           return
-builtin.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1],f32>,
+func.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1],f32>,
                                             %t1: !torch.vtensor<[1],f64>,
                                             %alpha: !torch.float) {
   %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],unk>
@@ -25,7 +25,7 @@ builtin.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
 // CHECK-SAME:         !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],f64>
 // CHECK:           return
-builtin.func @tensor_tensor$different_category(%t0: !torch.vtensor<[1],si32>,
+func.func @tensor_tensor$different_category(%t0: !torch.vtensor<[1],si32>,
                                  %t1: !torch.vtensor<[1],f64>,
                                  %alpha: !torch.float) {
   %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],unk>
@@ -41,7 +41,7 @@ builtin.func @tensor_tensor$different_category(%t0: !torch.vtensor<[1],si32>,
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
 // CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[],f64>, !torch.int -> !torch.vtensor<[1],f32>
 // CHECK:           return
-builtin.func @tensor_tensor$same_category_zero_rank_wider(
+func.func @tensor_tensor$same_category_zero_rank_wider(
                                                   %t0: !torch.vtensor<[1],f32>,
                                                   %t1: !torch.vtensor<[],f64>,
                                                   %alpha: !torch.int) {
@@ -58,7 +58,7 @@ builtin.func @tensor_tensor$same_category_zero_rank_wider(
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
 // CHECK-SAME:         !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[1],f32>
 // CHECK:           return
-builtin.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si64>,
+func.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si64>,
                                         %t1: !torch.vtensor<[],f32>,
                                         %alpha: !torch.int) {
   %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[1],unk>
@@ -73,7 +73,7 @@ builtin.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
 // CHECK-SAME:        !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor<[1],f32>
 // CHECK:           return
-builtin.func @tensor_tensor$alpha_wider_no_contribution(%t0: !torch.vtensor<[1],f32>,
+func.func @tensor_tensor$alpha_wider_no_contribution(%t0: !torch.vtensor<[1],f32>,
                                %t1: !torch.vtensor<[1],f32>,
                                %alpha: !torch.float) {
   %1 = torch.aten.add.Tensor %t0, %t1, %alpha: !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor<[1],unk>
@@ -89,7 +89,7 @@ builtin.func @tensor_tensor$alpha_wider_no_contribution(%t0: !torch.vtensor<[1],
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Scalar %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
 // CHECK-SAME:        !torch.vtensor<[1],si64>, !torch.float, !torch.int -> !torch.vtensor<[1],f32>
 // CHECK:           return
-builtin.func @tensor_scalar$scalar_higher_category(%t0: !torch.vtensor<[1],si64>, %scalar: !torch.float, %alpha: !torch.int) {
+func.func @tensor_scalar$scalar_higher_category(%t0: !torch.vtensor<[1],si64>, %scalar: !torch.float, %alpha: !torch.int) {
   %1 = torch.aten.add.Scalar %t0, %scalar, %alpha: !torch.vtensor<[1], si64>, !torch.float, !torch.int -> !torch.vtensor<[1],unk>
   return
 }
@@ -103,7 +103,7 @@ builtin.func @tensor_scalar$scalar_higher_category(%t0: !torch.vtensor<[1],si64>
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Scalar %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
 // CHECK-SAME:        !torch.vtensor<[1],si32>, !torch.int, !torch.int -> !torch.vtensor<[1],si32>
 // CHECK:           return
-builtin.func @tensor_scalar$scalar_same_category_wider(%t0: !torch.vtensor<[1],si32>, %scalar: !torch.int, %alpha: !torch.int) {
+func.func @tensor_scalar$scalar_same_category_wider(%t0: !torch.vtensor<[1],si32>, %scalar: !torch.int, %alpha: !torch.int) {
   %1 = torch.aten.add.Scalar %t0, %scalar, %alpha: !torch.vtensor<[1], si32>, !torch.int, !torch.int -> !torch.vtensor<[1],unk>
   return
 }


### PR DESCRIPTION
The updated LLVM code includes a patch to create bfloat16 array
attributes, thus enabling a different patch to torch-mlir to flesh out
support for the bfloat16 type.