### PR TITLE
[MLIR][TORCH] Add torch.Device type to backend contract scalar types

### DIFF
--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -124,6 +124,7 @@ TOSA_PASS_SET = {
     "OnesModuleInt_basic",
     "OnesModuleFloat_basic",
     "OnesModuleFalsePinMemory_basic",
+    "OnesModuleCPUDevice_basic",
     "NewZerosModuleDefaultDtype_basic",
     "NewZerosModuleInt2D_basic",
     "NewZerosModuleInt3D_basic",

--- a/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
+++ b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
@@ -30,7 +30,8 @@ using namespace mlir::torch::Torch;
 static LogicalResult checkType(Operation *op, Type type,
                                bool actuallyEmitDiagnostics) {
   // Allow various scalar types that backends are expected to be able to handle.
-  if (type.isa<Torch::IntType, Torch::FloatType, Torch::BoolType>())
+  if (type.isa<Torch::IntType, Torch::FloatType, Torch::BoolType,
+               Torch::DeviceType>())
     return success();
 
   // Backends are not expected to support dynamic computations on these types,

--- a/python/torch_mlir_e2e_test/test_suite/constant_alloc.py
+++ b/python/torch_mlir_e2e_test/test_suite/constant_alloc.py
@@ -195,6 +195,24 @@ def OnesModuleFalsePinMemory_basic(module, tu: TestUtils):
     module.forward()
 
 
+class OnesModuleCPUDevice(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return torch.ones(3, 4, device="cpu")
+
+
+@register_test_case(module_factory=lambda: OnesModuleCPUDevice())
+def OnesModuleCPUDevice_basic(module, tu: TestUtils):
+    module.forward()
+
+
 # ==============================================================================
 
 


### PR DESCRIPTION
This error was coming up for various models:
```
Traceback (most recent call last):
  File "v_diffusion_model_only.py", line 208, in <module>
    module = torch_mlir.compile(
  File "/home/vivek/work/02_07/vivekkhandelwal1-torch-mlir/build/tools/torch-mlir/python_packages/torch_mlir/torch_mlir/__init__.py", line 217, in compile
    run_pipeline_with_repro_report(mb.module,
  File "/home/vivek/work/02_07/vivekkhandelwal1-torch-mlir/build/tools/torch-mlir/python_packages/torch_mlir/torch_mlir/compiler_utils.py", line 73, in run_pipeline_with_repro_report
    raise TorchMlirCompilerError(trimmed_message) from None
torch_mlir.compiler_utils.TorchMlirCompilerError: Lowering TorchScript IR -> Torch Backend IR failed with the following diagnostics:
error: unsupported by backend contract: type '!torch.Device'
note: see current operation: %554 = "torch.constant.device"() {value = "cpu"} : () -> !torch.Device
```
because of `!torch.Device` missing from the list of valid scalar types satisfying backend contract. This commit fixes this issue by adding the type `!torch.Device` to the list.

IR dump of the v-diffusion model which throws this error: https://gist.github.com/e0d8bd737b698868238db176fa054565