### PR TITLE
build: retain object files after building PyTorch from source

### DIFF
--- a/build_tools/build_libtorch.sh
+++ b/build_tools/build_libtorch.sh
@@ -122,13 +122,13 @@ package_pytorch() {
   fi
 
   # Copy over all of the cmake files
-  mv build/lib*/torch/share     libtorch/
-  mv build/lib*/torch/include   libtorch/
-  mv build/lib*/torch/lib       libtorch/
+  cp -r build/lib*/torch/share     libtorch/
+  cp -r build/lib*/torch/include   libtorch/
+  cp -r build/lib*/torch/lib       libtorch/
   # Copy over all lib files
-  mv build/lib/*                libtorch/lib/
+  cp -r build/lib/*                libtorch/lib/
   # Copy over all include files
-  mv build/include/*            libtorch/include/
+  cp -r build/include/*            libtorch/include/
 
   (pushd "$PYTORCH_ROOT" && git rev-parse HEAD) > libtorch/build-hash
   echo "Installing libtorch in ${PYTORCH_ROOT}/../../"


### PR DESCRIPTION
With the goal of improving time spent in CI, this patch retains the
object files built while compiling PyTorch from source.  By doing so,
the build system would recognize that the object files are newer than
the source files, thus skipping a full rebuild.
    
Although this patch does not make any _functional_ changes, it still is
speculative.  So if we do not observe any significant improvement in
time spent in CI over the next few days, I will revert this patch so
that we can save some disk space.