### PR TITLE
Add a concept of "backend legal ops".

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
@@ -35,14 +35,26 @@ struct TorchLoweringPipelineOptions
       llvm::cl::desc(
           "Maximum number of invocations of the simplification pipeline."),
       llvm::cl::init(10)};
-  // If this option is false, decompose complex operations.
-  // If this option is true, skip decomposition of complex operations.
-  // TODO: This should be replaced with a list of operations to decompose.
-  // (or some other way to specify the set of allowed ops in the backend
-  // contract)
+  // If this option is true, decompose complex operations.
+  // If this option is false, skip decomposition of complex operations.
   Option<bool> decompose{*this, "decompose-complex-ops",
                          llvm::cl::desc("Decompose complex operations."),
                          llvm::cl::init(true)};
+  // A list of ops that should be considered legal for the backend.
+  // TODO: The meaning of this list should be formalized.
+  // A sketch of the semantics would be:
+  // - In torch_ods_gen.py, we mark each op as "legal in backend contract",
+  // "illegal in backend contract", or "conditionally legal in backend
+  // contract".
+  // This option would be a list of ops from the "conditionally legal" set
+  // which should be considered legal for a particular invocation of the
+  // lowering pipeline.
+  // TODO: The "decompose" flag should be expanded into this formulation
+  // of legality for the backend. Ultimately we will want LowerToBackendContract
+  // to check for a specific set of legal ops to stop its iteration.
+  ListOption<std::string> backendLegalOps{
+      *this, "backend-legal-ops",
+      llvm::cl::desc("List of ops to be considered legal for the backend.")};
 };
 
 /// Creates a pipeline that lowers the object graph IR that is produced by
@@ -93,7 +105,8 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createEraseModuleInitializerPass();
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createLowerToBackendContractPass(int maxIterations, bool decompose);
+createLowerToBackendContractPass(int maxIterations, bool decompose,
+                                 ArrayRef<std::string> backendLegalOps);
 
 StringRef getShapeLibrary();
 

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -218,6 +218,11 @@ def RefinePublicReturn : Pass<"torch-refine-public-return", "ModuleOp"> {
 def DecomposeComplexOps : Pass<"torch-decompose-complex-ops", "func::FuncOp"> {
   let summary = "Decompose complicated torch operations";
   let constructor = "mlir::torch::Torch::createDecomposeComplexOpsPass()";
+  let options = [
+    ListOption<"legalOps", "legal-ops", "std::string",
+               "List of operation names that should be considered legal",
+               "llvm::cl::ZeroOrMore">
+  ];
   let description = [{
     Decompose torch operation that are losslessly represented as combinations of
     other operations, modulo appropropriate compiler fusion. Note that this pass
@@ -270,7 +275,7 @@ def LowerToBackendContract
   let summary = "Perform simplifications until the backend contract is satisfied.";
   let constructor = [{
     mlir::torch::Torch::createLowerToBackendContractPass(
-      /*maxIterations=*/10, /*decompose=*/true)
+      /*maxIterations=*/10, /*decompose=*/true, /*backendLegalOps=*/{})
   }];
   let description = [{
     This pass performs the bulk of the lowering of the program's computations
@@ -311,9 +316,10 @@ def LowerToBackendContract
   let options = [
     Option<"maxIterations", "max-iterations", "int", /*default=*/"10",
            "Maximum number of invocations of the simplification pipeline.">,
-    // TODO: Make this a configurable set of ops.
     Option<"decompose", "decompose", "bool", /*default=*/"true",
-           "Decompose ops.">
+           "Decompose ops.">,
+    ListOption<"backendLegalOps", "backend-legal-ops", "std::string",
+               "List of ops to be considered legal for the backend.">
 
   ];
   // TODO: Debug why this is needed, even though the input program has func.func

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -2465,6 +2465,11 @@ public:
 namespace {
 class DecomposeComplexOpsPass
     : public DecomposeComplexOpsBase<DecomposeComplexOpsPass> {
+public:
+  DecomposeComplexOpsPass() = default;
+  DecomposeComplexOpsPass(ArrayRef<std::string> legalOps) {
+    this->legalOps = legalOps;
+  }
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
@@ -2629,6 +2634,10 @@ class DecomposeComplexOpsPass
     target.addIllegalOp<AtenNarrowOp>();
     patterns.add<DecomposeAten_EmbeddingBagOp>(context);
     target.addIllegalOp<Aten_EmbeddingBagOp>();
+
+    for (std::string opName : legalOps) {
+      target.addLegalOp(OperationName(opName, context));
+    }
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {

--- a/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
+++ b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
@@ -201,9 +201,11 @@ class LowerToBackendContractPass
     : public LowerToBackendContractBase<LowerToBackendContractPass> {
 public:
   LowerToBackendContractPass() = default;
-  LowerToBackendContractPass(int maxIterations, bool decompose) {
+  LowerToBackendContractPass(int maxIterations, bool decompose,
+                             ArrayRef<std::string> backendLegalOps) {
     this->maxIterations = maxIterations;
     this->decompose = decompose;
+    this->backendLegalOps = backendLegalOps;
   }
   void runOnOperation() override {
     ModuleOp module = getOperation();
@@ -211,6 +213,7 @@ public:
     OpPassManager pm(module.getOperationName());
     TorchLoweringPipelineOptions options;
     options.decompose = decompose;
+    options.backendLegalOps = backendLegalOps;
     createTorchSimplificationPipeline(pm, options);
 
     int i = 0;
@@ -241,7 +244,8 @@ public:
 } // namespace
 
 std::unique_ptr<OperationPass<ModuleOp>>
-mlir::torch::Torch::createLowerToBackendContractPass(int maxIterations,
-                                                     bool decompose) {
-  return std::make_unique<LowerToBackendContractPass>(maxIterations, decompose);
+mlir::torch::Torch::createLowerToBackendContractPass(
+    int maxIterations, bool decompose, ArrayRef<std::string> backendLegalOps) {
+  return std::make_unique<LowerToBackendContractPass>(maxIterations, decompose,
+                                                      backendLegalOps);
 }

--- a/lib/Dialect/Torch/Transforms/Passes.cpp
+++ b/lib/Dialect/Torch/Transforms/Passes.cpp
@@ -74,8 +74,8 @@ void mlir::torch::Torch::createTorchFunctionToTorchBackendPipeline(
   pm.addPass(createAdjustCallingConventionsPass());
   // Perform the bulk of lowering to the backend contract.
   // See the pass documentation for more information.
-  pm.addPass(createLowerToBackendContractPass(options.maxIterations,
-                                              options.decompose));
+  pm.addPass(createLowerToBackendContractPass(
+      options.maxIterations, options.decompose, options.backendLegalOps));
 }
 
 // A simplification pipeline to establish the invariants of the backend

--- a/test/Dialect/Torch/decompose-complex-ops-legal.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops-legal.mlir
@@ -1,0 +1,10 @@
+// RUN: torch-mlir-opt -torch-decompose-complex-ops="legal-ops=torch.aten.softmax.int" -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @torch.aten.softmax.int$cst_dim
+func.func @torch.aten.softmax.int$cst_dim(%t: !torch.tensor<[2,3],f32>) -> !torch.tensor<[2,3],f32> {
+  %none = torch.constant.none
+  %dim = torch.constant.int 1
+  // CHECK: torch.aten.softmax.int
+  %ret = torch.aten.softmax.int %t, %dim, %none : !torch.tensor<[2,3],f32>, !torch.int, !torch.none -> !torch.tensor<[2,3],f32>
+  return %ret : !torch.tensor<[2,3],f32>
+}


### PR DESCRIPTION
This is a first step towards formalizing the set of ops in our backend
contract. The goal is to eventually formalize `torch` dialect ops into 3
categories:
1. Legal in backend contract
2. Illegal in backend contract
3. Conditionally legal in backend contract

The "conditionally legal" set are the ops that we can optionally
decompose for backends.

This patch adds relevant pass options for this throughout the compiler,
in preparation for a new set of traits which will formalize this
classification.