### PR TITLE
Don't explicitly set MLIR_PDLL_TABLEGEN_EXE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,9 +106,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 else()
   message(STATUS "Torch-MLIR in-tree build.")
   # In-tree build with LLVM_EXTERNAL_PROJECTS=torch-mlir
-  if (TORCH_MLIR_ENABLE_MHLO)
-    set(MLIR_PDLL_TABLEGEN_EXE mlir-pdll)
-  endif()
 
   option(MLIR_ENABLE_BINDINGS_PYTHON "Enables MLIR Python Bindings" OFF)
   option(TORCH_MLIR_ENABLE_JIT_IR_IMPORTER "Enables JIT IR Importer" ON)


### PR DESCRIPTION
With llvm/llvm-project@91b6f76, the variable `MLIR_PDLL_TABLEGEN_EXE` is
set as a cache variable in MLIR upstream.

Likely requires an update of externals/mlir-hlo to
tensorflow/mlir-hlo@4f2a00b or later.