### PR TITLE
build: fix code so that the compiler does not emit warnings

### DIFF
--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorOps.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorOps.cpp
@@ -403,6 +403,7 @@ bool ScatterOp::payloadUsesValueFromOperand(OpOperand *opOperand) {
     bbArgNumber = 0; // block arg 0 is `update`.
   else {
     bool isValidOperand = operand == indices() || operand == original();
+    (void)isValidOperand;
     assert(isValidOperand &&
            "operand must belong to the current tm_tensor.scatter op");
     return true;

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -47,7 +47,7 @@ static Value createComparisonTemplate(OpBuilder &b, Location loc, Type type,
     if (intType.isSigned())
       return b.create<arith::CmpIOp>(loc, ispred, lhs, rhs);
   }
-  assert(false && "Unhandled element type for comparison");
+  llvm_unreachable("Unhandled element type for comparison");
 }
 
 static Value createGreaterThan(OpBuilder &b, Location loc, Type elementalType,

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -115,6 +115,7 @@ static torch_upstream::TypeKind getTypeKind(Type type) {
 /// types.
 static Optional<Type> meetElementTypes(Type lhs, Type rhs) {
   auto isNullOrBuiltIn = [](Type type) { return !type || isBuiltInType(type); };
+  (void)isNullOrBuiltIn;
   assert(isNullOrBuiltIn(lhs) && "`lhs` must be a builtin type");
   assert(isNullOrBuiltIn(rhs) && "`rhs` must be a builtin type");
 
@@ -173,6 +174,7 @@ struct ValueKnowledge {
 
   void setScalarType(Type type) {
     bool isValidScalarType = type.isa<NumberType, IntType, Torch::FloatType>();
+    (void)isValidScalarType;
     assert(isValidScalarType &&
            "scalarType can only be one of NumberType, IntType and FloatType");
     scalarType = type;


### PR DESCRIPTION
When compiling without assertions (i.e. in `NDEBUG` mode), a handful of
statements turn to NOPs, which results in warnings such as missing
return statement or unused variables and function.  This patch replaces
such statements with `llvm_unreachable()`, which informs the compiler
about program termination regardless of the `NDEBUG` mode.  This also
enables torch-mlir to be compiled using the flags `-Wall`, `-Wextra`,
`-Wpedantic`, and `-Werror`.