### PR TITLE
Fix unused-variables warnings about EmbeddingBag ops

### DIFF
--- a/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
@@ -218,10 +218,22 @@ public:
     Value weight = adaptor.weight();
     Value indices = adaptor.indices();
     Value offsets = adaptor.offsets();
-    Value scaleGradByFreq = adaptor.scale_grad_by_freq();
+    Value scaleGradByFreq = op.scale_grad_by_freq();
     Value mode = op.mode();
     Value sparse = op.sparse();
     Value includeLastOffset = op.include_last_offset();
+
+    bool scaleGradByFreqBool;
+    if (!matchPattern(scaleGradByFreq,
+                      m_TorchConstantBool(&scaleGradByFreqBool))) {
+      return rewriter.notifyMatchFailure(
+          op, "scale_grad_by_freq is expected to be a constant boolean value.");
+    }
+
+    if (scaleGradByFreqBool) {
+      return rewriter.notifyMatchFailure(
+          op, "Unimplemented: scale_grad_by_freq=True.");
+    }
 
     int64_t modeInt;
     if (!matchPattern(mode, m_TorchConstantInt(&modeInt))) {

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -2435,8 +2435,6 @@ public:
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(Aten_EmbeddingBagOp op,
                                 PatternRewriter &rewriter) const override {
-
-    Location loc = op.getLoc();
     Value weight = op.weight();
     Value indices = op.indices();
     Value offsets = op.offsets();


### PR DESCRIPTION
According to the documentation for
`torch.embedding_bag` (https://pytorch.org/docs/stable/generated/torch.nn.functional.embedding_bag.html),
the default value for `scale_grad_by_freq` is False.