### PR TITLE
Add support for lowering AtenMeanDimOp

### DIFF
--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -153,4 +153,5 @@ TOSA_PASS_SET = {
     "ConvolutionModule2DStatic_basic",
     "ElementwiseNegModule_basic",
     "TestMultipleTensorReturn_basic",
+    "ReduceMeanDimMultiModule_basic",
 }

--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -200,9 +200,11 @@ static Value createLinalgNeutralElementForReduceOp(OpBuilder &b, Location loc,
   return nullptr;
 }
 
-static Value createLinalgPayloadCalculationForReduceOp(
-    OpBuilder &b, Location loc, ValueRange payloadArgs, Operation *op,
-    ArrayRef<Value> operands, Type resultElementType) {
+static Value createLinalgPayloadCalculationForReduceOp(OpBuilder &b,
+                                                       Location loc,
+                                                       ValueRange payloadArgs,
+                                                       Operation *op,
+                                                       Type resultElementType) {
   if (isa<AtenSumOp, AtenSumDimIntListOp>(op)) {
     Value self =
         convertScalarToDtype(b, loc, payloadArgs[0], resultElementType);
@@ -294,7 +296,7 @@ public:
         rewriter, loc, tensorOperand, dimSet, keepDim, initElem,
         [&](OpBuilder &b, Location loc, ValueRange payloadArgs) {
           Value result = createLinalgPayloadCalculationForReduceOp(
-              b, loc, payloadArgs, op, operands, resultType.getElementType());
+              b, loc, payloadArgs, op, resultType.getElementType());
           if (!result) {
             hadErrorCreatingPayload = true;
             return;

--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -248,6 +248,63 @@ static Value createLinalgPayloadCalculationForReduceOp(OpBuilder &b,
 
 namespace {
 class ConvertReductionOp : public ConversionPattern {
+private:
+  struct ReductionOpInfo {
+    bool keepDim;
+    Value tensorOperand;
+    DenseSet<int64_t> dimSet;
+  };
+
+  template <typename T>
+  LogicalResult
+  computeReductionOpInfoFromDimOp(T op, ArrayRef<Value> operands,
+                                  ConversionPatternRewriter &rewriter,
+                                  ReductionOpInfo &opInfo) const {
+    opInfo.tensorOperand = operands[0];
+    auto inputType = opInfo.tensorOperand.getType().cast<RankedTensorType>();
+
+    if (!matchPattern(op.keepdim(), m_TorchConstantBool(&opInfo.keepDim)))
+      return failure();
+
+    SmallVector<int64_t> dimList;
+    if (!matchPattern(op.dim(), m_TorchConstantIntList(dimList)))
+      return failure();
+
+    for (auto dim : dimList) {
+      // Torch allows for negative values in dimSet to go in reverse
+      // order in the dimensions of the input tensor.
+      dim = dim >= 0 ? dim : dim + inputType.getRank();
+      // Drop invalid dimensions
+      if (dim < inputType.getRank())
+        opInfo.dimSet.insert(dim);
+    }
+
+    return success();
+  }
+
+  LogicalResult computeReductionOpInfo(Operation *op, ArrayRef<Value> operands,
+                                       ConversionPatternRewriter &rewriter,
+                                       ReductionOpInfo &opInfo) const {
+    opInfo.keepDim = false;
+
+    if (isa<AtenMaxOp, AtenSumOp>(op)) {
+      opInfo.tensorOperand = operands[0];
+      auto inputType = opInfo.tensorOperand.getType().cast<RankedTensorType>();
+
+      // `AtenSumOp` and `AtenMaxOp` reduces along all the dimensions of the
+      // input tensor.
+      for (int64_t i = 0; i < inputType.getRank(); i++)
+        opInfo.dimSet.insert(i);
+
+      return success();
+    }
+
+    if (auto sumOp = dyn_cast<AtenSumDimIntListOp>(op))
+      return computeReductionOpInfoFromDimOp(sumOp, operands, rewriter, opInfo);
+
+    return rewriter.notifyMatchFailure(op, "not a supported reduce op");
+  }
+
 public:
   ConvertReductionOp(TypeConverter &typeConverter, MLIRContext *context)
       : ConversionPattern(typeConverter, MatchAnyOpTypeTag(), /*benefit=*/1,
@@ -258,41 +315,9 @@ public:
     if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
       return failure();
 
-    // Every reduce operation must set a value for the `dimSet`,
-    // `tensorOperand`, and `keepDim` in accordance with their specification.
-    DenseSet<int64_t> dimSet;
-    Value tensorOperand;
-    bool keepDim = false;
-    if (isa<AtenSumOp>(op) || isa<AtenMaxOp>(op)) {
-      tensorOperand = operands[0];
-      auto inputType = tensorOperand.getType().cast<RankedTensorType>();
-
-      // `AtenSumOp` and `AtenMaxOp` reduces along all the dimensions of the
-      // input tensor.
-      for (int64_t i = 0; i < inputType.getRank(); i++)
-        dimSet.insert(i);
-    } else if (auto sumDimIntListOp = dyn_cast<AtenSumDimIntListOp>(op)) {
-      tensorOperand = operands[0];
-      auto inputType = tensorOperand.getType().cast<RankedTensorType>();
-
-      if (!matchPattern(sumDimIntListOp.keepdim(),
-                        m_TorchConstantBool(&keepDim)))
-        return failure();
-
-      SmallVector<int64_t> dimList;
-      if (!matchPattern(sumDimIntListOp.dim(), m_TorchConstantIntList(dimList)))
-        return failure();
-      for (auto dim : dimList) {
-        // Torch allows for negative values in dimSet to go in reverse
-        // order in the dimensions of the input tensor.
-        dim = dim >= 0 ? dim : dim + inputType.getRank();
-        // Drop invalid dimensions
-        if (dim < inputType.getRank())
-          dimSet.insert(dim);
-      }
-    } else {
-      return rewriter.notifyMatchFailure(op, "not a supported reduce op");
-    }
+    auto opInfo = ReductionOpInfo{false, Value{}, {}};
+    if (failed(computeReductionOpInfo(op, operands, rewriter, opInfo)))
+      return failure();
 
     Location loc = op->getLoc();
     auto resultType = getTypeConverter()
@@ -303,8 +328,8 @@ public:
 
     bool hadErrorCreatingPayload = false;
     Value generic = torch_to_linalg::createReductionLinalgGeneric(
-        rewriter, loc, tensorOperand, dimSet, keepDim, initElem,
-        [&](OpBuilder &b, Location loc, ValueRange payloadArgs) {
+        rewriter, loc, opInfo.tensorOperand, opInfo.dimSet, opInfo.keepDim,
+        initElem, [&](OpBuilder &b, Location loc, ValueRange payloadArgs) {
           Value result = createLinalgPayloadCalculationForReduceOp(
               b, loc, payloadArgs, op, resultType.getElementType());
           if (!result) {

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -35,113 +35,6 @@ template <typename elementType> static bool hasElementType(Value tensor) {
   return tensorElementType.isa<elementType>();
 }
 
-static Value createElementwiseLinalgGeneric(
-    OpBuilder &b, Location loc, ValueRange tensorOperands,
-    Type resultElementType,
-    function_ref<void(OpBuilder &, Location, ValueRange)> bodyBuild) {
-  // The overall error handling strategy here is best viewed by thinking about
-  // what happens for a single result dimension. This loop not structured that
-  // way because it is hard to create the affine maps for each operand unless
-  // we structure the loop to iterate over tensor operands as the outer loop
-  // instead of inner loop. This pseudocode gives better intuition:
-  // ```
-  // for each result dimension:
-  //   for each tensor operand:
-  //     if it doesn't even have high enough rank relative to the result:
-  //       continue
-  //     if it is a static size-1 along this result dimension:
-  //       continue
-  //     if this is the first tensor operand that didn't continue above:
-  //       take its dimension size as the size of the non-broadcasted
-  //       traversal along this dimension (this may include a dynamic size-1,
-  //       **non-broadcasted** traversal!)
-  //     emit error check "if the size does not match the non-broadcasted
-  //     traversal size along this dimension, error"
-  // ```
-  SmallVector<int64_t> operandRanks;
-  operandRanks.resize(tensorOperands.size());
-  llvm::transform(tensorOperands, operandRanks.begin(), [](Value tensor) {
-    return tensor.getType().dyn_cast<RankedTensorType>().getRank();
-  });
-
-  auto resultRankIt =
-      std::max_element(operandRanks.begin(), operandRanks.end());
-  assert(resultRankIt != operandRanks.end() && "Unable to get result rank.");
-  int64_t resultRank = *resultRankIt;
-
-  // Initialize the resultShape to all 1's, as a fallback in case
-  // all sizes along that result dimension are statically 1.
-  auto c1 = b.create<arith::ConstantIndexOp>(loc, /*value=*/1);
-  SmallVector<Value> resultShape(resultRank, c1);
-  SmallVector<AffineMap> indexingMaps;
-  for (Value tensorOperand : tensorOperands) {
-    SmallVector<AffineExpr> exprs;
-    auto type = tensorOperand.getType().cast<RankedTensorType>();
-    for (auto size : llvm::enumerate(type.getShape())) {
-      // If the size is statically known to be 1, we don't want any
-      // error guards to be spuriously emitted, since we are specifically
-      // allowing size-1 broadcasts in this case, as they correspond to a
-      // constant-0 indexing map.
-      if (size.value() == 1) {
-        exprs.push_back(b.getAffineConstantExpr(0));
-        continue;
-      }
-
-      // The rank of this operand might be smaller than the overall rank of
-      // the broadcast. Add an offset to correlate it to the correct
-      // dimension of the result.
-      auto resultDim = size.index() + (resultRank - type.getRank());
-
-      // The generated linalg op will now be iterating along the full size
-      // of this dimension. Record that fact.
-      exprs.push_back(b.getAffineDimExpr(resultDim));
-
-      // Now, we need to ensure that such iteration is not going to trigger
-      // undefined behavior, by doing appropriate checks against the current
-      // dimension size.
-      auto currentDimSize = getDimOp(b, loc, tensorOperand, size.index());
-
-      // If the result size of this dimension has so far only hit the
-      // statically-known-to-be-1 case above (i.e., we have not yet assigned a
-      // new Value to `resultShape[resultDim]`), then we have no other dynamic
-      // values to check against, and merely need to record the current
-      // dimension size.
-      if (resultShape[resultDim] == c1) {
-        resultShape[resultDim] = currentDimSize;
-        continue;
-      }
-
-      // We prohibit the size-1 dynamic broadcasting scenario, so just check
-      // for exact equality with the running result size.
-      // This is the check which protects against the undefined behavior of
-      // the generated linalg op in the case of iterating two operands with
-      // dimensions sizes that are expected to match.
-      auto equalToRunning =
-          b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                  resultShape[resultDim], currentDimSize);
-      b.create<cf::AssertOp>(loc, equalToRunning,
-                             "mismatched size for broadcast");
-    }
-    indexingMaps.push_back(AffineMap::get(
-        /*dimCount=*/resultRank, /*symbolCount=*/0, exprs, b.getContext()));
-  }
-
-  SmallVector<StringRef> iteratorTypes(resultRank,
-                                       getParallelIteratorTypeName());
-  // Add the indexing map for the outs init tensor.
-  indexingMaps.push_back(b.getMultiDimIdentityMap(resultRank));
-
-  Value initTensor = b.create<linalg::InitTensorOp>(
-      loc, getAsOpFoldResult(resultShape), resultElementType);
-  return b
-      .create<linalg::GenericOp>(loc,
-                                 /*resultTensorTypes=*/initTensor.getType(),
-                                 /*inputs=*/tensorOperands,
-                                 /*outputs=*/initTensor, indexingMaps,
-                                 iteratorTypes, bodyBuild)
-      .getResult(0);
-}
-
 template <arith::CmpFPredicate fpred, arith::CmpIPredicate iupred,
           arith::CmpIPredicate ispred>
 static Value createComparisonTemplate(OpBuilder &b, Location loc, Type type,
@@ -952,7 +845,7 @@ public:
                           ->convertType(op->getResult(0).getType())
                           .cast<RankedTensorType>();
     bool hadErrorCreatingPayload = false;
-    Value generic = createElementwiseLinalgGeneric(
+    Value generic = torch_to_linalg::createElementwiseLinalgGeneric(
         rewriter, loc, tensorOperands, resultType.getElementType(),
         [&](OpBuilder &b, Location loc, ValueRange payloadArgs) {
           Value result = createLinalgPayloadCalculationForElementwiseOp(
@@ -1019,7 +912,7 @@ public:
     Value zeroVal = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getZeroAttr(elementType));
 
-    Value finalRes = createElementwiseLinalgGeneric(
+    Value finalRes = torch_to_linalg::createElementwiseLinalgGeneric(
         rewriter, loc, {target}, elementType,
         [&](OpBuilder &b, Location loc, ValueRange args) {
           Value targetVal = args[0];

--- a/lib/Conversion/TorchToLinalg/Utils.h
+++ b/lib/Conversion/TorchToLinalg/Utils.h
@@ -42,6 +42,12 @@ Value createReductionLinalgGeneric(
     const DenseSet<int64_t> &dimSet, bool keepDim, Value initElem,
     function_ref<void(OpBuilder &, Location, ValueRange)> bodyBuild);
 
+// Create a pointwise operation that uses values in `tensorOperands`, such that
+// the element type of the resulting tensor is `resultElementType`.
+Value createElementwiseLinalgGeneric(
+    OpBuilder &b, Location loc, ValueRange tensorOperands,
+    Type resultElementType,
+    function_ref<void(OpBuilder &, Location, ValueRange)> bodyBuild);
 } // namespace torch_to_linalg
 } // namespace torch
 } // namespace mlir

--- a/python/torch_mlir_e2e_test/test_suite/reduction.py
+++ b/python/torch_mlir_e2e_test/test_suite/reduction.py
@@ -402,3 +402,60 @@ class ReduceMaxUnsignedIntModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceMaxUnsignedIntModule())
 def ReduceMaxUnsignedIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(100, (3, 4, 5)))
+
+# ==============================================================================
+
+class ReduceMeanDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, 5], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.mean(a, dim=-1)
+
+
+@register_test_case(module_factory=lambda: ReduceMeanDimModule())
+def ReduceMeanDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceMeanDimMultiModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, 4, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.mean(a, dim=(0,1))
+
+
+@register_test_case(module_factory=lambda: ReduceMeanDimMultiModule())
+def ReduceMeanDimMultiModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceMeanDimKeepDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.mean(a, dim=0, keepdim=True)
+
+
+@register_test_case(module_factory=lambda: ReduceMeanDimKeepDimModule())
+def ReduceMeanDimKeepDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))

--- a/test/Conversion/TorchToLinalg/reduction.mlir
+++ b/test/Conversion/TorchToLinalg/reduction.mlir
@@ -1,0 +1,50 @@
+// RUN: torch-mlir-opt <%s -convert-torch-to-linalg -split-input-file -verify-diagnostics | FileCheck %s
+
+func @torch.aten.mean.dim$invalid_dtype(%arg0: !torch.vtensor<[?,?,5],si32>) -> !torch.vtensor<[?,?,1],si32> {
+  %neg_1 = torch.constant.int -1
+  %true = torch.constant.bool true
+  %none = torch.constant.none
+  %dimList = torch.prim.ListConstruct %neg_1 : (!torch.int) -> !torch.list<int>
+  // expected-error@+2 {{only float types are valid for mean operation}}
+  // expected-error@+1 {{failed to legalize operation 'torch.aten.mean.dim' that was explicitly marked illegal}}
+  %1 = torch.aten.mean.dim %arg0, %dimList, %true, %none : !torch.vtensor<[?,?,5],si32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[?,?,1],si32>
+  return %1 : !torch.vtensor<[?,?,1],si32>
+}
+
+// -----
+
+func @torch.aten.mean.dim$invalid_dim(%arg0: !torch.vtensor<[?,?,?],f32>) -> !torch.vtensor<[?,?,?],f32> {
+  %neg_1 = torch.constant.int -1
+  %true = torch.constant.bool true
+  %none = torch.constant.none
+  %dimList = torch.prim.ListConstruct %neg_1 : (!torch.int) -> !torch.list<int>
+  // expected-error@+2 {{insufficient type information to determine tensor size; check input tensor annotations}}
+  // expected-error@+1 {{failed to legalize operation 'torch.aten.mean.dim' that was explicitly marked illegal}}
+  %1 = torch.aten.mean.dim %arg0, %dimList, %true, %none : !torch.vtensor<[?,?,?],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?],f32>
+  return %1 : !torch.vtensor<[?,?,?],f32>
+}
+
+// -----
+
+func @torch.aten.mean.dim$valid(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,1],f32> {
+  %neg_1 = torch.constant.int -1
+  %true = torch.constant.bool true
+  %none = torch.constant.none
+  %dimList = torch.prim.ListConstruct %neg_1 : (!torch.int) -> !torch.list<int>
+  %1 = torch.aten.mean.dim %arg0, %dimList, %true, %none : !torch.vtensor<[3,4,5],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[3,4,1],f32>
+  return %1 : !torch.vtensor<[3,4,1],f32>
+
+  // CHECK: %[[sumOp:.*]] = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins({{.*}} : tensor<3x4x5xf32>) outs({{.*}} : tensor<?x?x?xf32>) {
+  // CHECK: ^bb0(%[[arg1:.*]]: f32, %[[arg2:.*]]: f32):
+  // CHECK:   %[[add:.*]] = arith.addf %[[arg1]], %[[arg2]] : f32
+  // CHECK:   linalg.yield %[[add]] : f32
+  // CHECK: } -> tensor<?x?x?xf32>
+
+  // CHECK: %[[inverseSize:.*]] = arith.constant 2.000000e-01 : f32
+
+  // CHECK: linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[sumOp]] : tensor<?x?x?xf32>) outs({{.*}} : tensor<?x?x?xf32>) {
+  // CHECK: ^bb0(%[[arg1:.*]]: f32, %[[arg2:.*]]: f32):
+  // CHECK:   %[[mul:.*]] = arith.mulf %[[arg1]], %[[inverseSize]] : f32
+  // CHECK:   linalg.yield %[[mul]] : f32
+  // CHECK: } -> tensor<?x?x?xf32>
+}


### PR DESCRIPTION
This PR contains commits for adding support for lowering AtenMeanDimOp operations.  Although this PR contains multiple commits (to aid readability), I will squash them into a single commit before merging, if approved.

Perhaps the last two commits in this PR are the best places to start to understand the key approach of these commits.