### PR TITLE
Fix: 0 sizes tensor being regarded as unknown rank

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
@@ -149,8 +149,15 @@ MlirType torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
       auto shapeSymbol = symbolicShape[i];
       dims[i] = shapeSymbol.is_static() ? shapeSymbol.static_size() : -1;
     }
+
+    // `std::vector`'s `.data()` method can return nullptr when the
+    // size is 0. This triggers the "nothing known about sizes" case in
+    // the C API constructor, when we want the "we know we have 0 sizes"
+    // case. So use a dummy data pointer.
+    int64_t dummy;
+    int64_t *dimsData = dims.size() == 0 ? &dummy : dims.data();
     return torchMlirTorchNonValueTensorTypeGet(context, dims.size(),
-                                               /*optionalSizes=*/dims.data(),
+                                               /*optionalSizes=*/dimsData,
                                                /*optionalDtype=*/
                                                elementType);
   }


### PR DESCRIPTION
Input TorchScript graph:
```
graph(%x.1_ : Float(requires_grad=0, device=cuda:0)):
  %1 : int[] = prim::Constant[value=[2, 3, 224, 1]]()
  %2 : bool = prim::Constant[value=0]() # :0:0
  %3 : Float(2, 3, 224, 1, strides=[0, 0, 0, 0], requires_grad=0, device=cuda:0) = aten::expand(%x.1_, %1, %2) # test_broadcast.py:36:19
  return (%3)
```

I want to get the following torch dialect module being imported, with the `%arg0` static cast to `!torch.tensor<[], f32>`:
```
module {
  func @main(%arg0: !torch.tensor) -> !torch.tensor {
    %0 = torch.tensor_static_info_cast %arg0 : !torch.tensor to !torch.tensor<[],f32>
    %int2 = torch.constant.int 2
    %int3 = torch.constant.int 3
    %int224 = torch.constant.int 224
    %int1 = torch.constant.int 1
    %1 = torch.prim.ListConstruct %int2, %int3, %int224, %int1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
    %false = torch.constant.bool false
    %2 = torch.aten.expand %0, %1, %false : !torch.tensor<[],f32>, !torch.list<int>, !torch.bool -> !torch.tensor<[2,3,224,1],f32>
    %3 = torch.tensor_static_info_cast %2 : !torch.tensor<[2,3,224,1],f32> to !torch.tensor
    return %3 : !torch.tensor
  }
}
```

But I will get the following without the fix, which means the `%arg0`'s rank is unknown:
```
module {
  func @main(%arg0: !torch.tensor) -> !torch.tensor {
    %0 = torch.tensor_static_info_cast %arg0 : !torch.tensor to !torch.tensor<*,f32>
   ...
```

Indeed the fix is copied from the code line: https://github.com/llvm/torch-mlir/blob/main/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.cpp#L532