### PR TITLE
torch_mlir.compile: Allow ignoring traced shapes

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/CMakeLists.txt
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(TorchMLIRJITIRImporter ${LIBRARY_TYPE}
   function_importer.cpp
   module_builder.cpp
   node_importer.cpp
+  import_options_pybind.cpp
   ivalue_importer.cpp
   init_python_bindings.cpp
   torch_to_mlir_utils.cpp

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
@@ -23,6 +23,16 @@ struct ImportOptions {
   // a requirement to use a value-semantic tensor type (!torch.vtensor) in
   // signatures.
   bool assumeTensorsHaveValueSemantics = false;
+
+  // If this is set to true, then the shape and dtype information in the
+  // JIT IR graph should be ignored. This can be useful when importing from
+  // torch.jit.trace'd graphs, since those will have shapes burned into them.
+  // In certain scenarios, users know that their trace will be correct for
+  // a variety of shapes, and this option allows them to use such traced graphs.
+  //
+  // In that case, the appropriate shape information is provided via the type
+  // bound annotations on the function arguments instead.
+  bool ignoreExistingTensorShapesAndDtypes = false;
 };
 } // namespace torch_mlir
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options_pybind.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options_pybind.cpp
@@ -1,0 +1,24 @@
+//===- import_options_pybind.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "import_options_pybind.h"
+#include "import_options.h"
+
+namespace py = pybind11;
+
+using namespace torch_mlir;
+
+void torch_mlir::initImportOptionsBindings(py::module &m) {
+  py::class_<ImportOptions>(m, "ImportOptions")
+      .def(py::init<>())
+      .def_readwrite("assumeTensorsHaveValueSemantics",
+                     &ImportOptions::assumeTensorsHaveValueSemantics)
+      .def_readwrite("ignoreExistingTensorShapesAndDtypes",
+                     &ImportOptions::ignoreExistingTensorShapesAndDtypes);
+}

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options_pybind.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options_pybind.h
@@ -1,0 +1,19 @@
+//===- import_options_pybind.h ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIRJITIRIMPORTER_CSRC_IMPORT_OPTIONS_PYBIND_H
+#define TORCHMLIRJITIRIMPORTER_CSRC_IMPORT_OPTIONS_PYBIND_H
+
+#include <torch/csrc/utils/pybind.h>
+
+namespace torch_mlir {
+void initImportOptionsBindings(pybind11::module &m);
+} // namespace torch_mlir
+
+#endif // TORCHMLIRJITIRIMPORTER_CSRC_IMPORT_OPTIONS_PYBIND_H

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/init_python_bindings.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/init_python_bindings.cpp
@@ -13,6 +13,7 @@
 
 #include "class_annotator_pybind.h"
 #include "get_registered_ops.h"
+#include "import_options_pybind.h"
 #include "module_builder.h"
 
 using namespace torch_mlir;
@@ -21,4 +22,5 @@ PYBIND11_MODULE(_jit_ir_importer, m) {
   ModuleBuilder::bind(m);
   initClassAnnotatorBindings(m);
   initGetRegisteredOpsBindings(m);
+  initImportOptionsBindings(m);
 }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.h
@@ -13,6 +13,7 @@
 #include <memory>
 
 #include "class_annotator.h"
+#include "import_options.h"
 
 #include "mlir-c/IR.h"
 
@@ -25,7 +26,8 @@ namespace torch_mlir {
 /// Main entry-point for importing torch IValue's .
 /// Recursively imports `ivalue`, inserting operations at the end of `block`.
 MlirValue importIValue(c10::IValue ivalue, MlirBlock block, MlirContext context,
-                       ClassAnnotator &annotator);
+                       ClassAnnotator &annotator,
+                       const ImportOptions &importOptions);
 
 } // namespace torch_mlir
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/module_builder.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/module_builder.h
@@ -45,7 +45,8 @@ public:
   // annotations, if not none, provided in `maybeClassAnnotator` which should be
   // a ClassAnnotator.
   void importModule(torch::jit::Module jitModule,
-                    py::object maybeClassAnnotator);
+                    py::object maybeClassAnnotator,
+                    py::object maybeImportOptions);
 
 private:
   MlirBlock getBodyBlock();

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.cpp
@@ -221,8 +221,9 @@ void NodeImporter::importNode(Node *node, MlirBlock appendToBlock,
               mlirFlatSymbolRefAttrGet(context, toMlirStringRef(symName))));
     } else if (output->type()->cast<c10::ListType>()) {
       ClassAnnotator dummyAnnotator;
-      MlirValue listValue = importIValue(
-          node->ival(c10::attr::value), appendToBlock, context, dummyAnnotator);
+      MlirValue listValue =
+          importIValue(node->ival(c10::attr::value), appendToBlock, context,
+                       dummyAnnotator, importOptions);
       mapResults(node, mlirOpResultGetOwner(listValue));
       return; // Early return, since `importIValue` already added op to block.
     } else {

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
@@ -131,6 +131,13 @@ torch_mlir::getMlirTypeFromTorchType(MlirLocation loc,
                                  ? torchMlirTorchValueTensorTypeGet
                                  : torchMlirTorchNonValueTensorTypeGet;
 
+    if (importOptions.ignoreExistingTensorShapesAndDtypes) {
+      return getMlirTensorType(context,
+                               /*numSizes=*/-1,
+                               /*optionalSizes=*/nullptr,
+                               /*optionalDtype=*/{nullptr});
+    }
+
     // Element type.
     MlirType elementType = {nullptr};
     if (tensorType->scalarType()) {


### PR DESCRIPTION
In some cases, users know that a traced graph is valid for a wider set
of shapes than they originally traced it with. Provide an option for
users to ignore the shapes in the traced graph when they know it is
legal.

Fixes #997