### PR TITLE
build: pin torchvision to latest nightly

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -27,20 +27,37 @@ jobs:
 
     - name: Determine nightly PyTorch version
       run: |
+        set -eo pipefail
+
         cd ${GITHUB_WORKSPACE}
         python -m pip install wheel
-        # Fetch the most recent nightly PyTorch release
-        PT_RELEASE=$(python -m pip index versions -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html --pre torch | grep "Available versions" | tr ' ' '\n' | grep "^[0-9]" | sort --version-sort --reverse | head -n1 | tr -d ',' | sed 's/\([^+]*\).*/\1/')
-        printf -- "-f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html\n--pre\ntorch==%s\n" "${PT_RELEASE}" > pytorch-requirements.txt
+
+        # Fetch the most recent nightly torchvision release
+        VISION_RELEASE=$(python -m pip index versions -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html --pre torchvision | grep "Available versions" | tr ' ' '\n' | grep "^[0-9]" | sort --version-sort --reverse | head -n1 | tr -d ',' | sed 's/\([^+]*\).*/\1/')
+        echo "Found torchvision release ${VISION_RELEASE}"
+
+        # Fetch the whl file associated with the nightly torchvision release
+        rm -f torchvision-"${VISION_RELEASE}"*.whl
+        python -m pip download -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html --pre "torchvision==${VISION_RELEASE}"
+
+        PT_RELEASE=$(unzip -p torchvision-"${VISION_RELEASE}"*.whl 'torchvision-*/METADATA' | grep "^Requires-Dist: torch" | tr -d "()=" | awk '{ print $3 }' | sed 's/\([^+]*\).*/\1/')
+        echo "Found torch release ${PT_RELEASE}"
+
         # Fetch the whl file associated with the nightly release
         rm -f torch-"${PT_RELEASE}"*.whl
         python -m pip download -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html --pre "torch==${PT_RELEASE}"
+
+        printf -- "-f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html\n--pre\ntorch==%s\ntorchvision==%s\n" "${PT_RELEASE}" "${VISION_RELEASE}" > pytorch-requirements.txt
+
         # Read the commit hash from the downloaded whl file without extracting it
         PT_HASH=$(unzip -p torch-"${PT_RELEASE}"*.whl torch/version.py | grep git_version | awk '{ print $3 }' | tr -d "'")
+        echo "Found torch commit hash ${PT_HASH}"
+
         PT_HASH_CHANGED=0
         echo "${PT_HASH}" | cmp - pytorch-hash.txt --quiet || PT_HASH_CHANGED=$?
         echo "${PT_HASH}" > pytorch-hash.txt
         rm torch-"${PT_RELEASE}"*.whl
+
         # Write the release and hash to the environment file so that we can
         # retrieve them when creating a PR
         echo "PT_HASH=${PT_HASH}" >> ${GITHUB_ENV}

--- a/pytorch-requirements.txt
+++ b/pytorch-requirements.txt
@@ -1,3 +1,4 @@
 -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 --pre
 torch==1.14.0.dev20221113
+torchvision==0.15.0.dev20221113

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 -r pytorch-requirements.txt
 
 numpy
-torchvision
 
 # Build requirements.
 pybind11


### PR DESCRIPTION
We currently pin the `torch` package to the latest nightly version, but
since `torchvision` depends on the `torch` package, the pip resolver
then has to run through an extensive list of `torchvision` packages that
can be installed with the pinned `torch` package.  This search fails in
the RollPyTorch action, causing pip to settle on an old version of
`torchvision` that does not work with our tests.  In reality, we are
only interested in a specific version of the `torchvision` package.

To make the dependency explicit and to prevent test failures because of
incorrect package installations, this patch makes two key changes:

1. `torchvision` is now pinned to the latest nightly release in
   pytorch-requirements.txt along with the version of `torch` that is
   necessary to install the requested `torchvision` package

2. The RollPyTorch action now looks for the latest `torchvision` package
   instead of the latest `torch` package before writing the version
   numbers for pinning in pytorch-requirements.txt