### PR TITLE
types: use type of end value as result type for arange* op

### DIFF
--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -903,11 +903,9 @@ ChangeResult TypeAnalyzer::visitAtenArangeLikeOpHelper(
     // be `torch.int64`
     if ((start.hasValue() && (*start).getType().isa<Torch::FloatType>()) ||
         end.getType().isa<Torch::FloatType>() ||
-        (step.hasValue() && (*step).getType().isa<Torch::FloatType>())) {
-      // TODO: Should get the dtype from torch.get_default_dtype().
-      // For now, use float32 which is the initial default dtype.
-      knowledge.dtype = Float32Type::get(op->getContext());
-    } else
+        (step.hasValue() && (*step).getType().isa<Torch::FloatType>()))
+      knowledge.dtype = getDefaultDtypeForTorchScalar(end.getType());
+    else
       knowledge.dtype =
           IntegerType::get(op->getContext(), 64, IntegerType::Signed);
   }

--- a/test/Dialect/Torch/refine-types-ops.mlir
+++ b/test/Dialect/Torch/refine-types-ops.mlir
@@ -23,17 +23,17 @@ func @aten.arange.start$int64_dtype(%start: !torch.int, %end: !torch.int) -> !to
 // -----
 // CHECK-LABEL:   func @aten.arange.start$float32_dtype(
 // CHECK-SAME:                    %[[START:.*]]: !torch.float,
-// CHECK-SAME:                    %[[END:.*]]: !torch.int) -> !torch.vtensor {
+// CHECK-SAME:                    %[[END:.*]]: !torch.float) -> !torch.vtensor {
 // CHECK:           %[[NONE:.*]] = torch.constant.none
 // CHECK:           %[[T:.*]] = torch.aten.arange.start
 // CHECK-SAME:         %[[START]], %[[END]], %[[NONE]], %[[NONE]], %[[NONE]], %[[NONE]] :
-// CHECK-SAME:         !torch.float, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none
+// CHECK-SAME:         !torch.float, !torch.float, !torch.none, !torch.none, !torch.none, !torch.none
 // CHECK-SAME:         -> !torch.vtensor<*,f32>
 // CHECK:           %[[RET:.*]] = torch.tensor_static_info_cast %[[T]] : !torch.vtensor<*,f32> to !torch.vtensor
 // CHECK:           return %[[RET]] : !torch.vtensor
-func @aten.arange.start$float32_dtype(%start: !torch.float, %end: !torch.int) -> !torch.vtensor {
+func @aten.arange.start$float32_dtype(%start: !torch.float, %end: !torch.float) -> !torch.vtensor {
   %none = torch.constant.none
-  %ret = torch.aten.arange.start %start, %end, %none, %none, %none, %none: !torch.float, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor
+  %ret = torch.aten.arange.start %start, %end, %none, %none, %none, %none: !torch.float, !torch.float, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor
   return %ret : !torch.vtensor
 }
 


### PR DESCRIPTION
This patch uses the `getDefaultDtypeForTorchScalar()` on the end value
of the range operation to decide the result type, instead of forcing a
float32 type.  This patch also updates an existing test to reflect the
new semantics.