### PR TITLE
fix export torch.literal on gpu

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
@@ -302,7 +302,8 @@ MlirAttribute torch_mlir::convertTensorToMlirElementsAttr(at::Tensor tensor,
   // TODO: Support bool tensors.
   // TODO: More import formats in C-API.
   auto numElements = tensor.numel();
-  auto tensorData = tensor.data_ptr();
+  auto tensor_cpu = tensor.cpu().contiguous();
+  auto tensorData = tensor_cpu.data_ptr();
   switch (tensor.scalar_type()) {
   case ScalarType::Int:
     return mlirDenseElementsAttrInt32Get(


### PR DESCRIPTION
A tensor data can't be accessed from the host side if it's allocated on CUDA memory. This PR fixes it.