### PR TITLE
[MHLO]remove torch dialect from legal list

### DIFF
--- a/lib/Conversion/TorchToMhlo/TorchToMhlo.cpp
+++ b/lib/Conversion/TorchToMhlo/TorchToMhlo.cpp
@@ -43,8 +43,7 @@ public:
     MLIRContext *context = &getContext();
     ConversionTarget target(*context);
     target.addLegalDialect<chlo::ChloDialect, mhlo::MhloDialect,
-                           tensor::TensorDialect, arith::ArithmeticDialect,
-                           Torch::TorchDialect>();
+                           tensor::TensorDialect, arith::ArithmeticDialect>();
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });


### PR DESCRIPTION
All torch ops should be converted to mhlo after `TorchToMhlo` pass.
