### PR TITLE
[MLIR][TORCH] Add -convert-torch-to-tosa-custom pass for undecomposed selective ops

### DIFF
--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -114,6 +114,41 @@ def ConvertTorchToTosa : Pass<"convert-torch-to-tosa", "func::FuncOp"> {
   let constructor = "mlir::torch::createConvertTorchToTosaPass()";
 }
 
+def ConvertTorchToTosaCustom : Pass<"convert-torch-to-tosa-custom", "func::FuncOp"> {
+        let summary = "Convert Torch ops to TOSA custom ops";
+  let description = [{
+    The purpose to use tosa::custom is handle complex ops when we do not
+    want to decompose them into simple ops.
+    The aten op name will be used to construct a StringAttr as the identifier attribute for tosa::CustomOp.
+    So in the output the users know where the tosa::CustomOp is coming from by the StringAttr id.
+    Each input arg from Aten Dialect has to be converted to a tensor of number values as the
+    operand of tosa::CustomOp op.
+    The contract to follow:
+        AnyTorchTensorType 	->	TensorType<AnySizexAnyType>  of tosa::ConstOp
+        Torch_IntType		->      RankedTensorType<1xi64>  of tosa::ConstOp
+        Torch_FloatType		->      RankedTensorType<1xf32>  of tosa::ConstOp
+        ...
+        TODO:
+          1. Support more types: Torch_BoolType, Torch_QInt8Type, Torch_QUInt8Type
+              Torch_NoneType, Torch_StringType, Torch_OptionalType, Torch_ListType
+              Torch_NumberType, Torch_DictType, Torch_DeviceType, Torch_GeneratorType,
+              Torch_LinearParamsType, Torch_TupleType, Torch_UnionType,
+              Torch_AnyType, AnyTorchOptionalType,
+          2. Support multi result types
+    The examples are in the test/Conversion/TorchToTosa/custom.mlir
+  }];
+  let options = [
+    ListOption<"customOps", "custom-ops", "std::string",
+               "List of operation names that should be converted to tosa::custom",
+               "llvm::cl::ZeroOrMore">
+  ];
+
+  let constructor = [{
+      mlir::torch::createConvertTorchToTosaCustomPass(
+          /*customOps=*/{})
+  }];
+}
+
 def ConvertTorchToTMTensor : Pass<"convert-torch-to-tmtensor", "func::FuncOp"> {
   let summary = "Convert recognized Torch ops to TMTensor/Linalg ops";
   let description = [{

--- a/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
@@ -17,6 +17,9 @@
 namespace mlir {
 namespace torch {
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTosaPass();
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertTorchToTosaCustomPass(ArrayRef<std::string> customOps);
 }
 } // namespace mlir
 

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
@@ -28,7 +28,15 @@ void createTorchBackendToLinalgOnTensorsBackendPipeline(OpPassManager &pm);
 
 /// Creates a pipeline that lowers from the torch backend contract to the
 /// TOSA backend contract.
-void createTorchBackendToTosaBackendPipeline(OpPassManager &pm);
+struct TosaBackendPipelineOptions
+    : public PassPipelineOptions<TosaBackendPipelineOptions> {
+  ListOption<std::string> customOps{
+      *this, "custom-ops",
+      llvm::cl::desc("List of ops to be converted to tosa::CustomOp."),
+      llvm::cl::ZeroOrMore};
+};
+void createTorchBackendToTosaBackendPipeline(
+    OpPassManager &pm, const TosaBackendPipelineOptions &options);
 
 // Do not register the torch-to-mhlo pipeline if mhlo target is disabled
 #ifdef TORCH_MLIR_ENABLE_MHLO

--- a/lib/Conversion/TorchToTosa/CMakeLists.txt
+++ b/lib/Conversion/TorchToTosa/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_conversion_library(TorchMLIRTorchToTosa
   TorchToTosa.cpp
+  TorchToTosaCustom.cpp
   TosaLegalizeUtils.cpp
   TosaLegalizeCommon.cpp
 

--- a/lib/Conversion/TorchToTosa/TorchToTosaCustom.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosaCustom.cpp
@@ -1,0 +1,150 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeCommon.h"
+#include "torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/Dialect/Traits.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+#include <unordered_map>
+#include <iostream>
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+namespace {
+
+class ConvertSelectiveOpToTosaCustom : public ConversionPattern {
+public:
+  ArrayRef<std::string>  customOps;
+  ConvertSelectiveOpToTosaCustom(TypeConverter &typeConverter, MLIRContext *context,
+                                 ArrayRef<std::string> customOps)
+      : ConversionPattern(typeConverter, MatchAnyOpTypeTag(), /*benefit=*/1,
+                          context){
+    this->customOps = customOps;
+  }
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    std::string op_name = op->getName().getStringRef().str();
+    for (auto customOpName : customOps) {
+      if (customOpName == op_name) {
+        int num_operands = operands.size();
+        std::vector<mlir::Value> inputs_vec;
+        for (int i = 0; i < num_operands; i++) {
+          auto operand = op->getOperands()[i];
+          auto operand_type = operand.getType();
+          // type convert for operands
+          if (operand_type.template isa<torch::Torch::IntType>()) {
+            int64_t operand_tosa;
+            if (!matchPattern(operand, m_TorchConstantInt(&operand_tosa)))
+              return rewriter.notifyMatchFailure(
+                  op, "unimplemented: operand should be a torch.constant.int");
+            auto operand_tensor_int =
+                tosa::getConstTensor<int64_t>(rewriter, op, operand_tosa, {1});
+            inputs_vec.push_back(operand_tensor_int.value());
+          } else if (operand_type.template isa<torch::Torch::FloatType>()) {
+            double operand_tosa;
+            if (!matchPattern(operand, m_TorchConstantFloat(&operand_tosa)))
+              return rewriter.notifyMatchFailure(
+                  op,
+                  "unimplemented: operand should be a torch.constant.float");
+            auto operand_tensor_float =
+                tosa::getConstTensor<float>(rewriter, op, operand_tosa, {1});
+            inputs_vec.push_back(operand_tensor_float.value());
+          } else if (operand_type
+                         .template isa<torch::Torch::ValueTensorType>()) {
+            inputs_vec.push_back(operands[i]);
+          } else {
+            // TODO Handle more types like !torch.list<...>, !torch.device,
+            // !torch.string, !torch.none, !torch.generator.
+            return rewriter.notifyMatchFailure(
+                op, "unimplemented: inputs type. The input has to be int/float/tensor ");
+          }
+        }
+        // Create operands for tosa::CustomOp
+        llvm::ArrayRef<mlir::Value> ref(inputs_vec.data(), inputs_vec.size());
+        ValueRange custom_inputs(ref);
+        // Create output type for tosa::CustomOp
+        auto outType =
+            getTypeConverter()->convertType(op->getResult(0).getType());
+
+        rewriter.replaceOpWithNewOp<tosa::CustomOp>(
+            op, outType, op->getName().getStringRef(), custom_inputs);
+        return success();
+      }
+    }
+    return failure();
+  }
+};
+
+} // namespace
+
+// -----------------------------------------------------------------------------
+// TorchToTosaCustom Pass
+// -----------------------------------------------------------------------------
+
+namespace {
+class ConvertTorchToTosaCustom
+    : public ConvertTorchToTosaCustomBase<ConvertTorchToTosaCustom> {
+public:
+  ConvertTorchToTosaCustom() = default;
+  ConvertTorchToTosaCustom(ArrayRef<std::string> customOps) {
+    this->customOps = customOps;
+  }
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<tosa::TosaDialect>();
+    registry.insert<tensor::TensorDialect>();
+    registry.insert<arith::ArithDialect>();
+    TorchConversion::getBackendTypeConversionDependentDialects(registry);
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ConversionTarget target(*context);
+    target.addLegalDialect<tosa::TosaDialect, tensor::TensorDialect,
+                           arith::ArithDialect>();
+
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    TorchConversion::setupBackendTypeConversion(target, typeConverter);
+
+    RewritePatternSet patterns(context);
+
+    patterns.add<ConvertSelectiveOpToTosaCustom>(typeConverter,
+                                                 context, customOps);
+
+    for (std::string opName : customOps) {
+      target.addIllegalOp(OperationName(opName, context));
+    }
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::torch::createConvertTorchToTosaCustomPass(
+    ArrayRef<std::string> customOps) {
+  return std::make_unique<ConvertTorchToTosaCustom>(customOps);
+}

--- a/test/Conversion/TorchToTosa/custom.mlir
+++ b/test/Conversion/TorchToTosa/custom.mlir
@@ -1,0 +1,39 @@
+// RUN: torch-mlir-opt <%s -convert-torch-to-tosa-custom="custom-ops=torch.aten.softmax.int,torch.aten.rsub.Scalar" -split-input-file -verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL:   func.func @torch.aten.softmax.int$cst_dim(
+// CHECK-SAME:                                              %[[VAL_0:.*]]: !torch.vtensor<[2,3],f32>) -> !torch.vtensor<[2,3],f32> {
+// CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[2,3],f32> -> tensor<2x3xf32>
+// CHECK:           %[[VAL_2:.*]] = torch.constant.int 1
+// CHECK:           %[[VAL_3:.*]] = torch.constant.int 1
+// CHECK:           %[[VAL_4:.*]] = "tosa.const"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = "tosa.const"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = "tosa.custom"(%[[VAL_1]], %[[VAL_4]], %[[VAL_5]]) {identifier = "torch.aten.softmax.int"} : (tensor<2x3xf32>, tensor<1xi64>, tensor<1xi64>) -> tensor<2x3xf32>
+// CHECK:           %[[VAL_7:.*]] = torch_c.from_builtin_tensor %[[VAL_6]] : tensor<2x3xf32> -> !torch.vtensor<[2,3],f32>
+// CHECK:           return %[[VAL_7]] : !torch.vtensor<[2,3],f32>
+// CHECK:         }
+func.func @torch.aten.softmax.int$cst_dim(%t: !torch.vtensor<[2,3],f32>) -> !torch.vtensor<[2,3],f32> {
+  %dtype = torch.constant.int 1
+  %dim = torch.constant.int 1
+  %ret = torch.aten.softmax.int %t, %dim, %dtype : !torch.vtensor<[2,3],f32>, !torch.int, !torch.int -> !torch.vtensor<[2,3],f32>
+  return %ret : !torch.vtensor<[2,3],f32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten.rsub.Scalar$basic(
+// CHECK-SAME:                                            %[[VAL_0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
+// CHECK:           %[[VAL_2:.*]] = torch.constant.float 3.123400e+00
+// CHECK:           %[[VAL_3:.*]] = torch.constant.int 1
+// CHECK:           %[[VAL_4:.*]] = "tosa.const"() {value = dense<3.123400e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+// CHECK:           %[[VAL_5:.*]] = "tosa.const"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
+// CHECK:           %[[VAL_6:.*]] = "tosa.custom"(%[[VAL_1]], %[[VAL_4]], %[[VAL_5]]) {identifier = "torch.aten.rsub.Scalar"} : (tensor<?x?xf32>, tensor<1xf32>, tensor<1xi64>) -> tensor<?x?xf32>
+// CHECK:           %[[VAL_7:.*]] = torch_c.from_builtin_tensor %[[VAL_6]] : tensor<?x?xf32> -> !torch.vtensor<[?,?],f32>
+// CHECK:           return %[[VAL_7]] : !torch.vtensor<[?,?],f32>
+// CHECK:         }
+func.func @torch.aten.rsub.Scalar$basic(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %other = torch.constant.float 3.123400e+00
+  %alpha = torch.constant.int 1
+  %0 = torch.aten.rsub.Scalar %arg0, %other, %alpha : !torch.vtensor<[?,?],f32>, !torch.float, !torch.int -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}


### PR DESCRIPTION
Use tosa::custom op to represent softmax op which we deliberately choose not to decompose into simple ops.The reason to do this is in this RFC here: https://github.com/llvm/torch-mlir/issues/1519