### PR TITLE
`m_TorchConstant{Int/Bool}List` -> `m_TorchListOfConstant{Int/Bool}s`

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
@@ -121,11 +121,11 @@ m_TorchConstantBool(bool *bind_value) {
 
 namespace detail {
 /// Matches the constant integers stored in a `torch.ListConstruct`.
-struct torch_list_construct_op_binder {
+struct torch_list_of_constant_ints_op_binder {
   SmallVectorImpl<int64_t> &bind_values;
 
   /// Creates a matcher instance that binds the value to bvs if match succeeds.
-  torch_list_construct_op_binder(SmallVectorImpl<int64_t> &bvs)
+  torch_list_of_constant_ints_op_binder(SmallVectorImpl<int64_t> &bvs)
       : bind_values(bvs) {}
 
   bool match(Operation *op) {
@@ -145,18 +145,18 @@ struct torch_list_construct_op_binder {
 } // namespace detail
 
 /// Matches the constant integers stored in a `torch.prim.ListConstruct`.
-inline detail::torch_list_construct_op_binder
-m_TorchConstantIntList(SmallVectorImpl<int64_t> &bind_values) {
-  return detail::torch_list_construct_op_binder(bind_values);
+inline detail::torch_list_of_constant_ints_op_binder
+m_TorchListOfConstantInts(SmallVectorImpl<int64_t> &bind_values) {
+  return detail::torch_list_of_constant_ints_op_binder(bind_values);
 }
 
 namespace detail {
 /// Matches the constant bools stored in a `torch.ListConstruct`.
-struct torch_bool_list_construct_op_binder {
+struct torch_list_of_constant_bools_op_binder {
   SmallVectorImpl<bool> &bind_values;
 
   /// Creates a matcher instance that binds the value to bvs if match succeeds.
-  torch_bool_list_construct_op_binder(SmallVectorImpl<bool> &bvs)
+  torch_list_of_constant_bools_op_binder(SmallVectorImpl<bool> &bvs)
       : bind_values(bvs) {}
 
   bool match(Operation *op) {
@@ -176,9 +176,9 @@ struct torch_bool_list_construct_op_binder {
 } // namespace detail
 
 /// Matches the constant bools stored in a `torch.prim.ListConstruct`.
-inline detail::torch_bool_list_construct_op_binder
-m_TorchConstantBoolList(SmallVectorImpl<bool> &bind_values) {
-  return detail::torch_bool_list_construct_op_binder(bind_values);
+inline detail::torch_list_of_constant_bools_op_binder
+m_TorchListOfConstantBools(SmallVectorImpl<bool> &bind_values) {
+  return detail::torch_list_of_constant_bools_op_binder(bind_values);
 }
 
 namespace detail {

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -992,7 +992,7 @@ public:
       return failure();
 
     SmallVector<int64_t> dimensions;
-    if (!matchPattern(op.dims(), m_TorchConstantIntList(dimensions)))
+    if (!matchPattern(op.dims(), m_TorchListOfConstantInts(dimensions)))
       return rewriter.notifyMatchFailure(op, "all dimensions must be constant");
 
     Value inVector = adaptor.self();

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -110,7 +110,7 @@ public:
         rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
 
     SmallVector<int64_t> axis;
-    if (!matchPattern(adaptor.dims(), m_TorchConstantIntList(axis)))
+    if (!matchPattern(adaptor.dims(), m_TorchListOfConstantInts(axis)))
       return rewriter.notifyMatchFailure(op,
                                          "only constant dim lists supported");
     // Only used to calculate flipped values, i.e. those on the flip axes. Other
@@ -507,11 +507,11 @@ public:
     paddingIntValues = getTypeConvertedValues(rewriter, loc, getTypeConverter(),
                                               paddingIntValues);
     SmallVector<int64_t> strideInts;
-    if (!matchPattern(op.stride(), m_TorchConstantIntList(strideInts)))
+    if (!matchPattern(op.stride(), m_TorchListOfConstantInts(strideInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int strides");
     SmallVector<int64_t> dilationInts;
-    if (!matchPattern(op.dilation(), m_TorchConstantIntList(dilationInts)))
+    if (!matchPattern(op.dilation(), m_TorchListOfConstantInts(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
 

--- a/lib/Conversion/TorchToLinalg/Pooling.cpp
+++ b/lib/Conversion/TorchToLinalg/Pooling.cpp
@@ -47,9 +47,9 @@ checkAndGetPoolingParameters(OpTy op, ConversionPatternRewriter &rewriter,
   }
   kernelSizeIntValues = getTypeConvertedValues(
       rewriter, op.getLoc(), typeConverter, kernelSizeTorchInt);
-  if (!matchPattern(op.stride(), m_TorchConstantIntList(strideInts)))
+  if (!matchPattern(op.stride(), m_TorchListOfConstantInts(strideInts)))
     return rewriter.notifyMatchFailure(op, "only support constant int strides");
-  if (!matchPattern(op.padding(), m_TorchConstantIntList(paddingInts)))
+  if (!matchPattern(op.padding(), m_TorchListOfConstantInts(paddingInts)))
     return rewriter.notifyMatchFailure(op,
                                        "only support constant int paddings");
   if (!matchPattern(op.ceil_mode(), m_TorchConstantBool(&ceilMode)))
@@ -145,7 +145,7 @@ public:
     bool ceilMode;
     SmallVector<Value, 2> kernelSizeIntValues;
     SmallVector<int64_t, 2> strideInts, paddingInts, dilationInts;
-    if (!matchPattern(op.dilation(), m_TorchConstantIntList(dilationInts)))
+    if (!matchPattern(op.dilation(), m_TorchListOfConstantInts(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
     if (failed(checkAndGetPoolingParameters<AtenMaxPool2dOp>(
@@ -223,7 +223,7 @@ public:
     bool ceilMode;
     SmallVector<Value, 2> kernelSizeIntValues;
     SmallVector<int64_t, 2> strideInts, paddingInts, dilationInts;
-    if (!matchPattern(op.dilation(), m_TorchConstantIntList(dilationInts)))
+    if (!matchPattern(op.dilation(), m_TorchListOfConstantInts(dilationInts)))
       return rewriter.notifyMatchFailure(op,
                                          "only support constant int dilations");
     if (failed(checkAndGetPoolingParameters<AtenMaxPool2dWithIndicesOp>(

--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -278,7 +278,7 @@ private:
     SmallVector<int64_t> dimList;
     bool isNoneOrEmptyDimList =
         op.dim().getType().template isa<Torch::NoneType>();
-    if (matchPattern(op.dim(), m_TorchConstantIntList(dimList))) {
+    if (matchPattern(op.dim(), m_TorchListOfConstantInts(dimList))) {
       // Fix negative dimensions, if any, before adding to the list.
       for (int64_t dim : dimList) {
         dim = toPositiveDim(dim, inputType.getRank());

--- a/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
+++ b/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
@@ -47,7 +47,7 @@ public:
     // will get the lowered version of the operands which is harder to pattern
     // match.
     SmallVector<int64_t> padInts;
-    if (!matchPattern(op.pad(), m_TorchConstantIntList(padInts)))
+    if (!matchPattern(op.pad(), m_TorchListOfConstantInts(padInts)))
       return rewriter.notifyMatchFailure(
           op, "only support constant int pad ranges");
     uint64_t padRank = padInts.size() / 2;

--- a/lib/Conversion/TorchToMhlo/Basic.cpp
+++ b/lib/Conversion/TorchToMhlo/Basic.cpp
@@ -165,7 +165,7 @@ public:
     }
 
     SmallVector<int64_t> shape;
-    if (!matchPattern(op.size(), m_TorchConstantIntList(shape))) {
+    if (!matchPattern(op.size(), m_TorchListOfConstantInts(shape))) {
       return op.emitError("shape must be a list of Scalar constants");
     }
 
@@ -580,7 +580,7 @@ LogicalResult ConvertAtenOp<AtenPermuteOp>::matchAndRewrite(
                         "currently supported");
 
   SmallVector<int64_t> permValues;
-  if (!matchPattern(adaptor.dims(), m_TorchConstantIntList(permValues)))
+  if (!matchPattern(adaptor.dims(), m_TorchListOfConstantInts(permValues)))
     return rewriter.notifyMatchFailure(
         op, "only constant dimensions are currently supported");
 
@@ -914,7 +914,7 @@ LogicalResult ConvertAtenOp<AtenNativeLayerNormOp>::matchAndRewrite(
 
   SmallVector<int64_t> normalizedShape;
   if (!matchPattern(op.normalized_shape(),
-                    m_TorchConstantIntList(normalizedShape))) {
+                    m_TorchListOfConstantInts(normalizedShape))) {
     return rewriter.notifyMatchFailure(
         op, "normalized_shape must be a list of const int");
   }

--- a/lib/Conversion/TorchToMhlo/Linear.cpp
+++ b/lib/Conversion/TorchToMhlo/Linear.cpp
@@ -693,23 +693,23 @@ public:
     if (inputTy.getRank() < 3)
       return op.emitError("only input with at least 3 dims valid");
     SmallVector<int64_t> stride;
-    if (!matchPattern(op.stride(), m_TorchConstantIntList(stride))) {
+    if (!matchPattern(op.stride(), m_TorchListOfConstantInts(stride))) {
       return rewriter.notifyMatchFailure(op,
                                          "non-const stride list unsupported");
     }
     SmallVector<int64_t> padding;
-    if (!matchPattern(op.padding(), m_TorchConstantIntList(padding))) {
+    if (!matchPattern(op.padding(), m_TorchListOfConstantInts(padding))) {
       return rewriter.notifyMatchFailure(op,
                                          "non-const padding list unsupported");
     }
     SmallVector<int64_t> dilation;
-    if (!matchPattern(op.dilation(), m_TorchConstantIntList(dilation))) {
+    if (!matchPattern(op.dilation(), m_TorchListOfConstantInts(dilation))) {
       return rewriter.notifyMatchFailure(op,
                                          "non-const dilation list unsupported");
     }
     SmallVector<int64_t> outputPadding;
     if (!matchPattern(op.output_padding(),
-                      m_TorchConstantIntList(outputPadding))) {
+                      m_TorchListOfConstantInts(outputPadding))) {
       return rewriter.notifyMatchFailure(
           op, "non-const output_padding list unsupported");
     }

--- a/lib/Conversion/TorchToMhlo/Pooling.cpp
+++ b/lib/Conversion/TorchToMhlo/Pooling.cpp
@@ -93,18 +93,19 @@ LogicalResult ConvertAtenOp<AtenMaxPool2dOp>::matchAndRewrite(
   SmallVector<int64_t, 2> padding, kernelSize, stride, dilation;
   bool ceilMode = false;
 
-  if (!(matchPattern(op.kernel_size(), m_TorchConstantIntList(kernelSize)))) {
+  if (!(matchPattern(op.kernel_size(),
+                     m_TorchListOfConstantInts(kernelSize)))) {
     return rewriter.notifyMatchFailure(
         op, "non-const int kernel size unsupported!");
   }
-  if (!(matchPattern(op.stride(), m_TorchConstantIntList(stride)))) {
+  if (!(matchPattern(op.stride(), m_TorchListOfConstantInts(stride)))) {
     return rewriter.notifyMatchFailure(op, "non-const int stride unsupported!");
   }
-  if (!(matchPattern(op.padding(), m_TorchConstantIntList(padding)))) {
+  if (!(matchPattern(op.padding(), m_TorchListOfConstantInts(padding)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int padding unsupported!");
   }
-  if (!(matchPattern(op.dilation(), m_TorchConstantIntList(dilation)))) {
+  if (!(matchPattern(op.dilation(), m_TorchListOfConstantInts(dilation)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int dilation unsupported!");
   }
@@ -197,18 +198,19 @@ LogicalResult ConvertAtenOp<AtenMaxPool2dWithIndicesOp>::matchAndRewrite(
   SmallVector<int64_t, 2> padding, kernelSize, stride, dilation;
   bool ceilMode = false;
 
-  if (!(matchPattern(op.kernel_size(), m_TorchConstantIntList(kernelSize)))) {
+  if (!(matchPattern(op.kernel_size(),
+                     m_TorchListOfConstantInts(kernelSize)))) {
     return rewriter.notifyMatchFailure(
         op, "non-const int kernel size unsupported!");
   }
-  if (!(matchPattern(op.stride(), m_TorchConstantIntList(stride)))) {
+  if (!(matchPattern(op.stride(), m_TorchListOfConstantInts(stride)))) {
     return rewriter.notifyMatchFailure(op, "non-const int stride unsupported!");
   }
-  if (!(matchPattern(op.padding(), m_TorchConstantIntList(padding)))) {
+  if (!(matchPattern(op.padding(), m_TorchListOfConstantInts(padding)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int padding unsupported!");
   }
-  if (!(matchPattern(op.dilation(), m_TorchConstantIntList(dilation)))) {
+  if (!(matchPattern(op.dilation(), m_TorchListOfConstantInts(dilation)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int dilation unsupported!");
   }
@@ -389,14 +391,15 @@ LogicalResult ConvertAtenOp<AtenAvgPool2dOp>::matchAndRewrite(
   bool ceilMode = false;
   bool countIncludePad = true;
 
-  if (!(matchPattern(op.kernel_size(), m_TorchConstantIntList(kernelSize)))) {
+  if (!(matchPattern(op.kernel_size(),
+                     m_TorchListOfConstantInts(kernelSize)))) {
     return rewriter.notifyMatchFailure(
         op, "non-const int kernel size unsupported!");
   }
-  if (!(matchPattern(op.stride(), m_TorchConstantIntList(stride)))) {
+  if (!(matchPattern(op.stride(), m_TorchListOfConstantInts(stride)))) {
     return rewriter.notifyMatchFailure(op, "non-const int stride unsupported!");
   }
-  if (!(matchPattern(op.padding(), m_TorchConstantIntList(padding)))) {
+  if (!(matchPattern(op.padding(), m_TorchListOfConstantInts(padding)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int padding unsupported!");
   }

--- a/lib/Conversion/TorchToMhlo/Reduction.cpp
+++ b/lib/Conversion/TorchToMhlo/Reduction.cpp
@@ -499,7 +499,7 @@ LogicalResult ConvertAtenReductionOp<AtenSumDimIntListOp>::matchAndRewrite(
 
   SmallVector<int64_t> inputDims;
   SmallVector<int64_t> dims;
-  if (!matchPattern(op.dim(), m_TorchConstantIntList(inputDims))) {
+  if (!matchPattern(op.dim(), m_TorchListOfConstantInts(inputDims))) {
     return rewriter.notifyMatchFailure(op, "non-int dim list unsupported");
   }
   if (inputDims.size() == 0) {
@@ -595,7 +595,7 @@ LogicalResult ConvertAtenReductionOp<AtenFrobeniusNormDimOp>::matchAndRewrite(
   }
 
   SmallVector<int64_t> dims;
-  if (!matchPattern(op.dim(), m_TorchConstantIntList(dims))) {
+  if (!matchPattern(op.dim(), m_TorchListOfConstantInts(dims))) {
     return rewriter.notifyMatchFailure(
         op, "non-const integer `dim` is not supported");
   }

--- a/lib/Conversion/Utils/Utils.cpp
+++ b/lib/Conversion/Utils/Utils.cpp
@@ -85,7 +85,7 @@ void assertIsValidDim(OpBuilder &b, Location loc, Value dim, Value inputRank) {
 // TODO: loose this constraint when properly support list type
 bool isConstantIntListMatching(Value value, SmallVectorImpl<int64_t> &expects) {
   SmallVector<int64_t> intValues;
-  if (!matchPattern(value, m_TorchConstantIntList(intValues)))
+  if (!matchPattern(value, m_TorchListOfConstantInts(intValues)))
     return false;
 
   if (intValues.size() != expects.size())

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -1965,7 +1965,7 @@ OpFoldResult Aten__Contains__IntListOp::fold(ArrayRef<Attribute> operands) {
   if (!matchPattern(itemConstruct, m_TorchConstantInt(&item)))
     return nullptr;
 
-  if (!matchPattern(l(), m_TorchConstantIntList(list)))
+  if (!matchPattern(l(), m_TorchListOfConstantInts(list)))
     return nullptr;
 
   for (auto elem : list) {

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -1220,7 +1220,7 @@ public:
     }
 
     SmallVector<bool> outMask;
-    if (!matchPattern(op.output_mask(), m_TorchConstantBoolList(outMask)))
+    if (!matchPattern(op.output_mask(), m_TorchListOfConstantBools(outMask)))
       return rewriter.notifyMatchFailure(
           op, "only constant bool output_mask is supported.");
     // Support for `False` values for output mask unimplemented.


### PR DESCRIPTION
This commit renames the patterns used to match on lists of constant values to `m_TorchListOfConstant{valueType}s`. This is needed to avoid ambiguity for when `valueType` has `Optional` in it. In particular, it makes it clear whether the values in the list are optional or the list itself is optional.