### PR TITLE
[DO NOT MERGE] Prototype for external large weights.

### DIFF
--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -17,17 +17,22 @@ include "mlir/Pass/PassBase.td"
 //===----------------------------------------------------------------------===//
 
 def ConvertTorchToArith : Pass<"convert-torch-to-arith", "func::FuncOp"> {
-  let summary = "Convert recognized Torch ops to Std ops";
+  let summary = "Convert Torch ops to arith ops";
   let constructor = "mlir::torch::createConvertTorchToArithPass()";
 }
 
+def ConvertTorchToMLProgram : Pass<"convert-torch-to-mlprogram", "ModuleOp"> {
+  let summary = "Convert Torch ops to MLProgram ops";
+  let constructor = "mlir::torch::createConvertTorchToMLProgramPass()";
+}
+
 def ConvertTorchToSCF: Pass<"convert-torch-to-scf", "func::FuncOp"> {
-  let summary = "Convert recognized Torch ops to SCF ops";
+  let summary = "Convert Torch ops to SCF ops";
   let constructor = "mlir::torch::createConvertTorchToSCFPass()";
 }
 
 def ConvertTorchToLinalg : Pass<"convert-torch-to-linalg", "func::FuncOp"> {
-  let summary = "Convert recognized Torch ops to Linalg ops";
+  let summary = "Convert Torch ops to Linalg ops";
   let description = [{
     Convert ATen ops to linalg ops.
 

--- a/include/torch-mlir/Conversion/TorchToMLProgram/TorchToMLProgram.h
+++ b/include/torch-mlir/Conversion/TorchToMLProgram/TorchToMLProgram.h
@@ -1,4 +1,4 @@
-//===- PassDetail.h - Conversion Pass class details -------------*- C++ -*-===//
+//===------------------------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,20 +7,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TORCHMLIR_CONVERSION_PASSDETAIL_H
-#define TORCHMLIR_CONVERSION_PASSDETAIL_H
+#ifndef TORCHMLIR_CONVERSION_TORCHTOMLPROGRAM_TORCHTOMLPROGRAM_H
+#define TORCHMLIR_CONVERSION_TORCHTOMLPROGRAM_TORCHTOMLPROGRAM_H
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
+#include <memory>
 
 namespace mlir {
 namespace torch {
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTorchToMLProgramPass();
+}
+} // namespace mlir
 
-#define GEN_PASS_CLASSES
-#include "torch-mlir/Conversion/Passes.h.inc"
-
-} // namespace torch
-} // end namespace mlir
-
-#endif // TORCHMLIR_CONVERSION_PASSDETAIL_H
+#endif // TORCHMLIR_CONVERSION_TORCHTOMLPROGRAM_TORCHTOMLPROGRAM_H

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -958,6 +958,82 @@ def Torch_ValueTensorLiteralOp : Torch_Op<"vtensor.literal", [
   let hasFolder = 1;
 }
 
+def Torch_ExternalNonValueTensorLiteralOp : Torch_Op<"tensor.external.literal", [
+    AllowsTypeRefinement,
+    AllowedInModuleInitializer
+  ]> {
+  let summary = "Create a value of !torch.tensor type from an external literal";
+  let description = [{
+    Example:
+    ```
+    %0 = torch.tensor.external.literal(@fc.weight) : !torch.tensor<[2,3],f32>
+    ```
+
+    This is the non-value-semantic version of `torch.vtensor.external.literal`.
+    See the documentation there for more context.
+  }];
+  let arguments = (ins FlatSymbolRefAttr:$sym_name);
+  let results = (outs Torch_NonValueTensorType:$result);
+
+  let assemblyFormat = [{
+    `(` $sym_name `)` attr-dict `:` qualified(type($result))
+  }];
+}
+
+def Torch_ExternalValueTensorLiteralOp : Torch_Op<"vtensor.external.literal", [
+    AllowsTypeRefinement,
+  ]> {
+  let summary = "Create a value of !torch.vtensor type from an external literal";
+  let description = [{
+    Example:
+    ```
+    %0 = torch.vtensor.external.literal(@fc.weight) : !torch.vtensor<[2,3],f32>
+    ```
+
+    The use of the term "literal" for an external reference is a bit strange,
+    but is a natural byproduct of Torch-MLIR's evolution. Currently, Torch-MLIR
+    is in the process of aligning itself with PyTorch's vision of a trace-based
+    future, where backend compilers (here meaning Torch-MLIR's main lowering
+    pipeline to the backend contract) only handle traces, rather than
+    full stateful programs. For in-process on-demand compilation, such as a
+    TorchDynamo backend compiler, the traces never see any program state.
+    For Ahead-of-Time compilation, this gets trickier. To handle
+    programs for Ahead-of-Time, the idea (already proved out in the JAX space,
+    and in progress in PyTorch) is to capture traces and then use an outer layer
+    with a more general programming model (e.g. stateful,
+    more "Python-like"/dynamic) to orchestrate calls into the
+    traces and manage parameters and buffers. This outer layer would be manually
+    programmed by users, which avoids ~intractable problems related to lowering
+    fully general TorchScript modules which simultaneously have the bulk tensor
+    compute and orchestrate logic all in one program. Although this seems like
+    a usability reduction, it actually results in a much less brittle compiler,
+    which ultimately results in a usability improvement.
+
+    Torch-MLIR is currently in a hybrid state from that transition -- users
+    currently use Torch-MLIR's TorchScript frontend to compile Ahead-of-Time,
+    which embeds the constant parameters as literals into the program. Our
+    backend contract is effectively trace-like, but allows literals
+    (often quite large) for constant parameters. This is a somewhat
+    contradictory state. The natural state is for parameters to be handled as
+    first-class "module state" by the outer programming layer (for AoT) or
+    TorchDynamo/LTC (for in-process) independently from the trace.
+
+    Due to this hybrid state, it make sense to have a "literal" that is an
+    external reference, since that fits in with the existing flow that we
+    have for parameters.
+
+    Conceptually this op gets access to a single value-semantic value just like
+    a literal. The `sym_name` is really just replacing the dense attribute of
+    `torch.vtensor.literal` with a symbol reference.
+  }];
+  let arguments = (ins FlatSymbolRefAttr:$sym_name);
+  let results = (outs Torch_ValueTensorType:$result);
+
+  let assemblyFormat = [{
+    `(` $sym_name `)` attr-dict `:` qualified(type($result))
+  }];
+}
+
 def Torch_TensorStaticInfoCastOp : Torch_Op<"tensor_static_info_cast", [
     DeclareOpInterfaceMethods<CastOpInterface>,
     AllowsTypeRefinement,

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToArith)
+add_subdirectory(TorchToMLProgram)
 add_subdirectory(TorchToTosa)
 if(TORCH_MLIR_ENABLE_MHLO)
   add_subdirectory(TorchToMhlo)
@@ -12,6 +13,7 @@ add_subdirectory(Utils)
 set(linked_libs TorchMLIRTorchToLinalg
                 TorchMLIRTorchToSCF
                 TorchMLIRTorchToArith
+                TorchMLIRTorchToMLProgram
                 TorchMLIRTorchToTosa
                 TorchMLIRTorchToTMTensor
                 TorchMLIRConversionUtils)

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -13,12 +13,13 @@
 #include "mlir-hlo/Dialect/mhlo/transforms/passes.h"
 #include "mlir-hlo/Transforms/passes.h"
 #endif // TORCH_MLIR_ENABLE_MHLO
-#include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
-#include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToArith/TorchToArith.h"
-#include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
+#include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
+#include "torch-mlir/Conversion/TorchToMLProgram/TorchToMLProgram.h"
 #include "torch-mlir/Conversion/TorchToMhlo/TorchToMhlo.h"
+#include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
+#include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
 
 //===----------------------------------------------------------------------===//
 // Pass registration

--- a/lib/Conversion/TorchToMLProgram/CMakeLists.txt
+++ b/lib/Conversion/TorchToMLProgram/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_mlir_conversion_library(TorchMLIRTorchToMLProgram
+  TorchToMLProgram.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/TorchToMLProgram
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRFuncDialect
+  MLIRMLProgramDialect
+  TorchMLIRTorchDialect
+)
+
+torch_mlir_target_includes(TorchMLIRTorchToMLProgram)

--- a/lib/Conversion/TorchToMLProgram/TorchToMLProgram.cpp
+++ b/lib/Conversion/TorchToMLProgram/TorchToMLProgram.cpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/TorchToMLProgram/TorchToMLProgram.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
+#include "mlir/Dialect/Traits.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+
+namespace {
+class ConvertTorchToMLProgram
+    : public ConvertTorchToMLProgramBase<ConvertTorchToMLProgram> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<ml_program::MLProgramDialect>();
+    TorchConversion::getBackendTypeConversionDependentDialects(registry);
+  }
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    MLIRContext *context = &getContext();
+    ConversionTarget dummyTarget(*context);
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    TorchConversion::setupBackendTypeConversion(dummyTarget, typeConverter);
+
+    auto globalBuilder =
+        OpBuilder::atBlockBegin(&*module.getBodyRegion().begin());
+    module.walk([&](Torch::ExternalValueTensorLiteralOp op) {
+      auto type = typeConverter.convertType(op.getType());
+      globalBuilder.create<ml_program::GlobalOp>(
+          op.getLoc(), op.sym_nameAttr().getAttr(), type,
+          /*is_mutable=*/false,
+          /*value=*/ml_program::ExternAttr::get(context, type),
+          globalBuilder.getStringAttr("public"));
+      OpBuilder builder(op);
+      auto loadConst = builder.create<ml_program::GlobalLoadConstOp>(
+          op.getLoc(), type, op.sym_nameAttr());
+      Value torchTensor = builder.create<TorchConversion::FromBuiltinTensorOp>(
+          op.getLoc(), op.getType(), loadConst);
+      op.replaceAllUsesWith(torchTensor);
+      op.erase();
+    });
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::torch::createConvertTorchToMLProgramPass() {
+  return std::make_unique<ConvertTorchToMLProgram>();
+}

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -15,9 +15,10 @@
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
-#include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
-#include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToArith/TorchToArith.h"
+#include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
+#include "torch-mlir/Conversion/TorchToMLProgram/TorchToMLProgram.h"
+#include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
 #ifdef TORCH_MLIR_ENABLE_MHLO
@@ -63,6 +64,7 @@ void mlir::torch::registerTorchConversionPasses() {
 
 void TorchConversion::createTorchBackendToLinalgOnTensorsBackendPipeline(
     OpPassManager &pm) {
+  pm.addPass(createConvertTorchToMLProgramPass());
   // Lower to linalg + guards which is the input to codegen backends.
   // We do this first as it tends to involve pattern-matching against constants,
   // (e.g. dimensions which must be constant in a ranked programming model)

--- a/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -81,6 +82,8 @@ class VerifyLinalgOnTensorsBackendContractPass
     target.addDynamicallyLegalDialect<cf::ControlFlowDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<TMTensorDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<scf::SCFDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<ml_program::MLProgramDialect>(
+        opHasLegalTypes);
 
     // ConstantOp is used for tensors and for scalars.
     target.addDynamicallyLegalOp<arith::ConstantOp>(opHasLegalTypes);

--- a/python/torch_mlir/__init__.py
+++ b/python/torch_mlir/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
 
-from typing import Sequence, Union, List
+from typing import Sequence, Union, List, Optional
 from enum import Enum
 
 import sys
@@ -140,6 +140,7 @@ def compile(model: torch.nn.Module,
             output_type: Union[str, "OutputType"] = OutputType.TORCH,
             use_tracing: bool = False,
             ignore_traced_shapes = False,
+            use_external_references_if_numel_exceeds: Optional[int] = None,
             verbose: bool = False):
     """Convert a PyTorch model to MLIR.
 
@@ -161,6 +162,10 @@ def compile(model: torch.nn.Module,
             `TensorPlaceholder`'s used as `example_args`. Also,
             strictly-speaking, this option covers dtypes too, but we just say
             "shapes" to be succinct.
+        use_external_references_if_numel_exceeds: If non-None, then any tensors
+            with more than this number of elements will be referenced in the
+            IR with an external reference. This is useful for gigantic models
+            where materializing the weights in the IR is impractical.
         verbose: If true, print extra information about the conversion.
 
     Returns:
@@ -224,6 +229,7 @@ def compile(model: torch.nn.Module,
     mb = ModuleBuilder()
     import_options = ImportOptions()
     import_options.ignoreExistingTensorShapesAndDtypes = ignore_traced_shapes
+    import_options.useExternalReferencesIfNumelExceeds = use_external_references_if_numel_exceeds
     try:
         original_stderr = sys.stderr
         sys.stderr = StringIO()

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options.h
@@ -10,6 +10,8 @@
 #ifndef TORCHMLIRJITIRIMPORTER_CSRC_IMPORT_OPTIONS_H
 #define TORCHMLIRJITIRIMPORTER_CSRC_IMPORT_OPTIONS_H
 
+#include "c10/util/Optional.h"
+
 namespace torch_mlir {
 // Common import options across importers. We define this as a struct to avoid
 // an unstructured proliferation of different kinds of ways to control different
@@ -33,6 +35,10 @@ struct ImportOptions {
   // In that case, the appropriate shape information is provided via the type
   // bound annotations on the function arguments instead.
   bool ignoreExistingTensorShapesAndDtypes = false;
+
+  // If this is set, then external constant references will be used when
+  // importing tensors with numel exceeding the given threshold.
+  c10::optional<unsigned> useExternalReferencesIfNumelExceeds = c10::nullopt;
 };
 } // namespace torch_mlir
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options_pybind.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/import_options_pybind.cpp
@@ -20,5 +20,7 @@ void torch_mlir::initImportOptionsBindings(py::module &m) {
       .def_readwrite("assumeTensorsHaveValueSemantics",
                      &ImportOptions::assumeTensorsHaveValueSemantics)
       .def_readwrite("ignoreExistingTensorShapesAndDtypes",
-                     &ImportOptions::ignoreExistingTensorShapesAndDtypes);
+                     &ImportOptions::ignoreExistingTensorShapesAndDtypes)
+      .def_readwrite("useExternalReferencesIfNumelExceeds",
+                     &ImportOptions::useExternalReferencesIfNumelExceeds);
 }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.cpp
@@ -141,7 +141,7 @@ private:
   // them with the MlirOperation that they import into.
   std::unordered_set<c10::ClassType *> classTypes;
   // The stack of attribute names we have traversed to reach the current IValue.
-  // Used for diagnostics.
+  // Used for diagnostics and external literal names.
   std::vector<std::string> attributeNameStack;
   // The root module encountered during recursive IValue traversal.
   // Used for diagnostics.
@@ -360,19 +360,35 @@ MlirValue IValueImporter::rawImportIValue(c10::IValue ivalue) {
 
 MlirValue IValueImporter::importTensor(c10::IValue ivalue) {
   assert(ivalue.isTensor() && "expected a tensor!");
+  at::Tensor tensor = ivalue.toTensor();
 
   // TODO: Can we do better?
   MlirLocation loc = mlirLocationUnknownGet(context);
 
-  // Import the bulk tensor representation.
-  at::Tensor tensor = ivalue.toTensor().contiguous();
-  MlirAttribute denseElements = convertTensorToMlirElementsAttr(tensor, loc);
-
-  MlirOperation tensorOp = createMlirOperationAtEnd(
-      importBlock, "torch.tensor.literal", loc,
-      torchMlirTorchNonValueTensorTypeGetFromAttribute(denseElements),
-      toMlirNamedAttribute("value", denseElements));
-  MlirValue tensorReprValue = mlirOperationGetResult(tensorOp, 0);
+  MlirValue tensorReprValue;
+  if (importOptions.useExternalReferencesIfNumelExceeds.has_value() &&
+      tensor.numel() >
+          importOptions.useExternalReferencesIfNumelExceeds.value()) {
+    MlirType type = torchMlirTorchNonValueTensorTypeGet(
+        context, tensor.sizes().size(), tensor.sizes().data(),
+        getMlirTypeForTorchScalarType(loc, tensor.scalar_type()));
+    MlirAttribute symName = mlirFlatSymbolRefAttrGet(
+        context, toMlirStringRef(
+                     c10::QualifiedName(attributeNameStack).qualifiedName()));
+    MlirOperation tensorOp = createMlirOperationAtEnd(
+        importBlock, "torch.tensor.external.literal", loc, type,
+        toMlirNamedAttribute("sym_name", symName));
+    tensorReprValue = mlirOperationGetResult(tensorOp, 0);
+  } else {
+    // Import the bulk tensor representation as an inline literal.
+    MlirAttribute denseElements =
+        convertTensorToMlirElementsAttr(tensor.contiguous(), loc);
+    MlirOperation tensorOp = createMlirOperationAtEnd(
+        importBlock, "torch.tensor.literal", loc,
+        torchMlirTorchNonValueTensorTypeGetFromAttribute(denseElements),
+        toMlirNamedAttribute("value", denseElements));
+    tensorReprValue = mlirOperationGetResult(tensorOp, 0);
+  }
 
   // Construct the complete tensor value. This is trivial for most tensors, but
   // for quantized tensors (and probably sparse too, TBD) there is more for us

--- a/test/Conversion/TorchToMLProgram/basic.mlir
+++ b/test/Conversion/TorchToMLProgram/basic.mlir
@@ -1,0 +1,14 @@
+// RUN: torch-mlir-opt <%s -convert-torch-to-mlprogram | FileCheck %s
+
+
+// CHECK: #extern = #ml_program.extern : tensor<2x3xf32>
+// CHECK: ml_program.global public @fc.weight(#extern) : tensor<2x3xf32>
+
+// CHECK-LABEL:   func.func @torch.vtensor.external.literal() -> !torch.vtensor<[2,3],f32> {
+// CHECK:           %[[BUILTIN_TENSOR:.*]] = ml_program.global_load_const @fc.weight : tensor<2x3xf32>
+// CHECK:           %[[TORCH_TENSOR:.*]] = torch_c.from_builtin_tensor %[[BUILTIN_TENSOR]] : tensor<2x3xf32> -> !torch.vtensor<[2,3],f32>
+// CHECK:           return %[[TORCH_TENSOR]] : !torch.vtensor<[2,3],f32>
+func.func @torch.vtensor.external.literal() -> !torch.vtensor<[2,3],f32> {
+  %0 = torch.vtensor.external.literal(@fc.weight) : !torch.vtensor<[2,3],f32>
+  return %0 : !torch.vtensor<[2,3],f32>
+}

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -61,6 +61,12 @@ func.func @torch.vtensor.literal() {
   return
 }
 
+func.func @external_literals() -> (!torch.tensor<[2,3],f32>, !torch.vtensor<[3,4],si64>) {
+  %0 = torch.tensor.external.literal(@external_tensor) : !torch.tensor<[2,3],f32>
+  %1 = torch.vtensor.external.literal(@external_vtensor) : !torch.vtensor<[3,4],si64>
+  return %0, %1 : !torch.tensor<[2,3],f32>, !torch.vtensor<[3,4],si64>
+}
+
 func.func @derefine(%arg0: !torch.tensor) -> !torch.optional<tensor> {
   %0 = torch.derefine %arg0 : !torch.tensor to !torch.optional<tensor>
   return %0 : !torch.optional<tensor>

--- a/test/Dialect/Torch/reduce-op-variants.mlir
+++ b/test/Dialect/Torch/reduce-op-variants.mlir
@@ -113,6 +113,15 @@ func.func @torch.tensor.literal() -> !torch.tensor {
   return %0 : !torch.tensor
 }
 
+// CHECK-LABEL:   func.func @torch.tensor.external.literal() -> !torch.tensor<[7],f32> {
+// CHECK:           %[[VTENSOR:.*]] = torch.vtensor.external.literal(@fc.weight) : !torch.vtensor<[7],f32>
+// CHECK:           %[[TENSOR:.*]] = torch.copy.to_tensor %[[VTENSOR]] : !torch.tensor<[7],f32>
+// CHECK:           return %[[TENSOR]] : !torch.tensor<[7],f32>
+func.func @torch.tensor.external.literal() -> !torch.tensor<[7],f32> {
+  %0 = torch.tensor.external.literal(@fc.weight) : !torch.tensor<[7],f32>
+  return %0 : !torch.tensor<[7],f32>
+}
+
 // CHECK-LABEL:   func.func @convert_to_value_semantic_tensors_optional_list(
 // CHECK-SAME:         %[[SELF:.*]]: !torch.tensor<[5],f32>,
 // CHECK-SAME:         %[[INDICES:.*]]: !torch.tensor<[2,3],si64>) -> !torch.tensor {


### PR DESCRIPTION
This lowers them into ml_program.global

Example use like this:

```
import torch
import torch_mlir
import torchvision

resnet18 = torchvision.models.resnet18(pretrained=True)
resnet18.eval()

example_inputs = torch.randn(1, 2)
mlir_module = torch_mlir.compile(
    resnet18, torch.ones(1, 3, 224, 224), output_type="torch",
    use_external_references_if_numel_exceeds=1)
print(mlir_module)
```

Backend contract IR: https://gist.github.com/silvasean/aba4b3b01b5a5649f1216dc6dd6942d4
Linalg-on-tensors IR: https://gist.github.com/silvasean/5ed3b6de238995e232ef3e2cb5a9f609