### PR TITLE
python: add `CHECK-LABEL` statements to localize checks

### DIFF
--- a/test/python/importer/jit_ir/ivalue_import/object-identity-torch-bug.py
+++ b/test/python/importer/jit_ir/ivalue_import/object-identity-torch-bug.py
@@ -18,6 +18,7 @@ mb = ModuleBuilder()
 # `torch.Tensor` is just a pointer to a TensorImpl under the hood, and so
 # naively duplicating a Tensor retains the identity of the TensorImpl.
 
+# CHECK-LABEL: torch.class_type @__torch__.TestModule {
 class TestModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/python/importer/jit_ir/ivalue_import/quantization.py
+++ b/test/python/importer/jit_ir/ivalue_import/quantization.py
@@ -12,6 +12,7 @@ from torch_mlir.dialects.torch.importer.jit_ir import ModuleBuilder
 
 mb = ModuleBuilder()
 
+# CHECK-LABEL: torch.class_type @__torch__.TestModule {
 class TestModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/python/importer/jit_ir/ivalue_import/submodules.py
+++ b/test/python/importer/jit_ir/ivalue_import/submodules.py
@@ -22,6 +22,7 @@ class TestModule(torch.nn.Module):
         self.s0 = Submodule(0)
         self.s1 = Submodule(1)
 
+# CHECK-LABEL: torch.class_type @__torch__.TestModule {
 # CHECK:         %[[T:.*]] = torch.constant.bool true
 
 # CHECK:         %[[N0:.*]] = torch.constant.int 0


### PR DESCRIPTION
It seems as though an upstream change in PyTorch has caused the module
dump to include not just the module being tested, but also several
seemingly unrelated functions in the `torch._decom.decompositions`
namespace.  The presence of these new functions caused lit to match
variables against incorrect statements (i.e.  statements in the
unrelated functions instead of the module under test).

This patch inserts `CHECK-LABEL` statements in the failing tests so that
lit ignores these unrelated functions and only checks the statements at
or after the test module definition.