### PR TITLE
Implement Expand/Collapse Functionality for Aten.View

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -22,6 +22,14 @@ EAGER_MODE_XFAIL_SET = {
 }
 
 MHLO_PASS_SET = {
+    "ViewDoubleMergeStaticModule_basic",
+    "ViewCollapseOnesMiddleModule_basic",
+    "ViewFiveTestStaticModule_basic",
+    "ViewOffsetTestStaticModule_basic",
+    "ViewTwoFiveThreeStaticModule_basic",
+    "ViewTwoToThreeStaticModule_basic",
+    "ViewExpandOnesMiddleOppModule_basic",
+    "ViewOffsetBackwardTestStaticModule_basic",
     "FlattenStaticModule_basic",
     "FlattenRank0Module_basic",
     "TensorsConcatNegativeDimModule_basic",
@@ -159,6 +167,14 @@ MHLO_PASS_SET = {
 # Write the TOSA set as a "passing" set as it is very early in development
 # and very few tests work yet.
 TOSA_PASS_SET = {
+    "ViewDoubleMergeStaticModule_basic",
+    "ViewCollapseOnesMiddleModule_basic",
+    "ViewFiveTestStaticModule_basic",
+    "ViewOffsetTestStaticModule_basic",
+    "ViewTwoFiveThreeStaticModule_basic",
+    "ViewTwoToThreeStaticModule_basic",
+    "ViewExpandOnesMiddleOppModule_basic",
+    "ViewOffsetBackwardTestStaticModule_basic",
     "ElementwiseUnaryModule_basic",
     "ElementwiseBinaryModule_basic",
     "ElementwiseSigmoidModule_basic",

--- a/python/torch_mlir_e2e_test/test_suite/reshape_like.py
+++ b/python/torch_mlir_e2e_test/test_suite/reshape_like.py
@@ -84,6 +84,25 @@ class ViewExpandOnesMiddleModule(torch.nn.Module):
 def ViewExpandOnesMiddleModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1, 2))
 
+    # ==============================================================================
+
+class ViewCollapseOnesMiddleModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, 1, 1, 1, 1, 2], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(3, 1, 2)
+
+@register_test_case(module_factory=lambda: ViewCollapseOnesMiddleModule())
+def ViewCollapseOnesMiddleModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 1, 1, 1, 1, 2))
+
 # ==============================================================================
 
 class ViewDynamicExpandModule(torch.nn.Module):
@@ -237,6 +256,158 @@ class ViewDynamicExpandCollapseWithAtenIntModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ViewDynamicExpandCollapseWithAtenIntModule())
 def ViewDynamicExpandCollapseWithAtenIntModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 4, 8, 8))
+
+# ==============================================================================
+
+class ViewTwoToThreeStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3,2], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(2, 3)
+
+@register_test_case(module_factory=lambda: ViewTwoToThreeStaticModule())
+def ViewTwoToThreeStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 2))
+
+# ==============================================================================
+
+class ViewTwoFiveThreeStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, 5, 2], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(2, 5, 3)
+
+@register_test_case(module_factory=lambda: ViewTwoFiveThreeStaticModule())
+def ViewTwoFiveThreeStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 5, 2))
+
+# ==============================================================================
+
+class ViewFiveTestStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([2, 3, 4, 5, 6], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(2, 3, 4, 6, 5)
+
+@register_test_case(module_factory=lambda: ViewFiveTestStaticModule())
+def ViewFiveTestStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4, 5, 6))
+
+# ==============================================================================
+
+class ViewOffsetTestStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([2, 3, 2, 2, 5, 6], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(2, 3, 4, 6, 5)
+
+@register_test_case(module_factory=lambda: ViewOffsetTestStaticModule())
+def ViewOffsetTestStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 2, 2, 5, 6))
+
+# ==============================================================================
+
+class ViewOffsetBackwardTestStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([2, 3, 4, 5, 6], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(2, 3, 2, 2, 6, 5)
+
+@register_test_case(module_factory=lambda: ViewOffsetBackwardTestStaticModule())
+def ViewOffsetBackwardTestStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4, 5, 6))
+
+# ==============================================================================
+
+class ViewUnknown1TestStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([2, 3, -1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(3, 2, a.size(2))
+
+@register_test_case(module_factory=lambda: ViewUnknown1TestStaticModule())
+def ViewUnknown1TestStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 5))
+
+# ==============================================================================
+
+class ViewUnknown2TestStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, 2, 3], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(a.size(0), 3, 2)
+
+@register_test_case(module_factory=lambda: ViewUnknown2TestStaticModule())
+def ViewUnknown2TestStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 2, 3))
+
+# ==============================================================================
+
+class ViewDoubleMergeStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([2, 2, 4, 4], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(4, 16)
+
+@register_test_case(module_factory=lambda: ViewDoubleMergeStaticModule())
+def ViewDoubleMergeStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 2, 4, 4))
 
 # ==============================================================================
 
@@ -561,3 +732,4 @@ class ReshapeAliasCollapseModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReshapeAliasCollapseModule())
 def ReshapeAliasCollapseModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 4))
+


### PR DESCRIPTION
(Currently Unfinished, will also be squashing commits later once the commit is in better shape)

Currently working on making a fix so that a view with dimensions [3,2] can be displayed as [2,3].