### PR TITLE
llvm: update tag to e864ac6945

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,9 @@ if (TORCH_MLIR_ENABLE_MHLO)
     ${CMAKE_CURRENT_BINARY_DIR}/mlir-hlo
     EXCLUDE_FROM_ALL)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/externals/mlir-hlo/include)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/externals/mlir-hlo)
   include_directories(${CMAKE_CURRENT_BINARY_DIR}/mlir-hlo/include)
+  include_directories(${CMAKE_CURRENT_BINARY_DIR}/mlir-hlo)
 endif()
 
 set(TORCH_MLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/ScalarLoopOpInterface.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/ScalarLoopOpInterface.td
@@ -37,13 +37,13 @@ def ScalarLoopOpInterface : OpInterface<"ScalarLoopOpInterface"> {
       >,
       InterfaceMethod<
         /*desc=*/[{
-          Returns a list of `StringRef`s that describe the number of
+          Returns a list of `IteratorType`s that describe the number of
           loops and the iterator types of the operation. The list is
           expected to use
-          `getParallelIteratorTypeName()`/`getReductionIteratorTypeName()`
+          `utils::IteratorType::parallel`/`utils::IteratorType::reduction`
           from MLIR Structured Op Utils.
         }],
-        /*retType=*/"SmallVector<StringRef>",
+        /*retType=*/"SmallVector<utils::IteratorType>",
         /*methodName=*/"getLoopIteratorTypes"
       >,
       InterfaceMethod<

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorOps.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorOps.cpp
@@ -158,10 +158,10 @@ SmallVector<Range> ScanOp::getIterationDomain(OpBuilder &builder) {
   return loopBounds;
 }
 
-SmallVector<StringRef> ScanOp::getLoopIteratorTypes() {
-  SmallVector<StringRef> iteratorTypes(getOperandRank(),
-                                       getParallelIteratorTypeName());
-  iteratorTypes[dimension()] = getReductionIteratorTypeName();
+SmallVector<utils::IteratorType> ScanOp::getLoopIteratorTypes() {
+  SmallVector<utils::IteratorType> iteratorTypes(getOperandRank(),
+                                                 utils::IteratorType::parallel);
+  iteratorTypes[dimension()] = utils::IteratorType::reduction;
   return iteratorTypes;
 }
 
@@ -387,11 +387,11 @@ LogicalResult ScatterOp::verify() {
   return success();
 }
 
-SmallVector<StringRef> ScatterOp::getLoopIteratorTypes() {
-  SmallVector<StringRef> iteratorTypes(getUpdateType().getRank(),
-                                       getParallelIteratorTypeName());
+SmallVector<utils::IteratorType> ScatterOp::getLoopIteratorTypes() {
+  SmallVector<utils::IteratorType> iteratorTypes(getUpdateType().getRank(),
+                                                 utils::IteratorType::parallel);
   if (!unique_indices()) {
-    iteratorTypes[0] = getReductionIteratorTypeName();
+    iteratorTypes[0] = utils::IteratorType::reduction;
   }
   return iteratorTypes;
 }

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -10,7 +10,7 @@
 #include "torch-mlir/Conversion/Passes.h"
 
 #ifdef TORCH_MLIR_ENABLE_MHLO
-#include "mlir-hlo/Dialect/mhlo/transforms/passes.h"
+#include "mhlo/transforms/passes.h"
 #include "mlir-hlo/Transforms/passes.h"
 #endif // TORCH_MLIR_ENABLE_MHLO
 #include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -966,7 +966,8 @@ public:
     SmallVector<AffineMap> indexingMaps = {
         AffineMap::get(inputRank, 0, idExprs, op.getContext()),
         AffineMap::get(inputRank, 0, swapExprs, op.getContext())};
-    SmallVector<StringRef> iteratorTypes(inputRank, "parallel");
+    SmallVector<utils::IteratorType> iteratorTypes(
+        inputRank, utils::IteratorType::parallel);
     auto transpose = rewriter
                          .create<linalg::GenericOp>(
                              loc, outVector.getType(), inVector, outVector,
@@ -1035,7 +1036,8 @@ public:
     AffineMap outputMap = AffineMap::get(inputRank, /*symbolCount=*/0, swapExprs,
                                          op->getContext());
     SmallVector<AffineMap> indexingMaps{inputMap, outputMap};
-    SmallVector<StringRef> iteratorTypes(inputRank, getParallelIteratorTypeName());
+    SmallVector<utils::IteratorType> iteratorTypes(
+        inputRank, utils::IteratorType::parallel);
     auto transpose = rewriter
                          .create<linalg::GenericOp>(
                              loc, outVector.getType(), inVector, outVector,
@@ -1259,8 +1261,8 @@ public:
 
     AffineMap id = AffineMap::getMultiDimIdentityMap(selfType.getRank(),
                                                      rewriter.getContext());
-    SmallVector<StringRef> iteratorTypes(selfType.getRank(),
-                                         getParallelIteratorTypeName());
+    SmallVector<utils::IteratorType> iteratorTypes(
+        selfType.getRank(), utils::IteratorType::parallel);
     Value result = rewriter
                        .create<linalg::GenericOp>(
                            loc,

--- a/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
@@ -92,7 +92,8 @@ public:
 
     SmallVector<AffineMap, 2> affineMaps(2,
                                          rewriter.getMultiDimIdentityMap(rank));
-    SmallVector<StringRef> iteratorTypes(rank, getParallelIteratorTypeName());
+    SmallVector<utils::IteratorType> iteratorTypes(
+        rank, utils::IteratorType::parallel);
     auto genericOp = rewriter
                          .create<linalg::GenericOp>(
                              loc, result.getType(), indices, result, affineMaps,
@@ -146,8 +147,8 @@ public:
         indicesAffineMap,
         rewriter.getMultiDimIdentityMap(resultRank),
     };
-    SmallVector<StringRef> iteratorTypes(sizes.size(),
-                                         getParallelIteratorTypeName());
+    SmallVector<utils::IteratorType> iteratorTypes(
+        sizes.size(), utils::IteratorType::parallel);
     Value initTensor =
         rewriter.create<tensor::EmptyOp>(loc, getAsOpFoldResult(sizes), elemTy);
     Value embeddingResult =
@@ -311,9 +312,9 @@ public:
     };
 
     // Reduce along the indices dim
-    SmallVector<StringRef> iteratorTypes({getParallelIteratorTypeName(),
-                                          getReductionIteratorTypeName(),
-                                          getParallelIteratorTypeName()});
+    SmallVector<utils::IteratorType> iteratorTypes(
+        {utils::IteratorType::parallel, utils::IteratorType::reduction,
+         utils::IteratorType::parallel});
 
     Value embeddingDim = getDimOp(rewriter, loc, weight, 1);
     Value initTensor;
@@ -483,11 +484,11 @@ public:
 
     SmallVector<AffineExpr> resultExpr;
     AffineExpr indicesExpr = rewriter.getAffineDimExpr(dimInt);
-    SmallVector<StringRef> iteratorTypes;
+    SmallVector<utils::IteratorType> iteratorTypes(
+        inputRank, utils::IteratorType::parallel);
 
     for (unsigned i = 0; i < inputRank; i++) {
       resultExpr.push_back(rewriter.getAffineDimExpr(i));
-      iteratorTypes.push_back(getParallelIteratorTypeName());
     }
 
     auto indexingMaps = AffineMap::inferFromExprList({indicesExpr, resultExpr});
@@ -680,7 +681,6 @@ public:
     Value initTensor = rewriter.create<tensor::EmptyOp>(
         loc, getAsOpFoldResult(resultShape), elementType);
     SmallVector<AffineMap> indexingMaps;
-    SmallVector<StringRef> iteratorTypes;
 
     for (auto indexTensor : indexTensors) {
       RankedTensorType indexTensorType =
@@ -703,8 +703,9 @@ public:
     SmallVector<AffineExpr> resultExpr;
     for (auto i : llvm::seq(0, resultRank)) {
       resultExpr.push_back(rewriter.getAffineDimExpr(i));
-      iteratorTypes.push_back(getParallelIteratorTypeName());
     }
+    SmallVector<utils::IteratorType> iteratorTypes(
+        resultRank, utils::IteratorType::parallel);
 
     indexingMaps.push_back(
         AffineMap::get(resultRank, 0, resultExpr, op->getContext()));
@@ -865,8 +866,8 @@ public:
         loc, getAsOpFoldResult(dims), elementType);
 
     AffineMap idMap = rewriter.getMultiDimIdentityMap(inputRank);
-    SmallVector<StringRef> iteratorTypes(inputRank,
-                                         getParallelIteratorTypeName());
+    SmallVector<utils::IteratorType> iteratorTypes(
+        inputRank, utils::IteratorType::parallel);
 
     Value finalRes =
         rewriter
@@ -1052,10 +1053,10 @@ public:
                        /*symbolCount=*/0, affineExprs, op->getContext());
 
     SmallVector<AffineMap> indexingMaps{kernelMap, outputMap};
-    SmallVector<StringRef> iteratorTypes(gradOutputRank,
-                                         getParallelIteratorTypeName());
-    iteratorTypes.push_back(getReductionIteratorTypeName());
-    iteratorTypes.push_back(getReductionIteratorTypeName());
+    SmallVector<utils::IteratorType> iteratorTypes(
+        gradOutputRank, utils::IteratorType::parallel);
+    iteratorTypes.push_back(utils::IteratorType::reduction);
+    iteratorTypes.push_back(utils::IteratorType::reduction);
 
     Value finalRes =
         rewriter

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -122,7 +122,8 @@ public:
     Value initTensor = createZeroInitTensor(
         rewriter, loc, getTensorSizes(rewriter, loc, self), elementType);
 
-    SmallVector<StringRef> iteratorTypes(selfRank, "parallel");
+    SmallVector<utils::IteratorType> iteratorTypes(
+        selfRank, utils::IteratorType::parallel);
     SmallVector<AffineMap> indexingMaps(
         2, AffineMap::getMultiDimIdentityMap(selfRank, context));
     Value flipped =
@@ -368,12 +369,12 @@ public:
       SmallVector<AffineExpr> lhsExpr;
       SmallVector<AffineExpr> rhsExpr;
       SmallVector<AffineExpr> outExpr;
-      SmallVector<StringRef> iteratorTypes;
+      SmallVector<utils::IteratorType> iteratorTypes(
+          batchRank, utils::IteratorType::parallel);
       for (unsigned i = 0; i < batchRank; i++) {
         lhsExpr.push_back(rewriter.getAffineDimExpr(i));
         rhsExpr.push_back(rewriter.getAffineDimExpr(i));
         outExpr.push_back(rewriter.getAffineDimExpr(i));
-        iteratorTypes.push_back(getParallelIteratorTypeName());
       }
       lhsExpr.insert(lhsExpr.end(), {rewriter.getAffineDimExpr(batchRank),
                                      rewriter.getAffineDimExpr(batchRank + 1)});
@@ -389,7 +390,9 @@ public:
       auto indexingMaps =
           AffineMap::inferFromExprList({lhsExpr, rhsExpr, outExpr});
       iteratorTypes.insert(iteratorTypes.end(),
-                           {"parallel", "reduction", "parallel"});
+                           {utils::IteratorType::parallel,
+                            utils::IteratorType::reduction,
+                            utils::IteratorType::parallel});
 
       Value finalRes =
           rewriter
@@ -568,8 +571,8 @@ public:
       outDims[1] = weightInitDims[0];
       Value weightInitTensor =
           createZeroInitTensor(rewriter, loc, weightInitDims, elementType);
-      SmallVector<StringRef> iteratorTypes(inRank,
-                                           getParallelIteratorTypeName());
+      SmallVector<utils::IteratorType> iteratorTypes(
+          inRank, utils::IteratorType::parallel);
       SmallVector<AffineMap> indexingMaps{
           AffineMap::getMultiDimIdentityMap(inRank, context)};
       weight = rewriter
@@ -678,8 +681,8 @@ public:
           AffineMap::get(/*dimCount=*/resultRank, /*symbolCount=*/0,
                          rewriter.getAffineDimExpr(1), context),
           rewriter.getMultiDimIdentityMap(resultRank)};
-      SmallVector<StringRef> iteratorTypes(resultRank,
-                                           getParallelIteratorTypeName());
+      SmallVector<utils::IteratorType> iteratorTypes(
+          resultRank, utils::IteratorType::parallel);
       outputTensor = rewriter
                          .create<linalg::GenericOp>(
                              loc, initTensor.getType(), bias, initTensor,

--- a/lib/Conversion/TorchToLinalg/Pooling.cpp
+++ b/lib/Conversion/TorchToLinalg/Pooling.cpp
@@ -276,9 +276,10 @@ public:
     // and kW, respectively, as described in the algorithm above.
     SmallVector<AffineMap> indexingMaps =
         AffineMap::inferFromExprList({inputExprs, kernelExprs, outputExprs});
-    SmallVector<StringRef> iteratorTypes(4, getParallelIteratorTypeName());
-    iteratorTypes.push_back(getReductionIteratorTypeName());
-    iteratorTypes.push_back(getReductionIteratorTypeName());
+    SmallVector<utils::IteratorType> iteratorTypes(
+        4, utils::IteratorType::parallel);
+    iteratorTypes.push_back(utils::IteratorType::reduction);
+    iteratorTypes.push_back(utils::IteratorType::reduction);
 
     // Input format is : [N, C, H, W]
     Value inputShapeW = getDimOp(rewriter, loc, self, 3);
@@ -412,7 +413,8 @@ public:
         loc, getAsOpFoldResult(outTensorShape), resultElementType);
     SmallVector<AffineMap> indexingMapsAvg(2,
                                            rewriter.getMultiDimIdentityMap(4));
-    SmallVector<StringRef> iteratorTypesAvg(4, "parallel");
+    SmallVector<utils::IteratorType> iteratorTypesAvg(
+        4, utils::IteratorType::parallel);
 
     Value avgPool2d =
         rewriter

--- a/lib/Conversion/TorchToLinalg/Random.cpp
+++ b/lib/Conversion/TorchToLinalg/Random.cpp
@@ -113,8 +113,8 @@ public:
     auto resultRank = resultType.getRank();
     SmallVector<AffineMap, 1> indexingMaps(
         1, rewriter.getMultiDimIdentityMap(resultRank));
-    SmallVector<StringRef> iteratorTypes(resultRank,
-                                         getParallelIteratorTypeName());
+    SmallVector<utils::IteratorType> iteratorTypes(
+        resultRank, utils::IteratorType::parallel);
     SmallVector<Value> sizes = getTensorSizes(rewriter, loc, self);
     Value initTensor =
         rewriter.create<tensor::EmptyOp>(loc, getAsOpFoldResult(sizes), elemTy);

--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -119,19 +119,19 @@ public:
     // iterate over the input and output tensors.
     // Here we also set the type of iterator: parallel or reduction.
     SmallVector<AffineExpr> exprs;
-    SmallVector<StringRef> iteratorTypes;
+    SmallVector<utils::IteratorType> iteratorTypes;
     SmallVector<AffineExpr> resultExprs;
     for (auto size : llvm::enumerate(inputType.getShape())) {
       exprs.push_back(rewriter.getAffineDimExpr(size.index()));
 
       if (unsigned(dim) == size.index()) {
-        iteratorTypes.push_back(getReductionIteratorTypeName());
+        iteratorTypes.push_back(utils::IteratorType::reduction);
         // If `keepDim`, create affine map to the first element
         // in the current dimension.
         if (keepDim)
           resultExprs.push_back(rewriter.getAffineConstantExpr(0));
       } else {
-        iteratorTypes.push_back(getParallelIteratorTypeName());
+        iteratorTypes.push_back(utils::IteratorType::parallel);
         resultExprs.push_back(rewriter.getAffineDimExpr(size.index()));
       }
     }

--- a/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
+++ b/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
@@ -276,7 +276,7 @@ public:
     Value resultTensor = rewriter.create<tensor::EmptyOp>(
         loc, getAsOpFoldResult(resultShape), dtype);
 
-    StringRef iteratorType = getParallelIteratorTypeName();
+    auto iteratorType = utils::IteratorType::parallel;
     AffineMap indexingMap =
         AffineMap::getMultiDimIdentityMap(1, op->getContext());
 

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -1305,7 +1305,8 @@ public:
         indexingMap,                                // runningVar
         rewriter.getMultiDimIdentityMap(inputRank), // output
     };
-    SmallVector<StringRef> iteratorTypes(inputRank, "parallel");
+    SmallVector<utils::IteratorType> iteratorTypes(
+        inputRank, utils::IteratorType::parallel);
     Value batchNorm =
         rewriter
             .create<linalg::GenericOp>(
@@ -1397,8 +1398,8 @@ public:
 
     SmallVector<AffineMap> indexingMaps{gradOutMap, targetMap, totalWeightMap,
                                         resultMap};
-    SmallVector<StringRef> iteratorTypes(inputRank,
-                                         getParallelIteratorTypeName());
+    SmallVector<utils::IteratorType> iteratorTypes(
+        inputRank, utils::IteratorType::parallel);
 
     // The code generation is equivalent to the following pseudo-code:
     //

--- a/lib/Conversion/TorchToMhlo/Basic.cpp
+++ b/lib/Conversion/TorchToMhlo/Basic.cpp
@@ -12,8 +12,7 @@
 #include "../PassDetail.h"
 #include "./MhloLegalizeUtils.h"
 #include "./PopulatePatterns.h"
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
-#include "mlir-hlo/utils/hlo_utils.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "stablehlo/dialect/ChloOps.h"
@@ -23,6 +22,7 @@
 #include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "utils/hlo_utils.h"
 #include <iostream>
 #include <numeric>
 

--- a/lib/Conversion/TorchToMhlo/Gather.cpp
+++ b/lib/Conversion/TorchToMhlo/Gather.cpp
@@ -12,7 +12,7 @@
 #include "../PassDetail.h"
 #include "./MhloLegalizeUtils.h"
 #include "./PopulatePatterns.h"
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToMhlo/Linear.cpp
+++ b/lib/Conversion/TorchToMhlo/Linear.cpp
@@ -12,7 +12,7 @@
 #include "../PassDetail.h"
 #include "./MhloLegalizeUtils.h"
 #include "./PopulatePatterns.h"
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "stablehlo/dialect/ChloOps.h"

--- a/lib/Conversion/TorchToMhlo/MhloLegalizeUtils.cpp
+++ b/lib/Conversion/TorchToMhlo/MhloLegalizeUtils.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "./MhloLegalizeUtils.h"
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "torch-mlir/Conversion/TorchToMhlo/TorchToMhlo.h"

--- a/lib/Conversion/TorchToMhlo/Pooling.cpp
+++ b/lib/Conversion/TorchToMhlo/Pooling.cpp
@@ -12,7 +12,7 @@
 #include "../PassDetail.h"
 #include "./MhloLegalizeUtils.h"
 #include "./PopulatePatterns.h"
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "stablehlo/dialect/ChloOps.h"

--- a/lib/Conversion/TorchToMhlo/Reduction.cpp
+++ b/lib/Conversion/TorchToMhlo/Reduction.cpp
@@ -12,7 +12,7 @@
 #include "../PassDetail.h"
 #include "./MhloLegalizeUtils.h"
 #include "./PopulatePatterns.h"
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToMhlo/TorchToMhlo.cpp
+++ b/lib/Conversion/TorchToMhlo/TorchToMhlo.cpp
@@ -11,7 +11,7 @@
 
 #include "../PassDetail.h"
 #include "./PopulatePatterns.h"
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Traits.h"

--- a/lib/Conversion/TorchToMhlo/ViewLike.cpp
+++ b/lib/Conversion/TorchToMhlo/ViewLike.cpp
@@ -12,7 +12,7 @@
 #include "../PassDetail.h"
 #include "./MhloLegalizeUtils.h"
 #include "./PopulatePatterns.h"
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
+++ b/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
@@ -435,7 +435,8 @@ public:
 
     SmallVector<AffineMap> indexingMaps = AffineMap::inferFromExprList(
         {originalIndicesDimExprs, updatedIndicesDimExprs});
-    SmallVector<StringRef> iteratorTypes(tensorOperandRank + 1, "parallel");
+    SmallVector<utils::IteratorType> iteratorTypes(
+        tensorOperandRank + 1, utils::IteratorType::parallel);
 
     SmallVector<OpFoldResult> updatedIndicesShape =
         getAsOpFoldResult(getTensorSizes(rewriter, loc, indices));

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -21,7 +21,7 @@
 #include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
 #ifdef TORCH_MLIR_ENABLE_MHLO
-#include "mlir-hlo/Dialect/mhlo/transforms/passes.h"
+#include "mhlo/transforms/passes.h"
 #include "torch-mlir/Conversion/TorchToMhlo/TorchToMhlo.h"
 #endif
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"

--- a/lib/Dialect/TorchConversion/Transforms/VerifyMhloBackendContract.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyMhloBackendContract.cpp
@@ -9,7 +9,7 @@
 #ifdef TORCH_MLIR_ENABLE_MHLO
 #include "PassDetail.h"
 
-#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"

--- a/lib/RefBackend/RefBackend.cpp
+++ b/lib/RefBackend/RefBackend.cpp
@@ -332,8 +332,8 @@ Operation *createLinalgCopyOp(OpBuilder &b, Location loc, Value from,
          memrefTypeFrom.getRank() == memrefTypeTo.getRank());
   AffineMap id =
       AffineMap::getMultiDimIdentityMap(memrefTypeTo.getRank(), b.getContext());
-  SmallVector<StringRef> iteratorTypes(memrefTypeTo.getRank(),
-                                       getParallelIteratorTypeName());
+  SmallVector<utils::IteratorType> iteratorTypes(memrefTypeTo.getRank(),
+                                                 utils::IteratorType::parallel);
   return b.create<linalg::GenericOp>(
       loc,
       /*inputs=*/from,


### PR DESCRIPTION
Summary of changes:
1. Replace `string` iterator types by `IteratorType` enum. (https://github.com/llvm/llvm-project/commit/e6598b053dc71845423132ac0803b1ecd0b71d45)
2. Update `includes` wrt new directory layout of MLIR HLO codebase. (https://github.com/tensorflow/mlir-hlo/commit/9fd8d251a811f1bae0fde20744aef3e1817a11e8)
3. Update tags:
          llvm: e864ac694540342d5e59f59c525c5082f2594fb8 
          MHLO: eab364ba2a66bd0613efb94f8a738c1c97aaee92

Signed-Off-by: Gaurav Shukla <gaurav@nod-labs.com>