### PR TITLE
Add Windows CI and Release Builder

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -16,7 +16,7 @@ runs:
   - name: Set up Python
     uses: actions/setup-python@v2
     with:
-      python-version: 3.9
+      python-version: '3.10'
 
   - name: Install MLIR Python depends
     run: |

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os-arch: [ubuntu-x86_64, macos-arm64]
+        os-arch: [ubuntu-x86_64, macos-arm64, windows-x86_64]
         llvm-build: [in-tree, out-of-tree]
         torch-binary: [ON, OFF]
         exclude:
@@ -38,12 +38,16 @@ jobs:
           # Exclude macos-arm64 and llvm out-of-tree altogether
           - os-arch: macos-arm64
             llvm-build: out-of-tree
+          - os-arch: windows-x86_64
+            llvm-build: out-of-tree
         include:
           # Specify OS versions
           - os-arch: ubuntu-x86_64
             os: ubuntu-22.04
           - os-arch: macos-arm64
             os: macos-12
+          - os-arch: windows-x86_64
+            os: windows-latest
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -53,6 +57,7 @@ jobs:
         submodules: 'true'
 
     - name: Fetch PyTorch commit hash
+      if: ${{ matrix.os-arch != 'windows-x86_64' }}
       run: |
         PT_HASH="$(cat ${GITHUB_WORKSPACE}/pytorch-version.txt)"
         echo "PT_HASH=${PT_HASH}" >> ${GITHUB_ENV}
@@ -62,7 +67,14 @@ jobs:
       with:
         cache-suffix: ${{ matrix.os-arch }}-${{ matrix.llvm-build }}-${{ matrix.torch-binary }}
 
+    - name: Set up Visual Studio shell
+      if: ${{ matrix.os-arch == 'windows-x86_64' }}
+      uses: egor-tensin/vs-shell@v2
+      with:
+        arch: x64
+
     - name: Cache PyTorch Build
+      if: ${{ matrix.os-arch != 'windows-x86_64' }}
       id: cache-pytorch
       uses: actions/cache@v3
       with:
@@ -110,3 +122,8 @@ jobs:
       if: ${{ matrix.os-arch == 'macos-arm64' }}
       run: |
         cmake --build build_arm64
+    - name: Build torch-mlir (Windows)
+      if: ${{ matrix.os-arch == 'windows-x86_64' }}
+      shell: pwsh
+      run: |
+        ./build_tools/python_deploy/build_windows_ci.ps1

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -93,12 +93,56 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
       with:
         release_id: ${{ github.event.inputs.release_id }}
+        
+        
+  build_windows:
+    name: Windows Build
+    runs-on: windows-latest
+    steps:
+    - name: Get torch-mlir
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    - uses: ./.github/actions/setup-build
+      with:
+        cache-suffix: ''
+    - name: Set up Visual Studio shell
+      uses: egor-tensin/vs-shell@v2
+      with:
+        arch: x64
+    - name: Build Python wheels and smoke test.
+      shell: pwsh
+      run: |
+        ./build_tools/python_deploy/build_windows.ps1
+
+    # If we were given a release_id, then upload the package we just built
+    # to the github releases page.
+    - name: Upload Release Assets (if requested)
+      if: github.event.inputs.release_id != ''
+      id: upload-release-assets
+      uses: dwenegar/upload-release-assets@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
+      with:
+        release_id: ${{ github.event.inputs.release_id }}
+        assets_path: ./wheelhouse/torch*.whl
+    # Publishing is necessary to make the release visible to `pip`
+    # on the github releases page.
+    - name: Publish Release (if requested)
+      if: github.event.inputs.release_id != ''
+      id: publish_release
+      uses: eregon/publish-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
+      with:
+        release_id: ${{ github.event.inputs.release_id }}
 
   publish_releases:
     runs-on: ubuntu-latest
     needs:
     - build_linux
     - build_macos
+    - build_windows
 
     # Publish even if one of the builds failed
     if: ${{ always() }}

--- a/build_tools/python_deploy/build_windows.ps1
+++ b/build_tools/python_deploy/build_windows.ps1
@@ -1,0 +1,24 @@
+# Uncomment if you want to install Python. GHA provides this
+
+#Write-Host "Installing python"
+
+#Start-Process choco 'install python --version=3.10.8' -wait -NoNewWindow
+
+#Write-Host "python installation completed successfully"
+
+#Write-Host "Reload environment variables"
+#$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+#Write-Host "Reloaded environment variables"
+
+Write-Host "Installing Build Dependencies"
+python -m venv .\mlir_venv\
+.\mlir_venv\Scripts\activate
+pip install -r .\requirements.txt
+Write-Host "Build Deps installation completed successfully"
+
+Write-Host "Building torch-mlir"
+$env:CMAKE_GENERATOR='Ninja'
+$env:TORCH_MLIR_ENABLE_LTC='0'
+python -m pip wheel -v -w  wheelhouse ./  -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html  -r whl-requirements.txt
+
+Write-Host "Build completed successfully"

--- a/build_tools/python_deploy/build_windows_ci.ps1
+++ b/build_tools/python_deploy/build_windows_ci.ps1
@@ -1,0 +1,42 @@
+#Uncomment if you want to test locally. GHA provides Python
+#Write-Host "Installing python"
+
+#Start-Process choco 'install python --version=3.10.8' -wait -NoNewWindow
+
+#Write-Host "python installation completed successfully"
+
+#Write-Host "Reload environment variables"
+#$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+#Write-Host "Reloaded environment variables"
+
+Write-Host "Installing Build Dependencies"
+python -m venv .\mlir_venv\
+.\mlir_venv\Scripts\activate
+pip install -r .\requirements.txt
+Write-Host "Build Deps installation completed successfully"
+
+Write-Host "Building torch-mlir"
+
+#Start-Process cmake '-GNinja -Bbuild \
+#  -DCMAKE_BUILD_TYPE=Release \
+#  -DPython3_FIND_VIRTUALENV=ONLY \
+#  -DLLVM_ENABLE_PROJECTS=mlir \
+#  -DLLVM_EXTERNAL_PROJECTS="torch-mlir;torch-mlir-dialects" \
+#  -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD" \
+#  -DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR="$PWD"/externals/llvm-external-projects/torch-mlir-dialects \
+#  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+#  -DLLVM_TARGETS_TO_BUILD=host \
+#  /externals/llvm-project/llvm'
+#Write-Host "Build completed successfully"
+
+Write-Host "Building torch-mlir"
+$env:CMAKE_GENERATOR='Ninja'
+$env:TORCH_MLIR_ENABLE_LTC='0'
+python -m pip wheel -v -w  wheelhouse ./  -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html  -r whl-requirements.txt
+Write-Host "Build completed successfully"
+
+Write-Host "Testing torch-mlir"
+$env:PYTHONPATH = "$PWD/build/cmake_build/tools/torch-mlir/python_packages/torch_mlir;$PWD/examples"
+# Uncomment here to enable tests. TODO: Fix paths
+#cmake --build cmake_build/build --target check-torch-mlir-all
+Write-Host "Testing completed successfully"


### PR DESCRIPTION
Add a powershell script to build windows .whl packages Disable LTC as it doesn't build on Windows.

This works on my local Windows 11 setup. Will try to invoke from GHA next. 