### PR TITLE
Fix segfault when lowering to tosa.matmul - outputs don't need to be reshaped

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -1315,11 +1315,11 @@ public:
                 matmulLhs, matmulRhs)
             .getResult();
 
-    // Perform the reshape to output shape. This is always required unless both
-    // inputs are rank=3, in which case the tosa.matmul output itself is
+    // Perform the reshape to output shape. This is always required unless max
+    // input rank=3 and there was no broadcasting, in which case the tosa.matmul output itself is
     // correctly shaped.
     bool performOpReshape =
-        !(lhsRank == 3 && rhsRank == 3 && lhsShape[0] == rhsShape[0]);
+        !(maxInputRank == 3 && !performBatchDimBroadcast);
 
     if (performOpReshape) {
       // Since the output shape may be unknown, we construct it


### PR DESCRIPTION
Fix segfault when lowering to tosa.matmul - outputs don't need to be reshaped

TOSA Representation of PyTorch matmul (rough)​
```
a1 = reshape(a0)
b1 = reshape(b0)
a2 = broadcast(a1) (optional)
b2 = broadcast(b1) (optional)
c0 = matmul(a2, b2)
c1 = reshape(c0) (optional)
```

The problem occurs when:
 - the batch dimension of a0 is 1 
 - a0 is rank 3 & b0 is rank 2 or vice versa.
​
Example 1/ `a0: <1,6,1>, b0:<1,4>`
​
There is a segmentation fault because this kind of tensor triggers a optional reshape to the output but does not trigger the optional broadcasting. The function to create the output reshape uses variables that are initialised in the optional broadcast - thus it fails.

The solution I've implemented is to ensure that no output reshape occurs for inputs like Example 1.

**Recreate the problem**
​
```
import torch
import torch_mlir
​
class MmModule(torch.nn.Module):
​
    def __init__(self):
        super().__init__()
​
    def forward(self, lhs, rhs):
        return torch.matmul(lhs, rhs)
​
​
def test_mm_r3():
    input = ( torch.rand( 1, 6, 1 ),  torch.rand( 1, 4 ) )
    return MmModule(), input
​
def main():
    model, input = test_mm_r3()
    model.train(False)
    module = torch_mlir.compile(model, input, output_type=torch_mlir.OutputType.TOSA)
    print(module)
​
if __name__ == "__main__":
    main()
​
```
