### PR TITLE
Update releases pages after release builds

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -93,3 +93,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
       with:
         release_id: ${{ github.event.inputs.release_id }}
+
+    - name: Invoke Publish Releases Page
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: Publish releases page
+        token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
+        ref: "${{ env.tag_name }}"

--- a/.github/workflows/gh-pages-releases.yml
+++ b/.github/workflows/gh-pages-releases.yml
@@ -2,9 +2,6 @@
 name: Publish releases page
 
 on:
-  schedule:
-    - cron: '0 * * * *'
-
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove the periodic update since there are no changes after the nightly and it just clutters the Github Actions.