### PR TITLE
torch_mlir.compile: Allow OutputType as a string.

### DIFF
--- a/examples/torchscript_resnet18.py
+++ b/examples/torchscript_resnet18.py
@@ -67,7 +67,7 @@ labels = load_labels()
 
 resnet18 = models.resnet18(pretrained=True)
 resnet18.train(False)
-module = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type=torch_mlir.OutputType.LINALG_ON_TENSORS)
+module = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type="linalg-on-tensors")
 backend = refbackend.RefBackendLinalgOnTensorsBackend()
 compiled = backend.compile(module)
 jit_module = backend.load(compiled)

--- a/examples/torchscript_resnet18_all_output_types.py
+++ b/examples/torchscript_resnet18_all_output_types.py
@@ -11,10 +11,10 @@ import torch_mlir
 resnet18 = torchvision.models.resnet18(pretrained=True)
 resnet18.eval()
 
-module = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type=torch_mlir.OutputType.TORCH)
+module = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type="torch")
 print("TORCH OutputType\n", module.operation.get_asm(large_elements_limit=10))
-module = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type=torch_mlir.OutputType.LINALG_ON_TENSORS)
+module = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type="linalg-on-tensors")
 print("LINALG_ON_TENSORS OutputType\n", module.operation.get_asm(large_elements_limit=10))
 # TODO: Debug why this is so slow.
-module = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type=torch_mlir.OutputType.TOSA)
+module = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type="tosa")
 print("TOSA OutputType\n", module.operation.get_asm(large_elements_limit=10))

--- a/examples/torchscript_resnet_inference.ipynb
+++ b/examples/torchscript_resnet_inference.ipynb
@@ -326,7 +326,7 @@
    "source": [
     "resnet18 = torchvision.models.resnet18(weights=torchvision.models.ResNet18_Weights.DEFAULT)\n",
     "resnet18.eval()\n",
-    "compiled = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type=torch_mlir.OutputType.LINALG_ON_TENSORS)\n",
+    "compiled = torch_mlir.compile(resnet18, torch.ones(1, 3, 224, 224), output_type=\"linalg-on-tensors\")\n",
     "jit_module = compile_and_load_on_refbackend(compiled)"
    ]
   },
@@ -406,7 +406,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/python/test/compile_api/output_type_spec.py
+++ b/python/test/compile_api/output_type_spec.py
@@ -1,0 +1,25 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import torch
+
+import torch_mlir
+
+class TanhModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    def forward(self, x):
+        return torch.ops.aten.tanh(x)
+
+tanh_example_input = torch.ones(2, 3)
+
+print(torch_mlir.compile(TanhModule(), tanh_example_input, output_type=torch_mlir.OutputType.TORCH))
+# CHECK-LABEL: @forward
+# CHECK: torch.aten.tanh %{{.*}} : !torch.vtensor<[2,3],f32> -> !torch.vtensor<[2,3],f32>
+print(torch_mlir.compile(TanhModule(), tanh_example_input, output_type="torch"))
+# CHECK-LABEL: @forward
+# CHECK: torch.aten.tanh %{{.*}} : !torch.vtensor<[2,3],f32> -> !torch.vtensor<[2,3],f32>


### PR DESCRIPTION
A lot of code was super verbose with `torch_mlir.OutputType.XYZ`. Now,
you can simply do `"xyz"`. I updated a few examples.