### PR TITLE
Add Bazel buildifier to torch-mlir

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -184,6 +184,13 @@ Torch-MLIR can also be built using Bazel (apart from the official CMake build) f
 ```
 3. Find the built binary at `utils/bazel/bazel-bin/external/torch-mlir/torch-mlir-opt`.
 
+We welcome patches to torch-mlir's Bazel build. If you do contribute,
+please complete your PR with an invocation of buildifier to ensure
+the BUILD files are formatted consistently:
+```shell
+bazel run @torch-mlir//:buildifier
+```
+
 ## Docker Builds
 
 We have preliminary support for building with Docker images. Currently this

--- a/utils/bazel/WORKSPACE.bazel
+++ b/utils/bazel/WORKSPACE.bazel
@@ -53,3 +53,63 @@ load("@torch-mlir-raw//utils/bazel:configure.bzl", "torch_mlir_configure")
 torch_mlir_configure(
     name = "torch-mlir",
 )
+
+####### Buildifier Deps
+# https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# buildifier is written in Go and hence needs rules_go to be built.
+# See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains")
+
+go_register_toolchains(version = "1.17.2")
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+# If you use WORKSPACE.bazel, use the following line instead of the bare gazelle_dependencies():
+gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
+# gazelle_dependencies()
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568",
+    strip_prefix = "protobuf-3.19.4",
+    urls = [
+        "https://github.com/protocolbuffers/protobuf/archive/v3.19.4.tar.gz",
+    ],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    sha256 = "ae34c344514e08c23e90da0e2d6cb700fcd28e80c02e23e4d5715dddcb42f7b3",
+    strip_prefix = "buildtools-4.2.2",
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.2.2.tar.gz",
+    ],
+)

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -12,6 +12,7 @@ package(
 )
 
 # Format bazel BUILD and .bzl files with a standard convention
+# Invoke as `bazel run @torch-mlir//:buildifier`
 buildifier(
     name = "buildifier",
 )

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -3,11 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
 package(
     default_visibility = [
         "//visibility:public",
     ],
+)
+
+# Format bazel BUILD and .bzl files with a standard convention
+buildifier(
+    name = "buildifier",
 )
 
 # Torch Dialect/IR


### PR DESCRIPTION
Formats bazel BUILD and .bzl files with a standard convention. 

Invoke using
```
bazel run @torch-mlir//:buildifier
```