### PR TITLE
Add folding for aten.len.str and E2E test

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -6560,6 +6560,30 @@ def Torch_AtenEqStrOp : Torch_Op<"aten.eq.str", [
   let hasFolder = 1;
 }
 
+def Torch_AtenLenStrOp : Torch_Op<"aten.len.str", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::len.str : (str) -> (int)`";
+  let arguments = (ins
+    Torch_StringType:$s
+  );
+  let results = (outs
+    Torch_IntType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenLenStrOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 1, 1);
+    }
+    void AtenLenStrOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 1, 1);
+    }
+  }];
+  let hasFolder = 1;
+}
+
 def Torch_AtenStrOp : Torch_Op<"aten.str", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -787,6 +787,17 @@ void AtenLenTOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 }
 
 //===----------------------------------------------------------------------===//
+// AtenLenStrOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenLenStrOp::fold(ArrayRef<Attribute> operands) {
+  if(auto stringConstruct = s().getDefiningOp<ConstantStrOp>())
+    return getI64IntegerAttr(getContext(), stringConstruct.valueAttr().getValue().size());
+
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
 // AtenAddTensorOp
 //===----------------------------------------------------------------------===//
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -493,6 +493,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     # Str ops.
     emit("aten::add.str : (str, str) -> (str)")
     emit("aten::eq.str : (str, str) -> (bool)", has_folder=True)
+    emit("aten::len.str : (str) -> (int)", has_folder=True)
     emit("aten::str : (t) -> (str)")
     emit("aten::format : (...) -> (str)")
     emit("aten::join : (str, str[]) -> (str)")

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -2016,6 +2016,28 @@ def DetachModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class LenStrModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.str = "test"
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return torch.ops.aten.len(self.str)
+
+
+@register_test_case(module_factory=lambda: LenStrModule())
+def LenStrModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+# ==============================================================================
+
+
 class ScalarImplicitFloatModule(torch.nn.Module):
 
     def __init__(self):

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -457,6 +457,24 @@ func.func @torch.aten.eq.str$same_value() -> !torch.bool {
   return %2 : !torch.bool
 }
 
+// CHECK-LABEL:   func.func @torch.aten.len.str() -> !torch.int {
+// CHECK:           %[[INT7:.*]] = torch.constant.int 7
+// CHECK:           return %[[INT7]] : !torch.int
+func.func @torch.aten.len.str() -> !torch.int {
+  %str = torch.constant.str "example"
+  %2 = torch.aten.len.str %str : !torch.str -> !torch.int
+  return %2 : !torch.int
+}
+
+// CHECK-LABEL:   func.func @torch.aten.len.str$empty() -> !torch.int {
+// CHECK:           %[[INT0:.*]] = torch.constant.int 0
+// CHECK:           return %[[INT0]] : !torch.int
+func.func @torch.aten.len.str$empty() -> !torch.int {
+  %str = torch.constant.str ""
+  %2 = torch.aten.len.str %str : !torch.str -> !torch.int
+  return %2 : !torch.int
+}
+
 // CHECK-LABEL:   func.func @torch.aten.__not__
 // CHECK:           %[[TRUE:.*]] = torch.constant.bool true
 // CHECK:           return %[[TRUE]] : !torch.bool


### PR DESCRIPTION
New contributor to torch-mlir; starting with adding support for the aten.len.str.