### PR TITLE
[MHLO] add new options to pipeline

### DIFF
--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
@@ -36,9 +36,22 @@ void createTorchBackendToTosaBackendPipeline(
 
 // Do not register the torch-to-mhlo pipeline if mhlo target is disabled
 #ifdef TORCH_MLIR_ENABLE_MHLO
+struct MhloBackendPipelineOptions
+    : public PassPipelineOptions<MhloBackendPipelineOptions> {
+  Option<bool> enableStaticShape{
+      *this, "enable-static-shape",
+      llvm::cl::desc("Enable static shape conversion."), llvm::cl::init(false)};
+  // The i64 calculation is much slower than i32 on some devices, such as
+  // Nvidia GPU. One can truncate from i64 to i32 since dimension sizes
+  // are unlikely to exceed the range of i32(4GiB)
+  Option<bool> enableI32Index{
+      *this, "enable-i32-index",
+      llvm::cl::desc("Enable truncate index from i64 to i32(unsafely)"),
+      llvm::cl::init(false)};
+};
+
 void createTorchBackendToMhloBackendPipeline(
-    OpPassManager &pm,
-    const torch::Torch::TorchLoweringPipelineOptions &options);
+    OpPassManager &pm, const MhloBackendPipelineOptions &options);
 std::unique_ptr<OperationPass<ModuleOp>> createVerifyMhloBackendContractPass();
 #endif
 

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -53,7 +53,7 @@ void mlir::torch::registerTorchConversionPasses() {
       "contract.",
       TorchConversion::createTorchBackendToTosaBackendPipeline);
 #ifdef TORCH_MLIR_ENABLE_MHLO
-  mlir::PassPipelineRegistration<Torch::TorchLoweringPipelineOptions>(
+  mlir::PassPipelineRegistration<TorchConversion::MhloBackendPipelineOptions>(
       "torch-backend-to-mhlo-backend-pipeline",
       "Pipeline lowering torch backend contract to MHLO backend "
       "contract.",
@@ -121,8 +121,10 @@ void TorchConversion::createTorchBackendToTosaBackendPipeline(
 
 #ifdef TORCH_MLIR_ENABLE_MHLO
 void TorchConversion::createTorchBackendToMhloBackendPipeline(
-    OpPassManager &pm, const Torch::TorchLoweringPipelineOptions &options) {
-  pm.addNestedPass<func::FuncOp>(createConvertTorchToMhloPass());
+    OpPassManager &pm,
+    const TorchConversion::MhloBackendPipelineOptions &options) {
+  pm.addNestedPass<func::FuncOp>(createConvertTorchToMhloPass(
+      options.enableStaticShape, options.enableI32Index));
 
   // Clean up any non-canonical code introduced above..
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());


### PR DESCRIPTION
Follow up on the comments, add enableI32Index and enableStaticShape options in the pipeline:

> We already have this registered there:
> 
> ```
> #ifdef TORCH_MLIR_ENABLE_MHLO
>   mlir::PassPipelineRegistration<Torch::TorchLoweringPipelineOptions>(
>       "torch-backend-to-mhlo-backend-pipeline",
>       "Pipeline lowering torch backend contract to MHLO backend "
>       "contract.",
>       TorchConversion::createTorchBackendToMhloBackendPipeline);
> #endif
> ```
> 
> You can replace `Torch::TorchLoweringPipelineOptions` with a new struct with options parallel to `def ConvertTorchToMhlo : Pass<"convert-torch-to-mhlo", "func::FuncOp"> {` (this is redundant but required in MLIR now).

https://github.com/llvm/torch-mlir/pull/1315#issuecomment-1233552315