### PR TITLE
python: trim registration and loading of dialects and passes

### DIFF
--- a/include/torch-mlir-c/Registration.h
+++ b/include/torch-mlir-c/Registration.h
@@ -22,6 +22,9 @@ extern "C" {
  */
 MLIR_CAPI_EXPORTED void torchMlirRegisterAllDialects(MlirContext context);
 
+/** Registers upstream (MLIR) dialects used in Torch-MLIR IRs. */
+MLIR_CAPI_EXPORTED void torchMlirRegisterRequiredDialects(MlirContext context);
+
 /** Registers all passes for symbolic access with the global registry. */
 MLIR_CAPI_EXPORTED void torchMlirRegisterAllPasses();
 

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -14,6 +14,34 @@ add_mlir_public_c_api_library(TorchMLIRCAPI
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRAffineDialect
+  MLIRArithDialect
+  MLIRBufferizationDialect
+  MLIRControlFlowDialect
+  MLIRFuncDialect
+  MLIRLinalgDialect
+  MLIRMathDialect
+  MLIRMemRefDialect
+  MLIRSCFDialect
+  MLIRTensorDialect
+  MLIRTosaDialect
+  MLIRAffineToStandard
+  MLIRArithToLLVM
+  MLIRArithTransforms
+  MLIRBufferizationTransforms
+  MLIRControlFlowToLLVM
+  MLIRFuncToLLVM
+  MLIRFuncTransforms
+  MLIRLinalgToLLVM
+  MLIRLinalgTransforms
+  MLIRMathToLLVM
+  MLIRMemRefToLLVM
+  MLIRReconcileUnrealizedCasts
+  MLIRSCFToControlFlow
+  MLIRSCFTransforms
+  MLIRTensorTransforms
+  MLIRTosaToArith
+  MLIRTosaToLinalg
   MLIRSupport
   TorchMLIRTorchDialect
   TorchMLIRInitAll

--- a/lib/CAPI/Registration.cpp
+++ b/lib/CAPI/Registration.cpp
@@ -10,10 +10,26 @@
 #include "torch-mlir-c/Registration.h"
 
 #include "mlir/CAPI/IR.h"
-#include "mlir/Conversion/Passes.h"
-#include "mlir/Dialect/Linalg/Passes.h"
-#include "mlir/Transforms/Passes.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/InitAllPasses.h"
 #include "torch-mlir/InitAll.h"
+
+void torchMlirRegisterRequiredDialects(MlirContext context) {
+  mlir::DialectRegistry registry;
+  registry.insert<mlir::AffineDialect, mlir::arith::ArithDialect,
+                  mlir::bufferization::BufferizationDialect,
+                  mlir::func::FuncDialect, mlir::linalg::LinalgDialect,
+                  mlir::scf::SCFDialect, mlir::tensor::TensorDialect,
+                  mlir::tosa::TosaDialect>();
+  unwrap(context)->appendDialectRegistry(registry);
+}
 
 void torchMlirRegisterAllDialects(MlirContext context) {
   mlir::DialectRegistry registry;
@@ -23,4 +39,24 @@ void torchMlirRegisterAllDialects(MlirContext context) {
   unwrap(context)->loadAllAvailableDialects();
 }
 
-void torchMlirRegisterAllPasses() { mlir::torch::registerAllPasses(); }
+void torchMlirRegisterAllPasses() {
+  mlir::arith::registerArithPasses();
+  mlir::bufferization::registerBufferizationPasses();
+  mlir::func::registerFuncPasses();
+  mlir::registerConvertAffineToStandardPass();
+  mlir::registerConvertArithToLLVMPass();
+  mlir::registerConvertControlFlowToLLVMPass();
+  mlir::registerConvertFuncToLLVMPass();
+  mlir::registerConvertLinalgToLLVMPass();
+  mlir::registerConvertMathToLLVMPass();
+  mlir::registerConvertMemRefToLLVMPass();
+  mlir::registerLinalgPasses();
+  mlir::registerReconcileUnrealizedCastsPass();
+  mlir::registerSCFPasses();
+  mlir::registerSCFToControlFlowPass();
+  mlir::registerTosaToArithPass();
+  mlir::registerTosaToLinalgNamedPass();
+  mlir::registerTosaToLinalgPass();
+  mlir::tensor::registerTensorPasses();
+  mlir::torch::registerAllPasses();
+}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -50,6 +50,7 @@ declare_mlir_python_sources(TorchMLIRPythonSources.TopLevel
   SOURCES
     __init__.py
     compiler_utils.py
+    _mlir_libs/_site_initialize_0.py
 )
 
 declare_mlir_python_sources(TorchMLIRPythonSources.Dialects
@@ -127,8 +128,8 @@ set(_source_components
   # the only way to handle that is to create a separate mlir python package
   # tree, which seems excessive.
   MLIRPythonSources
-  MLIRPythonExtension.Core
-  MLIRPythonExtension.RegisterEverything
+  MLIRPythonSources.Core
+  MLIRPythonSources.ExecutionEngine
   TorchMLIRPythonSources
   TorchMLIRPythonExtensions
 )

--- a/python/TorchMLIRModule.cpp
+++ b/python/TorchMLIRModule.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/CAPI/IR.h"
 #include "torch-mlir-c/Dialects.h"
 #include "torch-mlir-c/Registration.h"
 
@@ -18,14 +19,6 @@ PYBIND11_MODULE(_torchMlir, m) {
 
   m.doc() = "torch-mlir main python extension";
 
-  m.def(
-      "register_dialect",
-      [](MlirContext context, bool load) {
-        MlirDialectHandle handle = mlirGetDialectHandle__torch__();
-        mlirDialectHandleRegisterDialect(handle, context);
-        if (load) {
-          mlirDialectHandleLoadDialect(handle, context);
-        }
-      },
-      py::arg("context"), py::arg("load") = true);
+  m.def("register_required_dialects", torchMlirRegisterRequiredDialects,
+        py::arg("context"));
 }

--- a/python/torch_mlir/_mlir_libs/_site_initialize_0.py
+++ b/python/torch_mlir/_mlir_libs/_site_initialize_0.py
@@ -1,0 +1,4 @@
+from . import _torchMlir
+
+def context_init_hook(context):
+    _torchMlir.register_required_dialects(context)

--- a/python/torch_mlir/dialects/torch/__init__.py
+++ b/python/torch_mlir/dialects/torch/__init__.py
@@ -4,4 +4,4 @@
 # Also available under a BSD-style license. See LICENSE.
 
 from .._torch_ops_gen import *
-from ..._mlir_libs._torchMlir import register_dialect
+from ..._mlir_libs._torchMlir import register_required_dialects

--- a/test/python/smoketest.py
+++ b/test/python/smoketest.py
@@ -4,4 +4,4 @@ import torch_mlir.ir
 from torch_mlir.dialects import torch
 
 with torch_mlir.ir.Context() as ctx:
-  torch.register_dialect(ctx)
+  torch.register_required_dialects(ctx)


### PR DESCRIPTION
In the interest of merging upstream LLVM quickly, a previous patch
(7f08169) updated the torch-mlir build to register all dialects and
passes through Python bindings.  This patch limits the dialects and
passes to only those that are used in torch-mlir.

Key to this change are the removal of
`MLIRPythonExtension.RegisterEverything` and the introduction of a new
Python module (`_mlir_libs/_site_initialize_0.py`), where we register
the dialects and passes used by torch-mlir.

Release build now passes for this branch: https://github.com/llvm/torch-mlir/actions/runs/2988625814