### PR TITLE
[MLIR][TORCH] Add support for ceil_mode = true for pooling ops

### DIFF
--- a/lib/Conversion/TorchToLinalg/Utils.cpp
+++ b/lib/Conversion/TorchToLinalg/Utils.cpp
@@ -71,7 +71,7 @@ Value torch_to_linalg::getOutputDimForConvOps(OpBuilder &b, Location loc,
                                               Value in, Value paddingInt,
                                               Value dilationInt,
                                               Value kernelSizeInt,
-                                              Value strideInt) {
+                                              Value strideInt, bool ceilMode) {
   Value c1 = b.create<arith::ConstantOp>(loc, b.getI64IntegerAttr(1));
   Value c2 = b.create<arith::ConstantOp>(loc, b.getI64IntegerAttr(2));
 
@@ -88,7 +88,11 @@ Value torch_to_linalg::getOutputDimForConvOps(OpBuilder &b, Location loc,
   Value temp =
       b.create<arith::SubIOp>(loc, inAddDoublePadding, dilationTimesKernelSize);
   Value dividend = b.create<arith::SubIOp>(loc, temp, c1);
-  Value division = b.create<arith::FloorDivSIOp>(loc, dividend, strideInt);
+  Value division;
+  if (ceilMode)
+    division = b.create<arith::CeilDivSIOp>(loc, dividend, strideInt);
+  else
+    division = b.create<arith::FloorDivSIOp>(loc, dividend, strideInt);
   Value out = b.create<arith::AddIOp>(loc, division, c1);
   return castIntToIndex(b, loc, out);
 }

--- a/lib/Conversion/TorchToLinalg/Utils.h
+++ b/lib/Conversion/TorchToLinalg/Utils.h
@@ -30,7 +30,8 @@ Value getZeroPaddedTensor(Operation *op, OpBuilder &b, Value &input,
 //  floor((dim_in + 2 * padding - dilation * (kernelSize - 1) - 1) / stride) + 1
 Value getOutputDimForConvOps(OpBuilder &b, Location loc, Value in,
                              Value paddingInt, Value dilationInt,
-                             Value kernelSizeInt, Value strideInt);
+                             Value kernelSizeInt, Value strideInt,
+                             bool ceilMode = false);
 
 // Create a reduction of `tensorOperand`, reducing along the dimensions
 // in `dimSet`. If `keepDim` is true, the output tensor is the same

--- a/python/torch_mlir_e2e_test/test_suite/pooling.py
+++ b/python/torch_mlir_e2e_test/test_suite/pooling.py
@@ -81,6 +81,30 @@ def MaxPool2dStaticModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1, 64, 112, 112))
 
 
+class MaxPool2dCeilModeTrueModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.mp2d = torch.nn.MaxPool2d(kernel_size=[6, 8],
+                                       stride=[2, 2],
+                                       padding=[3, 4],
+                                       dilation=2,
+                                       ceil_mode=True)
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return self.mp2d(x)
+
+
+@register_test_case(module_factory=lambda: MaxPool2dCeilModeTrueModule())
+def MaxPool2dCeilModeTrueModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1, 20, 20, low=0.5, high=1.0))
+
+
 class MaxPool2dWith3dInputModule(torch.nn.Module):
 
     def __init__(self):
@@ -318,6 +342,31 @@ class MaxPool2dWithIndicesAllOnesModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: MaxPool2dWithIndicesAllOnesModule())
 def MaxPool2dWithIndicesAllOnesModule_basic(module, tu: TestUtils):
     module.forward(torch.ones(1, 1, 8, 8))
+
+
+class MaxPool2dWithIndicesCeilModeTrueModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.max_pool2d_with_indices(x,
+                                                      kernel_size=[2, 2],
+                                                      stride=[1, 1],
+                                                      padding=[0, 0],
+                                                      dilation=[1, 1],
+                                                      ceil_mode=True)
+
+
+@register_test_case(
+    module_factory=lambda: MaxPool2dWithIndicesCeilModeTrueModule())
+def MaxPool2dWithIndicesCeilModeTrueModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1, 8, 8, low=0.5, high=1.0))
 
 
 class MaxPool2dWithIndicesWith3dInputModule(torch.nn.Module):
@@ -568,3 +617,28 @@ class AvgPool2dDivisorOverrideModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: AvgPool2dDivisorOverrideModule())
 def AvgPool2dDivisorOverrideModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(4, 4, 20, 20) - 0.5)
+
+
+class AvgPool2dCeilModeTrueModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.ap2d = torch.nn.AvgPool2d(kernel_size=[6, 8],
+                                       stride=[2, 2],
+                                       padding=[3, 4],
+                                       ceil_mode=False,
+                                       count_include_pad=True,
+                                       divisor_override=None)
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return self.ap2d(x)
+
+
+@register_test_case(module_factory=lambda: AvgPool2dCeilModeTrueModule())
+def AvgPool2dCeilModeTrueModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 4, 20, 20, low=0.5, high=1.0))


### PR DESCRIPTION
This commit adds support for aten.max_pool2d, aten.max_pool2d_with_indices,
and aten.avg_pool2d op for the cases where ceil_mode = true.

Signed-Off By: Vivek Khandelwal <vivek@nod-labs.com>