### PR TITLE
Publish releases page after both mac and linux builds.

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -94,6 +94,15 @@ jobs:
       with:
         release_id: ${{ github.event.inputs.release_id }}
 
+  publish_releases:
+    needs:
+    - build_linux
+    - build_macos
+
+    # Publish even if one of the builds failed
+    if: ${{ always() }}
+
+    steps:
     - name: Invoke Publish Releases Page
       uses: benc-uk/workflow-dispatch@v1
       with:


### PR DESCRIPTION
Mac was finishing first, causing linux releases to be lagged a day behind.

Related discussion in https://github.com/llvm/torch-mlir/pull/1432