### PR TITLE
Lower aten.linalg.vector_norm to linalg on tensors

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -3625,6 +3625,33 @@ def Torch_AtenBincountOp : Torch_Op<"aten.bincount", [
   }];
 }
 
+def Torch_AtenLinalgVectorNormOp : Torch_Op<"aten.linalg_vector_norm", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::linalg_vector_norm : (Tensor, Scalar, int[]?, bool, int?) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchScalarType:$ord,
+    AnyTorchOptionalListOfTorchIntType:$dim,
+    Torch_BoolType:$keepdim,
+    AnyTorchOptionalIntType:$dtype
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenLinalgVectorNormOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 5, 1);
+    }
+    void AtenLinalgVectorNormOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 5, 1);
+    }
+  }];
+}
+
 def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -35,113 +35,6 @@ template <typename elementType> static bool hasElementType(Value tensor) {
   return tensorElementType.isa<elementType>();
 }
 
-static Value createElementwiseLinalgGeneric(
-    OpBuilder &b, Location loc, ValueRange tensorOperands,
-    Type resultElementType,
-    function_ref<void(OpBuilder &, Location, ValueRange)> bodyBuild) {
-  // The overall error handling strategy here is best viewed by thinking about
-  // what happens for a single result dimension. This loop not structured that
-  // way because it is hard to create the affine maps for each operand unless
-  // we structure the loop to iterate over tensor operands as the outer loop
-  // instead of inner loop. This pseudocode gives better intuition:
-  // ```
-  // for each result dimension:
-  //   for each tensor operand:
-  //     if it doesn't even have high enough rank relative to the result:
-  //       continue
-  //     if it is a static size-1 along this result dimension:
-  //       continue
-  //     if this is the first tensor operand that didn't continue above:
-  //       take its dimension size as the size of the non-broadcasted
-  //       traversal along this dimension (this may include a dynamic size-1,
-  //       **non-broadcasted** traversal!)
-  //     emit error check "if the size does not match the non-broadcasted
-  //     traversal size along this dimension, error"
-  // ```
-  SmallVector<int64_t> operandRanks;
-  operandRanks.resize(tensorOperands.size());
-  llvm::transform(tensorOperands, operandRanks.begin(), [](Value tensor) {
-    return tensor.getType().dyn_cast<RankedTensorType>().getRank();
-  });
-
-  auto resultRankIt =
-      std::max_element(operandRanks.begin(), operandRanks.end());
-  assert(resultRankIt != operandRanks.end() && "Unable to get result rank.");
-  int64_t resultRank = *resultRankIt;
-
-  // Initialize the resultShape to all 1's, as a fallback in case
-  // all sizes along that result dimension are statically 1.
-  auto c1 = b.create<arith::ConstantIndexOp>(loc, /*value=*/1);
-  SmallVector<Value> resultShape(resultRank, c1);
-  SmallVector<AffineMap> indexingMaps;
-  for (Value tensorOperand : tensorOperands) {
-    SmallVector<AffineExpr> exprs;
-    auto type = tensorOperand.getType().cast<RankedTensorType>();
-    for (auto size : llvm::enumerate(type.getShape())) {
-      // If the size is statically known to be 1, we don't want any
-      // error guards to be spuriously emitted, since we are specifically
-      // allowing size-1 broadcasts in this case, as they correspond to a
-      // constant-0 indexing map.
-      if (size.value() == 1) {
-        exprs.push_back(b.getAffineConstantExpr(0));
-        continue;
-      }
-
-      // The rank of this operand might be smaller than the overall rank of
-      // the broadcast. Add an offset to correlate it to the correct
-      // dimension of the result.
-      auto resultDim = size.index() + (resultRank - type.getRank());
-
-      // The generated linalg op will now be iterating along the full size
-      // of this dimension. Record that fact.
-      exprs.push_back(b.getAffineDimExpr(resultDim));
-
-      // Now, we need to ensure that such iteration is not going to trigger
-      // undefined behavior, by doing appropriate checks against the current
-      // dimension size.
-      auto currentDimSize = getDimOp(b, loc, tensorOperand, size.index());
-
-      // If the result size of this dimension has so far only hit the
-      // statically-known-to-be-1 case above (i.e., we have not yet assigned a
-      // new Value to `resultShape[resultDim]`), then we have no other dynamic
-      // values to check against, and merely need to record the current
-      // dimension size.
-      if (resultShape[resultDim] == c1) {
-        resultShape[resultDim] = currentDimSize;
-        continue;
-      }
-
-      // We prohibit the size-1 dynamic broadcasting scenario, so just check
-      // for exact equality with the running result size.
-      // This is the check which protects against the undefined behavior of
-      // the generated linalg op in the case of iterating two operands with
-      // dimensions sizes that are expected to match.
-      auto equalToRunning =
-          b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                  resultShape[resultDim], currentDimSize);
-      b.create<cf::AssertOp>(loc, equalToRunning,
-                             "mismatched size for broadcast");
-    }
-    indexingMaps.push_back(AffineMap::get(
-        /*dimCount=*/resultRank, /*symbolCount=*/0, exprs, b.getContext()));
-  }
-
-  SmallVector<StringRef> iteratorTypes(resultRank,
-                                       getParallelIteratorTypeName());
-  // Add the indexing map for the outs init tensor.
-  indexingMaps.push_back(b.getMultiDimIdentityMap(resultRank));
-
-  Value initTensor = b.create<linalg::InitTensorOp>(
-      loc, getAsOpFoldResult(resultShape), resultElementType);
-  return b
-      .create<linalg::GenericOp>(loc,
-                                 /*resultTensorTypes=*/initTensor.getType(),
-                                 /*inputs=*/tensorOperands,
-                                 /*outputs=*/initTensor, indexingMaps,
-                                 iteratorTypes, bodyBuild)
-      .getResult(0);
-}
-
 template <arith::CmpFPredicate fpred, arith::CmpIPredicate iupred,
           arith::CmpIPredicate ispred>
 static Value createComparisonTemplate(OpBuilder &b, Location loc, Type type,
@@ -964,7 +857,7 @@ public:
                           ->convertType(op->getResult(0).getType())
                           .cast<RankedTensorType>();
     bool hadErrorCreatingPayload = false;
-    Value generic = createElementwiseLinalgGeneric(
+    Value generic = torch_to_linalg::createElementwiseLinalgGeneric(
         rewriter, loc, tensorOperands, resultType.getElementType(),
         [&](OpBuilder &b, Location loc, ValueRange payloadArgs) {
           Value result = createLinalgPayloadCalculationForElementwiseOp(
@@ -1031,7 +924,7 @@ public:
     Value zeroVal = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getZeroAttr(elementType));
 
-    Value finalRes = createElementwiseLinalgGeneric(
+    Value finalRes = torch_to_linalg::createElementwiseLinalgGeneric(
         rewriter, loc, {target}, elementType,
         [&](OpBuilder &b, Location loc, ValueRange args) {
           Value targetVal = args[0];
@@ -1068,8 +961,9 @@ public:
                                              /*inclusive=*/false);
       DenseSet<int64_t> dimSet(dimsToReduce.begin(), dimsToReduce.end());
 
+      auto opInfo = torch_to_linalg::ReductionOpInfo{false, finalRes, dimSet};
       finalRes = torch_to_linalg::createReductionLinalgGeneric(
-          rewriter, loc, finalRes, dimSet, /*keepDim=*/false,
+          rewriter, loc, opInfo,
           /*initElem=*/zeroVal,
           [&](OpBuilder &b, Location loc, ValueRange args) {
             Value newVal = args[0];

--- a/lib/Conversion/TorchToLinalg/Utils.cpp
+++ b/lib/Conversion/TorchToLinalg/Utils.cpp
@@ -98,23 +98,22 @@ Value torch_to_linalg::getOutputDimForConvOps(OpBuilder &b, Location loc,
 }
 
 Value torch_to_linalg::createReductionLinalgGeneric(
-    OpBuilder &b, Location loc, Value tensorOperand,
-    const DenseSet<int64_t> &dimSet, bool keepDim, Value initElem,
+    OpBuilder &b, Location loc, const ReductionOpInfo &opInfo, Value initElem,
     function_ref<void(OpBuilder &, Location, ValueRange)> bodyBuild) {
-  auto inputType = tensorOperand.getType().cast<RankedTensorType>();
+  auto inputType = opInfo.tensorOperand.getType().cast<RankedTensorType>();
 
   // Get the result shape by obtaining the size of each
   // dimension in the input tensor that is not getting reduced.
-  // If `keepDim` is true, the rank of the output tensor
+  // If `opInfo.keepDim` is true, the rank of the output tensor
   // is kept the same as the rank of the input tensor, and the
   // reduced dimensions are set to have size 1.
   auto c1 = b.create<arith::ConstantIndexOp>(loc, /*value=*/1);
   SmallVector<Value> resultShape;
   for (int64_t i = 0; i < inputType.getRank(); i++) {
-    auto currentDimSize = b.create<tensor::DimOp>(loc, tensorOperand, i);
-    if (!dimSet.contains(i))
+    auto currentDimSize = b.create<tensor::DimOp>(loc, opInfo.tensorOperand, i);
+    if (!opInfo.dimSet.contains(i))
       resultShape.push_back(currentDimSize);
-    else if (keepDim)
+    else if (opInfo.keepDim)
       resultShape.push_back(c1);
   }
 
@@ -127,11 +126,11 @@ Value torch_to_linalg::createReductionLinalgGeneric(
   for (auto size : llvm::enumerate(inputType.getShape())) {
     exprs.push_back(b.getAffineDimExpr(size.index()));
 
-    if (dimSet.contains(size.index())) {
+    if (opInfo.dimSet.contains(size.index())) {
       iteratorTypes.push_back(getReductionIteratorTypeName());
-      // If `keepDim`, create affine map to the first element
+      // If `opInfo.keepDim`, create affine map to the first element
       // in the current dimension.
-      if (keepDim)
+      if (opInfo.keepDim)
         resultExprs.push_back(b.getAffineConstantExpr(0));
     } else {
       iteratorTypes.push_back(getParallelIteratorTypeName());
@@ -146,7 +145,114 @@ Value torch_to_linalg::createReductionLinalgGeneric(
   return b
       .create<linalg::GenericOp>(
           loc, /*resultTensorTypes=*/accumulator.getType(),
-          /*inputs=*/tensorOperand,
+          /*inputs=*/opInfo.tensorOperand,
           /*outputs=*/accumulator, indexingMaps, iteratorTypes, bodyBuild)
+      .getResult(0);
+}
+
+Value torch_to_linalg::createElementwiseLinalgGeneric(
+    OpBuilder &b, Location loc, ValueRange tensorOperands,
+    Type resultElementType,
+    function_ref<void(OpBuilder &, Location, ValueRange)> bodyBuild) {
+  // The overall error handling strategy here is best viewed by thinking about
+  // what happens for a single result dimension. This loop not structured that
+  // way because it is hard to create the affine maps for each operand unless
+  // we structure the loop to iterate over tensor operands as the outer loop
+  // instead of inner loop. This pseudocode gives better intuition:
+  // ```
+  // for each result dimension:
+  //   for each tensor operand:
+  //     if it doesn't even have high enough rank relative to the result:
+  //       continue
+  //     if it is a static size-1 along this result dimension:
+  //       continue
+  //     if this is the first tensor operand that didn't continue above:
+  //       take its dimension size as the size of the non-broadcasted
+  //       traversal along this dimension (this may include a dynamic size-1,
+  //       **non-broadcasted** traversal!)
+  //     emit error check "if the size does not match the non-broadcasted
+  //     traversal size along this dimension, error"
+  // ```
+  SmallVector<int64_t> operandRanks;
+  operandRanks.resize(tensorOperands.size());
+  llvm::transform(tensorOperands, operandRanks.begin(), [](Value tensor) {
+    return tensor.getType().dyn_cast<RankedTensorType>().getRank();
+  });
+
+  auto resultRankIt =
+      std::max_element(operandRanks.begin(), operandRanks.end());
+  assert(resultRankIt != operandRanks.end() && "Unable to get result rank.");
+  int64_t resultRank = *resultRankIt;
+
+  // Initialize the resultShape to all 1's, as a fallback in case
+  // all sizes along that result dimension are statically 1.
+  auto c1 = b.create<arith::ConstantIndexOp>(loc, /*value=*/1);
+  SmallVector<Value> resultShape(resultRank, c1);
+  SmallVector<AffineMap> indexingMaps;
+  for (Value tensorOperand : tensorOperands) {
+    SmallVector<AffineExpr> exprs;
+    auto type = tensorOperand.getType().cast<RankedTensorType>();
+    for (auto size : llvm::enumerate(type.getShape())) {
+      // If the size is statically known to be 1, we don't want any
+      // error guards to be spuriously emitted, since we are specifically
+      // allowing size-1 broadcasts in this case, as they correspond to a
+      // constant-0 indexing map.
+      if (size.value() == 1) {
+        exprs.push_back(b.getAffineConstantExpr(0));
+        continue;
+      }
+
+      // The rank of this operand might be smaller than the overall rank of
+      // the broadcast. Add an offset to correlate it to the correct
+      // dimension of the result.
+      auto resultDim = size.index() + (resultRank - type.getRank());
+
+      // The generated linalg op will now be iterating along the full size
+      // of this dimension. Record that fact.
+      exprs.push_back(b.getAffineDimExpr(resultDim));
+
+      // Now, we need to ensure that such iteration is not going to trigger
+      // undefined behavior, by doing appropriate checks against the current
+      // dimension size.
+      auto currentDimSize = getDimOp(b, loc, tensorOperand, size.index());
+
+      // If the result size of this dimension has so far only hit the
+      // statically-known-to-be-1 case above (i.e., we have not yet assigned a
+      // new Value to `resultShape[resultDim]`), then we have no other dynamic
+      // values to check against, and merely need to record the current
+      // dimension size.
+      if (resultShape[resultDim] == c1) {
+        resultShape[resultDim] = currentDimSize;
+        continue;
+      }
+
+      // We prohibit the size-1 dynamic broadcasting scenario, so just check
+      // for exact equality with the running result size.
+      // This is the check which protects against the undefined behavior of
+      // the generated linalg op in the case of iterating two operands with
+      // dimensions sizes that are expected to match.
+      auto equalToRunning =
+          b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                  resultShape[resultDim], currentDimSize);
+      b.create<cf::AssertOp>(loc, equalToRunning,
+                             "mismatched size for broadcast");
+    }
+    indexingMaps.push_back(AffineMap::get(
+        /*dimCount=*/resultRank, /*symbolCount=*/0, exprs, b.getContext()));
+  }
+
+  SmallVector<StringRef> iteratorTypes(resultRank,
+                                       getParallelIteratorTypeName());
+  // Add the indexing map for the outs init tensor.
+  indexingMaps.push_back(b.getMultiDimIdentityMap(resultRank));
+
+  Value initTensor = b.create<linalg::InitTensorOp>(
+      loc, getAsOpFoldResult(resultShape), resultElementType);
+  return b
+      .create<linalg::GenericOp>(loc,
+                                 /*resultTensorTypes=*/initTensor.getType(),
+                                 /*inputs=*/tensorOperands,
+                                 /*outputs=*/initTensor, indexingMaps,
+                                 iteratorTypes, bodyBuild)
       .getResult(0);
 }

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -988,6 +988,14 @@ ChangeResult TypeAnalyzer::visitOperation(
   if (auto scalarImplicit = dyn_cast<AtenScalarImplicitOp>(op))
     return visitAtenScalarImplicitOp(scalarImplicit, operands);
 
+  if (auto vectorNorm = dyn_cast<AtenLinalgVectorNormOp>(op)) {
+    Type defaultDtype = operands[0]->getValue().dtype;
+    Type dtype = getDtypeOrDefault(vectorNorm.getContext(), vectorNorm.dtype(),
+                                   defaultDtype);
+    return visitReductionAlongDimIntListOp(
+        vectorNorm, vectorNorm.dim(), vectorNorm.keepdim(), dtype, operands);
+  }
+
   // Otherwise, this is an unknown operation. Just mark all results as
   // having reached a pessimistic fixpoint.
   return markAllPessimisticFixpoint(op->getResults());

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -3078,6 +3078,29 @@ module {
     %none = torch.constant.none
     return %none : !torch.none
   }
+  func.func @"__torch_mlir_shape_fn.aten.linalg_vector_norm"(%arg0: !torch.list<int>, %arg1: !torch.float, %arg2: !torch.optional<list<int>>, %arg3: !torch.bool, %arg4: !torch.optional<int>) -> !torch.list<int> {
+    %none = torch.constant.none
+    %true = torch.constant.bool true
+    %0 = torch.aten.__isnot__ %arg2, %none : !torch.optional<list<int>>, !torch.none -> !torch.bool
+    %1 = torch.prim.If %0 -> (!torch.list<int>) {
+      %2 = torch.prim.unchecked_cast %arg2 : !torch.optional<list<int>> -> !torch.list<int>
+      %3 = torch.derefine %arg4 : !torch.optional<int> to !torch.any
+      %4 = func.call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mean_dim(%arg0, %2, %arg3, %3) : (!torch.list<int>, !torch.list<int>, !torch.bool, !torch.any) -> !torch.list<int>
+      torch.prim.If.yield %4 : !torch.list<int>
+    } else {
+      %2 = torch.aten.len.t %arg0 : !torch.list<int> -> !torch.int
+      %3 = torch.prim.ListConstruct  : () -> !torch.list<int>
+      torch.prim.Loop %2, %true, init() {
+      ^bb0(%arg5: !torch.int):
+        %6 = torch.aten.append.t %3, %arg5 : !torch.list<int>, !torch.int -> !torch.list<int>
+        torch.prim.Loop.condition %true, iter()
+      } : (!torch.int, !torch.bool) -> ()
+      %4 = torch.derefine %arg4 : !torch.optional<int> to !torch.any
+      %5 = func.call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.upstream_shape_helpers.mean_dim(%arg0, %3, %arg3, %4) : (!torch.list<int>, !torch.list<int>, !torch.bool, !torch.any) -> !torch.list<int>
+      torch.prim.If.yield %5 : !torch.list<int>
+    }
+    return %1 : !torch.list<int>
+  }
 }
 )mlir");
 #pragma clang diagnostic pop

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -946,6 +946,11 @@ def hacky_get_unknown_dimension_size():
 def aten〇bincount(self: List[int], weights: Optional[List[int]] = None, minlength: int = 0) -> List[int]:
     return [hacky_get_unknown_dimension_size()]
 
+def aten〇linalg_vector_norm(self: List[int], ord: float = 2, dim: Optional[List[int]] = None, keepdim: bool = False, dtype: Optional[int] = None) -> List[int]:
+    if dim is None:
+        dim = list(range(len(self)))
+    return upstream_shape_helpers.mean_dim(self, dim, keepdim, dtype)
+
 # ==============================================================================
 # Shape library generator main().
 # ==============================================================================

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -365,6 +365,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::nll_loss_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)")
     emit("aten::nll_loss_backward : (Tensor, Tensor, Tensor, Tensor?, int, int, Tensor) -> (Tensor)")
     emit("aten::bincount : (Tensor, Tensor?, int) -> (Tensor)")
+    emit("aten::linalg_vector_norm : (Tensor, Scalar, int[]?, bool, int?) -> (Tensor)")
 
     # Misc tensor ops.
     emit("aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)")

--- a/python/torch_mlir_e2e_test/test_suite/reduction.py
+++ b/python/torch_mlir_e2e_test/test_suite/reduction.py
@@ -383,3 +383,111 @@ class ReduceMaxUnsignedIntModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceMaxUnsignedIntModule())
 def ReduceMaxUnsignedIntModule_basic(module, tu: TestUtils):
     module.forward(torch.randint(100, (3, 4, 5)))
+
+# ==============================================================================
+
+class ReduceL1NormModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=0, ord=1)
+
+@register_test_case(module_factory=lambda: ReduceL1NormModule())
+def ReduceL1NormModule_basic(module, tu: TestUtils):
+    module.forward(torch.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceL1NormWithDTypeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=0, ord=1, dtype=torch.float64)
+
+@register_test_case(module_factory=lambda: ReduceL1NormWithDTypeModule())
+def ReduceL1NormWithDTypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.float32))
+
+# ==============================================================================
+
+class ReduceL2NormModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=0)
+
+@register_test_case(module_factory=lambda: ReduceL2NormModule())
+def ReduceL2NormModule_basic(module, tu: TestUtils):
+    module.forward(torch.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceLN3NormModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=0, ord=-3)
+
+@register_test_case(module_factory=lambda: ReduceLN3NormModule())
+def ReduceLN3NormModule_basic(module, tu: TestUtils):
+    module.forward(torch.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceL3NormAllDimsModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=None, ord=3)
+
+@register_test_case(module_factory=lambda: ReduceL3NormAllDimsModule())
+def ReduceL3NormAllDimsModule_basic(module, tu: TestUtils):
+    module.forward(torch.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceL3NormKeepDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, keepdim=True, ord=3)
+
+@register_test_case(module_factory=lambda: ReduceL3NormKeepDimModule())
+def ReduceL3NormKeepDimModule_basic(module, tu: TestUtils):
+    module.forward(torch.rand(3, 4, 5))


### PR DESCRIPTION
This PR has five commits, the first three of which introduce non-functional changes to prepare for the actual change.  The second-to-last commit introduces a torch dialect op for the `aten.linalg.vector_norm` operation, whereas the last commit lowers the torch dialect op to linalg on tensors.