### PR TITLE
Update debug options in compilation errors

### DIFF
--- a/python/torch_mlir/compiler_utils.py
+++ b/python/torch_mlir/compiler_utils.py
@@ -45,7 +45,7 @@ def run_pipeline_with_repro_report(module,
         filename = os.path.join(tempfile.gettempdir(), module_name + ".mlir")
         with open(filename, 'w') as f:
             f.write(asm_for_error_report)
-        debug_options="-print-ir-after-all -mlir-disable-threading"
+        debug_options="-mlir-print-ir-after-all -mlir-disable-threading"
         raise Exception(f"""
 {description} failed with the following diagnostics:
 {sys.stderr.getvalue()}


### PR DESCRIPTION
The flag for printing the IR after each pass is now prefixed with
"mlir". This commit updates the flag in the error reporting for the
compiler.