### PR TITLE
torch: fold prim.dtype(bf16) to integer constant 15

### DIFF
--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -29,6 +29,9 @@ static int64_t getDtypeIntegerFromMlirType(Type dtype) {
   if (dtype.isa<Float32Type>())
     return 6;
 
+  if (dtype.isa<BFloat16Type>())
+    return 15;
+
   if (auto integerType = dtype.dyn_cast<IntegerType>()) {
     if (integerType.isSignedInteger(64))
       return 4;

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -884,6 +884,15 @@ func.func @torch.aten.remainder.int() -> !torch.int {
     return %ret : !torch.int
 }
 
+// CHECK-LABEL:   func.func @torch.prim.dtype$bfloat16(
+// CHECK-SAME:             %[[T:.*]]: !torch.tensor<*,bf16>) -> !torch.int {
+// CHECK:           %[[CST:.*]] = torch.constant.int 15
+// CHECK:           return %[[CST]] : !torch.int
+func.func @torch.prim.dtype$bfloat16(%t : !torch.tensor<*,bf16>) -> !torch.int {
+    %ret = torch.prim.dtype %t: !torch.tensor<*,bf16> -> !torch.int
+    return %ret : !torch.int
+}
+
 // CHECK-LABEL:   func.func @torch.prim.dtype$float(
 // CHECK-SAME:             %[[T:.*]]: !torch.tensor<*,f32>) -> !torch.int {
 // CHECK:           %[[CST:.*]] = torch.constant.int 6


### PR DESCRIPTION
A prior patch (63538de2) that added support for bfloat16 type did not
add the canonicalization pattern to fold `torch.prim.dtype` operations
on bfloat16 tensors into the integer constant 15.  This patch fixes the
problem.