### PR TITLE
python: lower `prim::{Load,Store,Enter,Exit}` nodes to torch dialect

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -549,6 +549,53 @@ def Torch_PrimIfYieldOp : Torch_Op<"prim.If.yield", [
   }];
 }
 
+def Torch_PrimStoreOp : Torch_Op<"prim.Store", []> {
+  let summary = "store operation";
+  let description = [{
+    This op represents a prim::Store node in the Python object graph.
+  }];
+  let arguments = (ins StrAttr:$name, AnyTorchType:$value);
+  let assemblyFormat = [{
+    $name `,` $value attr-dict `:` qualified(type($value))
+  }];
+}
+
+def Torch_PrimLoadOp : Torch_Op<"prim.Load", []> {
+  let summary = "load operation";
+  let description = [{
+    This op represents a prim::Load node in the Python object graph.
+  }];
+  let arguments = (ins StrAttr:$name);
+  let results = (outs AnyTorchType:$result);
+  let assemblyFormat = [{
+    $name attr-dict `:` qualified(type($result))
+  }];
+}
+
+def Torch_PrimEnterOp : Torch_Op<"prim.Enter", []> {
+  let summary = "enter operation";
+  let description = [{
+    This op represents a prim::Enter node in the Python object graph.
+  }];
+  let arguments = (ins AnyTorchType:$inp);
+  let results = (outs Torch_NoneType:$result);
+  let assemblyFormat = [{
+    $inp attr-dict `:` qualified(type($inp))
+  }];
+}
+
+def Torch_PrimExitOp : Torch_Op<"prim.Exit", []> {
+  let summary = "exit operation";
+  let description = [{
+    This op represents a prim::Exit node in the Python object graph.
+  }];
+  let arguments = (ins AnyTorchType:$inp);
+  let results = (outs AnyTorchTensorType:$result);
+  let assemblyFormat = [{
+    $inp attr-dict `:` qualified(type($inp)) `->` qualified(type($result))
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Ops corresponding to prim::Constant
 //===----------------------------------------------------------------------===//

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.cpp
@@ -115,6 +115,8 @@ void NodeImporter::importNode(Node *node, MlirBlock appendToBlock) {
 
   // Builtin interpreter ops with no operator/schema.
   switch (kind) {
+  case c10::prim::Enter:
+  case c10::prim::Exit:
   case c10::prim::ListUnpack:
   case c10::prim::ListConstruct:
   case c10::prim::CreateObject: {
@@ -150,6 +152,8 @@ void NodeImporter::importNode(Node *node, MlirBlock appendToBlock) {
                             rearrangeDictConstructInputs);
     return;
   }
+  case c10::prim::Load:
+  case c10::prim::Store:
   case c10::prim::GetAttr:
   case c10::prim::SetAttr: {
     createAndMapNodeWithAttribute(

--- a/test/python/importer/jit_ir/node_import/unimplemented.py
+++ b/test/python/importer/jit_ir/node_import/unimplemented.py
@@ -1,0 +1,44 @@
+import torch
+import torch_mlir
+
+# RUN: %PYTHON %s | torch-mlir-opt | FileCheck %s
+
+class Inner(object):
+    # CHECK-LABEL: func.func private @__torch__.Inner.foo(
+    # CHECK-SAME:      %[[ARG:.*]]: !torch.nn.Module<"__torch__.Inner">) {
+    # CHECK:         torch.constant.int 42
+    # CHECK:         torch.prim.Store "cls", %[[ARG]] : !torch.nn.Module<"__torch__.Inner">
+    # CHECK:         %[[DICT:.*]] = torch.prim.DictConstruct keys() values() -> !torch.dict<str, tensor>
+    # CHECK:         torch.prim.Store "this_dict", %[[DICT]] : !torch.dict<str, tensor>
+    # CHECK:         torch.prim.Load "this_dict" : !torch.dict<str, tensor>
+    # CHECK:         torch.constant.str "key"
+    # CHECK:         return
+    # CHECK:       }
+
+    @classmethod
+    def foo(cls):
+        this_dict = {}
+        this_dict["key"] = 42
+        return this_dict
+
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.inner = Inner()
+
+    # CHECK-LABEL: func.func private @__torch__.Model.forward
+    # CHECK-SAME:      (%[[module:.*]]: !torch.nn.Module<"__torch__.Model">, %[[tensor:.*]]: !torch.tensor
+    # CHECK:         %[[object:.*]] = torch.prim.CreateObject !torch.nn.Module<"__torch__.torch.autograd.grad_mode.no_grad">
+    # CHECK:         %[[init:.*]] = torch.prim.CallMethod %1["__init__"] () : !torch.nn.Module<"__torch__.torch.autograd.grad_mode.no_grad">, () -> !torch.none
+    # CHECK:         %[[enter:.*]] = torch.prim.Enter %[[object]] : !torch.nn.Module<"__torch__.torch.autograd.grad_mode.no_grad">
+    # CHECK:         %[[exit:.*]] = torch.prim.Exit %[[object]] : !torch.nn.Module<"__torch__.torch.autograd.grad_mode.no_grad"> -> !torch.tensor
+    # CHECK:         return %[[tensor]] : !torch.tensor
+
+    def forward(self, data):
+        with torch.no_grad():
+            return data
+
+output_type = torch_mlir.OutputType.RAW
+mod = torch_mlir.compile(Model(), [torch.tensor([0, 1, 2, 3])], output_type)
+print(mod)


### PR DESCRIPTION
TorchScript nodes like `prim::Load` and `prim::Store` aren't supported
in torch-mlir because they can't be lowered to backends, but such nodes
can occur in the TorchScript IR.

This patch adds a rudimentary translation from such nodes to
corresponding ops in the Torch dialect.  Since we expected such nodes to
go away during lowering because of the SymbolDCE pass, this patch does
not add code to lower these ops beyond the Torch dialect.