### PR TITLE
Revert requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/nightly/cpu
+-f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 --pre
 torch
 


### PR DESCRIPTION
https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html

is going to be deprecated via pip 22 since it is not html5.