### PR TITLE
Add E2E support for aten.upsample_bilinear2d.vec

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -6135,6 +6135,32 @@ def Torch_AtenBaddbmm_Op : Torch_Op<"aten.baddbmm_", [
   }];
 }
 
+def Torch_AtenUpsampleBilinear2dVecOp : Torch_Op<"aten.upsample_bilinear2d.vec", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::upsample_bilinear2d.vec : (Tensor, int[]?, bool, float[]?) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$input,
+    AnyTorchOptionalListOfTorchIntType:$output_size,
+    Torch_BoolType:$align_corners,
+    AnyTorchOptionalListOfTorchFloatType:$scale_factors
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenUpsampleBilinear2dVecOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 4, 1);
+    }
+    void AtenUpsampleBilinear2dVecOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 4, 1);
+    }
+  }];
+}
+
 def Torch_Aten__Contains__StrOp : Torch_Op<"aten.__contains__.str", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -6159,6 +6159,7 @@ def Torch_AtenUpsampleBilinear2dVecOp : Torch_Op<"aten.upsample_bilinear2d.vec",
       printDefaultTorchOp(printer, *this, 4, 1);
     }
   }];
+  let hasFolder = 1;
 }
 
 def Torch_Aten__Contains__StrOp : Torch_Op<"aten.__contains__.str", [

--- a/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
@@ -373,6 +373,7 @@ class ListOf<list<Type> allowedTypes, string descr> :
             descr, "::mlir::torch::Torch::ListType">;
 
 def AnyTorchListOfTorchBoolType : ListOf<[Torch_BoolType], "Bool list type (bool[])">;
+def AnyTorchListOfTorchFloatType : ListOf<[Torch_FloatType], "Float list type (float[])">;
 def AnyTorchListOfTorchIntType : ListOf<[Torch_IntType], "Int list type (int[])">;
 def AnyTorchListOfTorchStringType : ListOf<[Torch_StringType], "Str list type (str[])">;
 def AnyTorchListOfTensorType:
@@ -380,6 +381,7 @@ def AnyTorchListOfTensorType:
 def AnyTorchListOfOptionalTensorType :
       ListOf<[AnyTorchOptionalTensorType],
              "Any optional tensor list type (Tensor?[])">;
+def AnyTorchOptionalListOfTorchFloatType : OptionalOf<AnyTorchListOfTorchFloatType, "Optional torch float list type (float[]?)">;
 def AnyTorchOptionalListOfTorchIntType : OptionalOf<AnyTorchListOfTorchIntType, "Optional torch int list type (int[]?)">;
 
 // Note: TorchScript does not consider !torch.bool to be a Scalar.

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -556,6 +556,19 @@ OpFoldResult Aten__RangeLengthOp::fold(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// Aten__UpsampleBilinear2dVecOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenUpsampleBilinear2dVecOp::fold(ArrayRef<Attribute> operands) {
+  auto constructInput = input();
+  auto constructOutputSize = output_size();
+  auto constructAlignCorners = align_corners();
+  auto constructScaleFactors = scale_factors();
+
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
 // Aten__DeriveIndexOp
 //===----------------------------------------------------------------------===//
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -33,7 +33,9 @@ TORCH_TYPE_TO_ODS_TYPE = {
     "bool[]": "AnyTorchListOfTorchBoolType",
     "bool?": "AnyTorchOptionalBoolType",
     "float": "Torch_FloatType",
+    "float[]": "AnyTorchListOfTorchFloatType",
     "float?": "AnyTorchOptionalFloatType",
+    "float[]?": "AnyTorchOptionalListOfTorchFloatType",
     "t[]": "AnyTorchListType",
     "t": "AnyTorchType",
     "t1": "AnyTorchType",
@@ -469,6 +471,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::full : (int[], Scalar, int?, int?, Device?, bool?) -> (Tensor)")
     emit("aten::full_like : (Tensor, Scalar, int?, int?, Device?, bool?, int?) -> (Tensor)")
     emit_with_mutating_variants("aten::baddbmm : (Tensor, Tensor, Tensor, Scalar, Scalar) -> (Tensor)")
+    emit("aten::upsample_bilinear2d.vec : (Tensor, int[]?, bool, float[]?) -> (Tensor)")
 
     # Dict ops.
     emit("aten::__contains__.str : (Dict(str, t), str) -> (bool)", has_folder=True)

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -471,7 +471,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::full : (int[], Scalar, int?, int?, Device?, bool?) -> (Tensor)")
     emit("aten::full_like : (Tensor, Scalar, int?, int?, Device?, bool?, int?) -> (Tensor)")
     emit_with_mutating_variants("aten::baddbmm : (Tensor, Tensor, Tensor, Scalar, Scalar) -> (Tensor)")
-    emit("aten::upsample_bilinear2d.vec : (Tensor, int[]?, bool, float[]?) -> (Tensor)")
+    emit("aten::upsample_bilinear2d.vec : (Tensor, int[]?, bool, float[]?) -> (Tensor)", has_folder=True)
 
     # Dict ops.
     emit("aten::__contains__.str : (Dict(str, t), str) -> (bool)", has_folder=True)

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -147,13 +147,13 @@ class Upsample_Bilinear2D_Vec(torch.nn.Module):
     @export
     @annotate_args([
         None,
-        ([-1, -1], torch.float32, True),
+        ([-1, -1, -1, -1], torch.float32, True),
     ])
     def forward(self, lhs):
-        return torch.ops.aten.upsample_bilinear2d(lhs, None, True, [4.0, 4.0] )
+        return torch.ops.aten.upsample_bilinear2d(lhs, [4,4], False, None )
 @register_test_case(module_factory=lambda: Upsample_Bilinear2D_Vec())
 def Upsample_Bilinear2D_Vec_Test1(module, tu: TestUtils):
-    module.forward(tu.rand(2, 2))
+    module.forward(tu.rand(2, 1, 3, 4))
         
 
 # ==============================================================================

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -137,6 +137,23 @@ class ContainsIntListFalse(torch.nn.Module):
 @register_test_case(module_factory=lambda: ContainsIntListFalse())
 def ContainsIntList_False(module, tu: TestUtils):
     module.forward()
+
+# ==============================================================================
+
+
+class Upsample_Bilinear2D_Vec(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, lhs):
+        return torch.ops.aten.upsample_bilinear2d.vec(lhs, [1,1], True, [1.0, 1.0] )
+@register_test_case(module_factory=lambda: Upsample_Bilinear2D_Vec())
+def Upsample_Bilinear2D_Vec_Test1(module, tu: TestUtils):
+    module.forward(tu.rand(4, 4))
         
 
 # ==============================================================================

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -150,10 +150,10 @@ class Upsample_Bilinear2D_Vec(torch.nn.Module):
         ([-1, -1], torch.float32, True),
     ])
     def forward(self, lhs):
-        return torch.ops.aten.upsample_bilinear2d.vec(lhs, [1,1], True, [1.0, 1.0] )
+        return torch.ops.aten.upsample_bilinear2d(lhs, None, True, [4.0, 4.0] )
 @register_test_case(module_factory=lambda: Upsample_Bilinear2D_Vec())
 def Upsample_Bilinear2D_Vec_Test1(module, tu: TestUtils):
-    module.forward(tu.rand(4, 4))
+    module.forward(tu.rand(2, 2))
         
 
 # ==============================================================================


### PR DESCRIPTION
This is a draft that's still early in development, help would be appreciated. Currently have this error when running the test case: https://gist.github.com/JakopinA/0d3d9377c920f2cdba32465e16812626