### PR TITLE
Support pytorch extensions

### DIFF
--- a/build_tools/update_shape_lib.sh
+++ b/build_tools/update_shape_lib.sh
@@ -1,13 +1,31 @@
 #!/bin/bash
 # Updates auto-generated shape library files for the `torch` dialect.
-set -e
+#
+# Environment variables:
+#   TORCH_MLIR_EXT_MODULES: comma-separated list of python module names
+#     which register custom PyTorch operators upon being imported.
+#   TORCH_MLIR_EXT_PYTHONPATH: colon-separated list of paths necessary
+#     for importing PyTorch extensions specified in TORCH_MLIR_EXT_MODULES.
+# For more information on supporting custom operators, see:
+#   ${TORCH_MLIR}/python/torch_mlir/_torch_mlir_custom_op_example/README.md
+
+set -eo pipefail
 
 src_dir="$(realpath $(dirname $0)/..)"
 build_dir="$(realpath "${TORCH_MLIR_BUILD_DIR:-$src_dir/build}")"
 torch_transforms_cpp_dir="${src_dir}/lib/Dialect/Torch/Transforms"
 python_packages_dir="${build_dir}/tools/torch-mlir/python_packages"
 
-#ninja -C "${build_dir}"
-PYTHONPATH="${python_packages_dir}/torch_mlir" python \
+pypath="${python_packages_dir}/torch_mlir"
+if [ ! -z ${TORCH_MLIR_EXT_PYTHONPATH} ]; then
+  pypath="${pypath}:${TORCH_MLIR_EXT_PYTHONPATH}"
+fi
+ext_module="torch_mlir._torch_mlir_custom_op_example"
+if [ ! -z ${TORCH_MLIR_EXT_MODULES} ]; then
+  ext_module="${ext_module},${TORCH_MLIR_EXT_MODULES} "
+fi
+
+PYTHONPATH="${pypath}" python \
   -m torch_mlir.dialects.torch.importer.jit_ir.build_tools.shape_lib_gen \
+  --pytorch_op_extensions=${ext_module} \
   --torch_transforms_cpp_dir="${torch_transforms_cpp_dir}"

--- a/build_tools/update_torch_ods.sh
+++ b/build_tools/update_torch_ods.sh
@@ -1,14 +1,32 @@
 #!/bin/bash
 # Updates auto-generated ODS files for the `torch` dialect.
-set -euo pipefail
+#
+# Environment variables:
+#   TORCH_MLIR_EXT_MODULES: comma-separated list of python module names
+#     which register custom PyTorch operators upon being imported.
+#   TORCH_MLIR_EXT_PYTHONPATH: colon-separated list of paths necessary
+#     for importing PyTorch extensions specified in TORCH_MLIR_EXT_MODULES.
+# For more information on supporting custom operators, see:
+#   ${TORCH_MLIR}/python/torch_mlir/_torch_mlir_custom_op_example/README.md
+
+set -eo pipefail
 
 src_dir="$(realpath $(dirname $0)/..)"
 build_dir="$(realpath "${TORCH_MLIR_BUILD_DIR:-$src_dir/build}")"
 torch_ir_include_dir="${src_dir}/include/torch-mlir/Dialect/Torch/IR"
 python_packages_dir="${build_dir}/tools/torch-mlir/python_packages"
 
-#ninja -C "${build_dir}"
-PYTHONPATH="${python_packages_dir}/torch_mlir" python \
+pypath="${python_packages_dir}/torch_mlir"
+if [ ! -z ${TORCH_MLIR_EXT_PYTHONPATH} ]; then
+  pypath="${pypath}:${TORCH_MLIR_EXT_PYTHONPATH}"
+fi
+ext_module="torch_mlir._torch_mlir_custom_op_example"
+if [ ! -z ${TORCH_MLIR_EXT_MODULES} ]; then
+  ext_module="${ext_module},${TORCH_MLIR_EXT_MODULES}"
+fi
+
+PYTHONPATH="${pypath}" python \
   -m torch_mlir.dialects.torch.importer.jit_ir.build_tools.torch_ods_gen \
   --torch_ir_include_dir="${torch_ir_include_dir}" \
+  --pytorch_op_extensions="${ext_module}" \
   --debug_registry_dump="${torch_ir_include_dir}/JITOperatorRegistryDump.txt"

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -8292,3 +8292,26 @@ def Torch_QuantizedLinearOp : Torch_Op<"quantized.linear", [
   }];
 }
 
+def Torch_TorchMlirCustomOpExampleIdentityOp : Torch_Op<"_torch_mlir_custom_op_example.identity", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `_torch_mlir_custom_op_example::identity : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$t
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult TorchMlirCustomOpExampleIdentityOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 1, 1);
+    }
+    void TorchMlirCustomOpExampleIdentityOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 1, 1);
+    }
+  }];
+}
+

--- a/lib/Conversion/TorchToLinalg/CMakeLists.txt
+++ b/lib/Conversion/TorchToLinalg/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_conversion_library(TorchMLIRTorchToLinalg
+  CustomOpExample.cpp
   DataMovement.cpp
   IndirectDataMovement.cpp
   Linear.cpp

--- a/lib/Conversion/TorchToLinalg/CustomOpExample.cpp
+++ b/lib/Conversion/TorchToLinalg/CustomOpExample.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
+
+#include "../PassDetail.h"
+#include "PopulatePatterns.h"
+#include "Utils.h"
+#include "mlir/IR/Matchers.h"
+#include "torch-mlir/Conversion/Utils/Utils.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+namespace {
+class ConvertCustomOpExample
+  : public OpConversionPattern<TorchMlirCustomOpExampleIdentityOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(TorchMlirCustomOpExampleIdentityOp op,
+                                OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter
+                                ) const override {
+    // Type checks.
+    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+      return failure();
+    // Since the example op does nothing, we simply replace the uses of the
+    // return value with its argument, then remove the op.
+    rewriter.replaceOp(op, op->getOperands());
+
+    return success();
+  }
+};
+} // namespace
+
+void mlir::torch::torch_to_linalg::populateCustomOpExamplePatternsAndLegality(
+    TypeConverter &typeConverter,
+    RewritePatternSet &patterns,
+    ConversionTarget &target) {
+  MLIRContext *context = patterns.getContext();
+  target.addIllegalOp<TorchMlirCustomOpExampleIdentityOp>();
+  patterns.add<ConvertCustomOpExample>(typeConverter, context);
+}

--- a/lib/Conversion/TorchToLinalg/PopulatePatterns.h
+++ b/lib/Conversion/TorchToLinalg/PopulatePatterns.h
@@ -63,6 +63,9 @@ void populateIndirectDataMovementPatternsAndLegality(
 void populateTensorConstructorsPatternsAndLegality(TypeConverter &typeConverter,
                                                    RewritePatternSet &patterns,
                                                    ConversionTarget &target);
+void populateCustomOpExamplePatternsAndLegality(TypeConverter &typeConverter,
+                                                RewritePatternSet &patterns,
+                                                ConversionTarget &target);
 
 } // namespace torch_to_linalg
 } // namespace torch

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -62,6 +62,8 @@ public:
 
     RewritePatternSet patterns(context);
 
+    torch_to_linalg::populateCustomOpExamplePatternsAndLegality(
+        typeConverter, patterns, target);
     torch_to_linalg::populateTensorScalarInteropPatternsAndLegality(
         typeConverter, patterns, target);
     torch_to_linalg::populateLinearPatternsAndLegality(typeConverter, patterns,

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -642,7 +642,7 @@ ChangeResult TypeAnalyzer::visitOperation(
           AtenZero_Op, AtenIndexTensorOp, ValsemVariantAtenIndexPutImplOp,
           AtenIndexPutOp, ValsemVariantAtenCopyOp, AtenZeroFunctionalOp,
           AtenIndexPutHackedTwinOp, AtenMaskedFillScalarOp, AtenFlipOp,
-          PrimAbsScalarOp>(op)) {
+          PrimAbsScalarOp, TorchMlirCustomOpExampleIdentityOp>(op)) {
     return incorporateKnowledge(op->getResult(0), operands[0]->getValue());
   }
 

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -6508,6 +6508,10 @@ module {
     %3 = call @__torch__.torch.jit._shape_functions.mean_dim(%arg0, %1, %arg3, %2) : (!torch.list<int>, !torch.list<int>, !torch.bool, !torch.any) -> !torch.list<int>
     return %3 : !torch.list<int>
   }
+  func.func @"__torch_mlir_shape_fn._torch_mlir_custom_op_example.identity"(%arg0: !torch.list<int>) -> !torch.list<int> {
+    %0 = call @__torch__.torch.jit._shape_functions.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>
+    return %0 : !torch.list<int>
+  }
 }
 )mlir");
 #pragma clang diagnostic pop

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -72,6 +72,13 @@ endif()
 add_subdirectory(torch_mlir/eager_mode)
 
 ################################################################################
+# Custom op example
+# Required for running the update_torch_ods.sh and update_shape_lib.sh scripts.
+################################################################################
+
+add_subdirectory(torch_mlir/_torch_mlir_custom_op_example)
+
+################################################################################
 # Generate packages and shared library
 # Downstreams typically will not use these, but they are useful for local
 # testing.
@@ -117,4 +124,7 @@ if(TORCH_MLIR_ENABLE_JIT_IR_IMPORTER)
   add_dependencies(TorchMLIRPythonModules TorchMLIRE2ETestPythonModules)
 endif()
 
+add_dependencies(TorchMLIRPythonModules torch_mlir_custom_op_example)
+
 add_subdirectory(test)
+

--- a/python/torch_mlir/_torch_mlir_custom_op_example/CMakeLists.txt
+++ b/python/torch_mlir/_torch_mlir_custom_op_example/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Setup PyTorch
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../dialects/torch/importer/jit_ir/cmake/modules")
+include(TorchMLIRPyTorch)
+TorchMLIRProbeForPyTorchInstall()
+find_package(Torch 1.8 REQUIRED)
+TorchMLIRConfigurePyTorch()
+
+# Python sources
+declare_mlir_python_sources(TorchMLIRPythonSources.CustomOp
+  ROOT_DIR "${TORCH_MLIR_PYTHON_ROOT_DIR}"
+  ADD_TO_PARENT TorchMLIRPythonSources
+  SOURCES_GLOB
+    _torch_mlir_custom_op_example/__init__.py
+)
+
+# C++ extension
+include_directories(BEFORE
+  ${TORCH_INCLUDE_DIRS}
+)
+add_library(torch_mlir_custom_op_example SHARED torch_mlir_custom_op_example.cpp)
+target_link_libraries(torch_mlir_custom_op_example
+  ${TORCH_LIBRARIES}
+)
+# Because the custom op library is a bit odd, we'd like it to stay with the
+# Python component in the build directory.
+set_target_properties(torch_mlir_custom_op_example PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_torch_mlir_custom_op_example/"
+  COMPILE_FLAGS "${TORCH_CXXFLAGS}"
+)
+torch_mlir_python_target_compile_options(torch_mlir_custom_op_example)
+mlir_check_all_link_libraries(torch_mlir_custom_op_example)
+

--- a/python/torch_mlir/_torch_mlir_custom_op_example/README.md
+++ b/python/torch_mlir/_torch_mlir_custom_op_example/README.md
@@ -1,0 +1,22 @@
+# Torch-mlir custom op example
+
+This library is a stand-in for a PyTorch C++ extension (see [this PyTorch Tutorial](https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html) for more information).
+If you're reading this, you're likely looking to create or support a third-party PyTorch extension and add torch-mlir support to it.
+This isn't much different than [adding a new PyTorch op to torch-mlir](https://github.com/llvm/torch-mlir/wiki/Torch-ops-E2E-implementation).
+You'll still go through the exact same process, with just a small change:
+
+ - Before running `update_torch_ods.sh` or `update_shape_lib.sh`, you'll want to set the `TORCH_MLIR_EXT_PYTHONPATH` to point to wherever your extension lives and the `TORCH_MLIR_EXT_MODULES` to the name of the python module.
+
+For instance, let's say you've written a python package called `my_torch_ops`.
+If `my_torch_ops` lives in `/example/subdirectory/`, then you'll want to set `TORCH_MLIR_EXT_PYTHONPATH=/example/subdirectory` and `TORCH_MLIR_EXT_MODULES=my_torch_ops`.
+If you've installed your package (with `pip`, for instance), then you'll only need to set `TORCH_MLIR_EXT_MODULES=my_torch_ops`.
+Note that the `update_torch_ods.sh` and `update_shape_lib.sh` scripts do not use the `PYTHONPATH` environment variable in your current shell.
+This is on purpose, but it means that you either need to set `TORCH_MLIR_EXT_PYTHONPATH` to include your package or to include the paths set in your shell's `PYTHONPATH` variable.
+If you have more than one PyTorch extension, you can add them all by including each path in `TORCH_MLIR_EXT_PYTHONPATH` separated by colons (`:`) and each module in `TORCH_MLIR_EXT_MODULES` separated by commas (`,`).
+
+**It is important that your custom ops are registered with PyTorch as a side-effect of importing your extension.**
+(The `__init__.py` file in this directory is an example of how to do this.)
+
+Also, while this example library is a component of torch-mlir, in general this is not necessary or desirable.
+As long as your new ops are registered with PyTorch as a side effect of loading your Python module, then it can reside anywhere and doesn't really even need to be written to know about torch-mlir at all.
+Torch-mlir itself must be statically modified to support your ops using the normal process, but that support won't negatively affect torch-mlir users who do not use your extension.

--- a/python/torch_mlir/_torch_mlir_custom_op_example/__init__.py
+++ b/python/torch_mlir/_torch_mlir_custom_op_example/__init__.py
@@ -1,0 +1,8 @@
+import os
+import torch
+
+# Register _torch_mlir_custom_op_example.identity as a side-effect of importing.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+lib = os.path.join(*[current_dir, 'libtorch_mlir_custom_op_example.so'])
+torch.ops.load_library(lib)
+

--- a/python/torch_mlir/_torch_mlir_custom_op_example/torch_mlir_custom_op_example.cpp
+++ b/python/torch_mlir/_torch_mlir_custom_op_example/torch_mlir_custom_op_example.cpp
@@ -1,0 +1,14 @@
+// For writing an extension like this one, see:
+// https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html
+
+#include <torch/script.h> // One-stop header for PyTorch
+
+torch::Tensor identity(torch::Tensor t) {
+  // Do literally nothing.
+  return t;
+}
+
+TORCH_LIBRARY(_torch_mlir_custom_op_example, m) {
+  m.def("identity(Tensor t) -> Tensor");
+  m.impl("identity", &identity);
+}

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/registry.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/registry.py
@@ -138,6 +138,8 @@ class JitOperator:
                 op_class_name_atoms.append(s if s else "_")
         cpp_class_name = "".join(
             uppercase_first_letter(s) for s in op_class_name_atoms) + "Op"
+        # Disallow leading underscores in C++ to avoid illegal names.
+        cpp_class_name = cpp_class_name.lstrip("_")
         return op_name, cpp_class_name
 
     def get_shape_function_signature(self):

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -8,6 +8,7 @@
 from typing import List, Optional, TextIO
 
 import argparse
+import importlib
 import logging
 import os
 import sys
@@ -61,11 +62,18 @@ def get_ods_type(type: str):
     return ods_type
 
 
+def _name_thunk() -> None:
+  # Strictly exists for _get_main_module_name to harvest its __module__.
+  pass
 def _get_main_module_name() -> str:
-    # pytype: disable=attribute-error
-    return sys.modules["__main__"].__loader__.name
-    # pytype: enable=attribute-error
-
+    # If a Python module is loaded interactively or as part of a module
+    # directory, it uses a BuiltinImporter. If loaded from a file, it uses
+    # the SourceFileLoader. These two objects have different attributes.
+    loader = sys.modules["__main__"].__loader__
+    try:
+        return loader.name # pytype: disable=attribute-error
+    except AttributeError:
+        return _name_thunk.__module__
 
 ODS_BANNER = f"""//===-------------------------------------------------------*- tablegen -*-===//
 //
@@ -581,13 +589,31 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
         "quantized::linear : (Tensor, __torch__.torch.classes.quantized.LinearPackedParamsBase, float, int) -> (Tensor)",
         traits=["HasValueSemantics"])
 
+    # ==========================================================================
+    # `_torch_mlir_custom_op_example::` namespace.
+    #
+    # This is a demonstration of supporting an operation defined in a PyTorch
+    # extension.
+    # ==========================================================================
+
+    emit("_torch_mlir_custom_op_example::identity : (Tensor) -> (Tensor)")
+
 
 def dump_registered_ops(outfile: TextIO, registry: Registry):
     for _, v in sorted(registry.by_unique_key.items()):
         outfile.write(repr(v))
 
+def _maybe_import_op_extensions(args: argparse.Namespace):
+    extension_string = str.strip(args.pytorch_op_extensions)
+    if len(extension_string) > 0:
+        extension_names = extension_string.split(",")
+        for name in extension_names:
+            # Registration of new PyTorch ops should be a side-effect of
+            # importing these modules, so we don't need the return value.
+            importlib.import_module(name)
 
 def main(args: argparse.Namespace):
+    _maybe_import_op_extensions(args)
     registry = Registry.load()
     if args.debug_registry_dump:
         with open(args.debug_registry_dump, "w") as debug_registry_dump:
@@ -608,6 +634,11 @@ def _create_argparse() -> argparse.ArgumentParser:
     parser.add_argument(
         "--debug_registry_dump",
         help="File to dump the the PyTorch JIT operator registry into")
+    parser.add_argument(
+        "--pytorch_op_extensions",
+        type=str,
+        default="",
+        help="An optional, comma-separated list of Python modules which register additional PyTorch operators upon being imported. These modules can be used to build a torch-mlir which supports PyTorch extensions.")
     return parser
 
 

--- a/python/torch_mlir_e2e_test/test_suite/__init__.py
+++ b/python/torch_mlir_e2e_test/test_suite/__init__.py
@@ -53,3 +53,4 @@ def register_all_tests():
     from . import return_types
     from . import control_flow
     from . import stats
+    from . import custom_op_example

--- a/python/torch_mlir_e2e_test/test_suite/custom_op_example.py
+++ b/python/torch_mlir_e2e_test/test_suite/custom_op_example.py
@@ -1,0 +1,36 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+# Custom operators must be registered with PyTorch before being used.
+# This is part of the test.
+# Note that once this library has been loaded, the side effects mutate
+# the PyTorch op registry permanently.
+import torch_mlir._torch_mlir_custom_op_example
+
+class CustomOpExampleModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.ops._torch_mlir_custom_op_example.identity(a)
+
+
+@register_test_case(module_factory=lambda: CustomOpExampleModule())
+def CustomOpExampleModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+


### PR DESCRIPTION
PyTorch allows new operators to be registered dynamically in modules. Torch-mlir already makes it fairly straightforward to add support for new operators, and this commit just extends that support to allow new PyTorch ops to come from an external module.

Previously, there was no hook to allow extensions to be loaded before querying the op registry, so extension ops would never be generated. Moreover, a bug caused ops imported from an extension to be impossible to support via shape inference.

This does *not* allow ops to be dynamically loaded into torch-mlir. Torch-mlir must still be compiled with support built-in.

This should make tasks like [this one](https://github.com/llvm/torch-mlir/issues/462#issuecomment-989036106) in #462 (and to a lesser extent #504) somewhat easier.