### PR TITLE
Fix LTC lib_torch_mlir_ltc.so import error

### DIFF
--- a/docs/ltc_examples.md
+++ b/docs/ltc_examples.md
@@ -6,7 +6,7 @@ Refer to the main documentation [here](ltc_backend.md).
 ```python
 import torch
 import torch._lazy
-import torch_mlir.reference_lazy_backend._REFERENCE_LAZY_BACKEND as lazy_backend
+import torch_mlir._mlir_libs._REFERENCE_LAZY_BACKEND as lazy_backend
 
 # Register the example LTC backend.
 lazy_backend._initialize()

--- a/examples/ltc_backend_bert.py
+++ b/examples/ltc_backend_bert.py
@@ -113,7 +113,7 @@ def main(device='lazy', full_size=False):
     losses = train(model, num_epochs, num_training_steps, train_dataloader, device)
 
     # Get debug information from LTC
-    if 'torch_mlir.reference_lazy_backend._REFERENCE_LAZY_BACKEND' in sys.modules:
+    if 'torch_mlir._mlir_libs._REFERENCE_LAZY_BACKEND' in sys.modules:
         computation = lazy_backend.get_latest_computation()
         if computation:
             print(computation.debug_string())
@@ -148,7 +148,7 @@ if __name__ == "__main__":
             torch._lazy.ts_backend.init()
 
         elif args.device == "MLIR_EXAMPLE":
-            import torch_mlir.reference_lazy_backend._REFERENCE_LAZY_BACKEND as lazy_backend
+            import torch_mlir._mlir_libs._REFERENCE_LAZY_BACKEND as lazy_backend
 
             lazy_backend._initialize()
 

--- a/examples/ltc_backend_mnist.py
+++ b/examples/ltc_backend_mnist.py
@@ -65,7 +65,7 @@ def main(device='lazy'):
             torch._lazy.mark_step()
 
     # Get debug information from LTC
-    if 'torch_mlir.reference_lazy_backend._REFERENCE_LAZY_BACKEND' in sys.modules:
+    if 'torch_mlir._mlir_libs._REFERENCE_LAZY_BACKEND' in sys.modules:
         computation = lazy_backend.get_latest_computation()
         if computation:
             print(computation.debug_string())
@@ -93,7 +93,7 @@ if __name__ == "__main__":
             torch._lazy.ts_backend.init()
 
         elif args.device == "MLIR_EXAMPLE":
-            import torch_mlir.reference_lazy_backend._REFERENCE_LAZY_BACKEND as lazy_backend
+            import torch_mlir._mlir_libs._REFERENCE_LAZY_BACKEND as lazy_backend
 
             lazy_backend._initialize()
 

--- a/python/test/lazy_backend/device_data_name.py
+++ b/python/test/lazy_backend/device_data_name.py
@@ -9,7 +9,7 @@
 import torch
 import torch._lazy
 
-import torch_mlir.reference_lazy_backend._REFERENCE_LAZY_BACKEND as lazy_backend
+import torch_mlir._mlir_libs._REFERENCE_LAZY_BACKEND as lazy_backend
 
 from run_test import run_test
 

--- a/python/torch_mlir/csrc/base_lazy_backend/CMakeLists.txt
+++ b/python/torch_mlir/csrc/base_lazy_backend/CMakeLists.txt
@@ -86,7 +86,7 @@ target_link_libraries(torch_mlir_ltc_backend
 
 message(STATUS "TORCH_CXXFLAGS=${TORCH_CXXFLAGS} -Wno-pedantic")
 set_target_properties(torch_mlir_ltc_backend PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/base_lazy_backend"
+  LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs"
   OUTPUT_NAME lib_torch_mlir_ltc
   PREFIX ""
   SUFFIX ".so"

--- a/python/torch_mlir/csrc/reference_lazy_backend/CMakeLists.txt
+++ b/python/torch_mlir/csrc/reference_lazy_backend/CMakeLists.txt
@@ -26,7 +26,7 @@ mlir_configure_python_dev_packages()
 # Library definition
 ###########################################################################
 
-set(LIBRARY_OUTPUT_PATH  "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/reference_lazy_backend")
+set(LIBRARY_OUTPUT_PATH  "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs")
 set(OUTPUT_NAME "_REFERENCE_LAZY_BACKEND")
 
 if(TORCH_MLIR_ENABLE_LTC)
@@ -64,6 +64,10 @@ if(TORCH_MLIR_ENABLE_LTC)
           CXX_VISIBILITY_PRESET "hidden"
           COMPILE_FLAGS "${TORCH_CXXFLAGS} -Wno-pedantic"
           )
+  mlir_python_setup_extension_rpath(reference_lazy_backend)
+
+  torch_mlir_python_target_compile_options(reference_lazy_backend)
+  mlir_check_all_link_libraries(reference_lazy_backend)
 else()
   # To avoid import errors when LTC is disabled (and a bunch of checks
   # associated with that), we will generate a dummy placeholder library.

--- a/python/torch_mlir/csrc/reference_lazy_backend/CMakeLists.txt
+++ b/python/torch_mlir/csrc/reference_lazy_backend/CMakeLists.txt
@@ -26,6 +26,8 @@ mlir_configure_python_dev_packages()
 # Library definition
 ###########################################################################
 
+# We piggyback on the shared library setup/infra used by Torch-MLIR Python bindings for consistency.
+# https://github.com/llvm/torch-mlir/pull/1283
 set(LIBRARY_OUTPUT_PATH  "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs")
 set(OUTPUT_NAME "_REFERENCE_LAZY_BACKEND")
 

--- a/python/torch_mlir_e2e_test/torchscript/configs/lazy_tensor_core.py
+++ b/python/torch_mlir_e2e_test/torchscript/configs/lazy_tensor_core.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
 
-import torch_mlir.reference_lazy_backend._REFERENCE_LAZY_BACKEND as lazy_backend
+import torch_mlir._mlir_libs._REFERENCE_LAZY_BACKEND as lazy_backend
 import torch
 from torch.utils._pytree import tree_map
 


### PR DESCRIPTION
Addresses https://github.com/llvm/torch-mlir/issues/1271, which will allow LTC to work from the prebuild wheels without import issues.

Previously, we were missing some cmake macros to include `$ORIGIN` to the list of directories searched for shared libraries.

As part of this, the reference LTC backend + base LTC backend were moved to `_mlir_libs` to be consistent with our other libraries (and also because the both of the libs need to be in the same directory for linking).

cc: @ke1337 @antoniojkim 