### PR TITLE
[TORCH] Add decomposition of `aten.linear` op

### DIFF
--- a/python/torch_mlir/__init__.py
+++ b/python/torch_mlir/__init__.py
@@ -126,7 +126,7 @@ class TensorPlaceholder:
 # ops in the backend contract, and move these lists somewhere deeper in the
 # compiler where each backend can "own" its set of legal ops.
 BACKEND_LEGAL_OPS = {
-    OutputType.TOSA: ['torch.aten.flatten.using_ints','torch.aten.native_layer_norm'],
+    OutputType.TOSA: ['torch.aten.flatten.using_ints','torch.aten.native_layer_norm','torch.aten.linear'],
     OutputType.LINALG_ON_TENSORS: ['torch.aten.flatten.using_ints',],
     OutputType.MHLO: [],
 }


### PR DESCRIPTION
This commit adds decomposition of `aten.linear` op.

TODO: remove existing implementation and add a simple test case. Also handle the (3D,2D) case of matmul.

Signed-Off-by: Gaurav Shukla