### PR TITLE
Add static shape for scalar tensors

### DIFF
--- a/include/torch-mlir-c/TorchTypes.h
+++ b/include/torch-mlir-c/TorchTypes.h
@@ -154,6 +154,7 @@ MLIR_CAPI_EXPORTED bool torchMlirTypeIsATorchNonValueTensor(MlirType t);
 
 /// Gets a !torch.tensor type.
 ///
+/// - `numSizes` having a value of -1 denotes an unranked tensor.
 /// - `optionalSizes` is allowed to be null, meaning that no size
 /// information is present (and `numSizes` is ignored in that case).  -
 /// `optionalDtype` is allowed to be null, meaning that no dtype
@@ -180,6 +181,7 @@ MLIR_CAPI_EXPORTED bool torchMlirTypeIsATorchValueTensor(MlirType t);
 
 /// Gets a !torch.vtensor type.
 ///
+/// - `numSizes` having a value of -1 denotes an unranked tensor.
 /// - `optionalSizes` is allowed to be null, meaning that no size
 /// information is present (and `numSizes` is ignored in that case).
 /// - `optionalDtype` is allowed to be null, meaning that no dtype

--- a/include/torch-mlir-c/TorchTypes.h
+++ b/include/torch-mlir-c/TorchTypes.h
@@ -160,7 +160,7 @@ MLIR_CAPI_EXPORTED bool torchMlirTypeIsATorchNonValueTensor(MlirType t);
 /// information is present.
 MLIR_CAPI_EXPORTED MlirType torchMlirTorchNonValueTensorTypeGet(
     MlirContext context, intptr_t numSizes, const int64_t *optionalSizes,
-    MlirType optionalDtype, bool assumeZeroRankTensorsAreScalar = false);
+    MlirType optionalDtype);
 
 /// Gets the !torch.tensor type with the least static information.
 MLIR_CAPI_EXPORTED MlirType
@@ -186,7 +186,7 @@ MLIR_CAPI_EXPORTED bool torchMlirTypeIsATorchValueTensor(MlirType t);
 /// information is present.
 MLIR_CAPI_EXPORTED MlirType torchMlirTorchValueTensorTypeGet(
     MlirContext context, intptr_t numSizes, const int64_t *optionalSizes,
-    MlirType optionalDtype, bool assumeZeroRankTensorsAreScalar = false);
+    MlirType optionalDtype);
 
 /// Gets the !torch.tensor type with the least static information.
 MLIR_CAPI_EXPORTED MlirType

--- a/include/torch-mlir-c/TorchTypes.h
+++ b/include/torch-mlir-c/TorchTypes.h
@@ -160,7 +160,7 @@ MLIR_CAPI_EXPORTED bool torchMlirTypeIsATorchNonValueTensor(MlirType t);
 /// information is present.
 MLIR_CAPI_EXPORTED MlirType torchMlirTorchNonValueTensorTypeGet(
     MlirContext context, intptr_t numSizes, const int64_t *optionalSizes,
-    MlirType optionalDtype);
+    MlirType optionalDtype, bool assumeZeroRankTensorsAreScalar = false);
 
 /// Gets the !torch.tensor type with the least static information.
 MLIR_CAPI_EXPORTED MlirType
@@ -186,7 +186,7 @@ MLIR_CAPI_EXPORTED bool torchMlirTypeIsATorchValueTensor(MlirType t);
 /// information is present.
 MLIR_CAPI_EXPORTED MlirType torchMlirTorchValueTensorTypeGet(
     MlirContext context, intptr_t numSizes, const int64_t *optionalSizes,
-    MlirType optionalDtype);
+    MlirType optionalDtype, bool assumeZeroRankTensorsAreScalar = false);
 
 /// Gets the !torch.tensor type with the least static information.
 MLIR_CAPI_EXPORTED MlirType

--- a/lib/CAPI/TorchTypes.cpp
+++ b/lib/CAPI/TorchTypes.cpp
@@ -187,7 +187,8 @@ MlirType torchMlirTorchNonValueTensorTypeGet(MlirContext context,
                                              const int64_t *optionalSizes,
                                              MlirType optionalDtype) {
   Optional<ArrayRef<int64_t>> optionalSizesArrayRef = None;
-  if (optionalSizes)
+  // if numSizes == -1, then it is unranked.
+  if (numSizes > -1)
     optionalSizesArrayRef = llvm::makeArrayRef(optionalSizes, numSizes);
   return wrap(Torch::NonValueTensorType::get(
       unwrap(context), optionalSizesArrayRef, unwrap(optionalDtype)));
@@ -219,7 +220,8 @@ MlirType torchMlirTorchValueTensorTypeGet(MlirContext context,
                                           const int64_t *optionalSizes,
                                           MlirType optionalDtype) {
   Optional<ArrayRef<int64_t>> optionalSizesArrayRef = None;
-  if (optionalSizes)
+  // if numSizes == -1, then it is unranked.
+  if (numSizes > -1)
     optionalSizesArrayRef = llvm::makeArrayRef(optionalSizes, numSizes);
   return wrap(Torch::ValueTensorType::get(
       unwrap(context), optionalSizesArrayRef, unwrap(optionalDtype)));

--- a/lib/CAPI/TorchTypes.cpp
+++ b/lib/CAPI/TorchTypes.cpp
@@ -182,13 +182,12 @@ bool torchMlirTypeIsATorchNonValueTensor(MlirType t) {
   return unwrap(t).isa<Torch::NonValueTensorType>();
 }
 
-MlirType torchMlirTorchNonValueTensorTypeGet(
-    MlirContext context, intptr_t numSizes, const int64_t *optionalSizes,
-    MlirType optionalDtype, bool assumeZeroRankTensorsAreScalar) {
+MlirType torchMlirTorchNonValueTensorTypeGet(MlirContext context,
+                                             intptr_t numSizes,
+                                             const int64_t *optionalSizes,
+                                             MlirType optionalDtype) {
   Optional<ArrayRef<int64_t>> optionalSizesArrayRef = None;
-  // If assumeZeroRankTensorsAreScalar is true, then we will create an array
-  // even if it's empty to explicitly show the tensor is a scalar.
-  if (optionalSizes || assumeZeroRankTensorsAreScalar)
+  if (optionalSizes)
     optionalSizesArrayRef = llvm::makeArrayRef(optionalSizes, numSizes);
   return wrap(Torch::NonValueTensorType::get(
       unwrap(context), optionalSizesArrayRef, unwrap(optionalDtype)));
@@ -218,12 +217,9 @@ bool torchMlirTypeIsATorchValueTensor(MlirType t) {
 MlirType torchMlirTorchValueTensorTypeGet(MlirContext context,
                                           intptr_t numSizes,
                                           const int64_t *optionalSizes,
-                                          MlirType optionalDtype,
-                                          bool assumeZeroRankTensorsAreScalar) {
+                                          MlirType optionalDtype) {
   Optional<ArrayRef<int64_t>> optionalSizesArrayRef = None;
-  // If assumeZeroRankTensorsAreScalar is true, then we will create an array
-  // even if it's empty to explicitly show the tensor is a scalar.
-  if (optionalSizes || assumeZeroRankTensorsAreScalar)
+  if (optionalSizes)
     optionalSizesArrayRef = llvm::makeArrayRef(optionalSizes, numSizes);
   return wrap(Torch::ValueTensorType::get(
       unwrap(context), optionalSizesArrayRef, unwrap(optionalDtype)));

--- a/lib/CAPI/TorchTypes.cpp
+++ b/lib/CAPI/TorchTypes.cpp
@@ -182,12 +182,13 @@ bool torchMlirTypeIsATorchNonValueTensor(MlirType t) {
   return unwrap(t).isa<Torch::NonValueTensorType>();
 }
 
-MlirType torchMlirTorchNonValueTensorTypeGet(MlirContext context,
-                                             intptr_t numSizes,
-                                             const int64_t *optionalSizes,
-                                             MlirType optionalDtype) {
+MlirType torchMlirTorchNonValueTensorTypeGet(
+    MlirContext context, intptr_t numSizes, const int64_t *optionalSizes,
+    MlirType optionalDtype, bool assumeZeroRankTensorsAreScalar) {
   Optional<ArrayRef<int64_t>> optionalSizesArrayRef = None;
-  if (optionalSizes)
+  // If assumeZeroRankTensorsAreScalar is true, then we will create an array
+  // even if it's empty to explicitly show the tensor is a scalar.
+  if (optionalSizes || assumeZeroRankTensorsAreScalar)
     optionalSizesArrayRef = llvm::makeArrayRef(optionalSizes, numSizes);
   return wrap(Torch::NonValueTensorType::get(
       unwrap(context), optionalSizesArrayRef, unwrap(optionalDtype)));
@@ -217,9 +218,12 @@ bool torchMlirTypeIsATorchValueTensor(MlirType t) {
 MlirType torchMlirTorchValueTensorTypeGet(MlirContext context,
                                           intptr_t numSizes,
                                           const int64_t *optionalSizes,
-                                          MlirType optionalDtype) {
+                                          MlirType optionalDtype,
+                                          bool assumeZeroRankTensorsAreScalar) {
   Optional<ArrayRef<int64_t>> optionalSizesArrayRef = None;
-  if (optionalSizes)
+  // If assumeZeroRankTensorsAreScalar is true, then we will create an array
+  // even if it's empty to explicitly show the tensor is a scalar.
+  if (optionalSizes || assumeZeroRankTensorsAreScalar)
     optionalSizesArrayRef = llvm::makeArrayRef(optionalSizes, numSizes);
   return wrap(Torch::ValueTensorType::get(
       unwrap(context), optionalSizesArrayRef, unwrap(optionalDtype)));

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -17,7 +17,6 @@
 #include <torch/csrc/lazy/core/lazy_graph_executor.h>
 
 #include "../../dialects/torch/importer/jit_ir/csrc/function_importer.h"
-#include "../../dialects/torch/importer/jit_ir/csrc/import_options.h"
 #include "../utils/debug.h"
 #include "../utils/exception.h"
 #include "backend_impl.h"
@@ -121,14 +120,11 @@ ComputationPtr TorchMlirLoweringContext::Build() {
   }
 
   // Generate MLIR.
-  torch_mlir::ImportOptions import_options{
-      /*assumeTensorsHaveValueSemantics=*/true,
-      /*assumeZeroRankTensorsAreScalar=*/true};
   MlirOperation func_op = torch_mlir::importJitFunctionAsFuncOp(
       /*context=*/mlir_context_,
       /*function=*/generate_jit_fn().get(),
       /*getArgAttribute=*/[](int) -> MlirAttribute { return {nullptr}; },
-      /*importOptions=*/import_options);
+      /*importOptions=*/{/*assumeTensorsHaveValueSemantics=*/true});
 
   return std::make_shared<TorchMlirComputation>(
       func_op, mlir_context_, graph_, input_output_aliases_);

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 
 #include <torch/csrc/jit/api/compilation_unit.h>
-#include <torch/csrc/jit/passes/refine_types.h>
+#include <torch/csrc/jit/passes/refine_tuple_types.h>
 #include <torch/csrc/lazy/core/lazy_graph_executor.h>
 
 #include "../../dialects/torch/importer/jit_ir/csrc/function_importer.h"
@@ -110,9 +110,8 @@ ComputationPtr TorchMlirLoweringContext::Build() {
   PRINT_FUNCTION();
 
   // Since we mutated the types of some nodes to insert shape information, we
-  // must perform this pass to ensure other data structures (such as tuples)
-  // have up to date output types.
-  torch::jit::RefineTypes(graph_);
+  // must perform this pass to ensure tuples have up to date output types.
+  torch::jit::RefineTupleTypes(graph_);
 
   // Insert return values into graph.
   for (torch::jit::Value* output : root_tuple_) {

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 
 #include <torch/csrc/jit/api/compilation_unit.h>
+#include <torch/csrc/jit/passes/refine_types.h>
 #include <torch/csrc/lazy/core/lazy_graph_executor.h>
 
 #include "../../dialects/torch/importer/jit_ir/csrc/function_importer.h"
@@ -108,6 +109,11 @@ void TorchMlirLoweringContext::AddParameter(
 // embedded builder (returned by the builder() API).
 ComputationPtr TorchMlirLoweringContext::Build() {
   PRINT_FUNCTION();
+
+  // Since we mutated the types of some nodes to insert shape information, we
+  // must perform this pass to ensure other data structures (such as tuples)
+  // have up to date output types.
+  torch::jit::RefineTypes(graph_);
 
   // Insert return values into graph.
   for (torch::jit::Value* output : root_tuple_) {

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -16,6 +16,7 @@
 #include <torch/csrc/lazy/core/lazy_graph_executor.h>
 
 #include "../../dialects/torch/importer/jit_ir/csrc/function_importer.h"
+#include "../../dialects/torch/importer/jit_ir/csrc/import_options.h"
 #include "../utils/debug.h"
 #include "../utils/exception.h"
 #include "backend_impl.h"
@@ -114,11 +115,14 @@ ComputationPtr TorchMlirLoweringContext::Build() {
   }
 
   // Generate MLIR.
+  torch_mlir::ImportOptions import_options{
+      /*assumeTensorsHaveValueSemantics=*/true,
+      /*assumeZeroRankTensorsAreScalar=*/true};
   MlirOperation func_op = torch_mlir::importJitFunctionAsFuncOp(
       /*context=*/mlir_context_,
       /*function=*/generate_jit_fn().get(),
       /*getArgAttribute=*/[](int) -> MlirAttribute { return {nullptr}; },
-      /*importOptions=*/{/*assumeTensorsHaveValueSemantics=*/true});
+      /*importOptions=*/import_options);
 
   return std::make_shared<TorchMlirComputation>(
       func_op, mlir_context_, graph_, input_output_aliases_);

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
@@ -23,10 +23,6 @@ struct ImportOptions {
   // a requirement to use a value-semantic tensor type (!torch.vtensor) in
   // signatures.
   bool assumeTensorsHaveValueSemantics = false;
-  // If this is set to true, then all tensors with zero rank are assumed to be
-  // a scalar value; denoted with a shape of []. Otherwise, an unranked tensor
-  // is assumed to have an unknown shape, which has a shape of *.
-  bool assumeZeroRankTensorsAreScalar = false;
 };
 } // namespace torch_mlir
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
@@ -23,6 +23,10 @@ struct ImportOptions {
   // a requirement to use a value-semantic tensor type (!torch.vtensor) in
   // signatures.
   bool assumeTensorsHaveValueSemantics = false;
+  // If this is set to true, then all tensors with zero rank are assumed to be
+  // a scalar value; denoted with a shape of []. Otherwise, an unranked tensor
+  // is assumed to have an unknown shape, which has a shape of *.
+  bool assumeZeroRankTensorsAreScalar = false;
 };
 } // namespace torch_mlir
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
@@ -141,7 +141,7 @@ torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
     if (!sizes.rank()) {
       // Unranked.
       return getMlirTensorType(context,
-                               /*numSizes=*/0,
+                               /*numSizes=*/-1,
                                /*optionalSizes=*/nullptr,
                                /*optionalDtype=*/
                                elementType);

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
@@ -124,8 +124,6 @@ torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
   switch (kind) {
   case TypeKind::TensorType: {
     auto tensorType = torchType->cast<c10::TensorType>();
-    bool assumeZeroRankTensorsAreScalar =
-        importOptions.assumeZeroRankTensorsAreScalar;
     auto getMlirTensorType = importOptions.assumeTensorsHaveValueSemantics
                                  ? torchMlirTorchValueTensorTypeGet
                                  : torchMlirTorchNonValueTensorTypeGet;
@@ -146,9 +144,7 @@ torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
                                /*numSizes=*/0,
                                /*optionalSizes=*/nullptr,
                                /*optionalDtype=*/
-                               elementType,
-                               /*assumeZeroRankTensorsAreScalar=*/
-                               assumeZeroRankTensorsAreScalar);
+                               elementType);
     }
     // Ranked with possibly dynamic dims.
     auto &symbolicShape = tensorType->symbolic_sizes();
@@ -161,9 +157,7 @@ torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
     return getMlirTensorType(context, dims.size(),
                              /*optionalSizes=*/dims.data(),
                              /*optionalDtype=*/
-                             elementType,
-                             /*assumeZeroRankTensorsAreScalar=*/
-                             assumeZeroRankTensorsAreScalar);
+                             elementType);
   }
   case TypeKind::IntType: {
     return torchMlirTorchIntTypeGet(context);

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
@@ -124,6 +124,8 @@ torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
   switch (kind) {
   case TypeKind::TensorType: {
     auto tensorType = torchType->cast<c10::TensorType>();
+    bool assumeZeroRankTensorsAreScalar =
+        importOptions.assumeZeroRankTensorsAreScalar;
     auto getMlirTensorType = importOptions.assumeTensorsHaveValueSemantics
                                  ? torchMlirTorchValueTensorTypeGet
                                  : torchMlirTorchNonValueTensorTypeGet;
@@ -144,7 +146,9 @@ torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
                                /*numSizes=*/0,
                                /*optionalSizes=*/nullptr,
                                /*optionalDtype=*/
-                               elementType);
+                               elementType,
+                               /*assumeZeroRankTensorsAreScalar=*/
+                               assumeZeroRankTensorsAreScalar);
     }
     // Ranked with possibly dynamic dims.
     auto &symbolicShape = tensorType->symbolic_sizes();
@@ -157,7 +161,9 @@ torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
     return getMlirTensorType(context, dims.size(),
                              /*optionalSizes=*/dims.data(),
                              /*optionalDtype=*/
-                             elementType);
+                             elementType,
+                             /*assumeZeroRankTensorsAreScalar=*/
+                             assumeZeroRankTensorsAreScalar);
   }
   case TypeKind::IntType: {
     return torchMlirTorchIntTypeGet(context);


### PR DESCRIPTION
Previously scalar tensors were denoted with a type of `*` instead of `[]` in MLIR due to bug where an empty shape vector was interpreted as being an unranked tensor. The solution was to "key" the unranked case using a dimension number of -1.

Now that scalar tensor shapes are encoded explicitly, we found a previously unknown bug with JIT tuples. Since we inject shape information into the JIT graph ourselves, any previously constructed tuples will have outdated types. This related PR addresses those issues: https://github.com/pytorch/pytorch/pull/76919 Without it, the MLIR generated is illegal due to the aforementioned conflicting types.

cc: @ke1337 @antoniojkim 