### PR TITLE
Fix bazel CI

### DIFF
--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -53,7 +53,7 @@ jobs:
                    -v "$(pwd)":"/opt/src/torch-mlir" \
                    -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
                    torch-mlir:ci \
-                   ./utils/bazel/docker/run_bazel_build.sh
+                   bazel build @torch-mlir//:torch-mlir-opt
 
     # Switch back bazel cache directory to user ownership
     # to allow GHA post-cache step to save cache without


### PR DESCRIPTION
I accidentally broke bazel CI by forgetting to update the GHA workflow in my [previous PR](https://github.com/llvm/torch-mlir/pull/1587). This should get it back to green, my apologies.

Qualifying CI run: https://github.com/sjain-stanford/torch-mlir/actions/runs/3472523982

