### PR TITLE
Add verifiers for ToBuiltinTensorOp and FromBuiltinTensorOp

### DIFF
--- a/include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.td
+++ b/include/torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.td
@@ -42,6 +42,7 @@ def TorchConversion_ToBuiltinTensorOp : TorchConversion_Op<"to_builtin_tensor", 
   let assemblyFormat = [{
     $operand attr-dict `:` qualified(type($operand)) `->` qualified(type($result))
   }];
+  let hasVerifier = 1;
 }
 
 def TorchConversion_FromBuiltinTensorOp : TorchConversion_Op<"from_builtin_tensor">
@@ -60,6 +61,7 @@ def TorchConversion_FromBuiltinTensorOp : TorchConversion_Op<"from_builtin_tenso
   let assemblyFormat = [{
     $operand attr-dict `:` qualified(type($operand)) `->` qualified(type($result))
   }];
+  let hasVerifier = 1;
 }
 
 def TorchConversion_ToI1Op : TorchConversion_Op<"to_i1", [

--- a/test/Dialect/TorchConversion/ops.mlir
+++ b/test/Dialect/TorchConversion/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: torch-mlir-opt %s | torch-mlir-opt | FileCheck %s
+// RUN: torch-mlir-opt %s -split-input-file -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: func.func @builtin_tensor_interop(
 func.func @builtin_tensor_interop(%arg0: tensor<*xf32>, %arg1: tensor<3x?xi8>, %arg2: !torch.vtensor<*,f32>, %arg3: !torch.vtensor<[3,?],si8>) {
@@ -12,5 +12,37 @@ func.func @builtin_tensor_interop(%arg0: tensor<*xf32>, %arg1: tensor<3x?xi8>, %
   %3 = torch_c.to_builtin_tensor %arg2 : !torch.vtensor<*,f32> -> tensor<*xf32>
   // CHECK: torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[3,?],si8> -> tensor<3x?xi8>
   %4 = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[3,?],si8> -> tensor<3x?xi8>
+  return
+}
+
+// -----
+
+func.func @to_builtin_tensor_invalid_size(%arg0: !torch.vtensor<[3,?],si8>) {
+  // expected-error @+1 {{operand and result must have the same size and dtype}}
+  %1 = torch_c.to_builtin_tensor %arg0 : !torch.vtensor<[3,?],si8> -> tensor<?x?xi8>
+  return
+}
+
+// -----
+
+func.func @to_builtin_tensor_invalid_dtype(%arg0: !torch.vtensor<*,si8>) {
+  // expected-error @+1 {{operand and result must have the same size and dtype}}
+  %1 = torch_c.to_builtin_tensor %arg0 : !torch.vtensor<*,si8> -> tensor<*xi64>
+  return
+}
+
+// -----
+
+func.func @from_builtin_tensor_invalid_size(%arg0: tensor<3x?xi8>) {
+  // expected-error @+1 {{operand and result must have the same size and dtype}}
+  %1 = torch_c.from_builtin_tensor %arg0 : tensor<3x?xi8> -> !torch.vtensor<[?,?],si8>
+  return
+}
+
+// -----
+
+func.func @from_builtin_tensor_invalid_dtype(%arg0: tensor<*xi8>) {
+  // expected-error @+1 {{operand and result must have the same size and dtype}}
+  %1 = torch_c.from_builtin_tensor %arg0 : tensor<*xi8> -> !torch.vtensor<*,si64>
   return
 }


### PR DESCRIPTION
This commit adds verifiers to the ops `ToBuiltinTensorOp` and
`FromBuiltinTensorOp` that make sure that the input and output have
the same shape and data type.