### PR TITLE
types: allow bf16 as result type for various tensor ops

### DIFF
--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -505,7 +505,7 @@ ChangeResult TypeAnalyzer::visitOperation(
     return incorporateKnowledge(op->getResult(0), knowledge);
   }
 
-  // Dtype is always float32, except for float64 and nullptr.
+  // Dtype is always float32, except for bfloat16, float64 and nullptr.
   if (isa<AtenTanhOp, AtenExpOp, AtenSinOp, AtenCosOp, AtenSigmoidOp,
           AtenReciprocalOp, AtenLogOp, AtenSqrtOp, AtenLog2Op, AtenRsqrtOp,
           AtenErfOp>(op)) {
@@ -514,7 +514,7 @@ ChangeResult TypeAnalyzer::visitOperation(
     Type dtype = operands[0]->getValue().dtype;
     if (dtype) {
       knowledge.dtype = Float32Type::get(op->getContext());
-      if (dtype.isa<Float64Type>())
+      if (dtype.isa<BFloat16Type, Float64Type>())
         knowledge.dtype = dtype;
     }
     return incorporateKnowledge(op->getResult(0), knowledge);

--- a/test/Dialect/Torch/refine-types.mlir
+++ b/test/Dialect/Torch/refine-types.mlir
@@ -150,3 +150,12 @@ func @torch.overwrite.tensor.contents$static_overwrites_dynamic(%static: !torch.
   %result = torch.tensor_static_info_cast %dynamic_value_copy : !torch.vtensor to !torch.vtensor<[?],f32>
   return %result : !torch.vtensor<[?],f32>
 }
+
+// CHECK-LABEL:   func @bf16_result_type(
+// CHECK-SAME:                                          %[[ARG0:.*]]: !torch.vtensor<*,bf16>) -> !torch.vtensor<[2],bf16> {
+// CHECK:           %[[SQRT:.*]] = torch.aten.sqrt %[[ARG0]] : !torch.vtensor<*,bf16> -> !torch.vtensor<[2],bf16>
+// CHECK:           return %[[SQRT]] : !torch.vtensor<[2],bf16>
+func @bf16_result_type(%arg0: !torch.vtensor<*,bf16>) -> !torch.vtensor<[2],bf16> {
+  %1 = torch.aten.sqrt %arg0 : !torch.vtensor<*,bf16> -> !torch.vtensor<[2], bf16>
+  return %1 : !torch.vtensor<[2],bf16>
+}


### PR DESCRIPTION
Prior to this patch, the result type for several tensor operations could
only be float32, float64, or null.  This patch adds bf16 to the list of
allowed result types.