### PR TITLE
Use double quotes instead of single quotes

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -219,7 +219,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
         emit_op(operator, emitter_td, **kwargs)
         ns, unqual, overload = operator.triple
         # Underscore variant of functional ops should have "functional" part removed.
-        is_functional_op = overload == 'functional'
+        is_functional_op = overload == "functional"
         emit_op(registry.get_by_triple((ns, unqual + "_", overload if not is_functional_op else "")),
                 emitter_td,
                 traits=["IsTrailingUnderscoreInplaceVariant"] if not is_functional_op else [])


### PR DESCRIPTION
Oops missed some single quotes from the review comment in https://github.com/llvm/torch-mlir/pull/915, so fixing it here