### PR TITLE
Fix CI failure due to upstream PyTorch change in aten.mean.dim op

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/stats.py
+++ b/python/torch_mlir_e2e_test/test_suite/stats.py
@@ -97,7 +97,7 @@ class MeanDimDtypeModule(torch.nn.Module):
         ([-1, -1, -1], torch.float64, True),
     ])
     def forward(self, x):
-        return torch.ops.aten.mean(x, 0, dtype=torch.float32)
+        return torch.ops.aten.mean(x, (0,), dtype=torch.float32)
 
 
 @register_test_case(module_factory=lambda: MeanDimDtypeModule())


### PR DESCRIPTION
Fixes https://github.com/llvm/torch-mlir/issues/1121

Signed-Off By: Vivek Khandelwal<vivek@nod-labs.com>