### PR TITLE
ci: introduce read-only and read-write PyTorch build caches

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Update PyTorch Build Cache (if running on main branch)
       if: github.ref_name == 'main'
       id: cache-pytorch
-      uses: actions/cache@v3
+      uses: ashay/cache@v1
       with:
         path: ${{ github.workspace }}/build_tools/python_deploy/wheelhouse
-        key: ubuntu-x86_64-pytorch-${{ env.PT_HASH }}
+        key: ${{ runner.os }}-pytorch-${{ env.PT_HASH }}

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -73,13 +73,14 @@ jobs:
       with:
         arch: x64
 
-    - name: Cache PyTorch Build (if running on main branch)
-      if: github.ref_name == 'main' && matrix.os-arch != 'windows-x86_64'
+    - name: Cache PyTorch Build
+      if: matrix.os-arch != 'windows-x86_64'
       id: cache-pytorch
-      uses: actions/cache@v3
+      uses: ashay/cache@v1
       with:
         path: ${{ github.workspace }}/build_tools/python_deploy/wheelhouse
-        key: ${{ matrix.os-arch }}-pytorch-${{ env.PT_HASH }}
+        key: ${{ runner.os }}-pytorch-${{ env.PT_HASH }}
+        save: ${{ github.ref_name == 'main' && matrix.torch-binary == 'OFF' }}
 
     - name: Build and Test os-arch='ubuntu-x86_64' llvm-build='${{ matrix.llvm-build }}' torch-binary='${{ matrix.torch-binary }}'
       if: ${{ matrix.os-arch == 'ubuntu-x86_64' }}


### PR DESCRIPTION
Until recently, we had to either risk feature branches creating PyTorch
build caches (which were unusable by the main branch or other parallel
feature branches because of GitHub's rules around sharing caches among
branches) or we had to limit the PyTorch build caches to only the main
branch, causing CI runs on feature branches to be terribly slow because
they had to rebuild PyTorch each time.

This patch enables the best of both worlds, by using a fork
(github.com/ashay/cache) of the GitHub's cache action, where the fork
adds an option (called `save`) which, when set, uploads a new cache
entry.  We thus set this `save` flag only when we're building PyTorch
from source in Torch-MLIR's main branch, whereas all other builds set
this `save` flag to `false`.

The ability to conditionally update the cache has been an oft-requested
feature on the original (github.com/actions/cache) repository and
multiple unmerged PRs exist to allow conditional cache updates, so it is
likely that using the fork is only a temporary solution.

---

[Here](https://github.com/ashay/torch-mlir/actions/runs/3373754236/jobs/5598642372) is a run (on the main branch) that created a PyTorch build cache, and [here](https://github.com/ashay/torch-mlir/actions/runs/3374488481/jobs/5600163649) is a run in a feature branch that skips the cache update.