### PR TITLE
Update buildAndTest.yml

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-12, ubuntu-20.04]
+        os: [macos-12, ubuntu-22.04]
         targetarch: [x86_64, AArch64]
         python-version: ["3.10"]
         torch-binary: [ON, OFF]


### PR DESCRIPTION
Upstream PyTorch has fixed FBGEMM to allow us to use 22.04.