### PR TITLE
Reenable LTC in out-of-tree build

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -87,7 +87,6 @@ jobs:
           externals/llvm-project/llvm
         cmake --build llvm-build
 
-        # TODO: Reenable LTC once OOT build is successful (https://github.com/llvm/torch-mlir/issues/1154)
         cmake -GNinja -Bbuild \
           -DCMAKE_LINKER=lld \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -97,7 +96,6 @@ jobs:
           -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
           -DTORCH_MLIR_ENABLE_MHLO=ON \
           -DTORCH_MLIR_USE_INSTALLED_PYTORCH=${{ matrix.torch-binary }} \
-          -DTORCH_MLIR_ENABLE_LTC=OFF \
           -DPython3_EXECUTABLE=$(which python) \
           .
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/CMakeLists.txt
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/CMakeLists.txt
@@ -10,15 +10,7 @@ include_directories(BEFORE
   )
 link_directories("${TORCH_INSTALL_PREFIX}/lib")
 
-# TODO: Currently, out-of-tree build fails when LIBRARY_TYPE is set to SHARED, so we have this toggle.
-#       See https://github.com/llvm/torch-mlir/issues/1154 for more details.
-if(TORCH_MLIR_ENABLE_LTC)
-  set(LIBRARY_TYPE "SHARED")
-else()
-  set(LIBRARY_TYPE "MODULE")
-endif()
-
-add_library(TorchMLIRJITIRImporter ${LIBRARY_TYPE}
+add_library(TorchMLIRJITIRImporter SHARED
   class_annotator.cpp
   class_annotator_pybind.cpp
   get_registered_ops.cpp

--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,6 @@ class CMakeBuild(build_py):
                 f"-DMLIR_ENABLE_BINDINGS_PYTHON=ON",
                 f"-DLLVM_ENABLE_PROJECTS=mlir",
                 f"-DTORCH_MLIR_ENABLE_MHLO=ON",
-                # TODO: Reenable LTC once JIT importer linkage issue is fixed (https://github.com/llvm/torch-mlir/issues/1154)
-                f"-DTORCH_MLIR_ENABLE_LTC=OFF",
                 f"-DLLVM_EXTERNAL_PROJECTS=torch-mlir;torch-mlir-dialects",
                 f"-DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR={src_dir}",
                 f"-DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR={src_dir}/externals/llvm-external-projects/torch-mlir-dialects",


### PR DESCRIPTION
Addressing #1154 

I'm not entirely sure what changed... but it looks like out-of-tree build works even with LTC enabled now

cc: @antoniojkim @ke1337 