### PR TITLE
Strength the shape inference for aten.arange-like op

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -8914,6 +8914,55 @@ def Torch_AtenAddOp : Torch_Op<"aten.add", [
   }];
 }
 
+def Torch_AtenSubOp : Torch_Op<"aten.sub", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::sub : (Scalar, Scalar) -> (Scalar)`";
+  let arguments = (ins
+    AnyTorchScalarType:$a,
+    AnyTorchScalarType:$b
+  );
+  let results = (outs
+    AnyTorchScalarType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenSubOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 2, 1);
+    }
+    void AtenSubOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 2, 1);
+    }
+  }];
+  let hasFolder = 1;
+}
+
+def Torch_AtenCeilScalarOp : Torch_Op<"aten.ceil.Scalar", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::ceil.Scalar : (Scalar) -> (Scalar)`";
+  let arguments = (ins
+    AnyTorchScalarType:$a
+  );
+  let results = (outs
+    AnyTorchScalarType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenCeilScalarOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 1, 1);
+    }
+    void AtenCeilScalarOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 1, 1);
+    }
+  }];
+  let hasFolder = 1;
+}
+
 def Torch_AtenSqrtIntOp : Torch_Op<"aten.sqrt.int", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -759,7 +759,7 @@ def Torch_ConstantNumberOp : Torch_Op<"constant.number",
   let description = [{
     This op is used as a workaround to the fact that the constant 
     materialization in MLIR must materialize a constant with a single op. 
-    To materialize ops with a static `!torch.number type, we must use this op, 
+    To materialize ops with a static `!torch.number` type, we must use this op, 
     even though we statically know if it is an integer or a float.
 
     Note: This op unconditionally canonicalizes to 

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -753,6 +753,25 @@ def Torch_ConstantFloatOp : Torch_Op<"constant.float", [
   let hasFolder = 1;
 }
 
+def Torch_ConstantNumberOp : Torch_Op<"constant.number",
+    [ConstantLike, NoSideEffect]> {
+  let summary = "Materialize a constant `number` value.";
+  let description = [{
+    Note: 
+    1. For now, only integer or float input is supported.
+    2. This op will finally be converted to 
+       `torch.constant.{float,int}` + `torch.derefine`
+  }];
+  let arguments = (ins
+    AnyAttrOf<[F64Attr, I64Attr]>:$value
+  );
+  let results = (outs
+    Torch_NumberType:$result
+  );
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
+}
+
 def Torch_ConstantBoolOp : Torch_Op<"constant.bool", [
     ConstantLike,
     NoSideEffect,

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -757,10 +757,13 @@ def Torch_ConstantNumberOp : Torch_Op<"constant.number",
     [ConstantLike, NoSideEffect]> {
   let summary = "Materialize a constant `number` value.";
   let description = [{
-    Note: 
-    1. For now, only integer or float input is supported.
-    2. This op will finally be converted to 
-       `torch.constant.{float,int}` + `torch.derefine`
+    This op is used as a workaround to the fact that the constant 
+    materialization in MLIR must materialize a constant with a single op. 
+    To materialize ops with a static `!torch.number type, we must use this op, 
+    even though we statically know if it is an integer or a float.
+
+    Note: This op unconditionally canonicalizes to 
+    `torch.constant.{float,int}` + `torch.derefine`
   }];
   let arguments = (ins
     AnyAttrOf<[F64Attr, I64Attr]>:$value

--- a/lib/Dialect/Torch/IR/TorchDialect.cpp
+++ b/lib/Dialect/Torch/IR/TorchDialect.cpp
@@ -149,6 +149,14 @@ Operation *TorchDialect::materializeConstant(OpBuilder &builder,
   if (auto floatType = type.dyn_cast<Torch::FloatType>())
     return builder.create<Torch::ConstantFloatOp>(loc, value.cast<FloatAttr>());
 
+  if (auto numberType = type.dyn_cast<Torch::NumberType>()) {
+    if (auto floatValue = value.dyn_cast<mlir::FloatAttr>()) {
+      return builder.create<Torch::ConstantNumberOp>(loc, floatValue);
+    } else if (auto intValue = value.dyn_cast<mlir::IntegerAttr>()) {
+      return builder.create<Torch::ConstantNumberOp>(loc, intValue);
+    }
+  }
+  
   if (type.isa<Torch::BoolType>()) {
     return builder.create<Torch::ConstantBoolOp>(loc,
                                                  value.cast<IntegerAttr>());

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -1914,18 +1914,6 @@ OpFoldResult Aten__Contains__IntListOp::fold(ArrayRef<Attribute> operands) {
 }
 
 using BinaryIntOperatorFn = std::function<int64_t(int64_t, int64_t)>;
-template <typename OpTy>
-static std::enable_if_t<!std::is_same_v<OpTy, ArrayRef<Attribute>>,
-                        OpFoldResult>
-atenBinaryIntOperatorFoldHelper(OpTy op, BinaryIntOperatorFn f) {
-  int64_t lhs, rhs;
-  if (!matchPattern(op.getOperand(0), m_TorchConstantInt(&lhs)) ||
-      !matchPattern(op.getOperand(1), m_TorchConstantInt(&rhs)))
-    return nullptr;
-
-  return getI64IntegerAttr(op.getContext(), f(lhs, rhs));
-}
-
 static OpFoldResult
 atenBinaryIntOperatorFoldHelper(ArrayRef<Attribute> operands,
                                 BinaryIntOperatorFn f) {
@@ -1967,7 +1955,7 @@ atenBinaryFloatOperatorFoldHelper(ArrayRef<Attribute> operands,
 
 OpFoldResult AtenFloordivIntOp::fold(ArrayRef<Attribute> operands) {
   return atenBinaryIntOperatorFoldHelper(
-      *this, [](int64_t a, int64_t b) { return std::floor(a / (double)b); });
+    operands, [](int64_t a, int64_t b) { return std::floor(a / (double)b); });
 }
 
 //===----------------------------------------------------------------------===//
@@ -1976,7 +1964,7 @@ OpFoldResult AtenFloordivIntOp::fold(ArrayRef<Attribute> operands) {
 
 OpFoldResult AtenRemainderIntOp::fold(ArrayRef<Attribute> operands) {
   return atenBinaryIntOperatorFoldHelper(
-      *this, [](int64_t a, int64_t b) { return a % b; });
+    operands, [](int64_t a, int64_t b) { return a % b; });
 }
 
 //===----------------------------------------------------------------------===//
@@ -1985,7 +1973,7 @@ OpFoldResult AtenRemainderIntOp::fold(ArrayRef<Attribute> operands) {
 
 OpFoldResult AtenAddIntOp::fold(ArrayRef<Attribute> operands) {
   return atenBinaryIntOperatorFoldHelper(
-      *this, [](int64_t a, int64_t b) { return a + b; });
+    operands, [](int64_t a, int64_t b) { return a + b; });
 }
 
 //===----------------------------------------------------------------------===//
@@ -1994,7 +1982,7 @@ OpFoldResult AtenAddIntOp::fold(ArrayRef<Attribute> operands) {
 
 OpFoldResult AtenSubIntOp::fold(ArrayRef<Attribute> operands) {
   return atenBinaryIntOperatorFoldHelper(
-      *this, [](int64_t a, int64_t b) { return a - b; });
+    operands, [](int64_t a, int64_t b) { return a - b; });
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -20,7 +20,6 @@ StringRef mlir::torch::Torch::getShapeLibrary() {
 #ifndef _MSC_VER
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverlength-strings"
-#endif
   // clang-format off
   return "module {\n"
 "  func.func @__torch__.torch._decomp.decompositions.nll_loss_backward(%arg0: !torch.tensor, %arg1: !torch.tensor, %arg2: !torch.tensor, %arg3: !torch.optional<tensor>, %arg4: !torch.int, %arg5: !torch.int, %arg6: !torch.tensor) -> !torch.tensor {\n"
@@ -7820,5 +7819,3 @@ StringRef mlir::torch::Torch::getShapeLibrary() {
   // clang-format on
 #ifndef _MSC_VER
 #pragma clang diagnostic pop
-#endif
-}

--- a/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/ShapeLibrary.cpp
@@ -20,6 +20,7 @@ StringRef mlir::torch::Torch::getShapeLibrary() {
 #ifndef _MSC_VER
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverlength-strings"
+#endif
   // clang-format off
   return "module {\n"
 "  func.func @__torch__.torch._decomp.decompositions.nll_loss_backward(%arg0: !torch.tensor, %arg1: !torch.tensor, %arg2: !torch.tensor, %arg3: !torch.optional<tensor>, %arg4: !torch.int, %arg5: !torch.int, %arg6: !torch.tensor) -> !torch.tensor {\n"
@@ -968,7 +969,7 @@ StringRef mlir::torch::Torch::getShapeLibrary() {
 "      torch.prim.RaiseException %str, %none : !torch.str, !torch.none\n"
 "      torch.prim.If.yield\n"
 "    }\n"
-"    %1 = torch.operator \"aten.ceil.Scalar\"(%arg0) : (!torch.union<float, int>) -> !torch.number\n"
+"    %1 = torch.aten.ceil.Scalar %arg0 : !torch.union<float, int> -> !torch.number\n"
 "    %2 = torch.aten.Int.Scalar %1 : !torch.number -> !torch.int\n"
 "    %3 = torch.prim.ListConstruct %2 : (!torch.int) -> !torch.list<int>\n"
 "    return %3 : !torch.list<int>\n"
@@ -991,8 +992,8 @@ StringRef mlir::torch::Torch::getShapeLibrary() {
 "      torch.prim.RaiseException %str, %none : !torch.str, !torch.none\n"
 "      torch.prim.If.yield\n"
 "    }\n"
-"    %2 = torch.operator \"aten.sub\"(%arg1, %arg0) : (!torch.union<float, int>, !torch.union<float, int>) -> !torch.number\n"
-"    %3 = torch.operator \"aten.ceil.Scalar\"(%2) : (!torch.number) -> !torch.number\n"
+"    %2 = torch.aten.sub %arg1, %arg0 : !torch.union<float, int>, !torch.union<float, int> -> !torch.number\n"
+"    %3 = torch.aten.ceil.Scalar %2 : !torch.number -> !torch.number\n"
 "    %4 = torch.aten.Int.Scalar %3 : !torch.number -> !torch.int\n"
 "    %5 = torch.prim.ListConstruct %4 : (!torch.int) -> !torch.list<int>\n"
 "    return %5 : !torch.list<int>\n"
@@ -1028,7 +1029,7 @@ StringRef mlir::torch::Torch::getShapeLibrary() {
 "      }\n"
 "      torch.prim.If.yield\n"
 "    }\n"
-"    %2 = torch.operator \"aten.sub\"(%arg1, %arg0) : (!torch.union<float, int>, !torch.union<float, int>) -> !torch.number\n"
+"    %2 = torch.aten.sub %arg1, %arg0 : !torch.union<float, int>, !torch.union<float, int> -> !torch.number\n"
 "    %3 = torch.aten.div %2, %arg2 : !torch.number, !torch.union<float, int> -> !torch.float\n"
 "    %4 = torch.aten.ceil.float %3 : !torch.float -> !torch.int\n"
 "    %5 = torch.prim.ListConstruct %4 : (!torch.int) -> !torch.list<int>\n"
@@ -7819,3 +7820,5 @@ StringRef mlir::torch::Torch::getShapeLibrary() {
   // clang-format on
 #ifndef _MSC_VER
 #pragma clang diagnostic pop
+#endif
+}

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -592,6 +592,8 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::_set_item.t : (t[], int, t) -> (t[])")
     emit("aten::div : (Scalar, Scalar) -> (float)")
     emit("aten::add : (Scalar, Scalar) -> (Scalar)")
+    emit("aten::sub : (Scalar, Scalar) -> (Scalar)", has_folder=True)
+    emit("aten::ceil.Scalar : (Scalar) -> (Scalar)", has_folder=True)
     emit("aten::sqrt.int : (int) -> (float)", has_folder=True)
     emit("aten::Bool.float : (float) -> (bool)", has_folder=True)
     emit("aten::Bool.int : (int) -> (bool)", has_folder=True)


### PR DESCRIPTION
This PR is to solve issue #1305 .
A example IR is like:
```
%none = torch.constant.none
%int0 = torch.constant.int 0
%int5 = torch.constant.int 5
%0 = torch.aten.arange.start %int0, %int5, %none, %none, %none, %none : !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor
```
After shape simplification pipeline, %0 is unexpectedly deduced to have a dynamic shape.
```
...
%0 = torch.aten.arange.start %int0, %int5, %none, %none, %none, %none : !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[?],unk>
```
The solution in this PR can be briefly summarized as the following：
1. register aten.sub and aten.ceil.Scalar op, which is need in shape function of aten arange-like ops
2. design folder for aten.sub and aten.ceil.Scalar op
3. register a new constant-like op: Torch::ConstantNumberOp. This is because the shape function of aten arange-like ops requires the return type to be torch.number.
4. design canonicalizer for ConstantNumberOp to unconditionally convert it to Constant{Int,Float}Op and Derefine op.