### PR TITLE
[MLIR][TORCH] Fix vision models

### DIFF
--- a/python/torch_mlir/eager_mode/torch_mlir_tensor.py
+++ b/python/torch_mlir/eager_mode/torch_mlir_tensor.py
@@ -131,6 +131,8 @@ class TorchMLIRTensor(torch.Tensor):
                 if UNSUPPORTED_OPS.match(op_name):
                     raise UnsupportedByTorchMlirEagerMode(op_name)
 
+                requires_grad = requires_grad and "view" not in op_name
+
                 if not hasattr(func, "_schema"):
                     raise RuntimeError(f"op {func} has no schema.")
 


### PR DESCRIPTION
Fix https://github.com/llvm/torch-mlir/issues/1618 by stripping `requires_grad` from results of view ops.

The error that pytorch produces implies the solution:

```
RuntimeError: Attempted to make a tensor into a differentiable view, 
but the tensor already had **autograd metadata** associated with it.  ...
```


cc @powderluv @pashu123 