### PR TITLE
Add CustomOpExample.cpp to bazel target TorchMLIRTorchToLinalg

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -344,6 +344,7 @@ cc_library(
 cc_library(
     name = "TorchMLIRTorchToLinalg",
     srcs = [
+        "lib/Conversion/TorchToLinalg/CustomOpExample.cpp",
         "lib/Conversion/TorchToLinalg/DataMovement.cpp",
         "lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp",
         "lib/Conversion/TorchToLinalg/Linear.cpp",


### PR DESCRIPTION
fix undefined symbol:
_ZN4mlir5torch15torch_to_linalg42populateCustomOpExamplePatternsAndLegalityERNS_13TypeConverterERNS_17RewritePatternSetERNS_16ConversionTargetE
