### PR TITLE
[MHLO] Add configurable op decomposition rules

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
@@ -32,11 +32,20 @@ struct TorchLoweringPipelineOptions
   // If this option is false, only do the bare minimum for correctness.
   Option<bool> optimize{*this, "optimize", llvm::cl::desc("Do optimizations."),
                         llvm::cl::init(true)};
-  
+
   // If this option is false, decompose complex operations.
   // If this option is true, skip decomposition of complex operations.
-  Option<bool> decompose{*this, "decompose-complex-ops", llvm::cl::desc("Decompose complex operations."),
-                        llvm::cl::init(true)};                      
+  Option<bool> decompose{*this, "decompose-complex-ops",
+                         llvm::cl::desc("Decompose complex operations."),
+                         llvm::cl::init(true)};
+
+  // Disable decomposition rules for torch ops. Useless when
+  // decompose-complex-ops set to false.
+  Option<std::string> torchDecompositionSkipOps{
+      *this, "torch-decomposition-skip-ops",
+      llvm::cl::desc("Disable decomposition rules for these torch ops. Useless "
+                     "when decompose-complex-ops set to false."),
+      llvm::cl::init(",")};
 };
 
 /// Creates a pipeline that lowers the object graph IR that is produced by
@@ -67,6 +76,12 @@ std::unique_ptr<OperationPass<func::FuncOp>> createMaximizeValueSemanticsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createRefinePublicReturnPass();
 
 std::unique_ptr<OperationPass<func::FuncOp>> createDecomposeComplexOpsPass();
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createDecomposeComplexOpsPass(llvm::ArrayRef<std::string> skipOps);
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createDecomposeComplexOpsPass(std::string skipOps);
 
 std::unique_ptr<OperationPass<ModuleOp>> createPreprocessShapeLibraryPass();
 

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -217,7 +217,13 @@ def RefinePublicReturn : Pass<"torch-refine-public-return", "ModuleOp"> {
 
 def DecomposeComplexOps : Pass<"torch-decompose-complex-ops", "func::FuncOp"> {
   let summary = "Decompose complicated torch operations";
-  let constructor = "mlir::torch::Torch::createDecomposeComplexOpsPass()";
+  let constructor = "mlir::torch::Torch::createDecomposeComplexOpsPass()";  
+  let options = [
+    ListOption<"skipOps", "skipOps", "std::string", 
+               "Disable decompositions rules for these operations", 
+               "llvm::cl::ZeroOrMore">
+  ];
+
   let description = [{
     Decompose torch operation that are losslessly represented as combinations of
     other operations, modulo appropropriate compiler fusion. Note that this pass

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -2464,7 +2464,7 @@ private:
         AtenOnesLikeOp, DecomposeConstantTensorAllocLikeOp<AtenOnesLikeOp, 1>>(
         context, target, patterns);
     addDecompositionRules<
-        AtenZerosLikeOp, DecomposeConstantTensorAllocLikeOp<AtenOnesLikeOp, 0>>(
+        AtenZerosLikeOp, DecomposeConstantTensorAllocLikeOp<AtenZerosLikeOp, 0>>(
         context, target, patterns);
     addDecompositionRules<AtenRepeatOp, DecomposeAtenRepeatOp>(context, target,
                                                                patterns);

--- a/lib/Dialect/Torch/Transforms/Passes.cpp
+++ b/lib/Dialect/Torch/Transforms/Passes.cpp
@@ -163,7 +163,8 @@ void mlir::torch::Torch::createTorchFunctionToTorchBackendPipeline(
   }
 
   if (options.decompose) {
-    pm.addNestedPass<func::FuncOp>(Torch::createDecomposeComplexOpsPass());
+    pm.addNestedPass<func::FuncOp>(Torch::createDecomposeComplexOpsPass(
+        options.torchDecompositionSkipOps));
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   }
 

--- a/test/Dialect/Torch/configurable-decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/configurable-decompose-complex-ops.mlir
@@ -1,0 +1,18 @@
+// RUN: torch-mlir-opt -torch-decompose-complex-ops="skipOps=torch.aten.softmax.int,torch.aten.matmul" -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL:   func.func @matmul_no_decompose
+// CHECK:            torch.aten.matmul %arg0, %arg1
+func.func @matmul_no_decompose(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// ----
+// CHECK-LABEL:   func.func @softmax_no_decompose
+// CHECK:           torch.aten.softmax.int
+func.func @softmax_no_decompose(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %int1 = torch.constant.int 1
+  %none = torch.constant.none
+  %0 = torch.aten.softmax.int %arg0, %int1, %none : !torch.vtensor<[?,?],f32>, !torch.int, !torch.none -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}


### PR DESCRIPTION
See RFC #999 
We register some options in `TorchLoweringPipeline` and `DecomposeComplexOpsPass` to make the decomposition rules configurable.

Co-authored-by: Bairen Yi <yibairen.byron@bytedance.com>
Co-authored-by: Jiawei Wu <xremold@gmail.com>
Co-authored-by: Tianyou Guo <tianyou.gty@alibaba-inc.com>
Co-authored-by: Xu Yan <yancey.yx@alibaba-inc.com>
Co-authored-by: Ziheng Jiang <ziheng.jiang@bytedance.com>