### PR TITLE
python: [nfc] remove duplicate dialect registration

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/module_builder.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/module_builder.cpp
@@ -116,7 +116,6 @@ ModuleBuilder::ModuleBuilder(pybind11::object contextObj)
       unknownLoc(mlirLocationUnknownGet(context)) {
   // TODO: Rework this once dialect registration C-APIs are in place.
   // https://reviews.llvm.org/D88162
-  mlirRegisterAllDialects(context);
   torchMlirRegisterAllDialects(context);
 
   registerPythonSysStderrDiagnosticHandler(context);


### PR DESCRIPTION
Ever since https://reviews.llvm.org/D88155, the code for the MLIR Python
bindings registers all dialects in
`PyMlirContext::createNewContextForInit()`, so the (secondary) dialect
registration in torch-mlir's `ModuleBuilder` constructor is duplicate.
Although this did not present any major problems until now, we run into
a duplicate operation registration error after updating to the most
recent MLIR build.