### PR TITLE
build: un-pin the ninja pip package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pybind11
 wheel
 setuptools
 cmake
-ninja==1.10.2
+ninja
 
 # Workaround for what should be a torch dep
 # See discussion in #1174


### PR DESCRIPTION
Now that the ninja pip package issue has been resolved, this patch
removes the pinned version from requirements.txt so that we can go back
to using the most recent version of ninja.