### PR TITLE
Remove libtorch downloads

### DIFF
--- a/build_tools/build_libtorch.sh
+++ b/build_tools/build_libtorch.sh
@@ -5,8 +5,8 @@ set -xeu -o pipefail
 SRC_ROOT="$( cd "$(dirname "$0")" ; pwd -P)/.."
 PYTORCH_ROOT=${PYTORCH_ROOT:-$SRC_ROOT/externals/pytorch}
 PYTORCH_INSTALL_PATH=${PYTORCH_INSTALL_PATH:-$SRC_ROOT/libtorch}
+PYTORCH_REPO="${PYTORCH_REPO:-pytorch/pytorch}"
 PYTORCH_BRANCH="${PYTORCH_BRANCH:-master}"
-LIBTORCH_VARIANT="${LIBTORCH_VARIANT:-shared}"
 PT_C_COMPILER="${PT_C_COMPILER:-clang}"
 PT_CXX_COMPILER="${PT_CXX_COMPILER:-clang++}"
 CMAKE_OSX_ARCHITECTURES="${CMAKE_OSX_ARCHITECTURES:-arm64;x86_64}"
@@ -23,24 +23,12 @@ NC='\033[0m'
 
 echo "SRC_ROOT=${SRC_ROOT}"
 echo "PYTORCH_ROOT=${PYTORCH_ROOT}"
+echo "PYTORCH_REPO=${PYTORCH_REPO}"
 echo "PYTORCH_BRANCH=${PYTORCH_BRANCH}"
-echo "LIBTORCH_VARIANT=${LIBTORCH_VARIANT}"
-echo "LIBTORCH_SRC_BUILD=${LIBTORCH_SRC_BUILD}"
-echo "LIBTORCH_CACHE=${LIBTORCH_CACHE}"
 echo "CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}"
 export CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
 export CMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
 export CMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-
-if [[ "$LIBTORCH_VARIANT" == *"cxx11-abi"* ]]; then
-  echo _GLIBCXX_USE_CXX11_ABI=1
-  export _GLIBCXX_USE_CXX11_ABI=1
-  CXX_ABI=1
-else
-  echo _GLIBCXX_USE_CXX11_ABI=0
-  export _GLIBCXX_USE_CXX11_ABI=0
-  CXX_ABI=0
-fi
 
 retry () {
   "$@" || (sleep 1 && "$@") || (sleep 2 && "$@") || (sleep 4 && "$@") || (sleep 8 && "$@")
@@ -51,73 +39,9 @@ install_requirements() {
   ${PIP_BIN} list
 }
 
-# Check for an existing libtorch at $PYTORCH_ROOT
-check_existing_libtorch() {
-  if [[ -f "$PYTORCH_INSTALL_PATH/lib/libtorch.so" ]]; then
-    echo "Existing PYTORCH shared build found.. skipping build"
-    return 0
-  elif [[ -f "$PYTORCH_INSTALL_PATH/lib/libtorch.a" ]]; then
-    echo "Existing PYTORCH static build found.. skipping build"
-    return 0
-  elif [[ -f "$PYTORCH_INSTALL_PATH/lib/libtorch.dylib" ]]; then
-    echo "Existing PYTORCH shared dylib found.. skipping build"
-    return 0
-  fi
-  return 1
-}
-
-# Download and unzip into externals/pytorch/libtorch
-MACOS_X86_URL="https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip"
-# Download here (Pre-cxx11 ABI): https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip
-# Download here (cxx11 ABI): https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-shared-with-deps-latest.zip
-# Download static here (cxx11 ABI): https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-static-with-deps-latest.zip
-# static builds are broken upstream and ship shared libraries anyway. Hopefully we can reland the fix upstream.
-LINUX_X86_URL="https://download.pytorch.org/libtorch/nightly/cpu/libtorch-static-without-deps-latest.zip"
-
-download_libtorch() {
-  cd "$SRC_ROOT"
-  if [[ $(uname -s) = 'Darwin' ]]; then
-  echo "Apple macOS detected"
-  if [[ $(uname -m) == 'arm64' ]]; then
-    echo "${Red}Apple M1 Detected...no libtorch/ binaries available${NC}"
-    return 1
-  else
-    echo "Apple x86_64 Detected"
-    DOWNLOAD_URL=${MACOS_X86_URL}
-  fi
-elif [[ $(uname -s) = 'Linux' ]]; then
-  echo "Linux detected"
-  if [[ $(uname -m) == 'x86_64' ]]; then
-    DOWNLOAD_URL=${LINUX_X86_URL}
-  else
-    echo "${Red} Non x86_64 Linux platform detected... No libtorch/ binaries available${NC}"
-    return 1
-  fi
-else
-  echo "OS not detected. Pray and Play"
-  return 1
-fi
-  echo "Deleting any old libtorch*.."
-  rm -rf libtorch*
-  curl -O ${DOWNLOAD_URL}
-  unzip -q -o libtorch-*.zip
-  rm libtorch-*.zip
-  if [[ -f "$PYTORCH_INSTALL_PATH/lib/libtorch.so" ]]; then
-    echo "Verifying Pytorch install -- libtorch.so found"
-    return 0
-  elif [[ -f "$PYTORCH_INSTALL_PATH/lib/libtorch.a" ]]; then
-    echo "Verifying Pytorch install -- libtorch.a found"
-    return 0
-  elif [[ -f "$PYTORCH_INSTALL_PATH/lib/libtorch.dylib" ]]; then
-    echo "Verifying Pytorch install -- libtorch.dylib found"
-    return 0
-  fi
-  return 1
-}
-
 checkout_pytorch() {
   if [[ ! -d "$PYTORCH_ROOT" ]]; then
-    git clone --depth 1 --single-branch --branch "${PYTORCH_BRANCH}" https://github.com/pytorch/pytorch "$PYTORCH_ROOT"
+    git clone --depth 1 --single-branch --branch "${PYTORCH_BRANCH}" https://github.com/"$PYTORCH_REPO" "$PYTORCH_ROOT"
   fi
   cd "$PYTORCH_ROOT"
   git reset --hard HEAD
@@ -135,21 +59,6 @@ build_pytorch() {
   # ${PYTHON_BIN} setup.py clean
   rm -rf "${WHEELHOUSE:?}"/*
 
-  # Local fix for https://github.com/pytorch/pytorch/issues/81178
-  sed -i.bak -E 's/namespace ao \{/namespace ao \{\n#include <ATen\/native\/ao_sparse\/quantized\/cpu\/packed_params.h>/g' aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_deserialize.cpp
-  sed -i.bak -E 's/namespace ao \{/namespace ao \{\n#include <ATen\/native\/ao_sparse\/quantized\/cpu\/packed_params.h>/g' aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_serialize.cpp
-
-  # More flags that require interop testing
-  # USE_LIGHTWEIGHT_DISPATCH=OFF
-  # STATIC_DISPATCH_BACKEND=CPU
-  # BUILD_LITE_INTERPRETER=ON USE_LITE_INTERPRETER_PROFILER=OFF
-  # INTERN_BUILD_MOBILE=ON BUILD_CAFFE2_MOBILE=ON SELECTED_OP_LIST=
-  if [[ $LIBTORCH_VARIANT = *"static"* ]]; then
-    BUILD_SHARED_LIBS=OFF
-  else
-    BUILD_SHARED_LIBS=ON
-  fi
-
   if [[ -z "${MAX_JOBS:-""}" ]]; then
     if [[ "$(uname)" == 'Darwin' ]]; then
       MAX_JOBS=$(sysctl -n hw.ncpu)
@@ -158,13 +67,10 @@ build_pytorch() {
     fi
   fi
 
-  BUILD_CAFFE2_OPS=OFF \
-  BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} \
+  BUILD_SHARED_LIBS=ON \
   BUILD_TEST=OFF \
-  CC=${PT_C_COMPILER} \
-  CMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=${CXX_ABI}" \
+  GLIBCXX_USE_CXX11_ABI=1 \
   CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES} \
-  CXX=${PT_CXX_COMPILER} \
   INTERN_BUILD_ATEN_OPS=OFF \
   INTERN_DISABLE_ONNX=ON \
   INTERN_USE_EIGEN_BLAS=ON \
@@ -217,28 +123,10 @@ install_pytorch() {
   ${PIP_BIN} install  --force-reinstall $WHEELHOUSE/*
 }
 
-
 #main
-if [[ $LIBTORCH_SRC_BUILD = "ON" ]]; then
-  echo "Building libtorch from source"
-  checkout_pytorch
-  install_requirements
-  build_pytorch
-  package_pytorch
-  install_pytorch
-else
-  if check_existing_libtorch; then
-    echo "Found existing libtorch"
-    if [[ $LIBTORCH_CACHE = "ON" ]]; then
-      echo "${Yellow} libtorch is being cached. If you have a different PyTorch version pip installed unset LIBTORCH_CACHE ${NC}"
-    else
-      echo "${Red}Updating libtorch to the latest version. Set -DLIBTORCH_CACHE=ON to prevent autoupdating ${NC}"
-      echo "Downloading libtorch..."
-      download_libtorch
-    fi
-  else
-    echo "${Green}Installing latest version of libtorch. Set -DLIBTORCH_CACHE=ON in your next run to prevent autoupdating ${NC}"
-    echo "Downloading libtorch..."
-    download_libtorch
-  fi
-fi
+echo "Building libtorch from source"
+checkout_pytorch
+install_requirements
+build_pytorch
+package_pytorch
+install_pytorch

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -60,34 +60,23 @@ declare_mlir_python_extension(TorchMLIRPythonExtensions.Main
 # Optionally handle JIT IR importer.
 ################################################################################
 
-option(LIBTORCH_SRC_BUILD "Build libtorch from source" OFF)
-option(LIBTORCH_CACHE "Cache libtorch downloads" OFF)
-option(LIBTORCH_VARIANT "libtorch variant [shared|static]-[cxx11]" "libtorch-shared")
+option(TORCH_MLIR_USE_INSTALLED_PYTORCH "Build from local PyTorch in environment" ON)
 
 if(TORCH_MLIR_ENABLE_JIT_IR_IMPORTER)
-  # if LIBTORCH_SRC_BUILD=OFF (default) we link against a binary libtorch :
-  #   if LIBTORCH_CACHE=OFF (default) the build downloads the latest released version of libtorch
-  #   if LIBTORCH_CACHE=ON the build uses an available libtorch/ in the root directory.
-  #   In either case if there is no libtorch/ the latest released version for the platform is downloaded
-  #   A developer could unpack their own libtorch/ and it would be respected
-  # if LIBTORCH_SRC_BUILD=ON we build libtorch/pytorch and link against it
-  #   if LIBTORCH_VARIANT=*cxx11abi*  we build with the new CXX11 ABI similar to upstream pytorch/builder
-  #   if LIBTORCH_VARIANT=*shared*   (default) we build a shared library (and pytorch .whl)
-  #     else if LIBTORCH_VARIANT=*static*   we build a static libtorch
-  set(ENV{LIBTORCH_SRC_BUILD} ${LIBTORCH_SRC_BUILD})
-  set(ENV{LIBTORCH_CACHE} ${LIBTORCH_CACHE})
-  set(ENV{LIBTORCH_VARIANT} ${LIBTORCH_VARIANT})
-  set(ENV{CMAKE_OSX_ARCHITECTURES} ${CMAKE_OSX_ARCHITECTURES})
-  set(ENV{CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER_LAUNCHER})
-  set(ENV{CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER_LAUNCHER})
-  execute_process(
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../build_tools/build_libtorch.sh
-    RESULT_VARIABLE _result
-  )
-  if(_result)
-    message(FATAL_ERROR "Failed to run `build_libtorch.sh`")
+  if (NOT TORCH_MLIR_USE_INSTALLED_PYTORCH)
+    # Source builds
+    set(ENV{CMAKE_OSX_ARCHITECTURES} ${CMAKE_OSX_ARCHITECTURES})
+    set(ENV{CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER_LAUNCHER})
+    set(ENV{CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER_LAUNCHER})
+    execute_process(
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../build_tools/build_libtorch.sh
+      RESULT_VARIABLE _result
+    )
+    if(_result)
+      message(FATAL_ERROR "Failed to run `build_libtorch.sh`")
+    endif()
+    set(TORCH_INSTALL_PREFIX "libtorch")
   endif()
-  set(TORCH_INSTALL_PREFIX "libtorch")
   add_subdirectory(torch_mlir/dialects/torch/importer/jit_ir)
   add_subdirectory(torch_mlir_e2e_test)
 endif()

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/CMakeLists.txt
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/CMakeLists.txt
@@ -5,21 +5,14 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(TorchMLIRPyTorch)
 
-option(TORCH_MLIR_USE_INSTALLED_PYTORCH "Build from local PyTorch in environment" ON)
-
+TorchMLIRProbeForPyTorchInstall()
 if(TORCH_MLIR_USE_INSTALLED_PYTORCH)
-  TorchMLIRProbeForPyTorchInstall()
+  TorchMLIRConfigurePyTorch()
 else()  
   set(Torch_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../libtorch/share/cmake/Torch")
 endif()
 
 find_package(Torch 1.11 REQUIRED)
-
-if(TORCH_MLIR_USE_INSTALLED_PYTORCH)
-  TorchMLIRConfigurePyTorch()
-else()
-  TorchMLIRConfigureLibTorch()
-endif()
 
 message(STATUS "libtorch_python CXXFLAGS is ...${TORCH_CXXFLAGS}")
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Remove all the libtorch downloads. If the user sets
-DTORCH_MLIR_USE_INSTALLED_PYTORCH=OFF then just build from src.

Doesn't change developer workflow since we still default to local
PyTorch versions.

TEST: Build and verify all tests (except one xfail quant) pass on linux