### PR TITLE
Fix cache bug with Bazel builds in CI

### DIFF
--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -29,8 +29,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/bazel
-        # Continually update cache even if there's a "hit" during restore
-        # to avoid the cache going stale over time
+        # Continually update cache even if there's a "hit" during
+        # restore to avoid the cache going stale over time
         # https://github.com/actions/cache/blob/main/workarounds.md#update-a-cache
         key: torch_mlir-bazel-build-cache-${{ runner.os }}-${{ github.sha }}
         restore-keys: |

--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -29,7 +29,12 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/bazel
-        key: ubuntu_x86_64_torch_mlir_bazel_build_cache
+        # Continually update cache even if there's a "hit" during restore
+        # to avoid the cache going stale over time
+        # https://github.com/actions/cache/blob/main/workarounds.md#update-a-cache
+        key: torch_mlir-bazel-build-cache-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          torch_mlir-bazel-build-cache-${{ runner.os }}
 
     # Change bazel cache directory to root ownership
     # to allow writing to it from within the docker container.


### PR DESCRIPTION
Some time ago, bazel builds in CI were being sped up fine with caching. However, over time the cache got stale because `actions/cache@v3` apparently doesn't update caches when it "hits" unless it is configured to do so specifically. This requires using a uniqued per-commit `key` (to force it to update cache after each successful run) and a relaxed `restore-keys` which is not unique per-commit so newer commits can restore from the nearest hit.

Test GHA run 1 (no cache hit): [1h 1m 52s](https://github.com/sjain-stanford/torch-mlir/actions/runs/3474770334/usage)
Test GHA run 2 (cache hit, same commit): [5m 14s](https://github.com/sjain-stanford/torch-mlir/actions/runs/3475132135/usage)
Test GHA run 3 (cache hit, different commit): [6m 6s](https://github.com/sjain-stanford/torch-mlir/actions/runs/3475161009/usage)