### PR TITLE
Fix mhlo bazel rule name

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -464,7 +464,7 @@ cc_library(
         ":TorchMLIRConversionPassesIncGen",
         ":TorchMLIRTorchConversionDialect",
         ":TorchMLIRConversionUtils",
-        "@mlir-hlo//:hlo",
+        "@mlir-hlo//:mlir_hlo",
         "@llvm-project//mlir:Dialect"
     ]
 )


### PR DESCRIPTION
- The decency name changed in the recent update 55bbbec144334f77bece3595c7cbc9875b0be016