### PR TITLE
[torch_mlir.compile] Add support for multiple exported methods

### DIFF
--- a/python/test/compile_api/multiple_methods.py
+++ b/python/test/compile_api/multiple_methods.py
@@ -1,0 +1,35 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import torch
+import torch_mlir
+
+
+class TwoMethodsModule(torch.nn.Module):
+    def sin(self, x):
+        return torch.ops.aten.sin(x)
+
+    def cos(self, x):
+        return torch.ops.aten.cos(x)
+
+
+example_args = torch_mlir.ExampleArgs()
+example_args.add_method("sin", torch.ones(2, 3))
+example_args.add_method("cos", torch.ones(2, 4))
+
+# Note: Due to https://github.com/pytorch/pytorch/issues/88735 we need to
+# check the `use_tracing` case first.
+
+print(torch_mlir.compile(TwoMethodsModule(), example_args, use_tracing=True))
+# CHECK: module
+# CHECK-DAG: func.func @sin
+# CHECK-DAG: func.func @cos
+
+print(torch_mlir.compile(TwoMethodsModule(), example_args))
+# CHECK: module
+# CHECK-DAG: func.func @sin
+# CHECK-DAG: func.func @cos

--- a/python/test/compile_api/tracing.py
+++ b/python/test/compile_api/tracing.py
@@ -59,14 +59,14 @@ class DictModule(torch.nn.Module):
 
 
 try:
-    # CHECK: Only Tensors, TensorPlaceholders, or a sequences of Tensors and TensorPlaceholders are supported as inputs.
+    # CHECK: Only Tensors, TensorPlaceholder's, or sequences of Tensors and TensorPlaceholder's are supported as example args for method inputs. Got '{'a': tensor(3.)}'
     torch_mlir.compile(DictModule(), {'a': torch.tensor(3.0)}, use_tracing=True)
 except Exception as e:
     print(e)
 
 
 try:
-    # CHECK: Only Tensors, TensorPlaceholders, or a sequences of Tensors and TensorPlaceholders are supported as inputs.
+    # CHECK: Only Tensors, TensorPlaceholder's, or sequences of Tensors and TensorPlaceholder's are supported as example args for method inputs. Got '{'a': tensor(3.)}'
     torch_mlir.compile(DictModule(), [{'a': torch.tensor(3.0)}], use_tracing=True)
 except Exception as e:
     print(e)


### PR DESCRIPTION
For AoT deployments models often have multiple exported methods. This patch enables something like this:

```
class TwoMethodsModule(torch.nn.Module):
    def sin(self, x):
        return torch.ops.aten.sin(x)

    def cos(self, x):
        return torch.ops.aten.cos(x)

example_args = torch_mlir.ExampleArgs()
example_args.add_method("sin", torch.ones(2, 3))
example_args.add_method("cos", torch.ones(2, 4))
print(torch_mlir.compile(TwoMethodsModule(), example_args))
```

In the
[long-term](https://github.com/llvm/torch-mlir/blob/main/docs/long_term_roadmap.md#tools-for-advanced-aot-deployments) we will need to reconcile this with our story for stateful models and the backend contract being purely functional. For now, this provides some basic infra that seems harmless. Arguably, we could tighten up the backend contract even more to only allow a single compiled function which would prohibit this or require building out a layer above.

Fixes #1557