### PR TITLE
[LINALG] Fix handling of size-1 dims in `aten.view`

### DIFF
--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -140,6 +140,7 @@ TOSA_PASS_SET = {
     "ContiguousModule_basic",
     "DropoutModule_basic",
     "ViewExpandModule_basic",
+    "ViewExpandOnesModule_basic",
     "ViewCollapseInferredDimModule_basic",
     "ViewExpandInferredDimModule_basic",
     "ViewNoChangeStaticModule_basic",

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -321,19 +321,23 @@ public:
           reassociation[collapsedDim].push_back(expandedDim++);
         } else {
           int64_t remainingSizeToExpand = collapsedShape[collapsedDim];
-          // A do-while loop is used here to handle the cases where the
-          // collapsed shape tensor has a dimension of size 1.
-          do {
-            int64_t expandedDimSize = expandedShape[expandedDim];
-            if (expandedDim >= expandedDimNext ||
-                expandedShape[expandedDim] == kUnknownSize ||
-                remainingSizeToExpand % expandedDimSize != 0) {
+          for (int64_t i = expandedDim; i < expandedDimNext; i++) {
+            int64_t expandedDimSize = expandedShape[i];
+            if (expandedDimSize == kUnknownSize) {
+              return rewriter.notifyMatchFailure(
+                  op, "expected expanded dim sizes to be known");
+            }
+            if (remainingSizeToExpand % expandedDimSize != 0) {
+              if (expandedDimSize > remainingSizeToExpand &&
+                  remainingSizeToExpand == 1)
+                break;
               return rewriter.notifyMatchFailure(
                   op, "total number of elements mismatch in the expansion");
             }
-            reassociation[collapsedDim].push_back(expandedDim++);
+
             remainingSizeToExpand /= expandedDimSize;
-          } while (remainingSizeToExpand != 1);
+            reassociation[collapsedDim].push_back(expandedDim++);
+          }
         }
       }
     }

--- a/python/torch_mlir_e2e_test/test_suite/reshape_like.py
+++ b/python/torch_mlir_e2e_test/test_suite/reshape_like.py
@@ -29,6 +29,25 @@ def ViewExpandModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class ViewExpandOnesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 3], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(1, 1, 3, 1, 1)
+
+@register_test_case(module_factory=lambda: ViewExpandOnesModule())
+def ViewExpandOnesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 3))
+
+# ==============================================================================
+
 class ViewDynamicExpandModule(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
This commit adds support for several size-1 dims in a row in an
expansion using `aten.view`.