### PR TITLE
ci: re-enable auto execution of the RollPyTorch action

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -1,6 +1,8 @@
 name: Roll PyTorch
 
 on:
+  schedule:
+    - cron: '0 12 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Now that the RollPyTorch action seems to have become stable, this patch
enables that action to be run at around 4am Pacific Time every day.