### PR TITLE
CI script improvements

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -14,7 +14,7 @@ runs:
 
   steps:
   - name: Set up Python
-    uses: actions/setup-python@v2
+    uses: actions/setup-python@v4
     with:
       python-version: '3.10'
 

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -28,8 +28,20 @@ runs:
       python -m pip install -r requirements.txt
     shell: bash
 
-  - name: Install Ninja
-    uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
+  - name: Install Ninja (Linux)
+    if: ${{ runner.os == 'Linux' }}
+    run: sudo apt-get install -y ninja-build
+    shell: bash
+
+  - name: Install Ninja (macOS)
+    if: ${{ runner.os == 'macOS' }}
+    run: brew install ninja
+    shell: bash
+
+  - name: Install Ninja (Windows)
+    if: ${{ runner.os == 'Windows' }}
+    run: pip install ninja
+    shell: bash
 
   - name: Ccache for C++ compilation
     uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -47,5 +47,5 @@ runs:
     uses: hendrikmuhs/ccache-action@v1.2
     with:
       key: ${{ runner.os }}-torch_mlir_build_assets-${{ inputs.cache-suffix }}
-      max-size: 2G
+      max-size: 300M
       verbose: 2

--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   ubuntu-build:
     name: ubuntu-x86_64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout torch-mlir

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -43,9 +43,9 @@ jobs:
         include:
           # Specify OS versions
           - os-arch: ubuntu-x86_64
-            os: ubuntu-22.04
+            os: ubuntu-latest
           - os-arch: macos-arm64
-            os: macos-12
+            os: macos-latest
           - os-arch: windows-x86_64
             os: windows-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
     - name: Checkout torch-mlir
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
 

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -54,7 +54,7 @@ jobs:
 
   build_macos:
     name: MacOS Build
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
     - name: Get torch-mlir
       uses: actions/checkout@v2

--- a/.github/workflows/gh-pages-releases.yml
+++ b/.github/workflows/gh-pages-releases.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   scrape_and_publish_releases:
     name: "Scrape and publish releases"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     # Don't run this in everyone's forks.
     if: github.repository == 'llvm/torch-mlir'

--- a/.github/workflows/releaseSnapshotPackage.yml
+++ b/.github/workflows/releaseSnapshotPackage.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release_snapshot_package:
     name: "Tag snapshot release"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # Don't run this in everyone's forks.
     if: github.repository == 'llvm/torch-mlir'
     steps:


### PR DESCRIPTION
This PR contains four commits (see commit messages for details):

 - ci: update versions of external actions
 - ci: replace deprecated action with bash commands
 - ci: use smaller ccache artifacts to reduce evictions
 - ci: use consistent platform identifiers

@dellis23 I added you as a reviewer because I changed one of your workflows in the last commit so that the workflow runs on ubuntu-22.04 for consistency with the rest of the workflows.  Let me know if you'd like me to revert the change.  Thanks!