### PR TITLE
[TORCH] Add lowering of aten.detach op.

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -5650,30 +5650,6 @@ def Torch_AtenFullLikeOp : Torch_Op<"aten.full_like", [
   }];
 }
 
-def Torch_AtenAddOp : Torch_Op<"aten.add", [
-    AllowsTypeRefinement,
-    HasValueSemantics,
-    ReadOnly
-  ]> {
-  let summary = "Generated op for `aten::add : (Scalar, Scalar) -> (Scalar)`";
-  let arguments = (ins
-    AnyTorchScalarType:$a,
-    AnyTorchScalarType:$b
-  );
-  let results = (outs
-    AnyTorchScalarType:$result
-  );
-  let hasCustomAssemblyFormat = 1;
-  let extraClassDefinition = [{
-    ParseResult AtenAddOp::parse(OpAsmParser &parser, OperationState &result) {
-      return parseDefaultTorchOp(parser, result, 2, 1);
-    }
-    void AtenAddOp::print(OpAsmPrinter &printer) {
-      printDefaultTorchOp(printer, *this, 2, 1);
-    }
-  }];
-}
-
 def Torch_Aten__Contains__StrOp : Torch_Op<"aten.__contains__.str", [
     AllowsTypeRefinement,
     HasValueSemantics,
@@ -7086,6 +7062,30 @@ def Torch_AtenDivOp : Torch_Op<"aten.div", [
       return parseDefaultTorchOp(parser, result, 2, 1);
     }
     void AtenDivOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 2, 1);
+    }
+  }];
+}
+
+def Torch_AtenAddOp : Torch_Op<"aten.add", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::add : (Scalar, Scalar) -> (Scalar)`";
+  let arguments = (ins
+    AnyTorchScalarType:$a,
+    AnyTorchScalarType:$b
+  );
+  let results = (outs
+    AnyTorchScalarType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenAddOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 2, 1);
+    }
+    void AtenAddOp::print(OpAsmPrinter &printer) {
       printDefaultTorchOp(printer, *this, 2, 1);
     }
   }];

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -32,8 +32,8 @@ static bool isViewLikeOp(Operation *op) {
   // correct. We could potentially be more precise and identify the cases
   // that it does not return a view and treat those as having value
   // semantics.
-  return isa<AtenBroadcastToOp, AtenContiguousOp, AtenExpandAsOp, AtenExpandOp,
-             AtenFlattenUsingIntsOp, AtenPermuteOp, AtenReshapeOp,
+  return isa<AtenBroadcastToOp, AtenContiguousOp, AtenDetachOp, AtenExpandAsOp,
+             AtenExpandOp, AtenFlattenUsingIntsOp, AtenPermuteOp, AtenReshapeOp,
              Aten_ReshapeAliasOp, AtenSelectIntOp, AtenSliceTensorOp,
              AtenSqueezeDimOp, AtenSqueezeOp, AtenTOp, AtenToDtypeOp,
              AtenTransposeIntOp, AtenUnsqueezeOp, AtenViewOp,

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -100,6 +100,10 @@ module {
     %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
     return %0 : !torch.list<int>
   }
+  func @"__torch_mlir_shape_fn.aten.detach"(%arg0: !torch.list<int>) -> !torch.list<int> {
+    %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
+    return %0 : !torch.list<int>
+  }
   func @"__torch_mlir_shape_fn.aten.log2"(%arg0: !torch.list<int>) -> !torch.list<int> {
     %0 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
     return %0 : !torch.list<int>
@@ -2026,7 +2030,7 @@ module {
     %int0 = torch.constant.int 0
     %str = torch.constant.str "AssertionError: "
     %none = torch.constant.none
-    %0 = torch.operator "aten.ne.float_int"(%arg2, %int0) : (!torch.float, !torch.int) -> !torch.bool
+    %0 = torch.aten.ne.float_int %arg2, %int0 : !torch.float, !torch.int -> !torch.bool
     torch.prim.If %0 -> () {
       torch.prim.If.yield
     } else {
@@ -2035,7 +2039,7 @@ module {
     }
     %1 = torch.aten.lt.float_int %arg2, %int0 : !torch.float, !torch.int -> !torch.bool
     torch.prim.If %1 -> () {
-      %6 = torch.operator "aten.ge.float"(%arg0, %arg1) : (!torch.float, !torch.float) -> !torch.bool
+      %6 = torch.aten.ge.float %arg0, %arg1 : !torch.float, !torch.float -> !torch.bool
       torch.prim.If %6 -> () {
         torch.prim.If.yield
       } else {
@@ -2044,7 +2048,7 @@ module {
       }
       torch.prim.If.yield
     } else {
-      %6 = torch.operator "aten.ge.float"(%arg1, %arg0) : (!torch.float, !torch.float) -> !torch.bool
+      %6 = torch.aten.ge.float %arg1, %arg0 : !torch.float, !torch.float -> !torch.bool
       torch.prim.If %6 -> () {
         torch.prim.If.yield
       } else {
@@ -2055,7 +2059,7 @@ module {
     }
     %2 = torch.aten.sub.float %arg1, %arg0 : !torch.float, !torch.float -> !torch.float
     %3 = torch.aten.div.float %2, %arg2 : !torch.float, !torch.float -> !torch.float
-    %4 = torch.operator "aten.ceil.float"(%3) : (!torch.float) -> !torch.int
+    %4 = torch.aten.ceil.float %3 : !torch.float -> !torch.int
     %5 = torch.prim.ListConstruct %4 : (!torch.int) -> !torch.list<int>
     return %5 : !torch.list<int>
   }
@@ -2071,14 +2075,14 @@ module {
     %int0 = torch.constant.int 0
     %str = torch.constant.str "AssertionError: "
     %none = torch.constant.none
-    %0 = torch.operator "aten.ge.float_int"(%arg1, %int0) : (!torch.float, !torch.int) -> !torch.bool
+    %0 = torch.aten.ge.float_int %arg1, %int0 : !torch.float, !torch.int -> !torch.bool
     torch.prim.If %0 -> () {
       torch.prim.If.yield
     } else {
       torch.prim.RaiseException %str, %none : !torch.str, !torch.none
       torch.prim.If.yield
     }
-    %1 = torch.operator "aten.ge.float"(%arg1, %arg0) : (!torch.float, !torch.float) -> !torch.bool
+    %1 = torch.aten.ge.float %arg1, %arg0 : !torch.float, !torch.float -> !torch.bool
     torch.prim.If %1 -> () {
       torch.prim.If.yield
     } else {
@@ -2086,7 +2090,7 @@ module {
       torch.prim.If.yield
     }
     %2 = torch.aten.sub.float %arg1, %arg0 : !torch.float, !torch.float -> !torch.float
-    %3 = torch.operator "aten.ceil.float"(%2) : (!torch.float) -> !torch.int
+    %3 = torch.aten.ceil.float %2 : !torch.float -> !torch.int
     %4 = torch.prim.ListConstruct %3 : (!torch.int) -> !torch.list<int>
     return %4 : !torch.list<int>
   }
@@ -2102,14 +2106,14 @@ module {
     %int0 = torch.constant.int 0
     %str = torch.constant.str "AssertionError: "
     %none = torch.constant.none
-    %0 = torch.operator "aten.ge.float_int"(%arg0, %int0) : (!torch.float, !torch.int) -> !torch.bool
+    %0 = torch.aten.ge.float_int %arg0, %int0 : !torch.float, !torch.int -> !torch.bool
     torch.prim.If %0 -> () {
       torch.prim.If.yield
     } else {
       torch.prim.RaiseException %str, %none : !torch.str, !torch.none
       torch.prim.If.yield
     }
-    %1 = torch.operator "aten.ceil.float"(%arg0) : (!torch.float) -> !torch.int
+    %1 = torch.aten.ceil.float %arg0 : !torch.float -> !torch.int
     %2 = torch.prim.ListConstruct %1 : (!torch.int) -> !torch.list<int>
     return %2 : !torch.list<int>
   }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -325,6 +325,9 @@ def aten〇neg(self: List[int]) -> List[int]:
 def aten〇floor(self: List[int]) -> List[int]:
     return upstream_shape_helpers.unary(self)
 
+def aten〇detach(self: List[int]) -> List[int]:
+    return upstream_shape_helpers.unary(self)
+
 def aten〇log2(self: List[int]) -> List[int]:
     return upstream_shape_helpers.unary(self)
 

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -1836,3 +1836,24 @@ class FlipModule(torch.nn.Module):
     module_factory=lambda: FlipModule())
 def FlipModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 2, 4))
+
+# ==============================================================================
+
+class DetachModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.detach(x)
+
+
+@register_test_case(
+    module_factory=lambda: DetachModule())
+def DetachModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 2, 4))


### PR DESCRIPTION
`aten.detach` op is folded and returns the first operand since it's an
identity function(kind of identity just remove the has_grad attribute).