### PR TITLE
Add `--no-index` to CI's git-diff check on generated files

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -211,12 +211,12 @@ function _check_file_not_changed_by() {
   mv "$file_backup" "$file"
   # We use git-diff as "just a diff program" (no SCM stuff) because it has
   # nicer output than regular `diff`.
-  if ! git diff --quiet "$file" "$file_new"; then
+  if ! git diff --no-index --quiet "$file" "$file_new"; then
     echo "#######################################################"
     echo "Generated file '${file}' is not up to date (see diff below)"
     echo ">>> Please run '${cmd}' to update it <<<"
     echo "#######################################################"
-    git diff --color=always "$file" "$file_new"
+    git diff --no-index --color=always "$file" "$file_new"
     # TODO: Is there a better cleanup strategy that doesn't require duplicating
     # this inside and outside the `if`?
     rm "$file_new"


### PR DESCRIPTION
`git diff` does not work by default on untracked files. Since the function `_check_file_not_changed_by` stores the new generated file in an untracked file, `git diff` was not catching any modifications in the new generated file. This commit adds the flag `--no-index` to make `git diff` work with untracked files.