### PR TITLE
[LINALG] Lower `aten.Matmul` to `linalg.BatchMatmul`

### DIFF
--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -61,6 +61,7 @@ TOSA_PASS_SET = {
     "ElementwisePowModule_basic",
     "BmmModule_basic",
     "MmDagModule_basic",
+    "Matmul4dStatic_basic",
     "Matmul_dot",
     "Matmul_3d",
     "RsubFloatModule_basic",

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -890,90 +890,6 @@ public:
 };
 } // namespace
 
-// Broadcasts input tensor based on the broadcastToShape.
-static LogicalResult broadcastToGivenShape(Operation *op,
-                                           ConversionPatternRewriter &rewriter,
-                                           Value input,
-                                           SmallVector<Value> broadcastToShape,
-                                           Value &result) {
-  RankedTensorType inputType = input.getType().cast<RankedTensorType>();
-  ArrayRef<int64_t> inputShape = inputType.getShape();
-  if (broadcastToShape.size() < inputShape.size()) {
-    return rewriter.notifyMatchFailure(
-        op, "invalid shape: broadcastToShape size must not be smaller than the "
-            "size of the input shape");
-  }
-
-  Type elementType = inputType.getElementType();
-  Location loc = op->getLoc();
-  MLIRContext *context = op->getContext();
-  SmallVector<Value> outShape;
-
-  // Create affine map and shapes for tensor initialization.
-  SmallVector<AffineExpr> outExpr;
-  Value zero =
-      rewriter.create<arith::ConstantOp>(loc, rewriter.getI64IntegerAttr(0));
-  size_t diff = broadcastToShape.size() - inputShape.size();
-  for (size_t i = 0; i < broadcastToShape.size(); i++) {
-    Value shapeValue = broadcastToShape[i];
-    size_t j = i - diff;
-    if (i < diff) {
-      Value isValid = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::sge, shapeValue, zero);
-      rewriter.create<cf::AssertOp>(
-          loc, isValid,
-          rewriter.getStringAttr(
-              "negative values not allowed in new dimensions"));
-      outShape.push_back(castIntToIndex(rewriter, loc, shapeValue));
-      continue;
-    }
-    if (inputShape[j] == 1) {
-      // Broadcast singleton dimension
-      Value one =
-          rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
-      Value isNegative = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::slt, shapeValue, zero);
-      Value select = rewriter.create<arith::SelectOp>(
-          loc, isNegative, one, castIntToIndex(rewriter, loc, shapeValue));
-      outShape.push_back(select);
-      outExpr.push_back(mlir::getAffineConstantExpr(0, context));
-      continue;
-    }
-    // Non-broadcast case
-    Value dim = getDimOp(rewriter, loc, input, j);
-    Value isNegative = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::slt, shapeValue, zero);
-    Value isEqual = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::eq, castIndexToInt64(rewriter, loc, dim),
-        shapeValue);
-    Value isValid = rewriter.create<arith::OrIOp>(loc, isNegative, isEqual);
-    rewriter.create<cf::AssertOp>(
-        loc, isValid,
-        rewriter.getStringAttr(
-            "only broadcasting singleton dimensions supported"));
-    outShape.push_back(dim);
-    outExpr.push_back(mlir::getAffineDimExpr(i, context));
-  }
-
-  Value outTensor =
-      rewriter.create<linalg::InitTensorOp>(loc, outShape, elementType);
-
-  SmallVector<AffineMap> indexingMaps = {
-      AffineMap::get(broadcastToShape.size(), 0, outExpr, context),
-      rewriter.getMultiDimIdentityMap(broadcastToShape.size())};
-  SmallVector<StringRef> iteratorTypes(broadcastToShape.size(), "parallel");
-  result = rewriter
-               .create<linalg::GenericOp>(
-                   loc, outTensor.getType(), input, outTensor, indexingMaps,
-                   iteratorTypes,
-                   [](OpBuilder &b, Location loc, ValueRange args) {
-                     b.create<linalg::YieldOp>(loc, args[0]);
-                   })
-               .getResult(0);
-
-  return success();
-}
-
 namespace {
 class ConvertAtenBroadcastToOp : public OpConversionPattern<AtenBroadcastToOp> {
 public:
@@ -995,8 +911,8 @@ public:
         rewriter, op.getLoc(), getTypeConverter(), inShape);
 
     Value result;
-    if (failed(broadcastToGivenShape(op, rewriter, self, inShapeConverted,
-                                     result))) {
+    if (failed(torch_to_linalg::broadcastToGivenShape(
+            op, rewriter, self, inShapeConverted, result))) {
       return rewriter.notifyMatchFailure(
           op, "unable to perform broadcast operation");
     }
@@ -1060,8 +976,8 @@ public:
     for (unsigned i = 0; i < selfSizes.size(); i++)
       selfSizes[i] = castIndexToInt64(rewriter, loc, selfSizes[i]);
     Value broadcastedSrc;
-    if (failed(broadcastToGivenShape(op, rewriter, src, selfSizes,
-                                     broadcastedSrc))) {
+    if (failed(torch_to_linalg::broadcastToGivenShape(
+            op, rewriter, src, selfSizes, broadcastedSrc))) {
       return rewriter.notifyMatchFailure(
           op, "unable to perform broadcast operation");
     }

--- a/lib/Conversion/TorchToLinalg/Utils.h
+++ b/lib/Conversion/TorchToLinalg/Utils.h
@@ -54,6 +54,13 @@ Value createElementwiseLinalgGeneric(
     OpBuilder &b, Location loc, ValueRange tensorOperands,
     Type resultElementType,
     function_ref<void(OpBuilder &, Location, ValueRange)> bodyBuild);
+
+// Broadcasts input tensor based on the broadcastToShape.
+LogicalResult broadcastToGivenShape(Operation *op, PatternRewriter &rewriter,
+                                    Value input,
+                                    SmallVector<Value> broadcastToShape,
+                                    Value &result);
+
 } // namespace torch_to_linalg
 } // namespace torch
 } // namespace mlir

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -1129,8 +1129,10 @@ public:
       SmallVector<int32_t> transposedLhsDims;
 
       // Step: generate the common dim/shape information
+      bool hasDynamicDims = false;
       for (uint32_t dim = 0; dim < maxInputRank - 2; dim++) {
         bool isDynamicDim = ShapedType::isDynamic(lhsBroadcastedShape[dim]);
+        hasDynamicDims |= isDynamicDim;
         if (isDynamicDim ||
             lhsBroadcastedShape[dim] == rhsBroadcastedShape[dim]) {
           commonValue *= lhsBroadcastedShape[dim];
@@ -1138,11 +1140,13 @@ public:
         }
       }
 
+      // TODO: Handle the case when there are dynamic batch dimensions.
+      if (hasDynamicDims)
+        commonValue = ShapedType::kDynamicSize;
+
       // Step: generate the LHS squeezed dim/shape information.
-      bool hasDynamicDims = false;
       for (uint32_t dim = 0; dim < maxInputRank - 2; dim++) {
         bool isDynamicDim = ShapedType::isDynamic(lhsBroadcastedShape[dim]);
-        hasDynamicDims |= isDynamicDim;
         if (!isDynamicDim &&
             lhsBroadcastedShape[dim] != rhsBroadcastedShape[dim]) {
           lhsSqueezedValue *= lhsBroadcastedShape[dim];

--- a/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -130,3 +130,82 @@ def Matmul_4d(module, tu: TestUtils):
     module.forward(tu.rand(4, 5, 6, 7), tu.rand(4, 5, 7, 6))
     
 # ==============================================================================
+
+class Matmul4dStatic(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([4, 5, 6, 7], torch.float32, True),
+        ([4, 5, 7, 6], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: Matmul4dStatic())
+def Matmul4dStatic_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 5, 6, 7), tu.rand(4, 5, 7, 6))
+
+# ==============================================================================
+
+class MatmulStaticBroadcast(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([4, 1, 6, 7], torch.float32, True),
+        ([8, 1, 5, 7, 6], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: MatmulStaticBroadcast())
+def MatmulStaticBroadcast_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 1, 6, 7), tu.rand(8, 1, 5, 7, 6))
+
+# ==============================================================================
+
+class MatmulSingleDynamicBatchDim(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([4, -1, -1, -1], torch.float32, True),
+        ([4, -1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: MatmulSingleDynamicBatchDim())
+def MatmulSingleDynamicBatchDim_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 5, 6, 7), tu.rand(4, 5, 7, 6))
+    
+# ==============================================================================
+
+class MatmulBroadcastBatchDim(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([4, -1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: MatmulBroadcastBatchDim())
+def MatmulBroadcastBatchDim_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 5, 6, 7), tu.rand(5, 7, 6))
+    


### PR DESCRIPTION
This commit lowers `aten.matmul` to `linalg.BatchMatmul` under the
following conditions:
1. The result of matrix multiplication must have batch dimensions,
   i.e., rank greater than 2.
2. The resultant matrix must have at most 1 dynamic batch dimension.

It also handles broadcasting of batch dimensions when batch dimensions
of the matrices are broadcastable.

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>