### PR TITLE
Add mhlo to bazel build

### DIFF
--- a/utils/bazel/WORKSPACE.bazel
+++ b/utils/bazel/WORKSPACE.bazel
@@ -30,8 +30,17 @@ llvm_configure(
   repo_mapping = {
     "@python_runtime": "@local_config_python",
   },
+  targets = [
+      "X86",
+  ]
 )
 llvm_disable_optional_support_deps()
+
+
+local_repository(
+  name = "mlir-hlo",
+  path = "../../externals/mlir-hlo/"
+)
 
 new_local_repository(
     name = "torch-mlir-raw",

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -284,7 +284,7 @@ gentbl_cc_library(
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            ["-gen-pass-decls"],
+            ["-gen-pass-decls", "-DTORCH_MLIR_ENABLE_MHLO"],
             "include/torch-mlir/Conversion/Passes.h.inc",
         )
     ],
@@ -444,6 +444,32 @@ cc_library(
 )
 
 cc_library(
+    name = "TorchMLIRTorchToMhlo",
+    srcs = [
+        "lib/Conversion/TorchToMhlo/TorchToMhlo.cpp",
+        "lib/Conversion/TorchToMhlo/MhloLegalizeUtils.cpp",
+        "lib/Conversion/TorchToMhlo/BasicOp.cpp",
+        "lib/Conversion/TorchToMhlo/GatherOp.cpp",
+        "lib/Conversion/TorchToMhlo/ViewLikeOps.cpp",
+        "lib/Conversion/TorchToMhlo/MhloLegalizeUtils.h",
+        "lib/Conversion/TorchToMhlo/PopulatePatterns.h",
+        "lib/Conversion/PassDetail.h",
+    ],
+    hdrs = [
+        "include/torch-mlir/Conversion/TorchToMhlo/TorchToMhlo.h"
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchBackendTypeConversion",
+        ":TorchMLIRConversionPassesIncGen",
+        ":TorchMLIRTorchConversionDialect",
+        ":TorchMLIRConversionUtils",
+        "@mlir-hlo//:hlo",
+        "@llvm-project//mlir:Dialect"
+    ]
+)
+
+cc_library(
     name = "TorchMLIRConversionPasses",
     srcs = [
         "lib/Conversion/Passes.cpp"
@@ -457,7 +483,8 @@ cc_library(
         ":TorchMLIRTorchToSCF",
         ":TorchMLIRTorchToStd",
         ":TorchMLIRTorchToTosa",
-        ":TorchMLIRTorchToTMTensor"
+        ":TorchMLIRTorchToTMTensor",
+        ":TorchMLIRTorchToMhlo"
     ]
 )
 
@@ -487,6 +514,7 @@ cc_library(
         ":TorchMLIRTorchToStd",
         ":TorchMLIRTorchToTosa",
         ":TorchMLIRTorchToTMTensor",
+        ":TorchMLIRTorchToMhlo",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:LinalgDialect",


### PR DESCRIPTION
- Adds `@mlir-hlo` repo to bazel Workspace.
- Builds TorchToMhlo conversion `torch-mlir/Conversion/TorchToMhlo`

This should fixes the current broken bazel builds.  