### PR TITLE
Add support for `lift_fresh` op

### DIFF
--- a/build_tools/autogen_ltc_backend.yaml
+++ b/build_tools/autogen_ltc_backend.yaml
@@ -52,6 +52,7 @@ supported:
 
 # ops required for functionalization
 - lift
+- lift_fresh
 # Below are all operators that are "composite" in core,
 # but require us to explicitly re-enable functionalization in order to use them.
 # Why? These operators are all CompositeExplicitAutograd, which mean that they run

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_native_functions.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_native_functions.cpp
@@ -417,6 +417,12 @@ at::Tensor LazyNativeFunctions::lift(const at::Tensor& tensor) {
   return at::functionalization::impl::to_functional_tensor(tensor);
 }
 
+at::Tensor LazyNativeFunctions::lift_fresh(const at::Tensor& tensor) {
+  TORCH_INTERNAL_ASSERT(
+      !at::functionalization::impl::isFunctionalTensor(tensor));
+  return at::functionalization::impl::to_functional_tensor(tensor);
+}
+
 // All of the below ops correspond to CompositeExplicitAutograd kernels from core
 // that call into view operators internally.
 // These are all composite ops that LTC can technically re-use / get for free,


### PR DESCRIPTION
In upstream PyTorch, they switched the tensor constructor to use `lift_fresh` instead of `lift` which silently broken LTC. Adding support for this op should fix the examples being broken.

The upstream fix for the TS backend: https://github.com/pytorch/pytorch/pull/81928