### PR TITLE
Fix the input tensors inplace update issue for e2e tests

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/index_put.py
+++ b/python/torch_mlir_e2e_test/test_suite/index_put.py
@@ -133,12 +133,9 @@ class IndexPutImpl1DFloatAccumulateModule(torch.nn.Module):
         ([-1], torch.float32, True),
     ])
     def forward(self, input, index, value):
-        # Since the input is updated in-place, we pass input.clone() in place
-        # of input to avoid wrong results.
-        return torch.ops.aten._index_put_impl_(input.clone(), (index, ),
-                                               value,
-                                               accumulate=True,
-                                               unsafe=False)
+      return torch.ops.aten._index_put_impl_(input, (index,), value,
+                                            accumulate=True,
+                                            unsafe=False)
 
 
 @register_test_case(
@@ -214,12 +211,9 @@ class IndexPutImpl1DIntAccumulateModule(torch.nn.Module):
         ([-1], torch.int64, True),
     ])
     def forward(self, input, index, value):
-        # Since the input is updated in-place, we pass input.clone() in place
-        # of input to avoid wrong results.
-        return torch.ops.aten._index_put_impl_(input.clone(), (index, ),
-                                               value,
-                                               accumulate=True,
-                                               unsafe=False)
+      return torch.ops.aten._index_put_impl_(input, (index,), value,
+                                          accumulate=True,
+                                          unsafe=False)
 
 
 @register_test_case(module_factory=lambda: IndexPutImpl1DIntAccumulateModule())


### PR DESCRIPTION
Fix the inplace update tensor issue we had
where the torchscript execution would update the input value inplace
resulting the actual test not being able to see the original input
value.