### PR TITLE
ci: restrict PyTorch cache to just the main branch

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -68,7 +68,8 @@ jobs:
         git add pytorch-version.txt pytorch-requirements.txt lib/Dialect/Torch/Transforms/ShapeLibrary.cpp include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
         git diff --cached --exit-code || (git commit -m "update PyTorch version to ${{ env.PT_RELEASE }}" && git push --set-upstream origin main)
 
-    - name: Update PyTorch Build Cache
+    - name: Update PyTorch Build Cache (if running on main branch)
+      if: github.ref_name == 'main'
       id: cache-pytorch
       uses: actions/cache@v3
       with:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -73,8 +73,8 @@ jobs:
       with:
         arch: x64
 
-    - name: Cache PyTorch Build
-      if: ${{ matrix.os-arch != 'windows-x86_64' }}
+    - name: Cache PyTorch Build (if running on main branch)
+      if: github.ref_name == 'main' && matrix.os-arch != 'windows-x86_64'
       id: cache-pytorch
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
If PyTorch build caches are created on a branch other than the main
branch, then GitHub does not share those caches with the main branch,
making every CI run that runs for each PR slow.  This patch resolves the
problem by letting only the main branch create and use PyTorch build
caches.