### PR TITLE
Fix typos in md files

### DIFF
--- a/docs/adding_an_e2e_test.md
+++ b/docs/adding_an_e2e_test.md
@@ -146,7 +146,7 @@ object as the second argument. The `TestUtils` has some methods, such as
 and
 [`tu.randint`](https://github.com/llvm/torch-mlir/blob/8e880a2d009b67d45fb07434ab62ec2066a11185/python/torch_mlir_e2e_test/torchscript/framework.py#L185),
 that allow the creation of random tensors in a way that makes sure the compiled
-module and the golden trace recieve the same tensors as input. Therefore, all
+module and the golden trace receive the same tensors as input. Therefore, all
 random inputs should be generated through the `TestUtils` object.
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -325,7 +325,7 @@ blend of the benefits of the other two.
 All the backends are implemented using the MLIR [Dialect Conversion
 infrastructure](https://mlir.llvm.org/docs/DialectConversion/). This involves
 converting the `torch` dialect types to other types, so we closely follow the
-principes from the "Type Conversions the Not-So-Hard Way" talk
+principles from the "Type Conversions the Not-So-Hard Way" talk
 ([slides](https://drive.google.com/file/d/1FVbzCXxZzS9LBLuvpPNLWJD-XDkt54ky/view?usp=sharing),
 [recording](https://drive.google.com/file/d/1VfVajitgf8ZPnd-HRkJvaJiFLhBsluXN/view?usp=sharing)).
 We follow the standard `{include,lib}/Conversion/TorchTo*` convention used in
@@ -396,7 +396,7 @@ Because of this, many Torch-MLIR patches adding support for new ops have no
 `.mlir` unit tests, and only include end-to-end test(s). We generally make sure
 that our end-to-end tests are as targeted as possible. As a result, when
 debugging end-to-end test failures, the resulting reproducers (which our test
-framework automaticaly produces for failures) are usually already fully reduced
+framework automatically produces for failures) are usually already fully reduced
 test cases.
 
 ### Do's and Don'ts for unit vs end-to-end testing.

--- a/docs/development.md
+++ b/docs/development.md
@@ -273,7 +273,7 @@ docker build -t your-name/torch-mlir-ci --no-cache .
 
 ### Other configurable environmental variables
 
-The following additional environmental variables can be used to customie your docker build:
+The following additional environmental variables can be used to customize your docker build:
 
 * Custom Release Docker image:
   Defaults to `stellaraccident/manylinux2014_x86_64-bazel-5.1.0:latest`


### PR DESCRIPTION
This PR fixes typos in `.md` files.