### PR TITLE
[Bazel] Add EraseModuleInitializer to TorchMLIRTorchPasses library

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -169,6 +169,7 @@ cc_library(
         "lib/Dialect/Torch/Transforms/AdjustCallingConventions.cpp",
         "lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp",
         "lib/Dialect/Torch/Transforms/DropShapeCalculations.cpp",
+        "lib/Dialect/Torch/Transforms/EraseModuleInitializer.cpp",
         "lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp",
         "lib/Dialect/Torch/Transforms/InlineGlobalSlots.cpp",
         "lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp",


### PR DESCRIPTION
The torch-mlir bazel build is [failing](https://github.com/llvm/torch-mlir/runs/7737425906?check_suite_focus=true) since [this commit](https://github.com/llvm/torch-mlir/commit/504de5e70104c335dd45f6f2be695356d2b832fb) due to a linker failure (undefined symbol: `mlir::torch::Torch::createEraseModuleInitializerPass()`).

```
ERROR: /home/runner/.cache/bazel/_bazel_runner/db599744cd37f8c161e5034d9b9cd520/external/torch-mlir/BUILD.bazel:845:10: Linking external/torch-mlir/torch-mlir-opt failed: (Exit 1): clang failed: error executing command /usr/lib/llvm-11/bin/clang @bazel-out/k8-fastbuild/bin/external/torch-mlir/torch-mlir-opt-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ld.lld: error: undefined symbol: mlir::torch::Torch::createEraseModuleInitializerPass()
>>> referenced by Passes.cpp
>>>               bazel-out/k8-fastbuild/bin/external/torch-mlir/_objs/TorchMLIRTorchPasses/Passes.pic.o:(mlir::torch::Torch::createTorchFunctionToTorchBackendPipeline(mlir::OpPassManager&, mlir::torch::Torch::TorchLoweringPipelineOptions const&))
>>> referenced by Passes.cpp
>>>               bazel-out/k8-fastbuild/bin/external/torch-mlir/_objs/TorchMLIRTorchPasses/Passes.pic.o:((anonymous namespace)::registerEraseModuleInitializerPass()::'lambda'()::operator()() const)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR adds `lib/Dialect/Torch/Transforms/EraseModuleInitializer.cpp` to `TorchMLIRTorchPasses` library.