### PR TITLE
build: streamline options for enabling LTC and MHLO

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -75,7 +75,7 @@ jobs:
           -DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR="${GITHUB_WORKSPACE}/externals/llvm-external-projects/torch-mlir-dialects" \
           -DLLVM_TARGETS_TO_BUILD=host \
           -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-          -DTORCH_MLIR_ENABLE_MHLO=ON \
+          -DTORCH_MLIR_ENABLE_LTC=ON \
           -DTORCH_MLIR_USE_INSTALLED_PYTORCH="${{ matrix.torch-binary }}" \
           -DPython3_EXECUTABLE="$(which python)" \
           $GITHUB_WORKSPACE/externals/llvm-project/llvm
@@ -99,7 +99,6 @@ jobs:
           $GITHUB_WORKSPACE/externals/llvm-project/llvm
         cmake --build llvm-build
 
-        # TODO: Reenable LTC once OOT build is successful (https://github.com/llvm/torch-mlir/issues/1154)
         cmake -GNinja -Bbuild \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
@@ -109,9 +108,7 @@ jobs:
           -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm/" \
           -DMLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir/" \
           -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
-          -DTORCH_MLIR_ENABLE_MHLO=ON \
           -DTORCH_MLIR_USE_INSTALLED_PYTORCH="${{ matrix.torch-binary }}" \
-          -DTORCH_MLIR_ENABLE_LTC=OFF \
           -DPython3_EXECUTABLE="$(which python)" \
           $GITHUB_WORKSPACE
 
@@ -136,7 +133,6 @@ jobs:
           -DLLVM_USE_HOST_TOOLS=ON \
           -DLLVM_ENABLE_ZSTD=OFF \
           -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-          -DTORCH_MLIR_ENABLE_LTC=OFF \
           -DTORCH_MLIR_ENABLE_MHLO=OFF \
           -DTORCH_MLIR_USE_INSTALLED_PYTORCH="${{ matrix.torch-binary }}" \
           -DMACOSX_DEPLOYMENT_TARGET=12.0 \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,8 @@ if(TORCH_MLIR_ENABLE_MHLO)
   endif()
 endif()
 
-option(TORCH_MLIR_ENABLE_LTC "Enables LTC backend" ON)
+# TODO: Reenable LTC once OOT build is successful (https://github.com/llvm/torch-mlir/issues/1154)
+option(TORCH_MLIR_ENABLE_LTC "Enables LTC backend" OFF)
 
 torch_mlir_add_llvm_external_project(
   torch-mlir-dialects

--- a/setup.py
+++ b/setup.py
@@ -75,9 +75,6 @@ class CMakeBuild(build_py):
                 f"-DLLVM_TARGETS_TO_BUILD=host",
                 f"-DMLIR_ENABLE_BINDINGS_PYTHON=ON",
                 f"-DLLVM_ENABLE_PROJECTS=mlir",
-                f"-DTORCH_MLIR_ENABLE_MHLO=ON",
-                # TODO: Reenable LTC once JIT importer linkage issue is fixed (https://github.com/llvm/torch-mlir/issues/1154)
-                f"-DTORCH_MLIR_ENABLE_LTC=OFF",
                 f"-DLLVM_EXTERNAL_PROJECTS=torch-mlir;torch-mlir-dialects",
                 f"-DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR={src_dir}",
                 f"-DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR={src_dir}/externals/llvm-external-projects/torch-mlir-dialects",


### PR DESCRIPTION
Prior to this patch, LTC was enabled by default, but it was disabled in
setup.py and in the Github CI rules.  MHLO, on the other hand, was
enabled by default, but also (i.e. redundantly) enabled in setup.py and
in the Github CI rules.

This had the effect of LTC being left enabled unless the build is
triggered by setup.py or Github CI.  It also had the effect of forcing
us to update the option in multiple places, whenever it needed to be
changed.

This patch sets the options' default value at the option definintion,
and it explicitly sets the value only when the default is overriden,
like for disabling MHLO in in-tree builds on macOS.