### PR TITLE
Simplify Bazel build workflow

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -180,9 +180,9 @@ Torch-MLIR can also be built using Bazel (apart from the official CMake build) f
 ```
 2. Build torch-mlir using bazel (from container):
 ```shell
-./utils/bazel/docker/run_bazel_build.sh
+bazel build @torch-mlir//:torch-mlir-opt
 ```
-3. Find the built binary at `utils/bazel/bazel-bin/external/torch-mlir/torch-mlir-opt`.
+3. Find the built binary at `bazel-bin/external/torch-mlir/torch-mlir-opt`.
 
 ## Docker Builds
 

--- a/utils/bazel/docker/Dockerfile
+++ b/utils/bazel/docker/Dockerfile
@@ -37,4 +37,4 @@ RUN python3 -m pip install --upgrade --ignore-installed -r requirements.txt
 RUN apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /opt/src/torch-mlir
+WORKDIR /opt/src/torch-mlir/utils/bazel

--- a/utils/bazel/docker/run_bazel_build.sh
+++ b/utils/bazel/docker/run_bazel_build.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-cd "$(pwd)/utils/bazel" && bazel build @torch-mlir//:torch-mlir-opt


### PR DESCRIPTION
Remove `run_bazel_build.sh`, simplify docker's entrypoint to start container at `utils/bazel` directory, update docs.