### PR TITLE
Don't set MLIR_TABLEGEN_EXE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 else()
   message(STATUS "Torch-MLIR in-tree build.")
   # In-tree build with LLVM_EXTERNAL_PROJECTS=torch-mlir
-  # FIXME: This should really be inherited from the LLVM tree.  In particular,
-  # it's going to change when cross-compiling.
-  set(MLIR_TABLEGEN_EXE mlir-tblgen)
   if (TORCH_MLIR_ENABLE_MHLO)
     set(MLIR_PDLL_TABLEGEN_EXE mlir-pdll)
   endif()

--- a/externals/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
+++ b/externals/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
@@ -30,7 +30,6 @@ else()
   # Configure CMake and tablegen.
   list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
   list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
-  set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
   include(TableGen)
   include(AddLLVM)


### PR DESCRIPTION
With llvm/llvm-project@112499f landed, `MLIR_TABLEGEN_EXE` is given as a
cache variable in the MLIR core project. Other external projects, such
as TORCH-MLIR, should not set the variable as this breaks
cross-compilation.