### PR TITLE
[LINALG] Fix shape function of index.Tensor + support N-rank inputs

### DIFF
--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -6460,9 +6460,14 @@ module {
     return %0 : !torch.list<int>
   }
   func.func @"__torch_mlir_shape_fn.aten.index.Tensor"(%arg0: !torch.list<int>, %arg1: !torch.list<optional<list<int>>>) -> !torch.list<int> {
+    %false = torch.constant.bool false
+    %int-1 = torch.constant.int -1
     %true = torch.constant.bool true
     %none = torch.constant.none
     %str = torch.constant.str "AssertionError: More indices than dimensions to index"
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int9223372036854775807 = torch.constant.int 9223372036854775807
     %0 = torch.aten.len.t %arg1 : !torch.list<optional<list<int>>> -> !torch.int
     %1 = torch.aten.len.t %arg0 : !torch.list<int> -> !torch.int
     %2 = torch.aten.le.int %0, %1 : !torch.int, !torch.int -> !torch.bool
@@ -6473,21 +6478,97 @@ module {
       torch.prim.If.yield
     }
     %3 = torch.prim.ListConstruct  : () -> !torch.list<int>
-    %4 = torch.aten.len.t %arg1 : !torch.list<optional<list<int>>> -> !torch.int
-    %5 = torch.prim.Loop %4, %true, init(%3) {
+    %4 = torch.prim.ListConstruct  : () -> !torch.list<int>
+    %5 = torch.aten.len.t %arg0 : !torch.list<int> -> !torch.int
+    %6 = torch.prim.Loop %5, %true, init(%3) {
     ^bb0(%arg2: !torch.int, %arg3: !torch.list<int>):
-      %6 = torch.aten.__getitem__.t %arg1, %arg2 : !torch.list<optional<list<int>>>, !torch.int -> !torch.optional<list<int>>
-      %7 = torch.aten.__isnot__ %6, %none : !torch.optional<list<int>>, !torch.none -> !torch.bool
-      %8 = torch.prim.If %7 -> (!torch.list<int>) {
-        %9 = torch.prim.unchecked_cast %6 : !torch.optional<list<int>> -> !torch.list<int>
-        %10 = func.call @__torch__.torch.jit._shape_functions.broadcast(%arg3, %9) : (!torch.list<int>, !torch.list<int>) -> !torch.list<int>
-        torch.prim.If.yield %10 : !torch.list<int>
-      } else {
+      %10 = torch.aten.len.t %arg1 : !torch.list<optional<list<int>>> -> !torch.int
+      %11 = torch.aten.ge.int %arg2, %10 : !torch.int, !torch.int -> !torch.bool
+      %12 = torch.prim.If %11 -> (!torch.list<int>) {
+        %13 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<int>, !torch.int -> !torch.int
+        %14 = torch.aten.append.t %4, %13 : !torch.list<int>, !torch.int -> !torch.list<int>
         torch.prim.If.yield %arg3 : !torch.list<int>
+      } else {
+        %13 = torch.aten.__getitem__.t %arg1, %arg2 : !torch.list<optional<list<int>>>, !torch.int -> !torch.optional<list<int>>
+        %14 = torch.aten.__isnot__ %13, %none : !torch.optional<list<int>>, !torch.none -> !torch.bool
+        %15 = torch.prim.If %14 -> (!torch.list<int>) {
+          %16 = torch.prim.unchecked_cast %13 : !torch.optional<list<int>> -> !torch.list<int>
+          %17 = func.call @__torch__.torch.jit._shape_functions.broadcast(%arg3, %16) : (!torch.list<int>, !torch.list<int>) -> !torch.list<int>
+          torch.prim.If.yield %17 : !torch.list<int>
+        } else {
+          %16 = torch.aten.__getitem__.t %arg0, %arg2 : !torch.list<int>, !torch.int -> !torch.int
+          %17 = torch.aten.append.t %4, %16 : !torch.list<int>, !torch.int -> !torch.list<int>
+          torch.prim.If.yield %arg3 : !torch.list<int>
+        }
+        torch.prim.If.yield %15 : !torch.list<int>
       }
-      torch.prim.Loop.condition %true, iter(%8 : !torch.list<int>)
+      torch.prim.Loop.condition %true, iter(%12 : !torch.list<int>)
     } : (!torch.int, !torch.bool, !torch.list<int>) -> !torch.list<int>
-    return %5 : !torch.list<int>
+    %7 = torch.aten.len.t %4 : !torch.list<int> -> !torch.int
+    %8 = torch.aten.eq.int %7, %int0 : !torch.int, !torch.int -> !torch.bool
+    %9 = torch.prim.If %8 -> (!torch.list<int>) {
+      torch.prim.If.yield %6 : !torch.list<int>
+    } else {
+      %10 = torch.aten.len.t %arg1 : !torch.list<optional<list<int>>> -> !torch.int
+      %11 = torch.prim.ListConstruct %int9223372036854775807, %10 : (!torch.int, !torch.int) -> !torch.list<int>
+      %12 = torch.prim.min.self_int %11 : !torch.list<int> -> !torch.int
+      %13:3 = torch.prim.Loop %12, %true, init(%true, %int-1, %int-1) {
+      ^bb0(%arg2: !torch.int, %arg3: !torch.bool, %arg4: !torch.int, %arg5: !torch.int):
+        %16 = torch.aten.__getitem__.t %arg1, %arg2 : !torch.list<optional<list<int>>>, !torch.int -> !torch.optional<list<int>>
+        %17 = torch.aten.__isnot__ %16, %none : !torch.optional<list<int>>, !torch.none -> !torch.bool
+        %18:3 = torch.prim.If %17 -> (!torch.bool, !torch.int, !torch.int) {
+          %19 = torch.aten.eq.int %arg4, %int-1 : !torch.int, !torch.int -> !torch.bool
+          %20:3 = torch.prim.If %19 -> (!torch.bool, !torch.int, !torch.int) {
+            torch.prim.If.yield %arg3, %arg2, %arg2 : !torch.bool, !torch.int, !torch.int
+          } else {
+            %21 = torch.aten.sub.int %arg2, %arg5 : !torch.int, !torch.int -> !torch.int
+            %22 = torch.aten.ne.int %21, %int1 : !torch.int, !torch.int -> !torch.bool
+            %23 = torch.prim.If %22 -> (!torch.bool) {
+              torch.prim.If.yield %false : !torch.bool
+            } else {
+              torch.prim.If.yield %arg3 : !torch.bool
+            }
+            torch.prim.If.yield %23, %arg4, %arg5 : !torch.bool, !torch.int, !torch.int
+          }
+          torch.prim.If.yield %20#0, %20#1, %20#2 : !torch.bool, !torch.int, !torch.int
+        } else {
+          torch.prim.If.yield %arg3, %arg4, %arg5 : !torch.bool, !torch.int, !torch.int
+        }
+        torch.prim.Loop.condition %true, iter(%18#0, %18#1, %18#2 : !torch.bool, !torch.int, !torch.int)
+      } : (!torch.int, !torch.bool, !torch.bool, !torch.int, !torch.int) -> (!torch.bool, !torch.int, !torch.int)
+      %14 = torch.aten.__not__ %13#0 : !torch.bool -> !torch.bool
+      %15 = torch.prim.If %14 -> (!torch.list<int>) {
+        %16 = torch.aten.add.t %6, %4 : !torch.list<int>, !torch.list<int> -> !torch.list<int>
+        torch.prim.If.yield %16 : !torch.list<int>
+      } else {
+        %16 = torch.prim.ListConstruct  : () -> !torch.list<int>
+        torch.prim.Loop %13#1, %true, init() {
+        ^bb0(%arg2: !torch.int):
+          %20 = torch.aten.__getitem__.t %4, %arg2 : !torch.list<int>, !torch.int -> !torch.int
+          %21 = torch.aten.append.t %16, %20 : !torch.list<int>, !torch.int -> !torch.list<int>
+          torch.prim.Loop.condition %true, iter()
+        } : (!torch.int, !torch.bool) -> ()
+        %17 = torch.aten.len.t %6 : !torch.list<int> -> !torch.int
+        torch.prim.Loop %17, %true, init() {
+        ^bb0(%arg2: !torch.int):
+          %20 = torch.aten.__getitem__.t %6, %arg2 : !torch.list<int>, !torch.int -> !torch.int
+          %21 = torch.aten.append.t %16, %20 : !torch.list<int>, !torch.int -> !torch.list<int>
+          torch.prim.Loop.condition %true, iter()
+        } : (!torch.int, !torch.bool) -> ()
+        %18 = torch.aten.len.t %4 : !torch.list<int> -> !torch.int
+        %19 = torch.aten.__range_length %13#1, %18, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+        torch.prim.Loop %19, %true, init() {
+        ^bb0(%arg2: !torch.int):
+          %20 = torch.aten.__derive_index %arg2, %13#1, %int1 : !torch.int, !torch.int, !torch.int -> !torch.int
+          %21 = torch.aten.__getitem__.t %4, %20 : !torch.list<int>, !torch.int -> !torch.int
+          %22 = torch.aten.append.t %16, %21 : !torch.list<int>, !torch.int -> !torch.list<int>
+          torch.prim.Loop.condition %true, iter()
+        } : (!torch.int, !torch.bool) -> ()
+        torch.prim.If.yield %16 : !torch.list<int>
+      }
+      torch.prim.If.yield %15 : !torch.list<int>
+    }
+    return %9 : !torch.list<int>
   }
   func.func @"__torch_mlir_shape_fn.aten.cat"(%arg0: !torch.list<list<int>>, %arg1: !torch.int) -> !torch.list<int> {
     %0 = call @__torch__.torch.jit._shape_functions.cat(%arg0, %arg1) : (!torch.list<list<int>>, !torch.int) -> !torch.list<int>

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -976,11 +976,14 @@ def aten〇constant_pad_nd(self: List[int], pad: List[int], value: float = 0) ->
 def aten〇pad(self: List[int], pad: List[int], mode: str = "constant", value: Optional[float] = None) -> List[int]:
     return pad_shape_fn(self, pad)
 
+# See https://numpy.org/doc/stable/user/basics.indexing.html
 @check_shape_function([
     Invocation(TensorOfShape(2), [LongTensorOfShape(4)]), # Basic case.
     Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4), LongTensorOfShape(4)]), # More dimensions.
     Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4), LongTensorOfShape(6, 4)]), # Multidimensional index tensor along a dimension.
     Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4), None]), # Explicit None value.
+    Invocation(TensorOfShape(2, 3, 4, 5), [None, LongTensorOfShape(4), LongTensorOfShape(4)]), # Indexing tensors on consecutive dimensions.
+    Invocation(TensorOfShape(2, 3, 4, 5), [None, LongTensorOfShape(4), None, LongTensorOfShape(4)]), # Indexing tensors on non-consecutive dimensions.
     Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4, 5, 6), LongTensorOfShape(1, 5, 1)]), # Broadcasting of index tensors.
     Invocation(TensorOfShape(2, 3), [LongTensorOfShape(4)]), # Fewer index tensors than dimensions.
     ErrorInvocation(TensorOfShape(2, 3), [LongTensorOfShape(4), LongTensorOfShape(4), LongTensorOfShape(4)]), # More index tensors than dimensions.
@@ -988,10 +991,44 @@ def aten〇pad(self: List[int], pad: List[int], mode: str = "constant", value: O
 def aten〇index〇Tensor(self: List[int], indices: List[Optional[List[int]]]) -> List[int]:
     assert len(indices) <= len(self), "More indices than dimensions to index"
     broadcasted_shape: List[int] = []
-    for index_tensor_shape in indices:
+    unused_dim_sizes: List[int] = []
+    for i in range(len(self)):
+        if i >= len(indices):
+            unused_dim_sizes.append(self[i])
+        else:
+            index_tensor_shape = indices[i]
+            if index_tensor_shape is not None:
+                broadcasted_shape = upstream_shape_functions.broadcast(broadcasted_shape, index_tensor_shape)
+            else:
+                unused_dim_sizes.append(self[i])
+
+    if len(unused_dim_sizes) == 0:
+        return broadcasted_shape
+
+    prev_index_tensor_location = -1
+    first_index_tensor_location = -1
+    index_tensors_are_together = True
+    for e, index_tensor_shape in enumerate(indices):
         if index_tensor_shape is not None:
-            broadcasted_shape = upstream_shape_functions.broadcast(broadcasted_shape, index_tensor_shape)
-    return broadcasted_shape
+            if first_index_tensor_location == -1:
+                first_index_tensor_location = e
+                prev_index_tensor_location = e
+            elif e - prev_index_tensor_location != 1:
+                index_tensors_are_together = False
+
+    if not index_tensors_are_together:
+        return broadcasted_shape + unused_dim_sizes
+
+    # If index tensors are all in consecutive dimensions, the broadcasted
+    # shape is inserted in the location of the consecutive index tensors.
+    result_shape: List[int] = []
+    for i in range(first_index_tensor_location):
+        result_shape.append(unused_dim_sizes[i])
+    for broadcasted_size in broadcasted_shape:
+        result_shape.append(broadcasted_size)
+    for i in range(first_index_tensor_location, len(unused_dim_sizes)):
+        result_shape.append(unused_dim_sizes[i])
+    return result_shape
 
 def aten〇cat(tensors: List[List[int]], dim: int = 0) -> List[int]:
     return upstream_shape_functions.cat(tensors, dim)

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -1528,6 +1528,29 @@ def IndexTensorModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class IndexTensorModule3dInput(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, x, index):
+        return torch.ops.aten.index(x, (index,))
+
+
+@register_test_case(module_factory=lambda: IndexTensorModule3dInput())
+def IndexTensorModule3dInput_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5, 4, 3), torch.randint(3, (2, 3)))
+
+
+# ==============================================================================
+
+
 class SquareModule(torch.nn.Module):
 
     def __init__(self):


### PR DESCRIPTION
This commit fixes the shape function for `index.Tensor`, adding
support for multiple index tensors and `None`s in the indices
list. This commit also adds support for input tensors of rank greater
than 1. The lowering for `index.Tensor` still has the the limitation
that only a single index tensor along the first dimension of the input
tensor is supported.