### PR TITLE
mlir: add missing dependency on TableGen targets

### DIFF
--- a/lib/Dialect/Torch/Utils/CMakeLists.txt
+++ b/lib/Dialect/Torch/Utils/CMakeLists.txt
@@ -4,4 +4,8 @@ add_mlir_dialect_library(TorchMLIRTorchUtils
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/torch-mlir/Dialect/Torch/Utils
-  )
+
+  DEPENDS
+  MLIRTorchOpsIncGen
+  MLIRTorchTypesIncGen
+)


### PR DESCRIPTION
lib/Dialect/Torch/Utils/Utils.cpp includes TorchOps.h, which, by way of
included header files, refers to both TorchOps.h.inc as well as
TorchTypes.h.inc.  However, the build rules do not specify the
dependency of the `TorchMLIRTorchUtils` target on the TableGen generated
header files, causing spurious build errors.
    
This patch fixes the problem by adding `MLIRTorchOpsIncGen` and
`MLIRTorchTypesIncGen` to the list of dependencies of
`TorchMLIRTorchUtils`.