### PR TITLE
[MLIR] Add canonicalizer for aten.slice.t op

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -7705,6 +7705,7 @@ def Torch_AtenSliceTOp : Torch_Op<"aten.slice.t", [
       printDefaultTorchOp(printer, *this, 4, 1);
     }
   }];
+  let hasCanonicalizer = 1;
 }
 
 def Torch_AtenInsertTOp : Torch_Op<"aten.insert.t", [

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -1738,30 +1738,30 @@ void AtenSliceTOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
         llvm::to_vector<4>(listConstructOp.elements());
     int64_t size = static_cast<int64_t>(listElements.size());
 
-    int64_t st;
-    int64_t ed;
+    int64_t start;
+    int64_t end;
     int64_t step;
     if (op.start().getType().isa<Torch::NoneType>()) {
-      st = 0;
-    } else if (!matchPattern(op.start(), m_TorchConstantInt(&st))) {
+      start = 0;
+    } else if (!matchPattern(op.start(), m_TorchConstantInt(&start))) {
       return failure();
     }
     if (op.end().getType().isa<Torch::NoneType>()) {
-      ed = listElements.size();
-    } else if (!matchPattern(op.end(), m_TorchConstantInt(&ed))) {
+      end = listElements.size();
+    } else if (!matchPattern(op.end(), m_TorchConstantInt(&end))) {
       return failure();
     }
     if (!matchPattern(op.step(), m_TorchConstantInt(&step))) {
       return failure();
     }
 
-    st = st >= 0 ? st : st + size;
-    st = st >= 0 ? st : 0;
-    ed = ed >= 0 ? ed : ed + size;
-    ed = ed < size ? ed : size;
+    start = start >= 0 ? start : start + size;
+    start = start >= 0 ? start : 0;
+    end = end >= 0 ? end : end + size;
+    end = end < size ? end : size;
     SmallVector<Value> newListElements;
 
-    for (int64_t i = st; i < ed; i += step) {
+    for (int64_t i = start; i < end; i += step) {
       newListElements.push_back(listElements[i]);
     }
 

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -1722,6 +1722,43 @@ void AtenAddTOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 }
 
 //===----------------------------------------------------------------------===//
+// AtenSliceTOp
+//===----------------------------------------------------------------------===//
+
+void AtenSliceTOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
+                                               MLIRContext *context) {
+  patterns.add(+[](AtenSliceTOp op, PatternRewriter &rewriter) {
+    auto valueList = op.l();
+    auto listConstructOp = valueList.getDefiningOp<PrimListConstructOp>();
+    if (!listConstructOp) {
+      return failure();
+    }
+
+    SmallVector<Value> listElements =
+        llvm::to_vector<4>(listConstructOp.elements());
+    int64_t st;
+    int64_t ed;
+    int64_t step;
+    if (!matchPattern(op.start(), m_TorchConstantInt(&st)) ||
+        !matchPattern(op.end(), m_TorchConstantInt(&ed)) ||
+        !matchPattern(op.step(), m_TorchConstantInt(&step))) {
+      return failure();
+    }
+    st = st >= 0 ? st : st + listElements.size();
+    ed = ed >= 0 ? ed : ed + listElements.size();
+    SmallVector<Value> newListElements;
+
+    for (int64_t i = st; i < ed; i += step) {
+      newListElements.push_back(listElements[i]);
+    }
+
+    rewriter.replaceOpWithNewOp<PrimListConstructOp>(
+        op, Torch::ListType::get(listElements[0].getType()), newListElements);
+    return success();
+  });
+}
+
+//===----------------------------------------------------------------------===//
 // AtenEqIntListOp
 //===----------------------------------------------------------------------===//
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -532,7 +532,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::add.t : (t[], t[]) -> (t[])", has_canonicalizer=True)
     emit("aten::eq.int_list : (int[], int[]) -> (bool)", has_folder=True)
     emit("aten::list.t : (t[]) -> (t[])")
-    emit("aten::slice.t : (t[], int?, int?, int) -> (t[])")
+    emit("aten::slice.t : (t[], int?, int?, int) -> (t[])", has_canonicalizer=True)
     emit("aten::insert.t : (t[], int, t) -> ()")
     emit("aten::ne.int_list : (int[], int[]) -> (bool)")
     emit("aten::any.bool : (bool[]) -> (bool)")

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -682,6 +682,101 @@ func.func @torch.aten.add.t$concat_empty(%arg0: !torch.int) -> !torch.list<int> 
   return %2 : !torch.list<int>
 }
 
+// CHECK-LABEL:   func.func @torch.aten.slice.t$basic() -> !torch.list<int> {
+// CHECK:           %int0 = torch.constant.int 0
+// CHECK:           %int1 = torch.constant.int 1
+// CHECK:           %[[RET:.*]] = torch.prim.ListConstruct %int0, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           return %[[RET]] : !torch.list<int>
+func.func @torch.aten.slice.t$basic() -> !torch.list<int> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int-1 = torch.constant.int -1
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.aten.slice.t %0, %int0, %int-1, %int1 : !torch.list<int>, !torch.int, !torch.int, !torch.int -> !torch.list<int>
+  return %2 : !torch.list<int>
+}
+
+// CHECK-LABEL:   func.func @torch.aten.slice.t$none_start() -> !torch.list<int> {
+// CHECK:           %int0 = torch.constant.int 0
+// CHECK:           %int1 = torch.constant.int 1
+// CHECK:           %[[RET:.*]] = torch.prim.ListConstruct %int0, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           return %[[RET]] : !torch.list<int>
+func.func @torch.aten.slice.t$none_start() -> !torch.list<int> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int-1 = torch.constant.int -1
+  %none = torch.constant.none
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.aten.slice.t %0, %none, %int-1, %int1 : !torch.list<int>, !torch.none, !torch.int, !torch.int -> !torch.list<int>
+  return %2 : !torch.list<int>
+}
+
+// CHECK-LABEL:   func.func @torch.aten.slice.t$none_end() -> !torch.list<int> {
+// CHECK:           %int0 = torch.constant.int 0
+// CHECK:           %int1 = torch.constant.int 1
+// CHECK:           %int2 = torch.constant.int 2
+// CHECK:           %[[RET:.*]] = torch.prim.ListConstruct %int0, %int1, %int2 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           return %[[RET]] : !torch.list<int>
+func.func @torch.aten.slice.t$none_end() -> !torch.list<int> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int-1 = torch.constant.int -1
+  %none = torch.constant.none
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.aten.slice.t %0, %int0, %none, %int1 : !torch.list<int>, !torch.int, !torch.none, !torch.int -> !torch.list<int>
+  return %2 : !torch.list<int>
+}
+
+// CHECK-LABEL:   func.func @torch.aten.slice.t$start_exceed_range() -> !torch.list<int> {
+// CHECK:           %int0 = torch.constant.int 0
+// CHECK:           %int1 = torch.constant.int 1
+// CHECK:           %[[RET:.*]] = torch.prim.ListConstruct %int0, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           return %[[RET]] : !torch.list<int>
+func.func @torch.aten.slice.t$start_exceed_range() -> !torch.list<int> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int-1 = torch.constant.int -1
+  %int-1000 = torch.constant.int -1000
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.aten.slice.t %0, %int-1000, %int-1, %int1 : !torch.list<int>, !torch.int, !torch.int, !torch.int -> !torch.list<int>
+  return %2 : !torch.list<int>
+}
+
+// CHECK-LABEL:   func.func @torch.aten.slice.t$end_exceed_range() -> !torch.list<int> {
+// CHECK:           %int0 = torch.constant.int 0
+// CHECK:           %int1 = torch.constant.int 1
+// CHECK:           %int2 = torch.constant.int 2
+// CHECK:           %[[RET:.*]] = torch.prim.ListConstruct %int0, %int1, %int2 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           return %[[RET]] : !torch.list<int>
+func.func @torch.aten.slice.t$end_exceed_range() -> !torch.list<int> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int-1 = torch.constant.int -1
+  %int1000 = torch.constant.int 1000
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.aten.slice.t %0, %int0, %int1000, %int1 : !torch.list<int>, !torch.int, !torch.int, !torch.int -> !torch.list<int>
+  return %2 : !torch.list<int>
+}
+
+// Not canonicalized because of mutated l list
+// CHECK-LABEL: func.func @torch.aten.slice.t$no_canonicalize_l_mutated()
+func.func @torch.aten.slice.t$no_canonicalize_l_mutated() -> !torch.list<int> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int-1 = torch.constant.int -1
+  %0 = torch.prim.ListConstruct %int0, %int1, %int2 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  // CHECK: torch.aten.slice.t
+  %2 = torch.aten.slice.t %0, %int0, %int-1, %int1 : !torch.list<int>, !torch.int, !torch.int, !torch.int -> !torch.list<int>
+  %3 = torch.aten.append.t %0, %int-1 : !torch.list<int>, !torch.int -> !torch.list<int>
+  return %2 : !torch.list<int>
+}
+
 // CHECK-LABEL:   func.func @torch.aten.eq.int_list$fold$literals_of_different_sizes
 // CHECK:           %[[RET:.*]] = torch.constant.bool false
 // CHECK:           return %[[RET]] : !torch.bool


### PR DESCRIPTION
`aten.slice.t` op lacks a canonicalizer. It will cause the shape-simplification pipeline fails to infer %3 to have a static shape in the following IR:
```
%0 = torch.tensor.literal(dense_resource<__elided__> : tensor<4x300xf32>) : !torch.tensor<[4,300],f32>
%1 = torch.prim.ListConstruct %int16, %int75, %int2, %int2 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
%2 = torch.aten.slice.t %1, %int0, %int-2, %int1 : !torch.list<int>, !torch.int, !torch.int, !torch.int -> !torch.list<int>
%3 = torch.aten.view %0, %2 : !torch.tensor<[4,300],f32>, !torch.list<int> -> !torch.tensor<[?,?],f32>
```
This PR adds a canonicalizer for `aten.slice.t` op. The basic idea is replacing `aten.slice.t` op with a new `prim.ListConstruct` op, when the former's operand comes from `prim.ListConstruct` op and all its parameters (i.e. `start`, `end` and `step`) are constant integers (or none if possible) .