### PR TITLE
[MLIR][TORCH] Add negative dim support for `aten.cat` and `aten.slice` op

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -104,7 +104,7 @@ class IsFloatingPointFloat(torch.nn.Module):
 def IsFloatingPointFloat_True(module, tu: TestUtils):
     module.forward(tu.rand(3))
 
-    	
+
 # ==============================================================================
 
 
@@ -137,7 +137,7 @@ class ContainsIntListFalse(torch.nn.Module):
 @register_test_case(module_factory=lambda: ContainsIntListFalse())
 def ContainsIntList_False(module, tu: TestUtils):
     module.forward()
-        
+
 
 # ==============================================================================
 
@@ -590,6 +590,30 @@ class TensorsConcatModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: TensorsConcatModule())
 def TensorsConcatModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 2, 4), tu.rand(2, 1, 4), tu.rand(2, 3, 4))
+
+
+# ==============================================================================
+
+
+class TensorsConcatNegativeDimModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x, y, z):
+        return torch.cat([x, y, z], dim=-2)
+
+
+@register_test_case(module_factory=lambda: TensorsConcatNegativeDimModule())
+def TensorsConcatNegativeDimModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 2, 4), tu.rand(2, 1, 4), tu.rand(2, 3, 4))
 
 

--- a/python/torch_mlir_e2e_test/test_suite/slice_like.py
+++ b/python/torch_mlir_e2e_test/test_suite/slice_like.py
@@ -46,7 +46,7 @@ class SliceOutOfUpperBoundIndexModule(torch.nn.Module):
         result =  x[:8, :5, 8:]
         cat_tensor = torch.ones((6,4,1), dtype=torch.float32)
         return torch.cat((result,cat_tensor), dim=2)
-        
+
 
 @register_test_case(module_factory=lambda: SliceOutOfUpperBoundIndexModule())
 def SliceOutOfUpperBoundIndexModule_basic(module, tu: TestUtils):
@@ -268,6 +268,31 @@ class SliceScatterZeroDimModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: SliceScatterZeroDimModule())
 def SliceScatterZeroDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(6, 8), tu.rand(1, 8))
+
+
+class SliceScatterNegativeDimModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x, src):
+        return torch.ops.aten.slice_scatter(x,
+                                            src,
+                                            dim=-2,
+                                            start=0,
+                                            end=1,
+                                            step=1)
+
+
+@register_test_case(module_factory=lambda: SliceScatterNegativeDimModule())
+def SliceScatterNegativeDimModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(6, 8), tu.rand(1, 8))
 
 class SliceScatterStepVariationModule(torch.nn.Module):


### PR DESCRIPTION
This commit adds the support for negative dim cases for `aten.cat`,
`aten.slice.Tensor` and `aten.slice_scatter` op.

Signed-Off By: Vivek Khandelwal <vivek@nod-labs.com>