### PR TITLE
[MHLO]fix lowering failed on reduction op with i32 shape

### DIFF
--- a/lib/Conversion/TorchToMhlo/Reduction.cpp
+++ b/lib/Conversion/TorchToMhlo/Reduction.cpp
@@ -88,7 +88,7 @@ getMaxInDim(ConversionPatternRewriter &rewriter, Operation *op, Value &input,
   Value initIndex;
   if (mlir::mhlo::kMhloDimSizeBits == 32) {
     initIndex =
-      mhlo::getConstTensor<int64_t>(rewriter, op, {0}, {}).getValue();
+      mhlo::getConstTensor<int32_t>(rewriter, op, {0}, {}).getValue();
   } else {
     initIndex =
       mhlo::getConstTensor<int64_t>(rewriter, op, {0}, {}).getValue();


### PR DESCRIPTION
This PR fixed lowering failed on `ten::max_dim` with i32 shape type.
