### PR TITLE
Add -s flag to run e2e tests sequentially

### DIFF
--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -56,6 +56,10 @@ torch-mlir).
 See `build_tools/torchscript_e2e_heavydep_tests/generate_serialized_tests.sh`
 for more information on building these artifacts.
 ''')
+    parser.add_argument('-s', '--sequential',
+                        default=False,
+                        action='store_true',
+                        help='run e2e tests sequentially rather than in parallel')
     return parser
 
 def main():
@@ -98,7 +102,7 @@ def main():
         sys.exit(1)
 
     # Run the tests.
-    results = run_tests(tests, config)
+    results = run_tests(tests, config, args.sequential)
 
     # Report the test results.
     failed = report_results(results, xfail_set, args.verbose)

--- a/python/torch_mlir_e2e_test/torchscript/framework.py
+++ b/python/torch_mlir_e2e_test/torchscript/framework.py
@@ -330,8 +330,10 @@ def run_workers_in_parallel(task_queue: mp.Queue, worker):
         p.join()
 
 
-def run_tests(tests: List[Test], config: TestConfig) -> List[TestResult]:
+def run_tests(tests: List[Test], config: TestConfig, sequential = False) -> List[TestResult]:
     """Invoke the given `Test`'s with the provided `TestConfig`."""
+    if sequential:
+        return [compile_and_run_test(test, config) for test in tests]
 
     # To run e2e tests in parallel:
     # The tests are put into a synchronized queue. Multiple worker processes are


### PR DESCRIPTION
A user might want to avoid the extra layer of multiprocessing libary for
debugging purpose. In such cases, the -s flag can be used to force
sequential execution.