### PR TITLE
build: pin ninja pip version temporarily to resolve build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pybind11
 wheel
 setuptools
 cmake
-ninja
+ninja==1.10.2
 
 # Workaround for what should be a torch dep
 # See discussion in #1174


### PR DESCRIPTION
Going from ninja v1.10.2 to v1.11.1, there is a change that breaks
the CI builds with the following error:

```
CMake Error at CMakeLists.txt:47 (project):
  Running
   '/main_checkout/torch-mlir/docker_venv/bin/ninja' '--version'
  failed with:
CMake Error: CMAKE_ASM_COMPILER not set, after EnableLanguage
```

Ostensibly, the reason for the error about the ASM compiler is because
llvm-project/llvm/CMakeLists.txt includes ASM among the list of
languages used in the LLVM project. Adding `-DCMAKE_ASM_COMPILER=clang`                            
does not resolve the error.

Until we figure out why the new version of ninja causes the build
failures, this patch pins the ninja to the one that worked.