### PR TITLE
[Bazel] Add `LowerToBackendContract.cpp` to `TorchMLIRTorchPasses` bazel target

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -172,6 +172,7 @@ cc_library(
         "lib/Dialect/Torch/Transforms/EraseModuleInitializer.cpp",
         "lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp",
         "lib/Dialect/Torch/Transforms/InlineGlobalSlots.cpp",
+        "lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp",
         "lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp",
         "lib/Dialect/Torch/Transforms/Passes.cpp",
         "lib/Dialect/Torch/Transforms/PrepareForGlobalizeObjectGraph.cpp",


### PR DESCRIPTION
Pass is introduced in [this commit](https://github.com/llvm/torch-mlir/commit/57681f794764a34c34e2be7f07f7dfbcafa683c1). Including it to the bazel targets to get a green build.