### PR TITLE
bump llvm tag to 3580daa

### DIFF
--- a/include/torch-mlir-c/Dialects.h
+++ b/include/torch-mlir-c/Dialects.h
@@ -10,7 +10,7 @@
 #ifndef TORCHMLIR_C_DIALECTS_H
 #define TORCHMLIR_C_DIALECTS_H
 
-#include "mlir-c/Registration.h"
+#include "mlir-c/IR.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -110,7 +110,7 @@ set(_source_components
   # tree, which seems excessive.
   MLIRPythonSources
   MLIRPythonExtension.Core
-  MLIRPythonExtension.AllPassesRegistration
+  MLIRPythonExtension.RegisterEverything
   MLIRPythonExtension.ExecutionEngine
   TorchMLIRPythonSources
   TorchMLIRPythonExtensions

--- a/python/TorchMLIRModule.cpp
+++ b/python/TorchMLIRModule.cpp
@@ -8,7 +8,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir-c/Bindings/Python/Interop.h"
-#include "mlir-c/Registration.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "torch-mlir-c/Dialects.h"
 #include "torch-mlir-c/Registration.h"

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py
@@ -18,7 +18,6 @@ import torch.jit._shape_functions as upstream_shape_functions
 
 from torch_mlir.dialects.torch.importer.jit_ir import ModuleBuilder
 from torch_mlir.passmanager import PassManager
-import torch_mlir.all_passes_registration
 
 from .registry import Registry
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/module_builder.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/module_builder.cpp
@@ -17,7 +17,6 @@
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/Diagnostics.h"
-#include "mlir-c/Registration.h"
 #include "torch-mlir-c/Registration.h"
 
 namespace py = pybind11;

--- a/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -10,8 +10,6 @@ from torch_mlir.ir import *
 from torch_mlir.passmanager import *
 from torch_mlir.execution_engine import *
 from torch_mlir.runtime import *
-# Imported for side effects.
-import torch_mlir.all_passes_registration
 import torch_mlir.dialects.torch
 from torch_mlir.compiler_utils import run_pipeline_with_repro_report
 

--- a/python/torch_mlir_e2e_test/tosa_backends/linalg_on_tensors.py
+++ b/python/torch_mlir_e2e_test/tosa_backends/linalg_on_tensors.py
@@ -5,8 +5,6 @@
 
 from torch_mlir.ir import *
 from torch_mlir.passmanager import *
-# Imported for side effects.
-import torch_mlir.all_passes_registration
 from torch_mlir.compiler_utils import run_pipeline_with_repro_report
 
 from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import RefBackendLinalgOnTensorsBackend


### PR DESCRIPTION
This patch makes some rudimentary changes to torch-mlir's use of MLIR
Python bindings to work with the most recent LLVM code.  We can perhaps
do better by being more selective in what we link against, instead of
using `MLIRPythonExtension.RegisterEverything`.