### PR TITLE
[LINALG] Fix handling of size-1 dims in `aten.view` again.

### DIFF
--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -142,6 +142,8 @@ TOSA_PASS_SET = {
     "DropoutModule_basic",
     "ViewExpandModule_basic",
     "ViewExpandOnesModule_basic",
+    "ViewExpandOnesBeforeAndAfterModule_basic",
+    "ViewExpandOnesMiddleModule_basic",
     "ViewCollapseInferredDimModule_basic",
     "ViewExpandInferredDimModule_basic",
     "ViewNoChangeStaticModule_basic",

--- a/python/torch_mlir_e2e_test/test_suite/reshape_like.py
+++ b/python/torch_mlir_e2e_test/test_suite/reshape_like.py
@@ -36,15 +36,53 @@ class ViewExpandOnesModule(torch.nn.Module):
     @export
     @annotate_args([
         None,
+        ([1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(1, 1, 1, 1, 1)
+
+@register_test_case(module_factory=lambda: ViewExpandOnesModule())
+def ViewExpandOnesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1))
+
+# ==============================================================================
+
+class ViewExpandOnesBeforeAndAfterModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
         ([1, 3], torch.float32, True),
     ])
 
     def forward(self, a):
         return a.view(1, 1, 3, 1, 1)
 
-@register_test_case(module_factory=lambda: ViewExpandOnesModule())
-def ViewExpandOnesModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: ViewExpandOnesBeforeAndAfterModule())
+def ViewExpandOnesBeforeAndAfterModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1, 3))
+
+# ==============================================================================
+
+class ViewExpandOnesMiddleModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, 1, 2], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(3, 1, 1, 1, 1, 2)
+
+@register_test_case(module_factory=lambda: ViewExpandOnesMiddleModule())
+def ViewExpandOnesMiddleModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 1, 2))
 
 # ==============================================================================
 


### PR DESCRIPTION
A previous fix to the handling of size-1 dims in
`aten.view` (https://github.com/llvm/torch-mlir/pull/962) resulted in
the wrong grouping of dimensions when size-1 dims where between two
dims of size greater than 1. This commit fixes that.