### PR TITLE
Make numerical stability test more perverse

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/stats.py
+++ b/python/torch_mlir_e2e_test/test_suite/stats.py
@@ -688,4 +688,4 @@ class VarCorrectionLargeInputModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: VarCorrectionLargeInputModule())
 def VarCorrectionLargeInputModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(3, 4, 1024, 8192))
+    module.forward(100 + tu.rand(3, 4, 1024, 8192))


### PR DESCRIPTION
To test the summation stability of `torch.aten.var`, add a large
constant to it, which increases the effective precision requirements.