### PR TITLE
Disable libzstd detection to fix M1 builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ class CMakeBuild(build_py):
                 f"-DLLVM_TARGETS_TO_BUILD=host",
                 f"-DMLIR_ENABLE_BINDINGS_PYTHON=ON",
                 f"-DLLVM_ENABLE_PROJECTS=mlir",
+                f"-DLLVM_ENABLE_ZSTD=OFF",
                 f"-DLLVM_EXTERNAL_PROJECTS=torch-mlir;torch-mlir-dialects",
                 f"-DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR={src_dir}",
                 f"-DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR={src_dir}/externals/llvm-external-projects/torch-mlir-dialects",


### PR DESCRIPTION
Previously we `sudo rm -f` the non-universal zstd installed in the GHA. The CI has this fix but it doesn't take effect in the Release builds without this change.