### PR TITLE
[bazel build] Add recently added torch->mhlo conversion pass to bazel

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -451,6 +451,7 @@ cc_library(
         "lib/Conversion/TorchToMhlo/BasicOp.cpp",
         "lib/Conversion/TorchToMhlo/GatherOp.cpp",
         "lib/Conversion/TorchToMhlo/ViewLikeOps.cpp",
+        "lib/Conversion/TorchToMhlo/ReductionOp.cpp",
         "lib/Conversion/TorchToMhlo/MhloLegalizeUtils.h",
         "lib/Conversion/TorchToMhlo/PopulatePatterns.h",
         "lib/Conversion/PassDetail.h",


### PR DESCRIPTION
- Fixes bazel build after commit 636f5acb103283522193f8673f411808ec475b95 