### PR TITLE
Set ccache logging to verbose temporarily

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -36,3 +36,4 @@ runs:
     with:
       key: ${{ runner.os }}-torch_mlir_build_assets-${{ inputs.cache-suffix }}
       max-size: 2G
+      verbose: 2


### PR DESCRIPTION
This is to debug what is causing the exactly ccache look up failures etc.