### PR TITLE
Only set Torch_DIR when TORCH_MLIR_USE_INSTALLED_PYTORCH is off

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/CMakeLists.txt
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/CMakeLists.txt
@@ -4,12 +4,13 @@
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(TorchMLIRPyTorch)
-set(Torch_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../libtorch/share/cmake/Torch")
 
 option(TORCH_MLIR_USE_INSTALLED_PYTORCH "Build from local PyTorch in environment" ON)
 
 if(TORCH_MLIR_USE_INSTALLED_PYTORCH)
   TorchMLIRProbeForPyTorchInstall()
+else()  
+  set(Torch_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../libtorch/share/cmake/Torch")
 endif()
 
 find_package(Torch 1.11 REQUIRED)


### PR DESCRIPTION
Previously, `Torch_DIR` was set regardless of whether `TORCH_MLIR_USE_INSTALLED_PYTORCH` was on or off, which caused some linkage issues with Lazy Tensor Core. This PR modifies the build to only set this variable when `TORCH_MLIR_USE_INSTALLED_PYTORCH` is off.

cc: @antoniojkim 