### PR TITLE
build: check exit code without causing script to fail

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -34,8 +34,8 @@ jobs:
         python -m pip download -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html --pre "torch==${PT_RELEASE}"
         # Read the commit hash from the downloaded whl file without extracting it
         PT_HASH=$(unzip -p torch-"${PT_RELEASE}"*.whl torch/version.py | grep git_version | awk '{ print $3 }' | tr -d "'")
-        echo "${PT_HASH}" | cmp - pytorch-version.txt --quiet
-        PT_HASH_CHANGED=$?
+        PT_HASH_CHANGED=0
+        echo "${PT_HASH}" | cmp - pytorch-version.txt --quiet || PT_HASH_CHANGED=$?
         echo "${PT_HASH}" > pytorch-version.txt
         rm torch-"${PT_RELEASE}"*.whl
         # Write the release and hash to the environment file so that we can


### PR DESCRIPTION
A bug in the CI script caused the entire script to fail if the exit code
of the command for comparing with the existing hash returned a non-zero
exit status.  The non-zero exit status for this comparison does not
imply failed execution, since it only indicates that the hash has
changed.

---

See fixed action here: https://github.com/llvm/torch-mlir/actions/runs/3168739550/jobs/5160152336