### PR TITLE
torch_mlir.compile: add support for dynamic sizes.

### DIFF
--- a/python/test/compile_api/basic.py
+++ b/python/test/compile_api/basic.py
@@ -1,0 +1,53 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import torch
+
+import torch_mlir
+
+class TanhModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    def forward(self, x):
+        return torch.ops.aten.tanh(x)
+
+tanh_example_input = torch.ones(2, 3)
+
+# Simplest case: One example argument.
+print(torch_mlir.compile(TanhModule(), tanh_example_input))
+# CHECK-LABEL: @forward
+# CHECK: torch.aten.tanh %{{.*}} : !torch.vtensor<[2,3],f32> -> !torch.vtensor<[2,3],f32>
+
+# Use a TensorPlaceholder to represent dynamic axes.
+placeholder = torch_mlir.TensorPlaceholder.like(tanh_example_input, dynamic_axes=[1])
+print(torch_mlir.compile(TanhModule(), placeholder))
+# CHECK-LABEL: @forward
+# CHECK: torch.aten.tanh %{{.*}} : !torch.vtensor<[2,?],f32> -> !torch.vtensor<[2,?],f32>
+
+# Explicitly construct a TensorPlaceholder.
+placeholder = torch_mlir.TensorPlaceholder([-1, 2], torch.float32)
+print(torch_mlir.compile(TanhModule(), placeholder))
+# CHECK-LABEL: @forward
+# CHECK: torch.aten.tanh %{{.*}} : !torch.vtensor<[?,2],f32> -> !torch.vtensor<[?,2],f32>
+
+class MmModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    def forward(self, lhs, rhs  ):
+        return torch.ops.aten.mm(lhs, rhs)
+
+# N > 1 inputs.
+mm_example_inputs = [torch.ones(2, 3), torch.ones(3, 4)]
+print(torch_mlir.compile(MmModule(), mm_example_inputs))
+# CHECK-LABEL: @forward
+# CHECK: torch.aten.mm %{{.*}}, %{{.*}} : !torch.vtensor<[2,3],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor<[2,4],f32>
+
+# Mixes Tensor's and TensorPlaceholder's.
+mm_dynamic_inputs = [mm_example_inputs[0], torch_mlir.TensorPlaceholder.like(mm_example_inputs[1], dynamic_axes=[1])]
+print(torch_mlir.compile(MmModule(), mm_dynamic_inputs))
+# CHECK-LABEL: @forward
+# CHECK: torch.aten.mm %{{.*}}, %{{.*}} : !torch.vtensor<[2,3],f32>, !torch.vtensor<[3,?],f32> -> !torch.vtensor<[2,?],f32>

--- a/python/torch_mlir/__init__.py
+++ b/python/torch_mlir/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
 
-from typing import List
+from typing import Union, List
 from enum import Enum
 
 import torch
@@ -32,8 +32,59 @@ class OutputType(Enum):
     LINALG_ON_TENSORS = 2
 
 
+class TensorPlaceholder:
+    """A class that represents a formal parameter of a given shape and dtype.
+
+    This class can be constructed explicitly from a shape and dtype:
+    ```python
+    placeholder = TensorPlaceholder([3, 4], torch.float32)
+    ```
+
+    This class can also be constructed from a `torch.Tensor` which is already
+    known to be a valid input to the function. In this case, a set of
+    dynamic axes are allowed to be specified.
+    ```python
+    placeholder = TensorPlaceholder.like(torch.ones(3, 4), dynamic_axes=[1])
+    # Equivalent to `TensorPlaceholder([3, -1], torch.float32)`
+    ```
+    """
+
+    def __init__(self, shape: List[int], dtype: torch.dtype):
+        """Create a tensor with shape `shape` and dtype `dtype`.
+
+        Args:
+            shape: The shape of the tensor. A size of `-1` indicates that the
+            dimension has an unknown size.
+            dtype: The dtype of the tensor.
+        """
+        self.shape = shape
+        self.dtype = dtype
+
+    @staticmethod
+    def like(tensor: torch.Tensor, dynamic_axes: List[int] = None):
+        """Create a tensor placeholder that is like the given tensor.
+
+        Args:
+            tensor: The tensor to create a placeholder for.
+            dynamic_axes: A list of dynamic axes. If specified, the compiled
+            module will allow those axes to be any size at runtime.
+        """
+        if dynamic_axes is None:
+            dynamic_axes = []
+        shape = []
+        for i, dim in enumerate(tensor.shape):
+            if i in dynamic_axes:
+                shape.append(-1)
+            else:
+                shape.append(dim)
+        return TensorPlaceholder(shape, tensor.dtype)
+
+
+_example_arg = Union[TensorPlaceholder, torch.Tensor]
+
+
 def compile(model: torch.nn.Module,
-            example_args: List[torch.Tensor],
+            example_args: Union[_example_arg, List[_example_arg]],
             output_type: OutputType = OutputType.TORCH,
             use_tracing=False):
     """Convert a PyTorch model to MLIR.
@@ -43,11 +94,13 @@ def compile(model: torch.nn.Module,
         example_args: A list of example arguments to use when inferring the
             shapes of the arguments to `forward` method of the model.
             A single tensor is treated as a list of a single tensor.
+            A TensorPlaceholder object is also allowed in the place of any
+            Tensor.
         output_type: The kind of output to produce. See `OutputType` for more
             details.
         use_tracing: If True, use `torch.jit.trace` to convert the model to
             JIT IR rather than `torch.jit.script`.
-    
+
     Returns:
         An MLIR module that contains the converted model in the specified
         output type.
@@ -55,22 +108,30 @@ def compile(model: torch.nn.Module,
 
     # TODO: Don't hardcode "forward". See `torch.onnx.export` and
     # `torch.jit.trace_module` for API inspiration.
-    # TODO: Support dynamic dimension sizes. See `torch.onnx.export`'s
-    # `dynamic_axes` for API inspiration, or do something more ergonomic
-    # like a tensor wrapper possibly.
     if use_tracing:
         scripted = torch.jit.trace(model, tuple(example_args))
     else:
         scripted = torch.jit.script(model)
 
-    if isinstance(example_args, torch.Tensor):
+    # Special case -- many models have just one input, so canonicalize a single
+    # tensor to a list of a single tensor to make the API more ergonomic.
+    if not isinstance(example_args, list):
         example_args = [example_args]
+
+    # Convert all concrete inputs to TensorPlaceholder's, for consistency.
+    arg_placeholders = []
+    for arg in example_args:
+        if isinstance(arg, TensorPlaceholder):
+            arg_placeholders.append(arg)
+        else:
+            assert isinstance(arg, torch.Tensor)
+            arg_placeholders.append(TensorPlaceholder.like(arg))
 
     class_annotator = ClassAnnotator()
     forward_annotation = [None]
-    for arg in example_args:
+    for arg in arg_placeholders:
         # Assume that all tensors have value semantics for now.
-        forward_annotation.append((list(arg.shape), arg.dtype, True))
+        forward_annotation.append((arg.shape, arg.dtype, True))
     class_annotator.exportNone(scripted._c._type())
     class_annotator.exportPath(scripted._c._type(), ["forward"])
     class_annotator.annotateArgs(


### PR DESCRIPTION
We do this by inroducing a TensorPlaceholder class, which can be used to
specify dynamic sizes. Internally, we canonicalize all example inputs
to TensorPlaceholder's.

This commit also adds some basic testing, which was missing before.

Fixes https://github.com/llvm/torch-mlir/issues/854