### PR TITLE
Dockerize and Cache Bazel {Local, CI} Builds

### DIFF
--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -20,20 +20,38 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-
     - name: Checkout torch-mlir
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
 
-    - name: Build with bazel
+    - name: Setup cache for bazel
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/bazel
+        key: ubuntu_x86_64_torch_mlir_bazel_build_cache
+
+    - name: Set bazel cache permissions
       run: |
-        cd $GITHUB_WORKSPACE/utils/bazel
-        bazel build @torch-mlir//...
+        sudo chown -R root:root "${HOME}/.cache/bazel"
+
+    - name: Build docker image
+      run: |
+        docker build -f utils/bazel/docker/Dockerfile \
+                     -t torch-mlir:ci \
+                     .
+
+    - name: Bazel build torch-mlir
+      run: |
+        docker run --rm \
+                   -v "$(pwd)":"/opt/src/torch-mlir" \
+                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   torch-mlir:ci \
+                   ./utils/bazel/docker/run_bazel_build.sh
+
+    - name: Switch bazel cache permissions
+      run: |
+        sudo chown -R "$USER":"$USER" "${HOME}/.cache/bazel"
 
     - name: Send mail
       if: failure()

--- a/development.md
+++ b/development.md
@@ -175,14 +175,15 @@ manually `source`'d in a shell.
 
 Torch-MLIR can also be built using Bazel (apart from the official CMake build) for users that depend on Bazel in their workflows. To build `torch-mlir-opt` using Bazel, follow these steps:
 
-1. Install [Bazel](https://docs.bazel.build/versions/main/install.html) if you don't already have it
-2. Install a relatively new release of [Clang](https://releases.llvm.org/download.html)
-3. Build:
+1. Launch an interactive docker container with the required deps installed:
 ```shell
-cd utils/bazel
-bazel build @torch-mlir//...
+./utils/bazel/docker/run_docker.sh
 ```
-4. Find the built binary at `bazel-bin/external/torch-mlir/torch-mlir-opt`.
+2. Build torch-mlir using bazel (from container):
+```shell
+./utils/bazel/docker/run_bazel_build.sh
+```
+3. Find the built binary at `utils/bazel/bazel-bin/external/torch-mlir/torch-mlir-opt`.
 
 
 # Testing

--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -4,8 +4,8 @@
 
 build --action_env=CC=clang
 build --action_env=CXX=clang++
-build --cxxopt=-std=c++17 
-build --host_cxxopt=-std=c++17 
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
 build --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=0
 build --cxxopt=-U__GXX_ABI_VERSION
 build --cxxopt=-D__GXX_ABI_VERSION=1011

--- a/utils/bazel/docker/Dockerfile
+++ b/utils/bazel/docker/Dockerfile
@@ -1,0 +1,34 @@
+ARG BASE_IMG=ubuntu:18.04
+FROM ${BASE_IMG} as dev-base
+
+ARG ARCH="x86_64"
+ARG BAZEL_VERSION=5.2.0
+
+# Install basic packages
+RUN apt-get update                                              && \
+    apt-get install -y                                             \
+    clang-10                                                       \
+    curl                                                           \
+    git                                                            \
+    python3-pip                                                    \
+    python3.8                                                      \
+    python3.8-dev                                                  \
+    wget                                                           \
+    unzip
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 10
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 10
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 10
+
+# Install bazel
+RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${ARCH} -O /usr/bin/bazel \
+    && chmod a+x /usr/bin/bazel
+
+COPY requirements.txt /opt/app/requirements.txt
+WORKDIR /opt/app
+RUN python -m pip install --upgrade pip
+RUN python -m pip install --ignore-installed -r requirements.txt
+
+WORKDIR /opt/src/torch-mlir

--- a/utils/bazel/docker/run_bazel_build.sh
+++ b/utils/bazel/docker/run_bazel_build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cd "$(pwd)/utils/bazel" && bazel build @torch-mlir//...

--- a/utils/bazel/docker/run_docker.sh
+++ b/utils/bazel/docker/run_docker.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+docker build -f utils/bazel/docker/Dockerfile \
+             -t torch-mlir:dev \
+             .
+
+docker run -it \
+           -v "$(pwd)":"/opt/src/torch-mlir" \
+           -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+           torch-mlir:dev


### PR DESCRIPTION
This PR adds:
- A minimal docker wrapper to the bazel GHA workflow to make it reproducible locally
 - Bazel cache to speed up GHA workflows (down to ~5 minutes from ~40+minutes)

This is a no-op for non-bazel workflows and an incremental improvement.