### PR TITLE
ci: use the LLVM linker instead of GNU ld

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -183,7 +183,9 @@ function build_in_tree() {
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_C_COMPILER=clang \
       -DCMAKE_CXX_COMPILER=clang++ \
-      -DCMAKE_LINKER=lld \
+      -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+      -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+      -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
       -DLLVM_ENABLE_ASSERTIONS=ON \
       -DCMAKE_C_COMPILER_LAUNCHER=ccache \
       -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -286,7 +288,9 @@ function build_out_of_tree() {
         -DCMAKE_CXX_COMPILER=clang++ \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_LINKER=lld \
+        -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+        -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+        -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
         -DLLVM_ENABLE_ASSERTIONS=ON \
         -DLLVM_ENABLE_PROJECTS=mlir \
         -DLLVM_TARGETS_TO_BUILD=host \
@@ -302,7 +306,9 @@ function build_out_of_tree() {
       -DCMAKE_CXX_COMPILER=clang++ \
       -DCMAKE_C_COMPILER_LAUNCHER=ccache \
       -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-      -DCMAKE_LINKER=lld \
+      -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+      -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+      -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
       -DLLVM_DIR="/main_checkout/torch-mlir/llvm-build/lib/cmake/llvm/" \
       -DMLIR_DIR="/main_checkout/torch-mlir/llvm-build/lib/cmake/mlir/" \
       -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \


### PR DESCRIPTION
Without this patch, CI logs contained the line:

    -- Linker detection: GNU ld

GNU ld is notoriously slow at linking large binaries, so this patch
swaps GNU ld with the LLVM linker.

Since the linker invocation is driven through the compiler, perhaps the
best way to use the LLVM linker is to tell the compiler which linker
binary to use.  This patch adds the `-fuse-ld=lld` flag to all Linux
builds of Torch-MLIR in CI to make it use lld.