### PR TITLE
Change custom op tests to xfail.

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/__init__.py
+++ b/python/torch_mlir_e2e_test/test_suite/__init__.py
@@ -15,6 +15,7 @@ COMMON_TORCH_MLIR_LOWERING_XFAILS = {
     "ConvolutionModule1D_basic",
     "MaxPool2dWith3dInputModule_basic",
     "MaxPool2dWithIndicesWith3dInputModule_basic",
+    "CustomOpExampleModule_basic"
 }
 
 def register_all_tests():

--- a/python/torch_mlir_e2e_test/test_suite/custom_op_example.py
+++ b/python/torch_mlir_e2e_test/test_suite/custom_op_example.py
@@ -15,7 +15,12 @@ from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
 # This is part of the test.
 # Note that once this library has been loaded, the side effects mutate
 # the PyTorch op registry permanently.
-import torch_mlir._torch_mlir_custom_op_example
+try:
+  import torch_mlir._torch_mlir_custom_op_example
+except ImportError:
+  # Delay import failure. This allows us to xfail the CustomOp tests at the
+  # cost of slightly more complicated error messages later.
+  pass
 
 class CustomOpExampleModule(torch.nn.Module):
     def __init__(self):


### PR DESCRIPTION
MacOS builds are currently breaking on the custom op library, so it has
been temporarily disabled. This updates the end-to-end tests to xfail
the associated tests.