### PR TITLE
[Docker] Minimal setup to run CMake builds + unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+ARG BASE_IMG=nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04
+FROM ${BASE_IMG} as dev-base
+
+ARG ARCH="x86_64"
+ARG TARGETARCH="amd64"
+ARG BAZEL_VERSION=4.2.1
+
+# Install basic packages
+RUN apt-get update                                              && \
+    apt-get install -y                                             \
+    python3.8                                                      \
+    python3.8-dev                                                  \
+    cmake                                                          \
+    ninja-build                                                    \
+    git                                                            \
+    python3-pip                                                    \
+    wget                                                           \
+    clang                                                          \
+    automake                                                       \
+    libtool                                                        \
+    curl                                                           \
+    make                                                           \
+    unzip
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 10
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10
+
+# Install bazel
+RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${ARCH} -O /usr/bin/bazel \
+    && chmod a+x /usr/bin/bazel
+
+COPY requirements.txt /opt/app/requirements.txt
+WORKDIR /opt/app
+RUN python -m pip install --upgrade pip
+RUN python -m pip install -r requirements.txt
+
+WORKDIR /opt/src/torch-mlir/torch-mlir

--- a/development.md
+++ b/development.md
@@ -8,6 +8,28 @@ cd torch-mlir
 git submodule update --init
 ```
 
+## Minimal Docker Setup for CMake Builds
+
+We provide a minimal self-contained docker setup with the required dependencies
+for a CMake build of torch-mlir. This allows easy and consistent setup for local
+validation of PRs using unit tests and python regression tests. It is not meant to
+be used for testing builds on multiple platforms / architectures (aka matrix testing)
+or for out-of-tree builds.
+
+```shell
+# Build an image and launch a docker container
+./run_docker.sh
+
+# Run CMake build
+./run_cmake_build.sh
+
+# Run unit tests (+ python + dialect LIT tests)
+./run_unit_test.sh
+
+# Run integration tests
+./run_integration_test.sh
+```
+
 ## Setup your Python VirtualEnvironment and Dependencies
 
 Also, ensure that you have the appropriate `python-dev` package installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ wheel
 setuptools
 cmake
 ninja
+pyyaml
 
 # Test Requirements
 pillow

--- a/run_cmake_build.sh
+++ b/run_cmake_build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Configure cmake to build torch-mlir in-tree
+cmake -GNinja -Bbuild \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DPython3_FIND_VIRTUALENV=ONLY \
+  -DLLVM_ENABLE_PROJECTS=mlir \
+  -DLLVM_EXTERNAL_PROJECTS="torch-mlir;torch-mlir-dialects" \
+  -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR=`pwd` \
+  -DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR=`pwd`/externals/llvm-external-projects/torch-mlir-dialects \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DLLVM_TARGETS_TO_BUILD=host \
+  externals/llvm-project/llvm
+
+# Build just torch-mlir (not all of LLVM)
+cmake --build build --target tools/torch-mlir/all

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker build -t torch-mlir-cmake:dev .
+
+docker run -v $(pwd):/opt/src/torch-mlir/torch-mlir -it torch-mlir-cmake:dev

--- a/run_integration_test.sh
+++ b/run_integration_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+export PYTHONPATH="$(pwd)/build/tools/torch-mlir/python_packages/torch_mlir"
+
+
+# refbackend e2e tests
+python -m e2e_testing.torchscript.main --config=refbackend -v
+
+# eagermode backend e2e tests
+python -m e2e_testing.torchscript.main --config=eager_mode -v
+
+# tosa backend e2e tests
+python -m e2e_testing.torchscript.main --config=tosa -v
+
+# ltc backend e2e tests
+python -m e2e_testing.torchscript.main --config=lazy_tensor_core -v

--- a/run_unit_test.sh
+++ b/run_unit_test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Run torch-mlir unit tests.
+cmake --build build --target check-torch-mlir
+
+# Run torch-mlir-python unit tests.
+cmake --build build --target check-torch-mlir-python
+
+# Run torch-mlir-dialects unit tests.
+cmake --build build --target check-torch-mlir-dialects


### PR DESCRIPTION
Adds a very minimal (optional) docker setup to quickly get CMake builds + LIT tests running consistently in a reproducible way.

**Context:** While we (Cruise) use the `Bazel` build of torch-mlir internally, we also need the `CMake` build setup on our end to validate our PRs won't break CI (before sending them upstream). Some of us had initial hurdles getting the CMake builds working locally (python venv issues similar to https://github.com/llvm/torch-mlir/issues/647 requiring `python-dev` to be installed). This PR addresses such issues by reducing the (somewhat manual and env dependent) build+test steps to the following:

```shell
# Build an image and launch a docker container
./run_docker.sh

# Run CMake build
./run_cmake_build.sh

# Run CMake unit tests (+ python + dialect unit tests)
./run_cmake_test.sh
```

It is not meant to be used for testing builds on multiple platforms / architectures (aka matrix testing) or for out-of-tree builds.

Please LMK if you'd also like a GitHub actions workflow (non-gating) to test this? Also, feel free to reject this if this is too far from what we should allow in torch-mlir.

cc: @silvasean

(thanks @asaadaldien for the initial `Dockerfile`)