### PR TITLE
Add bazel builds to PR tests

### DIFF
--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
In a "Lemony Snicket's A Series of Unfortunate Events" type move, I merged https://github.com/llvm/torch-mlir/pull/958 and then had to immediately submit https://github.com/llvm/torch-mlir/pull/966 as a patch because it broke [bazel build](https://github.com/llvm/torch-mlir/runs/7016365690?check_suite_focus=true), which slipped past me because it wasn't in the tests. Not sure what your guys budget is for GHA/CI but maybe bazel build should be part of the PR set too?