### PR TITLE
Ensure that imported function input type and block arg types are consistent

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.cpp
@@ -57,6 +57,10 @@ MlirOperation torch_mlir::importJitFunctionAsFuncOp(
        i++) {
     resultTypes.push_back(mlirFunctionTypeGetResult(functionType, i));
   }
+  std::vector<MlirType> inputTypes;
+  for (int i = 0, e = mlirFunctionTypeGetNumInputs(functionType); i != e; i++) {
+    inputTypes.push_back(mlirFunctionTypeGetInput(functionType, i));
+  }
   auto createTerminator = [&](c10::ArrayRef<MlirValue> yieldedValues,
                               MlirBlock appendToBlock) {
     createMlirOperationAtEnd(
@@ -65,7 +69,7 @@ MlirOperation torch_mlir::importJitFunctionAsFuncOp(
   };
   MlirBlock block = importBlock(
       context, torch::jit::toGraphFunction(*function).graph()->block(),
-      createTerminator);
+      createTerminator, inputTypes);
   mlirRegionAppendOwnedBlock(bodyRegion, block);
   return func;
 }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.h
@@ -24,8 +24,22 @@ namespace torch_mlir {
 using CreateTerminatorFn =
     std::function<void(c10::ArrayRef<MlirValue>, MlirBlock)>;
 
-MlirBlock importBlock(MlirContext context, torch::jit::Block *jitBlock,
-                      CreateTerminatorFn createTerminator);
+/// Import `jitBlock` into a corresponding `MlirBlock`.
+///
+/// Because `jit::Block` does not have a concept of terminator in the MLIR sense
+/// (it is kind of "built-in" to the block, and not a free op chosen by the
+/// enclosing op), the `createTerminator` function will be used to create the
+/// terminator for the created block. Type adjustments like handling
+/// derefinement can be handled there as well.
+///
+/// `blockArgTypes`, if present, gives a set of types that the block arguments
+/// are required to be for correctness. The code will internally attempt to
+/// adjust the types to the block argument types.
+/// TODO: Formalize what type conversions are allowed here.
+MlirBlock importBlock(
+    MlirContext context, torch::jit::Block *jitBlock,
+    CreateTerminatorFn createTerminator,
+    c10::optional<c10::ArrayRef<MlirType>> blockArgTypes = c10::nullopt);
 
 } // namespace torch_mlir
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.h
@@ -42,7 +42,7 @@ MlirType getMlirTypeFromTorchType(MlirLocation loc,
 /// Creates a FunctionType suitable for expressing the signature of `schema`.
 ///
 /// This can differ from the type inferred from the block of a
-/// torch::jit::Function due to derefinement.
+/// torch::jit::Function due to derefinement and refinement of tensor types.
 MlirType getFunctionTypeFromSchema(MlirContext context,
                                    const c10::FunctionSchema &schema);
 

--- a/test/python/importer/jit_ir/node_import/function-block-arg-adjustment.py
+++ b/test/python/importer/jit_ir/node_import/function-block-arg-adjustment.py
@@ -1,0 +1,32 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See LICENSE.pytorch for license information.
+
+import torch
+from torch_mlir.dialects.torch.importer.jit_ir import ModuleBuilder
+
+from torch._C import CompilationUnit
+
+
+# RUN: %PYTHON %s | torch-mlir-opt | FileCheck %s
+
+# Import TorchScript IR string as ScriptFunction.
+def create_script_function(func_name, ts_ir_str):
+    cu = CompilationUnit()
+    return cu.create_function(func_name, torch._C.parse_ir(ts_ir_str))
+
+# CHECK-LABEL:   func @__torch__.refined_block_arg(
+# CHECK-SAME:                                      %[[ARG:.*]]: !torch.tensor) -> !torch.tensor {
+# CHECK:           %[[REFINED:.*]] = torch.tensor_static_info_cast %[[ARG]] : !torch.tensor to !torch.tensor<[1,384],f32>
+# CHECK:           %[[RESULT:.*]] = torch.derefine %[[REFINED]] : !torch.tensor<[1,384],f32> to !torch.tensor
+# CHECK:           return %[[RESULT]] : !torch.tensor
+script_function = create_script_function('__torch__.refined_block_arg', '''
+graph(%0 : Float(1, 384)):
+    return (%0)
+''')
+
+mb = ModuleBuilder()
+mb.import_function(script_function)
+
+mb.module.operation.print()
+print()


### PR DESCRIPTION
Ensure that imported function input type and block arg types are consistent.

I wasn't able to find exactly what frontend situation created it, but
`torch.jit.trace` will sometimes create functions where the
`jit::Block`'s param node has refined tensor types. So we need to adjust
the function's formal param types to those refined types.