### PR TITLE
[TORCH][MLIR] Add lowering of split like operations.

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -5913,6 +5913,126 @@ def Torch_AtenFullLikeOp : Torch_Op<"aten.full_like", [
   }];
 }
 
+def Torch_AtenSplitOp : Torch_Op<"aten.split", [
+    AllowsTypeRefinement,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::split : (Tensor, int[], int) -> (Tensor[])`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchListOfTorchIntType:$split_sizes,
+    Torch_IntType:$dim
+  );
+  let results = (outs
+    AnyTorchListOfTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenSplitOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 3, 1);
+    }
+    void AtenSplitOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 3, 1);
+    }
+  }];
+}
+
+def Torch_AtenSplitSizesOp : Torch_Op<"aten.split.sizes", [
+    AllowsTypeRefinement,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::split.sizes : (Tensor, int[], int) -> (Tensor[])`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchListOfTorchIntType:$split_size,
+    Torch_IntType:$dim
+  );
+  let results = (outs
+    AnyTorchListOfTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenSplitSizesOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 3, 1);
+    }
+    void AtenSplitSizesOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 3, 1);
+    }
+  }];
+}
+
+def Torch_AtenSplitWithSizesOp : Torch_Op<"aten.split_with_sizes", [
+    AllowsTypeRefinement,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::split_with_sizes : (Tensor, int[], int) -> (Tensor[])`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchListOfTorchIntType:$split_sizes,
+    Torch_IntType:$dim
+  );
+  let results = (outs
+    AnyTorchListOfTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenSplitWithSizesOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 3, 1);
+    }
+    void AtenSplitWithSizesOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 3, 1);
+    }
+  }];
+}
+
+def Torch_AtenSplitTensorOp : Torch_Op<"aten.split.Tensor", [
+    AllowsTypeRefinement,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::split.Tensor : (Tensor, int, int) -> (Tensor[])`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    Torch_IntType:$split_size,
+    Torch_IntType:$dim
+  );
+  let results = (outs
+    AnyTorchListOfTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenSplitTensorOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 3, 1);
+    }
+    void AtenSplitTensorOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 3, 1);
+    }
+  }];
+}
+
+def Torch_AtenChunkOp : Torch_Op<"aten.chunk", [
+    AllowsTypeRefinement,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::chunk : (Tensor, int, int) -> (Tensor[])`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    Torch_IntType:$chunks,
+    Torch_IntType:$dim
+  );
+  let results = (outs
+    AnyTorchListOfTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenChunkOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 3, 1);
+    }
+    void AtenChunkOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 3, 1);
+    }
+  }];
+}
+
 def Torch_Aten__Contains__StrOp : Torch_Op<"aten.__contains__.str", [
     AllowsTypeRefinement,
     HasValueSemantics,
@@ -8139,3 +8259,4 @@ def Torch_QuantizedLinearOp : Torch_Op<"quantized.linear", [
     }
   }];
 }
+

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
@@ -32,11 +32,15 @@ struct TorchLoweringPipelineOptions
   // If this option is false, only do the bare minimum for correctness.
   Option<bool> optimize{*this, "optimize", llvm::cl::desc("Do optimizations."),
                         llvm::cl::init(true)};
-  
+
+  Option<bool> decomposeEarly{*this, "decompose-complex-ops-early",
+                              llvm::cl::desc("Decompose complex operations."),
+                              llvm::cl::init(true)};
   // If this option is false, decompose complex operations.
   // If this option is true, skip decomposition of complex operations.
-  Option<bool> decompose{*this, "decompose-complex-ops", llvm::cl::desc("Decompose complex operations."),
-                        llvm::cl::init(true)};                      
+  Option<bool> decompose{*this, "decompose-complex-ops",
+                         llvm::cl::desc("Decompose complex operations."),
+                         llvm::cl::init(true)};
 };
 
 /// Creates a pipeline that lowers the object graph IR that is produced by
@@ -67,6 +71,9 @@ std::unique_ptr<OperationPass<func::FuncOp>> createMaximizeValueSemanticsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createRefinePublicReturnPass();
 
 std::unique_ptr<OperationPass<func::FuncOp>> createDecomposeComplexOpsPass();
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createDecomposeComplexOpsEarlyPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createPreprocessShapeLibraryPass();
 

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -231,6 +231,19 @@ def DecomposeComplexOps : Pass<"torch-decompose-complex-ops", "func::FuncOp"> {
   }];
 }
 
+def DecomposeComplexOpsEarly : Pass<"torch-decompose-complex-ops-early", "func::FuncOp"> {
+  let summary = "Decompose complicated torch operations before shape inference";
+  let constructor = "mlir::torch::Torch::createDecomposeComplexOpsEarlyPass()";
+  let description = [{
+    Decompose torch operation that are losslessly represented as combinations of
+    other operations, modulo appropropriate compiler fusion before shape inference.
+
+    An example of the transformations done in this pass is:
+    - convert aten.softmax to softmax(x, dim)
+            => tmp=exp(x); tmp / sum(tmp, dim, keepdim=True)
+  }];
+}
+
 def ReifyShapeCalculations : Pass<"torch-reify-shape-calculations", "ModuleOp"> {
   let summary = "Decompose complicated torch operations";
   let constructor = "mlir::torch::Torch::createReifyShapeCalculationsPass()";

--- a/lib/Dialect/Torch/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Torch/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(TorchMLIRTorchPasses
   AdjustCallingConventions.cpp
   DecomposeComplexOps.cpp
+  DecomposeComplexOpsEarly.cpp
   DropShapeCalculations.cpp
   Passes.cpp
   GlobalizeObjectGraph.cpp

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -16,7 +16,9 @@
 #include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include <cstdint>
 
 using namespace mlir;
 using namespace mlir::torch;

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOpsEarly.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOpsEarly.cpp
@@ -1,0 +1,206 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
+#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include <cstdint>
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+namespace {
+class DecomposeAtenSplitSizesOp : public OpRewritePattern<AtenSplitSizesOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AtenSplitSizesOp op,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<int64_t> splitSizes;
+    // TODO: Support non static splitSizes.
+    if (!matchPattern(op.split_size(), m_TorchConstantIntList(splitSizes)))
+      return failure();
+
+    int64_t dim;
+    if (!matchPattern(op.dim(), m_TorchConstantInt(&dim)))
+      return rewriter.notifyMatchFailure(op, "dim must be constant");
+
+    auto listType = op.getType().template cast<Torch::ListType>();
+    Location loc = op.getLoc();
+
+    // Calculate the end indices of the slices.
+    SmallVector<int64_t> endIdx;
+    endIdx.push_back(splitSizes[0]);
+    for (unsigned i = 1; i < splitSizes.size(); i++) {
+      endIdx.push_back(splitSizes[i] + endIdx[i - 1]);
+    }
+    int64_t start = 0;
+    SmallVector<Value> listOfTensors;
+    Value stepVal = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(1));
+
+    // For each of the split create slice operation to slice the input tensor
+    // from `start` to `endIdx`.
+    for (unsigned i = 0; i < splitSizes.size(); i++) {
+      Value startVal = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(start));
+      Value endVal = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(endIdx[i]));
+      Type resultType = listType.getContainedType();
+      Value slice = rewriter.create<AtenSliceTensorOp>(
+          loc, resultType, op.self(), op.dim(), startVal, endVal, stepVal);
+      listOfTensors.push_back(slice);
+      start = endIdx[i];
+    }
+
+    Value result = rewriter.create<PrimListConstructOp>(
+        loc, Torch::ListType::get(listType.getContainedType()), listOfTensors);
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+
+template <typename SplitTensorLikeOp>
+class DecomposeAtenSplitTensorLikeOp
+    : public OpRewritePattern<SplitTensorLikeOp> {
+public:
+  using OpRewritePattern<SplitTensorLikeOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(SplitTensorLikeOp op,
+                                PatternRewriter &rewriter) const override {
+    int64_t dim;
+    if (!matchPattern(op.dim(), m_TorchConstantInt(&dim)))
+      return rewriter.notifyMatchFailure(op, "dim must be constant");
+
+    auto listType = op.getType().template cast<Torch::ListType>();
+    Location loc = op.getLoc();
+
+    auto viewOp = dyn_cast<AtenViewOp>(op.self().getDefiningOp());
+    if (!viewOp)
+      return failure();
+
+    auto sizesListOp =
+        dyn_cast<PrimListConstructOp>(viewOp.size().getDefiningOp());
+    if (!sizesListOp)
+      return failure();
+    SmallVector<Value> sizes = sizesListOp.elements();
+
+    auto constantDimSizeOp =
+        dyn_cast<ConstantIntOp>(sizes[dim].getDefiningOp());
+    if (!constantDimSizeOp)
+      return rewriter.notifyMatchFailure(op, "dim size must be constant");
+
+    int64_t dimSize = constantDimSizeOp.value().getSExtValue();
+    int64_t splitSize = 0, chunks = 0;
+    // TODO: Support non static splitSizes.
+    if (isa<AtenSplitTensorOp>(op)) {
+      if (!matchPattern(op.getOperand(1), m_TorchConstantInt(&splitSize)))
+        return rewriter.notifyMatchFailure(op, "split_size must be constant");
+      chunks = (dimSize + splitSize - 1) / splitSize;
+    } else if (isa<AtenChunkOp>(op)) {
+      if (!matchPattern(op.getOperand(1), m_TorchConstantInt(&chunks)))
+        return rewriter.notifyMatchFailure(op,
+                                           "number of chunks must be constant");
+      splitSize = dimSize / chunks;
+    }
+
+    // Calculate the end indices of the slices.
+    SmallVector<int64_t> endIdx;
+    endIdx.push_back(splitSize * 1);
+    for (unsigned i = 1; i < chunks - 1; i++) {
+      endIdx.push_back(splitSize * (i + 1));
+    }
+    endIdx.push_back(dimSize);
+    int64_t start = 0;
+    SmallVector<Value> listOfTensors;
+    Value stepVal = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(1));
+
+    // For each of the split create slice operation to slice the input tensor
+    // from `start` to `endIdx`.
+    for (unsigned i = 0; i < chunks; i++) {
+      Value startVal = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(start));
+      Value endVal = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(endIdx[i]));
+      Type resultType = listType.getContainedType();
+      Value slice = rewriter.create<AtenSliceTensorOp>(
+          loc, resultType, op.self(), op.dim(), startVal, endVal, stepVal);
+      listOfTensors.push_back(slice);
+      start = endIdx[i];
+    }
+
+    Value result = rewriter.create<PrimListConstructOp>(
+        loc, Torch::ListType::get(listType.getContainedType()), listOfTensors);
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+
+template <typename SplitSizesLikeOp>
+class DecomposeAtenSplitSizesLikeOp
+    : public OpRewritePattern<SplitSizesLikeOp> {
+public:
+  using OpRewritePattern<SplitSizesLikeOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(SplitSizesLikeOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<AtenSplitSizesOp>(op, op.getType(), op.self(),
+                                                  op.split_sizes(), op.dim());
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class DecomposeComplexOpsEarlyPass
+    : public DecomposeComplexOpsEarlyBase<DecomposeComplexOpsEarlyPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    ConversionTarget target(*context);
+    target.addLegalDialect<Torch::TorchDialect>();
+
+    patterns.add<DecomposeAtenSplitSizesOp>(context);
+    target.addIllegalOp<AtenSplitSizesOp>();
+    patterns.add<DecomposeAtenSplitSizesLikeOp<AtenSplitOp>>(context);
+    target.addIllegalOp<AtenSplitOp>();
+    patterns.add<DecomposeAtenSplitSizesLikeOp<AtenSplitWithSizesOp>>(context);
+    target.addIllegalOp<AtenSplitWithSizesOp>();
+    patterns.add<DecomposeAtenSplitTensorLikeOp<AtenSplitTensorOp>>(context);
+    target.addIllegalOp<AtenSplitTensorOp>();
+    patterns.add<DecomposeAtenSplitTensorLikeOp<AtenChunkOp>>(context);
+    target.addIllegalOp<AtenChunkOp>();
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::torch::Torch::createDecomposeComplexOpsEarlyPass() {
+  return std::make_unique<DecomposeComplexOpsEarlyPass>();
+}

--- a/lib/Dialect/Torch/Transforms/Passes.cpp
+++ b/lib/Dialect/Torch/Transforms/Passes.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -90,6 +91,8 @@ void mlir::torch::Torch::createTorchFunctionToTorchBackendPipeline(
 
   // Incorporate user annotations and remove signature Python-isms.
   pm.addPass(createAdjustCallingConventionsPass());
+  if (options.decomposeEarly)
+    pm.addNestedPass<func::FuncOp>(createDecomposeComplexOpsEarlyPass());
 
   if (options.optimize) {
     // Eliminate the PrimTupleIndexOp generated from the
@@ -154,7 +157,6 @@ void mlir::torch::Torch::createTorchFunctionToTorchBackendPipeline(
     // only-used-in-training operations on `torch.global_slot`'s.
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   }
-  
   if (options.decompose)
     pm.addNestedPass<func::FuncOp>(Torch::createDecomposeComplexOpsPass());
 

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -3078,6 +3078,96 @@ module {
     } : (!torch.int, !torch.bool) -> ()
     return %none : !torch.none
   }
+  func.func @"__torch_mlir_shape_fn.aten.split"(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.int) -> !torch.list<list<int>> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.split(%arg0, %arg1, %arg2) : (!torch.list<int>, !torch.list<int>, !torch.int) -> !torch.list<list<int>>
+    return %0 : !torch.list<list<int>>
+  }
+  func.func @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.split(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.int) -> !torch.list<list<int>> {
+    %int1 = torch.constant.int 1
+    %int0 = torch.constant.int 0
+    %true = torch.constant.bool true
+    %0 = torch.aten.len.t %arg0 : !torch.list<int> -> !torch.int
+    %1 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.maybe_wrap_dim(%arg2, %0, %true) : (!torch.int, !torch.int, !torch.bool) -> !torch.int
+    %2 = torch.prim.ListConstruct  : () -> !torch.list<list<int>>
+    %3 = torch.prim.ListConstruct  : () -> !torch.list<int>
+    %4 = torch.aten.len.t %arg1 : !torch.list<int> -> !torch.int
+    torch.prim.Loop %4, %true, init() {
+    ^bb0(%arg3: !torch.int):
+      %6 = torch.aten.eq.int %arg3, %int0 : !torch.int, !torch.int -> !torch.bool
+      torch.prim.If %6 -> () {
+        %7 = torch.aten.__getitem__.t %arg0, %int0 : !torch.list<int>, !torch.int -> !torch.int
+        %8 = torch.aten.append.t %3, %7 : !torch.list<int>, !torch.int -> !torch.list<int>
+        torch.prim.If.yield
+      } else {
+        %7 = torch.aten.sub.int %arg3, %int1 : !torch.int, !torch.int -> !torch.int
+        %8 = torch.aten.__getitem__.t %3, %7 : !torch.list<int>, !torch.int -> !torch.int
+        %9 = torch.aten.__getitem__.t %arg0, %arg3 : !torch.list<int>, !torch.int -> !torch.int
+        %10 = torch.aten.add.int %8, %9 : !torch.int, !torch.int -> !torch.int
+        %11 = torch.aten.append.t %3, %10 : !torch.list<int>, !torch.int -> !torch.list<int>
+        torch.prim.If.yield
+      }
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    %5 = torch.prim.Loop %4, %true, init(%int0) {
+    ^bb0(%arg3: !torch.int, %arg4: !torch.int):
+      %6 = torch.aten.__getitem__.t %3, %arg3 : !torch.list<int>, !torch.int -> !torch.int
+      %7 = torch.prim.ListConstruct  : () -> !torch.list<int>
+      %8 = torch.aten.len.t %arg0 : !torch.list<int> -> !torch.int
+      %9 = torch.prim.Loop %8, %true, init(%arg3) {
+      ^bb0(%arg5: !torch.int, %arg6: !torch.int):
+        %12 = torch.aten.eq.int %arg5, %1 : !torch.int, !torch.int -> !torch.bool
+        torch.prim.If %12 -> () {
+          %13 = torch.aten.sub.int %6, %arg4 : !torch.int, !torch.int -> !torch.int
+          %14 = torch.aten.append.t %7, %13 : !torch.list<int>, !torch.int -> !torch.list<int>
+          torch.prim.If.yield
+        } else {
+          %13 = torch.aten.__getitem__.t %arg0, %arg5 : !torch.list<int>, !torch.int -> !torch.int
+          %14 = torch.aten.append.t %7, %13 : !torch.list<int>, !torch.int -> !torch.list<int>
+          torch.prim.If.yield
+        }
+        torch.prim.Loop.condition %true, iter(%arg5 : !torch.int)
+      } : (!torch.int, !torch.bool, !torch.int) -> !torch.int
+      %10 = torch.aten.append.t %2, %7 : !torch.list<list<int>>, !torch.list<int> -> !torch.list<list<int>>
+      %11 = torch.aten.__getitem__.t %arg1, %9 : !torch.list<int>, !torch.int -> !torch.int
+      torch.prim.Loop.condition %true, iter(%11 : !torch.int)
+    } : (!torch.int, !torch.bool, !torch.int) -> !torch.int
+    return %2 : !torch.list<list<int>>
+  }
+  func.func @"__torch_mlir_shape_fn.aten.split.sizes"(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.int) -> !torch.list<list<int>> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.split(%arg0, %arg1, %arg2) : (!torch.list<int>, !torch.list<int>, !torch.int) -> !torch.list<list<int>>
+    return %0 : !torch.list<list<int>>
+  }
+  func.func @"__torch_mlir_shape_fn.aten.split_with_sizes"(%arg0: !torch.list<int>, %arg1: !torch.list<int>, %arg2: !torch.int) -> !torch.list<list<int>> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.split(%arg0, %arg1, %arg2) : (!torch.list<int>, !torch.list<int>, !torch.int) -> !torch.list<list<int>>
+    return %0 : !torch.list<list<int>>
+  }
+  func.func @"__torch_mlir_shape_fn.aten.split.Tensor"(%arg0: !torch.list<int>, %arg1: !torch.int, %arg2: !torch.int) -> !torch.list<list<int>> {
+    %int1 = torch.constant.int 1
+    %true = torch.constant.bool true
+    %0 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<int>, !torch.int -> !torch.int
+    %1 = torch.aten.add.int %0, %arg1 : !torch.int, !torch.int -> !torch.int
+    %2 = torch.aten.sub.int %1, %int1 : !torch.int, !torch.int -> !torch.int
+    %3 = torch.aten.floordiv.int %2, %arg1 : !torch.int, !torch.int -> !torch.int
+    %4 = torch.prim.ListConstruct  : () -> !torch.list<int>
+    torch.prim.Loop %3, %true, init() {
+    ^bb0(%arg3: !torch.int):
+      %11 = torch.aten.append.t %4, %arg1 : !torch.list<int>, !torch.int -> !torch.list<int>
+      torch.prim.Loop.condition %true, iter()
+    } : (!torch.int, !torch.bool) -> ()
+    %5 = torch.aten.mul.int %arg1, %3 : !torch.int, !torch.int -> !torch.int
+    %6 = torch.aten.sub.int %5, %0 : !torch.int, !torch.int -> !torch.int
+    %7 = torch.aten.sub.int %arg1, %6 : !torch.int, !torch.int -> !torch.int
+    %8 = torch.aten.sub.int %3, %int1 : !torch.int, !torch.int -> !torch.int
+    %9 = torch.aten._set_item.t %4, %8, %7 : !torch.list<int>, !torch.int, !torch.int -> !torch.list<int>
+    %10 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.split(%arg0, %4, %arg2) : (!torch.list<int>, !torch.list<int>, !torch.int) -> !torch.list<list<int>>
+    return %10 : !torch.list<list<int>>
+  }
+  func.func @"__torch_mlir_shape_fn.aten.chunk"(%arg0: !torch.list<int>, %arg1: !torch.int, %arg2: !torch.int) -> !torch.list<list<int>> {
+    %0 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<int>, !torch.int -> !torch.int
+    %1 = torch.aten.floordiv.int %0, %arg1 : !torch.int, !torch.int -> !torch.int
+    %2 = call @"__torch_mlir_shape_fn.aten.split.Tensor"(%arg0, %1, %arg2) : (!torch.list<int>, !torch.int, !torch.int) -> !torch.list<list<int>>
+    return %2 : !torch.list<list<int>>
+  }
   func.func @"__torch_mlir_shape_fn.aten.bincount"(%arg0: !torch.list<int>, %arg1: !torch.optional<list<int>>, %arg2: !torch.int) -> !torch.list<int> {
     %0 = call @__torch__.hacky_get_unknown_dimension_size() : () -> !torch.int
     %1 = torch.prim.ListConstruct %0 : (!torch.int) -> !torch.list<int>

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -916,6 +916,26 @@ def aten〇index〇Tensor(self: List[int], indices: List[Optional[List[int]]]) -
 def aten〇cat(tensors: List[List[int]], dim: int = 0) -> List[int]:
     return upstream_shape_helpers.cat(tensors, dim)
 
+def aten〇split(self: List[int], split_sizes: List[int], dim: int = 0) -> List[List[int]]:
+    return upstream_shape_helpers.split(self, split_sizes, dim)
+
+def aten〇split〇sizes(self: List[int], split_size: List[int], dim: int = 0) -> List[List[int]]:
+    return upstream_shape_helpers.split(self, split_size, dim)
+
+def aten〇split_with_sizes(self: List[int], split_sizes: List[int], dim: int = 0) -> List[List[int]]:
+    return upstream_shape_helpers.split(self, split_sizes, dim)
+
+def aten〇split〇Tensor(self: List[int], split_size: int, dim: int = 0) -> List[List[int]]:
+    dim_size = self[dim]
+    chunks = (dim_size + split_size - 1) // split_size
+    split_sizes = [split_size for i in range(chunks)]
+    split_sizes[chunks - 1] = split_size - (split_size * chunks - dim_size)
+    return upstream_shape_helpers.split(self, split_sizes, dim)
+
+def aten〇chunk(self: List[int], chunks: int, dim: int = 0) -> List[List[int]]:
+    split_size = self[dim] // chunks
+    return aten〇split〇Tensor(self, split_size, dim)
+
 class DummyClassType:
     def __init__(self):
         pass

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -454,6 +454,11 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::t : (Tensor) -> (Tensor)")
     emit("aten::full : (int[], Scalar, int?, int?, Device?, bool?) -> (Tensor)")
     emit("aten::full_like : (Tensor, Scalar, int?, int?, Device?, bool?, int?) -> (Tensor)")
+    emit("aten::split : (Tensor, int[], int) -> (Tensor[])")
+    emit("aten::split.sizes : (Tensor, int[], int) -> (Tensor[])")
+    emit("aten::split_with_sizes : (Tensor, int[], int) -> (Tensor[])")
+    emit("aten::split.Tensor : (Tensor, int, int) -> (Tensor[])")
+    emit("aten::chunk : (Tensor, int, int) -> (Tensor[])")
 
     # Dict ops.
     emit("aten::__contains__.str : (Dict(str, t), str) -> (bool)", has_folder=True)

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/upstream_shape_helpers.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/upstream_shape_helpers.py
@@ -665,3 +665,27 @@ def pad(input: List[int], pad: List[int]):
     for i in range(len(pad) // 2):
         input[-(i + 1)] += pad[2 * i] + pad[2 * i + 1]
     return input
+
+def split(input: List[int], split_sizes: List[int], dim: int = 0):
+    dim = maybe_wrap_dim(dim, len(input))
+    results: List[List[int]] = []
+    end_idx: List[int] = []
+    num_splits = len(split_sizes)
+    for i in range(num_splits):
+        if(i == 0):
+            end_idx.append(input[0])
+        else:
+            end_idx.append(end_idx[i-1] + input[i])
+    start = 0
+    step = 1
+    for i in range(num_splits):
+        end = end_idx[i]
+        temp: List[int] = []
+        for i in range(len(input)):
+          if i == dim:
+            temp.append(end - start)
+          else:
+            temp.append(input[i])
+        results.append(temp)
+        start = split_sizes[i]
+    return results

--- a/python/torch_mlir_e2e_test/test_suite/slice_like.py
+++ b/python/torch_mlir_e2e_test/test_suite/slice_like.py
@@ -232,3 +232,107 @@ def SelectIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(10, (5,5)))
 
 # ==============================================================================
+
+class SplitModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        split_sizes = [1, 3, 5]
+        dim = 0
+        splits = torch.ops.aten.split(x, split_sizes, dim)
+        return splits[0], splits[1], splits[2]
+
+@register_test_case(module_factory=lambda: SplitModule())
+def SplitModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(9, 6, 8))
+
+# ==============================================================================
+
+class SplitStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([9, 6, 8], torch.float32, True),
+    ])
+    def forward(self, x):
+        split_sizes = [1, 3, 2]
+        dim = 1
+        splits = torch.ops.aten.split(x, split_sizes, dim)
+        return splits[0], splits[1], splits[2]
+
+@register_test_case(module_factory=lambda: SplitStaticModule())
+def SplitStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(9, 6, 8))
+
+# ==============================================================================
+
+class SplitWithSizesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        split_sizes = [1, 3, 4]
+        dim = 2
+        splits = torch.ops.aten.split_with_sizes(x, split_sizes, dim)
+        return splits[0], splits[1], splits[2]
+
+@register_test_case(module_factory=lambda: SplitWithSizesModule())
+def SplitWithSizestModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(9, 6, 8))
+
+# ==============================================================================
+
+class SplitTensorModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        split_size = 2
+        dim = 2
+        splits = torch.ops.aten.split(x.view(9, 6, 8), split_size, dim)
+        return splits[0], splits[1], splits[2], splits[3]
+
+@register_test_case(module_factory=lambda: SplitTensorModule())
+def SplitTensorModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(9, 6, 8))
+
+class ChunkModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        chunks = 4
+        dim = 2
+        splits = torch.ops.aten.chunk(x.view(9, 6, 8), chunks, dim)
+        return splits[0], splits[1], splits[2], splits[3]
+
+@register_test_case(module_factory=lambda: ChunkModule())
+def ChunkModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(9, 6, 8))
+
+
+


### PR DESCRIPTION
Added lowerings for all split like operations. This include
`aten.split`, `aten.split.Sizes`, `aten.split_with_sizes`,
`aten.split.Tensor`  and `aten.chunk` ops. This commit also adds a pass
`DecomposeComplexOpsEarly` which decomposes complex ops like
split ops before shape inference.

Signed-Off-By: Prateek Gupta<prateek@nod-labs.com>