### PR TITLE
[Bazel] Make pytorch-requirements.txt available within the docker container

### DIFF
--- a/utils/bazel/docker/Dockerfile
+++ b/utils/bazel/docker/Dockerfile
@@ -27,8 +27,9 @@ RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSIO
     && chmod a+x /usr/bin/bazel
 
 COPY requirements.txt /opt/app/requirements.txt
+COPY pytorch-requirements.txt /opt/app/pytorch-requirements.txt
 WORKDIR /opt/app
 RUN python -m pip install --upgrade pip
-RUN python -m pip install --ignore-installed -r requirements.txt
+RUN python -m pip install --upgrade --ignore-installed -r requirements.txt
 
 WORKDIR /opt/src/torch-mlir


### PR DESCRIPTION
Updates the bazel Dockerfile to match changes from https://github.com/llvm/torch-mlir/pull/1419. This should get the bazel build back to green.

Also triggered bazel build on GHA here: https://github.com/sjain-stanford/torch-mlir/actions/runs/3154741943. Let's wait for it to complete before landing this.