### PR TITLE
[LINALG] Add 0-rank case for `aten.permute`

### DIFF
--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -696,9 +696,12 @@ public:
     for (unsigned i = 0; i < inputRank; i++)
       swapExprs.push_back(idExprs[dimensions[i]]);
 
-    SmallVector<AffineMap> indexingMaps =
-        AffineMap::inferFromExprList({idExprs, swapExprs});
-    SmallVector<StringRef> iteratorTypes(inputRank, "parallel");
+    AffineMap inputMap = AffineMap::get(inputRank, /*symbolCount=*/0, idExprs,
+                                        op->getContext());
+    AffineMap outputMap = AffineMap::get(inputRank, /*symbolCount=*/0, swapExprs,
+                                         op->getContext());
+    SmallVector<AffineMap> indexingMaps{inputMap, outputMap};
+    SmallVector<StringRef> iteratorTypes(inputRank, getParallelIteratorTypeName());
     auto transpose = rewriter
                          .create<linalg::GenericOp>(
                              loc, outVector.getType(), inVector, outVector,

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -434,6 +434,44 @@ def PermuteModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class PermuteNegativeIndexModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([None, ([3, 4, 2], torch.float32, True)])
+    def forward(self, x):
+        return x.permute(0, -1, 1)
+
+
+@register_test_case(module_factory=lambda: PermuteNegativeIndexModule())
+def PermuteNegativeIndexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 2))
+
+
+# ==============================================================================
+
+
+class Permute0RankModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([None, ([], torch.float32, True)])
+    def forward(self, x):
+        return x.permute([])
+
+
+@register_test_case(module_factory=lambda: Permute0RankModule())
+def Permute0RankModule_basic(module, tu: TestUtils):
+    module.forward(torch.tensor(3.0))
+
+
+# ==============================================================================
+
+
 class TransposeIntNegDimsModule(torch.nn.Module):
 
     def __init__(self):
@@ -450,25 +488,6 @@ class TransposeIntNegDimsModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: TransposeIntNegDimsModule())
 def TransposeIntNegDimsModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(3, 4, 2))
-
-
-# ==============================================================================
-
-
-class PermuteNegativeIndexModule(torch.nn.Module):
-
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([None, ([3, 4, 2], torch.float32, True)])
-    def forward(self, x):
-        return x.permute(0, -1, 1)
-
-
-@register_test_case(module_factory=lambda: PermuteNegativeIndexModule())
-def PermuteNegativeIndexModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 2))
 
 


### PR DESCRIPTION
The function `AffineMap::inferFromExprList` does not work if the first
vector of expressions is empty, because it uses these expressions to
obtain the context. This prevented `aten.permute` from working for
inputs of 0-rank. This commit adds support for 0-rank inputs.