### PR TITLE
Add a way to turn off crashing tests

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -236,7 +236,9 @@ function test_in_tree() {
   python -m e2e_testing.main --config=eager_mode -v
 
   echo ":::: Run TOSA e2e integration tests"
-  python -m e2e_testing.main --config=tosa -v
+  # crashing_tests_to_not_attempt_to_run_and_a_bug_is_filed issues:
+  # - AvgPool2dFloatModule_basic,AvgPool2dCeilModeTrueModule_basic: https://github.com/llvm/torch-mlir/issues/1361
+  python -m e2e_testing.main --config=tosa -v --crashing_tests_to_not_attempt_to_run_and_a_bug_is_filed AvgPool2dFloatModule_basic AvgPool2dCeilModeTrueModule_basic
 
   # Temporarily disabled in top of main (https://github.com/llvm/torch-mlir/pull/1292)
   #echo ":::: Run Lazy Tensor Core e2e integration tests"

--- a/python/torch_mlir_e2e_test/test_suite/pooling.py
+++ b/python/torch_mlir_e2e_test/test_suite/pooling.py
@@ -604,6 +604,9 @@ class AvgPool2dFloatModule(torch.nn.Module):
     def forward(self, x):
         return self.ap2d(x)
 
+@register_test_case(module_factory=lambda: AvgPool2dFloatModule())
+def AvgPool2dFloatModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 4, 20, 20) - 0.5)
 
 class AvgPool2dIntModule(torch.nn.Module):
 
@@ -698,3 +701,7 @@ class AvgPool2dCeilModeTrueModule(torch.nn.Module):
     ])
     def forward(self, x):
         return self.ap2d(x)
+
+@register_test_case(module_factory=lambda: AvgPool2dCeilModeTrueModule())
+def AvgPool2dCeilModeTrueModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 4, 20, 20, low=0.5, high=1.0))


### PR DESCRIPTION
This adds a very long and obnoxious option to disable crashing tests. The right fix here is to use the right multiprocessing techniques to ensure that segfaulting tests can be XFAILed like normal tests, but we currently don't know how to implement "catch a segfault" in Python (patches or even just ideas welcome).

Motivated by #1361, where we ended up removing two tests from *all* backends due to a failure in one backend, which is undesirable.