### PR TITLE
Only import the LTC backend that's used in example models

### DIFF
--- a/examples/ltc_backend_bert.py
+++ b/examples/ltc_backend_bert.py
@@ -17,11 +17,9 @@ import argparse
 import sys
 from typing import List
 
-import ltc_backend.ltc_backend._EXAMPLE_MLIR_BACKEND as ltc_backend
 import torch
 import torch._C
 import torch._lazy
-import torch._lazy.ts_backend
 from datasets import load_dataset
 from datasets.dataset_dict import DatasetDict
 from torch.utils.data import DataLoader
@@ -146,9 +144,11 @@ if __name__ == "__main__":
 
     if args.device in ("TS", "MLIR_EXAMPLE"):
         if args.device == "TS":
+            import torch._lazy.ts_backend
             torch._lazy.ts_backend.init()
 
         elif args.device == "MLIR_EXAMPLE":
+            import ltc_backend.ltc_backend._EXAMPLE_MLIR_BACKEND as ltc_backend
             ltc_backend._initialize()
 
         device = "lazy"

--- a/examples/ltc_backend_mnist.py
+++ b/examples/ltc_backend_mnist.py
@@ -8,10 +8,8 @@ Example use of the example Torch MLIR LTC backend.
 import argparse
 import sys
 
-import ltc_backend.ltc_backend._EXAMPLE_MLIR_BACKEND as ltc_backend
 import torch
 import torch._lazy
-import torch._lazy.ts_backend
 import torch.nn.functional as F
 
 
@@ -91,9 +89,11 @@ if __name__ == "__main__":
 
     if args.device in ("TS", "MLIR_EXAMPLE"):
         if args.device == "TS":
+            import torch._lazy.ts_backend
             torch._lazy.ts_backend.init()
 
         elif args.device == "MLIR_EXAMPLE":
+            import ltc_backend.ltc_backend._EXAMPLE_MLIR_BACKEND as ltc_backend
             ltc_backend._initialize()
 
         device = "lazy"


### PR DESCRIPTION
Fixing namespace resolution issue from importing both TS and MLIR libraries into example models. Now we only import the library that we're going to use, based on the user's selection of LTC backend.

cc: @ke1337 @antoniojkim @silvasean 

This PR has already been reviewed internally within Cerebras, so we will be merging immediately.