### PR TITLE
[tosa] Add support for some cases of aten.broadcast_to op

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -23,7 +23,6 @@ EAGER_MODE_XFAIL_SET = {
 }
 
 MHLO_PASS_SET = {
-    "BroadcastToIdentityCaseStaticModule_basic",
     "GatherStaticModule_basic",
     "GatherModule_basic",
     "Gather2DInputModdule_basic",
@@ -454,7 +453,8 @@ TOSA_PASS_SET = {
     "_LogSoftmaxModuleStable_basic",
     "LiftFreshCopyModule_basic",
     "ReduceSumDimIntListKeepDimNegativeDimStaticModule_basic",
-    "BroadcastToIdentityCaseStaticModule_basic",
+    "BroadcastToSameRankStaticModule_basic",
+    "BroadcastZeroRankInputStaticModule_basic",
     "SliceStaticModule_basic",
 }
 

--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -50,6 +50,8 @@ bool isBuiltInType(Type type);
 // -1 is returned if the tensorRank can't be determined.
 int getTensorRank(Value tensor);
 
+bool isViewLikeOp(Operation *op);
+
 } // namespace Torch
 } // namespace torch
 } // namespace mlir

--- a/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
+++ b/lib/Dialect/Torch/Transforms/MaximizeValueSemantics.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
 
 using namespace mlir;
 using namespace mlir::torch;
@@ -25,20 +26,6 @@ static Value assertNonValueTensor(Value tensor) {
   assert(tensor.getType().isa<NonValueTensorType>() &&
          "tensor is expected to be a non-value tensor");
   return tensor;
-}
-
-static bool isViewLikeOp(Operation *op) {
-  // AtenContiguousOp might return a view, so this is conservatively
-  // correct. We could potentially be more precise and identify the cases
-  // that it does not return a view and treat those as having value
-  // semantics.
-  return isa<AtenBroadcastToOp, AtenContiguousOp, AtenDetachOp, AtenExpandAsOp,
-             AtenExpandOp, AtenFlattenUsingIntsOp, AtenPermuteOp, AtenReshapeOp,
-             Aten_ReshapeAliasOp, AtenSelectIntOp, AtenSliceTensorOp,
-             AtenSqueezeDimOp, AtenSqueezeOp, AtenTOp, AtenToDtypeOp,
-             AtenTransposeIntOp, AtenUnsqueezeOp, AtenViewOp,
-             TensorStaticInfoCastOp, AtenToDtypeLayoutOp, AtenNumpyTOp,
-             AtenNarrowOp, AtenToDeviceOp>(op);
 }
 
 namespace {

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -142,3 +142,17 @@ int Torch::getTensorRank(Value tensor) {
   }
   return tensorRank;
 }
+
+bool Torch::isViewLikeOp(Operation *op) {
+  // AtenContiguousOp might return a view, so this is conservatively
+  // correct. We could potentially be more precise and identify the cases
+  // that it does not return a view and treat those as having value
+  // semantics.
+  return isa<AtenBroadcastToOp, AtenContiguousOp, AtenDetachOp, AtenExpandAsOp,
+             AtenExpandOp, AtenFlattenUsingIntsOp, AtenPermuteOp, AtenReshapeOp,
+             Aten_ReshapeAliasOp, AtenSelectIntOp, AtenSliceTensorOp,
+             AtenSqueezeDimOp, AtenSqueezeOp, AtenTOp, AtenToDtypeOp,
+             AtenTransposeIntOp, AtenUnsqueezeOp, AtenViewOp,
+             TensorStaticInfoCastOp, AtenToDtypeLayoutOp, AtenNumpyTOp,
+             AtenNarrowOp, AtenToDeviceOp>(op);
+}

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -1089,7 +1089,7 @@ def BroadcastToModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
-class BroadcastToIdentityCaseStaticModule(torch.nn.Module):
+class BroadcastToSameRankStaticModule(torch.nn.Module):
 
     def __init__(self):
         super().__init__()
@@ -1097,16 +1097,41 @@ class BroadcastToIdentityCaseStaticModule(torch.nn.Module):
     @export
     @annotate_args([
         None,
+        ([3, 1, 8], torch.float32, True),
         ([3, 1, 1], torch.float32, True),
     ])
-    def forward(self, x):
-        return torch.broadcast_to(x, [3, 1, 1])
+    def forward(self, x, y):
+        y = torch.broadcast_to(y, [3, 1, 8])
+        return torch.ops.aten.sub(x, y)
 
 
-@register_test_case(module_factory=lambda: BroadcastToIdentityCaseStaticModule())
-def BroadcastToIdentityCaseStaticModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(3, 1, 1))
+@register_test_case(module_factory=lambda: BroadcastToSameRankStaticModule())
+def BroadcastToSameRankStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 1, 8), tu.rand(3, 1, 1))
 
+
+# ==============================================================================
+
+
+class BroadcastZeroRankInputStaticModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, 1, 8], torch.float32, True),
+        ([], torch.float32, True),
+    ])
+    def forward(self, x, y):
+        y = torch.broadcast_to(y, [3, 1, 8])
+        return torch.ops.aten.sub(x, y)
+
+
+@register_test_case(module_factory=lambda: BroadcastZeroRankInputStaticModule())
+def BroadcastZeroRankInputStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 1, 8), tu.rand())
 
 # ==============================================================================
 


### PR DESCRIPTION
This commit adds support for TorchToTosa lowering of `aten.broadcast_to` op for cases:
1.) When the rank of input and output tensor is equal.
2.) When the rank of input tensor is zero.

Signed-Off By: Vivek Khandelwal<vivek@nod-labs.com>