### PR TITLE
build: add missing dependency on MLIRTorchTypesIncGen

### DIFF
--- a/lib/Dialect/TorchConversion/IR/CMakeLists.txt
+++ b/lib/Dialect/TorchConversion/IR/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_dialect_library(TorchMLIRTorchConversionDialect
 
   DEPENDS
   MLIRTorchConversionOpsIncGen
+  MLIRTorchTypesIncGen
 
   LINK_COMPONENTS
   Core

--- a/lib/RefBackend/CMakeLists.txt
+++ b/lib/RefBackend/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_library(TorchMLIRRefBackend
   ${PROJECT_SRC_DIR}/include/torch-mlir/RefBackend
 
   DEPENDS
+  MLIRTorchTypesIncGen
   TorchMLIRRefBackendPassIncGen
 
   LINK_COMPONENTS


### PR DESCRIPTION
Because of the missing dependency, CI saw non-deterministic failures,
where the build failed because the TorchTypes.h.inc file was not
available to include, likely due to the order in which the targets
happened to be compiled.  This patch fixes the problem by making sure
that the TorchTypes.h.inc file is generated before it is referenced.

---

For instance, [here](https://github.com/llvm/torch-mlir/actions/runs/3109273006/jobs/5039344777) is an example of CI failing even though the change is unrelated.