### PR TITLE
Include torch-mlir builds in OOT workflow

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Get torch-mlir
+    - name: Checkout torch-mlir
       uses: actions/checkout@v2
       with:
         submodules: 'true'
@@ -44,13 +44,13 @@ jobs:
       with:
         cache-suffix: ${{ matrix.os }}-${{ matrix.targetarch }}-${{ matrix.llvmtype }}-${{ matrix.llvmbuildtype }}
 
-    - name: llvm-binary-torch-src-or-binary
+    - name: Configure llvm-binary-torch-src-or-binary
       # Should be the fastest builds for CI and fails fast
       # OSX CMake flags are ignore on Linux
       if: matrix.llvmtype == 'binary'
       run: |
         cd $GITHUB_WORKSPACE
-        cmake $GITHUB_WORKSPACE/externals/llvm-project/llvm -B build -GNinja \
+        cmake -GNinja -Bbuild \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_LINKER=lld \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -66,15 +66,16 @@ jobs:
           -DTORCH_MLIR_USE_INSTALLED_PYTORCH=${{ matrix.torch-binary }} \
           -DCMAKE_OSX_ARCHITECTURES=${{ matrix.taregetarch }} \
           -DMACOSX_DEPLOYMENT_TARGET=10.15 \
-          -DLLVM_TARGETS_TO_BUILD=host
+          -DLLVM_TARGETS_TO_BUILD=host \
+          $GITHUB_WORKSPACE/externals/llvm-project/llvm
 
-    - name: llvm-source-out-of-tree-torch-src-or-binary
+    - name: Configure llvm-source-out-of-tree-torch-src-or-binary
       # This build takes a while but is expected to almost always be cached.
       # A cache invalidation occurs when the committed LLVM version is changed.
       if: matrix.llvmtype == 'source'
       run: |
         cd $GITHUB_WORKSPACE
-        cmake -Bllvm-build -GNinja \
+        cmake -GNinja -Bllvm-build \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_LINKER=lld \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -101,35 +102,40 @@ jobs:
           -DPython3_EXECUTABLE=$(which python) \
           .
 
-    - name: Build and run check-torch-mlir-all
+    - name: Build torch-mlir
+      # Build step for both in-tree and out-of-tree workflows
+      run: |
+        cmake --build build
+
+    - name: Run torch-mlir unit tests
       if: matrix.llvmtype == 'binary'
       run: |
         cd $GITHUB_WORKSPACE
         export PYTHONPATH="$GITHUB_WORKSPACE/build/tools/torch-mlir/python_packages/torch_mlir"
         cmake --build build --target check-torch-mlir-all
 
-    - name: RefBackend - TorchScript end-to-end tests
+    - name: Run RefBackend - TorchScript end-to-end tests
       if: matrix.llvmtype == 'binary'
       run: |
         cd $GITHUB_WORKSPACE
         export PYTHONPATH="$GITHUB_WORKSPACE/build/tools/torch-mlir/python_packages/torch_mlir"
         python -m e2e_testing.torchscript.main --config=refbackend -v
 
-    - name: EagerMode - TorchScript end-to-end tests
+    - name: Run EagerMode - TorchScript end-to-end tests
       if: matrix.llvmtype == 'binary'
       run: |
         cd $GITHUB_WORKSPACE
         export PYTHONPATH="$GITHUB_WORKSPACE/build/tools/torch-mlir/python_packages/torch_mlir"
         python -m e2e_testing.torchscript.main --config=eager_mode -v
 
-    - name: TOSA backend - TorchScript end-to-end tests
+    - name: Run TOSA backend - TorchScript end-to-end tests
       if: matrix.llvmtype == 'binary'
       run: |
         cd $GITHUB_WORKSPACE
         export PYTHONPATH="$GITHUB_WORKSPACE/build/tools/torch-mlir/python_packages/torch_mlir"
         python -m e2e_testing.torchscript.main --config=tosa -v
 
-    - name: Lazy Tensor Core - TorchScript end-to-end tests
+    - name: Run Lazy Tensor Core - TorchScript end-to-end tests
       if: matrix.llvmtype == 'binary'
       run: |
         cd $GITHUB_WORKSPACE


### PR DESCRIPTION
The matrix jobs in GHA are intended to be setup for checking "build + tests" for in-tree, but "build only" for out-of-tree workflows. However (as discovered [here](https://github.com/llvm/torch-mlir/issues/1162#issuecomment-1208762623)) at the moment building torch-mlir OOT is skipped in CI. We're just "building llvm" and "configuring cmake to build torch-mlir", but the build itself is [gated](https://github.com/llvm/torch-mlir/blob/f85ae9c685d6c9f2d43fe60fdad2ad5d3183ec52/.github/workflows/buildAndTest.yml#L103) for the OOT case with:
```
      if: matrix.llvmtype == 'binary'
```
partly because it is combined with the unit test target which is skipped for OOT. 

As seen below, both build and test steps are skipped for OOT case:
![image](https://user-images.githubusercontent.com/19234106/183573855-97ca03ad-2912-44d7-9030-4fa39d8e4d20.png)

This PR splits the build from `check-torch-mlir-all` and moves it into the previous step (which have appropriate gating already).