### PR TITLE
doc: [nfc] add instruction for running Python regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ cmake --build build --target tools/torch-mlir/all
 # Run unit tests.
 cmake --build build --target check-torch-mlir
 
+# Run Python regression tests.
+cmake --build build --target check-torch-mlir-python
+
 # Build everything (including LLVM if in-tree)
 cmake --build build
 ```


### PR DESCRIPTION
Prior to this patch, the top-level README did not include the line for
running the Python regression tests in `//python/test`.  This patch
fixes the problem by adding a line to run the `check-torch-mlir-python`
target.