### PR TITLE
Add PyYaml to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,9 @@ setuptools
 cmake
 ninja
 
+# Workaround for what should be a torch dep
+# See discussion in #1174
+pyyaml
+
 # Test Requirements
 pillow


### PR DESCRIPTION
Building on a fresh environment + virtualenv + in-tree build errors out
becayse PyYaml isn't installed. Adding to requirements.txt fixes that.

Fixes #1173 