### PR TITLE
torch_mlir.compile: allow custom backend_legal_ops set

### DIFF
--- a/python/test/compile_api/backend_legal_ops.py
+++ b/python/test/compile_api/backend_legal_ops.py
@@ -1,0 +1,23 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import torch
+
+import torch_mlir
+
+class AddmmModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    def forward(self, x, y, z):
+        return torch.ops.aten.addmm(x, y, z)
+
+example_args = 3 * [torch_mlir.TensorPlaceholder([-1, -1], torch.float32)]
+
+print(torch_mlir.compile(AddmmModule(), example_args,
+      output_type="torch", backend_legal_ops=["torch.aten.addmm"]))
+# CHECK-LABEL: @forward
+# CHECK: torch.aten.addmm


### PR DESCRIPTION
Allow customizing `backend_legal_ops` for "torch" output type, since we don't know which backend will be used (it might be a custom backend). We don't allow customizing the `backend_legal_ops` for the other output types (Linalg, TOSA, MHLO) since those backends control their set of legal ops directly.

Fixes #1418