### PR TITLE
Add torch-to-mhlo e2e support for AtenArangeStartStepOp

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -23,6 +23,20 @@ EAGER_MODE_XFAIL_SET = {
 }
 
 MHLO_PASS_SET = {
+    "ArangeDtypeFloatModule_basic",
+    "ArangeDtypeIntModule_basic",
+    "ArangeFalsePinMemoryModule_basic",
+    "ArangeFloatModule_basic",
+    "ArangeIntModule_basic",
+    "ArangeNegativeStartFloatModule_basic",
+    "ArangeNegativeStartIntModule_basic",
+    "ArangeStartFloatModule_basic",
+    "ArangeStartIntModule_basic",
+    "ArangeStartNegativeStepFloatModule_basic",
+    "ArangeStartNegativeStepIntModule_basic",
+    "ArangeStartStepFloatModule_basic",
+    "ArangeStartStepIntModule_basic",
+    "ArangeZeroElementOutputModule_basic",
     "ElementwiseClampModule_basic",
     "ElementwiseClampMinModule_basic",
     "ElementwiseClampMaxModule_basic",

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -8888,6 +8888,7 @@ def Torch_AtenDivOp : Torch_Op<"aten.div", [
       printDefaultTorchOp(printer, *this, 2, 1);
     }
   }];
+  let hasFolder = 1;
 }
 
 def Torch_AtenAddOp : Torch_Op<"aten.add", [

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -2018,6 +2018,20 @@ OpFoldResult AtenSubOp::fold(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// AtenDivOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenDivOp::fold(ArrayRef<Attribute> operands) {
+  if (!operands[0] || !operands[1]) {
+    return nullptr;
+  }
+  // Since AtenDivOp always returns float value, we don't need to deal with the
+  // case where the operands are both integers separately.
+  return atenBinaryFloatOperatorFoldHelper(
+      operands, [](double a, double b) -> double { return a / b; });
+}
+
+//===----------------------------------------------------------------------===//
 // AtenCeilScalarOp
 //===----------------------------------------------------------------------===//
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -590,7 +590,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
          has_canonicalizer=True)
     emit("aten::__getitem__.t : (t[], int) -> (t)", has_canonicalizer=True)
     emit("aten::_set_item.t : (t[], int, t) -> (t[])")
-    emit("aten::div : (Scalar, Scalar) -> (float)")
+    emit("aten::div : (Scalar, Scalar) -> (float)", has_folder=True)
     emit("aten::add : (Scalar, Scalar) -> (Scalar)")
     emit("aten::sub : (Scalar, Scalar) -> (Scalar)", has_folder=True)
     emit("aten::ceil.Scalar : (Scalar) -> (Scalar)", has_folder=True)


### PR DESCRIPTION
This PR adds e2e support for `AtenArangeStartStepOp` in torch-to-mhlo conversion. Besides, this PR also adds a folder for `AtenDivOp`, which is missed in PR #1367 .