### PR TITLE
[MLIR][TORCH] Add E2E support for `aten.to.dtype_layout` op

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -5074,6 +5074,36 @@ def Torch_AtenToDtypeOp : Torch_Op<"aten.to.dtype", [
   let hasFolder = 1;
 }
 
+def Torch_AtenToDtypeLayoutOp : Torch_Op<"aten.to.dtype_layout", [
+    AllowsTypeRefinement,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::to.dtype_layout : (Tensor, int?, int?, Device?, bool?, bool, bool, int?) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchOptionalIntType:$dtype,
+    AnyTorchOptionalIntType:$layout,
+    AnyTorchOptionalDeviceType:$device,
+    AnyTorchOptionalBoolType:$pin_memory,
+    Torch_BoolType:$non_blocking,
+    Torch_BoolType:$copy,
+    AnyTorchOptionalIntType:$memory_format
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenToDtypeLayoutOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 8, 1);
+    }
+    void AtenToDtypeLayoutOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 8, 1);
+    }
+  }];
+  let hasFolder = 1;
+}
+
 def Torch_AtenToOtherOp : Torch_Op<"aten.to.other", [
     AllowsTypeRefinement,
     ReadOnly

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -33,10 +33,11 @@ static bool isViewLikeOp(Operation *op) {
   // that it does not return a view and treat those as having value
   // semantics.
   return isa<AtenBroadcastToOp, AtenContiguousOp, AtenExpandAsOp, AtenExpandOp,
-             AtenFlattenUsingIntsOp, AtenPermuteOp, AtenReshapeOp, Aten_ReshapeAliasOp,
-             AtenSelectIntOp, AtenSliceTensorOp, AtenSqueezeDimOp,
-             AtenSqueezeOp, AtenTOp, AtenToDtypeOp, AtenTransposeIntOp,
-             AtenUnsqueezeOp, AtenViewOp, TensorStaticInfoCastOp>(op);
+             AtenFlattenUsingIntsOp, AtenPermuteOp, AtenReshapeOp,
+             Aten_ReshapeAliasOp, AtenSelectIntOp, AtenSliceTensorOp,
+             AtenSqueezeDimOp, AtenSqueezeOp, AtenTOp, AtenToDtypeOp,
+             AtenTransposeIntOp, AtenUnsqueezeOp, AtenViewOp,
+             TensorStaticInfoCastOp, AtenToDtypeLayoutOp>(op);
 }
 
 namespace {

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -164,6 +164,9 @@ module {
     %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
     return %0 : !torch.list<int>
   }
+  func @"__torch_mlir_shape_fn.aten.to.dtype_layout"(%arg0: !torch.list<int>, %arg1: !torch.optional<int>, %arg2: !torch.optional<int>, %arg3: !torch.optional<Device>, %arg4: !torch.optional<bool>, %arg5: !torch.bool, %arg6: !torch.bool, %arg7: !torch.optional<int>) -> !torch.list<int> {
+    return %arg0 : !torch.list<int>
+  }
   func @"__torch_mlir_shape_fn.aten.to.other"(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.bool, %arg3: !torch.bool, %arg4: !torch.optional<int>) -> !torch.list<int> {
     %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
     return %0 : !torch.list<int>

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -373,6 +373,9 @@ def aten〇rsub〇Scalar(self: List[int], other: float, alpha: float = 1) -> Lis
 def aten〇to〇dtype(self: List[int], dtype: int, non_blocking: bool = False, copy: bool = False, memory_format: Optional[int] = None) -> List[int]:
     return upstream_shape_helpers.unary(self)
 
+def aten〇to〇dtype_layout(self: List[int], dtype: Optional[int] = None, layout: Optional[int] = None, device: Optional[device] = None, pin_memory: Optional[bool] = None, non_blocking: bool = False, copy: bool = False, memory_format: Optional[int] = None) -> List[int]:
+    return self
+
 def aten〇to〇other(self: List[int], other: List[int], non_blocking: bool = False, copy: bool = False, memory_format: Optional[int] = None) -> List[int]:
     return upstream_shape_helpers.unary(self)
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -425,6 +425,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::max : (Tensor) -> (Tensor)")
     emit("aten::max.dim : (Tensor, int, bool) -> (Tensor, Tensor)")
     emit("aten::to.dtype : (Tensor, int, bool, bool, int?) -> (Tensor)", has_folder=True)
+    emit("aten::to.dtype_layout : (Tensor, int?, int?, Device?, bool?, bool, bool, int?) -> (Tensor)", has_folder=True)
     emit("aten::to.other : (Tensor, Tensor, bool, bool, int?) -> (Tensor)")
     emit("aten::to.prim_Device : (Tensor, Device?, int?, bool, bool) -> (Tensor)")
     emit("aten::type_as : (Tensor, Tensor) -> (Tensor)")

--- a/python/torch_mlir_e2e_test/test_suite/type_conversion.py
+++ b/python/torch_mlir_e2e_test/test_suite/type_conversion.py
@@ -11,17 +11,17 @@ from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
 
 # ==============================================================================
 
+
 class TypeConversionF32ToF64Module(torch.nn.Module):
+
     def __init__(self):
         super().__init__()
 
     @export
-    @annotate_args([
-        None,
-        ([-1, -1], torch.float32, True)
-    ])
+    @annotate_args([None, ([-1, -1], torch.float32, True)])
     def forward(self, x):
         return x.to(torch.float64)
+
 
 @register_test_case(module_factory=lambda: TypeConversionF32ToF64Module())
 def TypeConversionF32ToF64Module_basic(module, tu: TestUtils):
@@ -29,117 +29,165 @@ def TypeConversionF32ToF64Module_basic(module, tu: TestUtils):
 
 
 class TypeConversionF64ToF32Module(torch.nn.Module):
+
     def __init__(self):
         super().__init__()
 
     @export
-    @annotate_args([
-        None,
-        ([-1, -1], torch.float64, True)
-    ])
+    @annotate_args([None, ([-1, -1], torch.float64, True)])
     def forward(self, x):
         return x.to(torch.float32)
+
 
 @register_test_case(module_factory=lambda: TypeConversionF64ToF32Module())
 def TypeConversionF64ToF32Module_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 5).type(torch.float64))
 
+
 class TypeConversionI32ToI64Module(torch.nn.Module):
+
     def __init__(self):
         super().__init__()
 
     @export
-    @annotate_args([
-        None,
-        ([-1, -1], torch.int32, True)
-    ])
+    @annotate_args([None, ([-1, -1], torch.int32, True)])
     def forward(self, x):
         return x.to(torch.int64)
+
 
 @register_test_case(module_factory=lambda: TypeConversionI32ToI64Module())
 def TypeConversionI32ToI64Module_basic(module, tu: TestUtils):
     module.forward(torch.randint(5, [2, 3]).type(torch.int32))
 
+
 class TypeConversionI64ToI32Module(torch.nn.Module):
+
     def __init__(self):
         super().__init__()
 
     @export
-    @annotate_args([
-        None,
-        ([-1, -1], torch.int64, True)
-    ])
+    @annotate_args([None, ([-1, -1], torch.int64, True)])
     def forward(self, x):
         return x.to(torch.int32)
+
 
 @register_test_case(module_factory=lambda: TypeConversionI64ToI32Module())
 def TypeConversionI64ToI32Module_basic(module, tu: TestUtils):
     module.forward(torch.randint(5, [2, 3]))
 
+
 class TypeConversionI1ToI32Module(torch.nn.Module):
+
     def __init__(self):
         super().__init__()
 
     @export
-    @annotate_args([
-        None,
-        ([-1,-1], torch.bool, True)
-    ])
+    @annotate_args([None, ([-1, -1], torch.bool, True)])
     def forward(self, x):
         return x.to(torch.int32)
 
+
 @register_test_case(module_factory=lambda: TypeConversionI1ToI32Module())
 def TypeConversionI1ToI32Module_basic(module, tu: TestUtils):
-    tensor = torch.randint(0, 2, (3,4),dtype=torch.bool)
+    tensor = torch.randint(0, 2, (3, 4), dtype=torch.bool)
     module.forward(tensor)
 
+
 class TypeConversionI1ToI64Module(torch.nn.Module):
+
     def __init__(self):
         super().__init__()
 
     @export
-    @annotate_args([
-        None,
-        ([-1,-1], torch.bool, True)
-    ])
+    @annotate_args([None, ([-1, -1], torch.bool, True)])
     def forward(self, x):
         return x.to(torch.int64)
 
+
 @register_test_case(module_factory=lambda: TypeConversionI1ToI64Module())
 def TypeConversionI1ToI64Module_basic(module, tu: TestUtils):
-    tensor = torch.randint(0, 2, (3,4), dtype=torch.bool)
+    tensor = torch.randint(0, 2, (3, 4), dtype=torch.bool)
     module.forward(tensor)
 
+
 class TypeConversionI1ToF32Module(torch.nn.Module):
+
     def __init__(self):
         super().__init__()
 
     @export
-    @annotate_args([
-        None,
-        ([-1,-1], torch.bool, True)
-    ])
+    @annotate_args([None, ([-1, -1], torch.bool, True)])
     def forward(self, x):
         return x.to(torch.float32)
 
+
 @register_test_case(module_factory=lambda: TypeConversionI1ToF32Module())
 def TypeConversionI1ToF32Module_basic(module, tu: TestUtils):
-    tensor = torch.randint(0, 2, (3,4), dtype=torch.bool)
+    tensor = torch.randint(0, 2, (3, 4), dtype=torch.bool)
     module.forward(tensor)
 
+
 class TypeConversionI1ToF64Module(torch.nn.Module):
+
     def __init__(self):
         super().__init__()
 
     @export
-    @annotate_args([
-        None,
-        ([-1,-1], torch.bool, True)
-    ])
+    @annotate_args([None, ([-1, -1], torch.bool, True)])
     def forward(self, x):
         return x.to(torch.float64)
 
+
 @register_test_case(module_factory=lambda: TypeConversionI1ToF64Module())
 def TypeConversionI1ToF64Module_basic(module, tu: TestUtils):
-    tensor = torch.randint(0, 2, (3,4), dtype=torch.bool)
+    tensor = torch.randint(0, 2, (3, 4), dtype=torch.bool)
     module.forward(tensor)
+
+
+# ==============================================================================
+
+
+class ToDtypeLayoutNoneModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([None, ([-1, -1], torch.float32, True)])
+    def forward(self, x):
+        return torch.ops.aten.to(x,
+                                 dtype=torch.float64,
+                                 layout=None,
+                                 device=None,
+                                 pin_memory=None,
+                                 non_blocking=False,
+                                 copy=False,
+                                 memory_format=None)
+
+
+@register_test_case(module_factory=lambda: ToDtypeLayoutNoneModule())
+def ToDtypeLayoutNoneModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 5))
+
+
+class ToDtypeLayoutStridedModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([None, ([-1, -1], torch.float32, True)])
+    def forward(self, x):
+        return torch.ops.aten.to(x,
+                                 dtype=torch.float64,
+                                 layout=torch.strided,
+                                 device=None,
+                                 pin_memory=None,
+                                 non_blocking=False,
+                                 copy=False,
+                                 memory_format=None)
+
+
+@register_test_case(module_factory=lambda: ToDtypeLayoutStridedModule())
+def ToDtypeLayoutStridedModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 5))

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -1162,3 +1162,14 @@ func @torch.aten.div.float$fold_cst_operands() -> !torch.float {
   %0 = torch.aten.div.float %float4, %float2 : !torch.float, !torch.float -> !torch.float
   return %0 : !torch.float
 }
+
+// CHECK-LABEL:   func @torch.aten.to.dtype_layout$same_dtype(
+// CHECK-SAME:            %[[ARG:.*]]: !torch.tensor<[?,?],f32>) -> !torch.tensor<[?,?],f32> {
+// CHECK-NEXT:      return %[[ARG]] : !torch.tensor<[?,?],f32>
+func @torch.aten.to.dtype_layout$same_dtype(%arg0: !torch.tensor<[?,?],f32>) -> !torch.tensor<[?,?],f32> {
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %int6 = torch.constant.int 6
+  %0 = torch.aten.to.dtype_layout %arg0, %int6, %none, %none, %none, %false, %false, %none : !torch.tensor<[?,?],f32>, !torch.int, !torch.none, !torch.none, !torch.none, !torch.bool, !torch.bool, !torch.none -> !torch.tensor<[?,?],f32>
+  return %0 : !torch.tensor<[?,?],f32>
+}

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -873,3 +873,21 @@ func @torch.aten.pad(%arg0: !torch.vtensor<[?,?,?],f64>, %arg1: !torch.float) ->
   %1 = torch.aten.pad %arg0, %0, %str, %arg1 : !torch.vtensor<[?,?,?],f64>, !torch.list<int>, !torch.str, !torch.float -> !torch.vtensor<[?,?,?],f64>
   return %1 : !torch.vtensor<[?,?,?],f64>
 }
+
+// -----
+// CHECK-LABEL:   func @torch.aten.to.dtype_layout(
+// CHECK-SAME:                  %[[SELF:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f64> {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[CST0:.*]] = torch.constant.int 0
+// CHECK:           %[[CST7:.*]] = torch.constant.int 7
+// CHECK:           %[[OUT:.*]] = torch.aten.to.dtype %[[SELF]], %[[CST7]], %[[FALSE]], %[[FALSE]], %[[NONE]] : !torch.vtensor<[?,?],f32>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,?],f64>
+// CHECK:           return %[[OUT]] : !torch.vtensor<[?,?],f64>
+func @torch.aten.to.dtype_layout(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f64> {
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int7 = torch.constant.int 7
+  %0 = torch.aten.to.dtype_layout %arg0, %int7, %int0, %none, %none, %false, %false, %none : !torch.vtensor<[?,?],f32>, !torch.int, !torch.int, !torch.none, !torch.none, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,?],f64>
+  return %0 : !torch.vtensor<[?,?],f64>
+}


### PR DESCRIPTION
This commit decomposes `aten.to.dtype_layout` op into `aten.to.dtype` op.

Signed-Off By: Vivek Khandelwal <vivek@nod-labs.com>