### PR TITLE
Missed dependency on building the TorchMLIRConversionPasses target.

### DIFF
--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -13,6 +13,8 @@ add_mlir_library(TorchMLIRConversionPasses
 
   DEPENDS
   TorchMLIRConversionPassIncGen
+  MLIRTorchOpsIncGen
+  MLIRTorchTypesIncGen
 
   LINK_COMPONENTS
   Core


### PR DESCRIPTION
I met a build error on building the TorchMLIRConversionPasses target.

The dependency of the target missed some TorchType definition.

To add these dependency to fix the build error.