### PR TITLE
Use pre-compiled headers for PyTorch Source builds

### DIFF
--- a/build_tools/build_libtorch.sh
+++ b/build_tools/build_libtorch.sh
@@ -99,6 +99,7 @@ build_pytorch() {
   USE_PYTORCH_QNNPACK=ON \
   USE_QNNPACK=OFF \
   USE_XNNPACK=OFF \
+  USE_PRECOMPILED_HEADERS=1 \
   ${PYTHON_BIN} setup.py  bdist_wheel -d "$WHEELHOUSE"
 }
 


### PR DESCRIPTION
This should speed up source builds and ccache. May cause issues on macOS (https://github.com/pytorch/pytorch/issues/80018)