### PR TITLE
[Bazel] Remove MHLO enable flag

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -314,10 +314,7 @@ gentbl_cc_library(
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            [
-                "-gen-pass-decls",
-                "-DTORCH_MLIR_ENABLE_MHLO",
-            ],
+            ["-gen-pass-decls"],
             "include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h.inc",
         ),
     ],


### PR DESCRIPTION
The `-DTORCH_MLIR_ENABLE_MHLO` flag was recently introduced for `TorchMLIRTorchConversionPassesIncGen` [here](https://sourcegraph.com/github.com/llvm/torch-mlir@99093d0623c3d3e6fb961ad0c8fda5ee9fc264fe/-/blob/utils/bazel/torch-mlir-overlay/BUILD.bazel?L319) in [this recent PR](https://github.com/llvm/torch-mlir/pull/1321) (was already present for `TorchMLIRConversionPassesIncGen` [here](https://sourcegraph.com/github.com/llvm/torch-mlir@99093d0623c3d3e6fb961ad0c8fda5ee9fc264fe/-/blob/utils/bazel/torch-mlir-overlay/BUILD.bazel?L288)). Before this PR, the MHLO sources in TorchConversion were not being built. This indicates a build issue that pre-existed but didn’t trigger until this path was enabled recently. Disabling to get the build green for now, until we can diagnose and fix the build for MHLO sources in TorchConversion.