### PR TITLE
remove spurious ref in publish pages

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -154,4 +154,3 @@ jobs:
       with:
         workflow: Publish releases page
         token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
-        ref: "${{ env.tag_name }}"


### PR DESCRIPTION
We don't need to pass in optional tag information.