### PR TITLE
Add build flag for out-of-tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,9 @@ torch_mlir_add_llvm_external_project(
   TORCH_MLIR_DIALECTS
   ${CMAKE_CURRENT_SOURCE_DIR}/externals/llvm-external-projects/torch-mlir-dialects)
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+option(TORCH_MLIR_OOT_BUILD "Specifies an out of tree build" OFF)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR TORCH_MLIR_OOT_BUILD)
   message(STATUS "Torch-MLIR out-of-tree build.")
   # Out-of-tree build
 


### PR DESCRIPTION
Needed for external builds when we have an out-of-tree build (e.g. onnx-mlir)