### PR TITLE
build: fix bazel build after adding VerifyConversionToValueSemantics.cpp

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -181,6 +181,7 @@ cc_library(
         "lib/Dialect/Torch/Transforms/ShapeLibrary.cpp",
         "lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp",
         "lib/Dialect/Torch/Transforms/PassDetail.h",
+        "lib/Dialect/Torch/Transforms/VerifyConversionToValueSemantics.cpp",
     ],
     hdrs = [
         "include/torch-mlir/Dialect/Torch/Transforms/Passes.h",


### PR DESCRIPTION
A previous patch added a new file
("VerifyConversionToValueSemantics.cpp") to the build, but it did not
add it to the list files known to bazel.  This patch fixes the problem.