### PR TITLE
Use Docker for Bazel Build

### DIFF
--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -20,20 +20,23 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-
     - name: Checkout torch-mlir
       uses: actions/checkout@v2
       with:
         submodules: 'true'
 
-    - name: Build with bazel
+    - name: Build docker image
       run: |
-        cd $GITHUB_WORKSPACE/utils/bazel
-        bazel build @torch-mlir//...
+        docker build -f build_tools/docker/Dockerfile \
+                     -t torch-mlir-bazel:ci \
+                     .
+
+    - name: Bazel build torch-mlir
+      run: |
+        docker run --rm \
+                   -v "$(pwd)":/opt/src/torch-mlir \
+                   torch-mlir-bazel:ci \
+                   ./build_tools/docker/run_bazel_build.sh
 
     - name: Send mail
       if: failure()

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -57,62 +57,36 @@ jobs:
       with:
         cache-suffix: ${{ matrix.os-arch }}-${{ matrix.llvm-build }}-${{ matrix.torch-binary }}
 
-    - name: Configure os-arch='ubuntu-x86_64' llvm-build='in-tree' torch-binary='${{ matrix.torch-binary }}'
+    - name: Build docker image
+      if: ${{ matrix.os-arch == 'ubuntu-x86_64' }}
+      run: |
+        docker build -f build_tools/docker/Dockerfile \
+                     -t torch-mlir-cmake:ci \
+                     .
+
+    - name: Build torch-mlir (os-arch='ubuntu-x86_64' llvm-build='in-tree' torch-binary='${{ matrix.torch-binary }}')
       # Fastest build, most used dev flow
       if: ${{ matrix.os-arch == 'ubuntu-x86_64' && matrix.llvm-build == 'in-tree' }}
       run: |
-        cmake -GNinja -Bbuild \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_C_COMPILER=clang \
-          -DCMAKE_CXX_COMPILER=clang++ \
-          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_LINKER=lld \
-          -DLLVM_ENABLE_ASSERTIONS=ON \
-          -DLLVM_ENABLE_PROJECTS=mlir \
-          -DLLVM_EXTERNAL_PROJECTS="torch-mlir;torch-mlir-dialects" \
-          -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$GITHUB_WORKSPACE" \
-          -DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR="${GITHUB_WORKSPACE}/externals/llvm-external-projects/torch-mlir-dialects" \
-          -DLLVM_TARGETS_TO_BUILD=host \
-          -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-          -DTORCH_MLIR_ENABLE_LTC=ON \
-          -DTORCH_MLIR_USE_INSTALLED_PYTORCH="${{ matrix.torch-binary }}" \
-          -DPython3_EXECUTABLE="$(which python)" \
-          $GITHUB_WORKSPACE/externals/llvm-project/llvm
+        docker run --rm \
+                   -v "$(pwd)":/opt/src/torch-mlir \
+                   -e CCACHE_DIR=/opt/src/torch-mlir/.ccache \
+                   -e TORCH_BINARY="${{ matrix.torch-binary }}" \
+                   torch-mlir-cmake:ci \
+                   ./build_tools/docker/run_cmake_build.sh
 
-    - name: Configure os-arch='ubuntu-x86_64' llvm-build='out-of-tree' torch-binary='${{ matrix.torch-binary }}'
+    - name: Build torch-mlir (os-arch='ubuntu-x86_64' llvm-build='out-of-tree' torch-binary='${{ matrix.torch-binary }}')
       # Most elaborate build, but cached
       if: ${{ matrix.os-arch == 'ubuntu-x86_64' && matrix.llvm-build == 'out-of-tree' }}
       run: |
-        cmake -GNinja -Bllvm-build \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_C_COMPILER=clang \
-          -DCMAKE_CXX_COMPILER=clang++ \
-          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_LINKER=lld \
-          -DLLVM_ENABLE_ASSERTIONS=ON \
-          -DLLVM_ENABLE_PROJECTS=mlir \
-          -DLLVM_TARGETS_TO_BUILD=host \
-          -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-          -DPython3_EXECUTABLE="$(which python)" \
-          $GITHUB_WORKSPACE/externals/llvm-project/llvm
-        cmake --build llvm-build
+        docker run --rm \
+                   -v "$(pwd)":/opt/src/torch-mlir \
+                   -e CCACHE_DIR=/opt/src/torch-mlir/.ccache \
+                   -e TORCH_BINARY="${{ matrix.torch-binary }}" \
+                   torch-mlir-cmake:ci \
+                   ./build_tools/docker/run_cmake_build_oot.sh
 
-        cmake -GNinja -Bbuild \
-          -DCMAKE_C_COMPILER=clang \
-          -DCMAKE_CXX_COMPILER=clang++ \
-          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_LINKER=lld \
-          -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm/" \
-          -DMLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir/" \
-          -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
-          -DTORCH_MLIR_USE_INSTALLED_PYTORCH="${{ matrix.torch-binary }}" \
-          -DPython3_EXECUTABLE="$(which python)" \
-          $GITHUB_WORKSPACE
-
-    - name: Configure os-arch='macos-arm64' llvm-build='in-tree' torch-binary='${{ matrix.torch-binary }}'
+    - name: Build torch-mlir (os-arch='macos-arm64' llvm-build='in-tree' torch-binary='${{ matrix.torch-binary }}')
       # cross compile, can't test arm64
       if: ${{ matrix.os-arch == 'macos-arm64' && matrix.llvm-build == 'in-tree' }}
       run: |
@@ -138,42 +112,20 @@ jobs:
           -DMACOSX_DEPLOYMENT_TARGET=12.0 \
           -DPython3_EXECUTABLE="$(which python)" \
           $GITHUB_WORKSPACE/externals/llvm-project/llvm
-
-    - name: Build torch-mlir
-      if: ${{ matrix.os-arch == 'ubuntu-x86_64' }}
-      run: |
-        cmake --build build
-
-    - name: Build torch-mlir (cross-compile)
-      if: ${{ matrix.os-arch == 'macos-arm64' }}
-      run: |
         cmake --build build_arm64
 
     - name: Run torch-mlir unit tests
       if: ${{ matrix.os-arch == 'ubuntu-x86_64' }}
       run: |
-        cmake --build build --target check-torch-mlir-all
+        docker run --rm \
+                   -v "$(pwd)":/opt/src/torch-mlir \
+                   torch-mlir-cmake:ci \
+                   ./build_tools/docker/run_unit_tests.sh
 
-    - name: Run refbackend e2e integration tests
+    - name: Run torch-mlir integration tests
       if: ${{ matrix.os-arch == 'ubuntu-x86_64' && matrix.llvm-build == 'in-tree' }}
       run: |
-        export PYTHONPATH="$GITHUB_WORKSPACE/build/tools/torch-mlir/python_packages/torch_mlir"
-        python -m e2e_testing.torchscript.main --config=refbackend -v
-
-    - name: Run eager_mode e2e integration tests
-      if: ${{ matrix.os-arch == 'ubuntu-x86_64' && matrix.llvm-build == 'in-tree' }}
-      run: |
-        export PYTHONPATH="$GITHUB_WORKSPACE/build/tools/torch-mlir/python_packages/torch_mlir"
-        python -m e2e_testing.torchscript.main --config=eager_mode -v
-
-    - name: Run tosa e2e integration tests
-      if: ${{ matrix.os-arch == 'ubuntu-x86_64' && matrix.llvm-build == 'in-tree' }}
-      run: |
-        export PYTHONPATH="$GITHUB_WORKSPACE/build/tools/torch-mlir/python_packages/torch_mlir"
-        python -m e2e_testing.torchscript.main --config=tosa -v
-
-    - name: Run lazy_tensor_core e2e integration tests
-      if: ${{ matrix.os-arch == 'ubuntu-x86_64' && matrix.llvm-build == 'in-tree' }}
-      run: |
-        export PYTHONPATH="$GITHUB_WORKSPACE/build/tools/torch-mlir/python_packages/torch_mlir"
-        python -m e2e_testing.torchscript.main --config=lazy_tensor_core -v
+        docker run --rm \
+                   -v "$(pwd)":/opt/src/torch-mlir \
+                   torch-mlir-cmake:ci \
+                   ./build_tools/docker/run_integration_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 .cache/
+.ccache
 .vscode
 .env
 *.code-workspace
@@ -10,6 +11,7 @@ externals/pytorch/
 libtorch*
 
 /build/
+/llvm-build/
 __pycache__
 *.pyc
 

--- a/build_tools/docker/Dockerfile
+++ b/build_tools/docker/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get update                                              && \
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 10
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10
 
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 10
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 10
+
 # Install bazel
 RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${ARCH} -O /usr/bin/bazel \
     && chmod a+x /usr/bin/bazel

--- a/build_tools/docker/Dockerfile
+++ b/build_tools/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update                                              && \
     git                                                            \
     python3-pip                                                    \
     wget                                                           \
-    clang                                                          \
+    clang-10                                                       \
     automake                                                       \
     libtool                                                        \
     curl                                                           \

--- a/build_tools/docker/Dockerfile
+++ b/build_tools/docker/Dockerfile
@@ -1,0 +1,40 @@
+ARG BASE_IMG=ubuntu:18.04
+FROM ${BASE_IMG} as dev-base
+
+ARG ARCH="x86_64"
+ARG TARGETARCH="amd64"
+ARG BAZEL_VERSION=4.2.1
+
+# Install basic packages
+RUN apt-get update                                              && \
+    apt-get install -y                                             \
+    python3.8                                                      \
+    python3.8-dev                                                  \
+    cmake                                                          \
+    ccache                                                         \
+    ninja-build                                                    \
+    git                                                            \
+    python3-pip                                                    \
+    wget                                                           \
+    clang                                                          \
+    automake                                                       \
+    libtool                                                        \
+    curl                                                           \
+    make                                                           \
+    unzip
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 10
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10
+
+# Install bazel
+RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${ARCH} -O /usr/bin/bazel \
+    && chmod a+x /usr/bin/bazel
+
+COPY externals/llvm-project/mlir/python/requirements.txt /opt/app/mlir-requirements.txt
+COPY requirements.txt /opt/app/torch-mlir-requirements.txt
+WORKDIR /opt/app
+RUN python -m pip install --upgrade pip
+RUN python -m pip install -r mlir-requirements.txt
+RUN python -m pip install -r torch-mlir-requirements.txt
+
+WORKDIR /opt/src/torch-mlir

--- a/build_tools/docker/run_bazel_build.sh
+++ b/build_tools/docker/run_bazel_build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cd "$(pwd)/utils/bazel" && bazel build @torch-mlir//...

--- a/build_tools/docker/run_cmake_build.sh
+++ b/build_tools/docker/run_cmake_build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+torch_binary="${TORCH_BINARY:-ON}"
+
+
+# Configure cmake to build torch-mlir in-tree
+cmake -GNinja -Bbuild \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_LINKER=lld \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DLLVM_ENABLE_PROJECTS=mlir \
+  -DLLVM_EXTERNAL_PROJECTS="torch-mlir;torch-mlir-dialects" \
+  -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$(pwd)" \
+  -DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR="$(pwd)/externals/llvm-external-projects/torch-mlir-dialects" \
+  -DLLVM_TARGETS_TO_BUILD=host \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DTORCH_MLIR_ENABLE_LTC=ON \
+  -DTORCH_MLIR_USE_INSTALLED_PYTORCH="${torch_binary}" \
+  -DPython3_EXECUTABLE="$(which python)" \
+  externals/llvm-project/llvm
+
+# Build torch-mlir
+cmake --build build

--- a/build_tools/docker/run_cmake_build_oot.sh
+++ b/build_tools/docker/run_cmake_build_oot.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+torch_binary="${TORCH_BINARY:-ON}"
+
+
+# Configure cmake to build torch-mlir out-of-tree
+cmake -GNinja -Bllvm-build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_LINKER=lld \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DLLVM_ENABLE_PROJECTS=mlir \
+  -DLLVM_TARGETS_TO_BUILD=host \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DPython3_EXECUTABLE="$(which python)" \
+  externals/llvm-project/llvm
+
+# Build llvm
+cmake --build llvm-build
+
+# TODO: Reenable LTC once OOT build is successful (https://github.com/llvm/torch-mlir/issues/1154)
+cmake -GNinja -Bbuild \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_LINKER=lld \
+  -DLLVM_DIR="$(pwd)/llvm-build/lib/cmake/llvm/" \
+  -DMLIR_DIR="$(pwd)/llvm-build/lib/cmake/mlir/" \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
+  -DTORCH_MLIR_USE_INSTALLED_PYTORCH="${torch_binary}" \
+  -DPython3_EXECUTABLE="$(which python)" \
+  .
+
+# Build torch-mlir
+cmake --build build

--- a/build_tools/docker/run_docker.sh
+++ b/build_tools/docker/run_docker.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+docker build -f build_tools/docker/Dockerfile \
+             -t torch-mlir-cmake:dev \
+             .
+
+docker run -it \
+           -v "$(pwd)":/opt/src/torch-mlir \
+           -e CCACHE_DIR=/opt/src/torch-mlir/.ccache \
+           torch-mlir-cmake:dev

--- a/build_tools/docker/run_integration_tests.sh
+++ b/build_tools/docker/run_integration_tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+export PYTHONPATH="$(pwd)/build/tools/torch-mlir/python_packages/torch_mlir"
+
+# refbackend e2e tests
+python -m e2e_testing.torchscript.main --config=refbackend -v -s
+
+# eagermode backend e2e tests
+python -m e2e_testing.torchscript.main --config=eager_mode -v -s
+
+# tosa backend e2e tests
+python -m e2e_testing.torchscript.main --config=tosa -v -s
+
+# ltc backend e2e tests
+python -m e2e_testing.torchscript.main --config=lazy_tensor_core -v -s

--- a/build_tools/docker/run_unit_tests.sh
+++ b/build_tools/docker/run_unit_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Full suite
+# cmake --build build --target check-torch-mlir-all
+
+# Run torch-mlir unit tests.
+cmake --build build --target check-torch-mlir
+
+# Run torch-mlir-python unit tests.
+cmake --build build --target check-torch-mlir-python
+
+# Run torch-mlir-dialects unit tests.
+cmake --build build --target check-torch-mlir-dialects

--- a/development.md
+++ b/development.md
@@ -8,6 +8,28 @@ cd torch-mlir
 git submodule update --init
 ```
 
+## Docker Setup for CMake Builds + Tests (Ubuntu_x86-64 only)
+
+We provide a minimal self-contained docker setup with the required dependencies
+for a CMake build of torch-mlir. This allows easy and consistent setup for reproducing
+CI locally and local validation of PRs using unit tests and python integration tests.
+It is only supported for the most used developer workflows using Ubuntu_x86-64 platform,
+and does not support cross-compiling on MacOS-arm-64 platform.
+
+```shell
+# Build an image and launch an interactive docker container
+./build_tools/docker/run_docker.sh
+
+# Run cmake build (either in-tree or out-of-tree)
+./build_tools/docker/run_cmake_build{_oot}.sh
+
+# Run torch-mlir unit tests (+ python + dialect LIT tests)
+./build_tools/docker/run_unit_tests.sh
+
+# Run torch-mlir integration tests
+./build_tools/docker/run_integration_tests.sh
+```
+
 ## Setup your Python VirtualEnvironment and Dependencies
 
 Also, ensure that you have the appropriate `python-dev` package installed

--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -2,8 +2,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-build --action_env=CC=clang-10
-build --action_env=CXX=clang-cpp-10
+build --action_env=CC=clang
+build --action_env=CXX=clang++
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
 build --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=0

--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -2,10 +2,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-build --action_env=CC=clang
-build --action_env=CXX=clang++
-build --cxxopt=-std=c++17 
-build --host_cxxopt=-std=c++17 
+build --action_env=CC=clang-10
+build --action_env=CXX=clang-cpp-10
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
 build --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=0
 build --cxxopt=-U__GXX_ABI_VERSION
 build --cxxopt=-D__GXX_ABI_VERSION=1011


### PR DESCRIPTION
A follow-on to https://github.com/llvm/torch-mlir/pull/1225 to launch bazel builds in GHA (as well as locally) inside a docker container. Requires #1225 to land first.

Review just the following files (non bazel diffs are split into #1225 for ease of review):
* `.github/workflows/bazelBuildAndTest.yml`
* `build_tools/docker/run_bazel_build.sh`
* `utils/bazel/.bazelrc`