### PR TITLE
Remove unused input tensor from linalg.generic in aten.convolution

### DIFF
--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -572,11 +572,11 @@ public:
           createZeroInitTensor(rewriter, loc, weightInitDims, elementType);
       SmallVector<StringRef> iteratorTypes(inRank,
                                            getParallelIteratorTypeName());
-      SmallVector<AffineMap> indexingMaps(
-          2, AffineMap::getMultiDimIdentityMap(inRank, context));
+      SmallVector<AffineMap> indexingMaps{
+          AffineMap::getMultiDimIdentityMap(inRank, context)};
       weight = rewriter
                    .create<linalg::GenericOp>(
-                       loc, weightInitTensor.getType(), weight,
+                       loc, weightInitTensor.getType(), ValueRange{},
                        weightInitTensor, indexingMaps, iteratorTypes,
                        [&](OpBuilder &b, Location loc, ValueRange args) {
                          SmallVector<Value> indices;


### PR DESCRIPTION
This commit removes the `weight` tensor from the inputs of one of the `linalg.generic` ops generated by the `aten.convolution` linalg lowering, since the indexed values are not actually used by the body of the `linalg.generic`. Moreover, in general the `weight` tensor does not have the same shape as the output tensor of the `linalg.generic`, so both tensors being indexed by the same indexing maps is wrong.