### PR TITLE
Fix modulus operation in LCG algorithm used for torch::GetNextSeed

### DIFF
--- a/lib/RefBackend/RefBackend.cpp
+++ b/lib/RefBackend/RefBackend.cpp
@@ -258,9 +258,10 @@ static Value lowerGetNextSeed(OpBuilder &b, Location loc) {
   // temp = multiplier * currentSeed + incrementStep
   Value mul = b.create<arith::MulIOp>(loc, currentSeed, multiplier);
   Value temp = b.create<arith::AddIOp>(loc, mul, incrementStep);
-  // temp mod 64 = temp & 63
-  Value cst127 = b.create<arith::ConstantOp>(loc, b.getI64IntegerAttr(127));
-  Value nextSeed = b.create<arith::AndIOp>(loc, temp, cst127);
+  // temp mod 2**64 = temp & (2**64 - 1) = temp & i64MaxValue
+  Value i64Max = b.create<arith::ConstantOp>(
+      loc, b.getIntegerAttr(b.getIntegerType(64), APInt::getMaxValue(64)));
+  Value nextSeed = b.create<arith::AndIOp>(loc, temp, i64Max);
   b.create<memref::StoreOp>(loc, nextSeed, globalVar);
   return nextSeed;
 }

--- a/test/RefBackend/insert-rng-globals.mlir
+++ b/test/RefBackend/insert-rng-globals.mlir
@@ -8,8 +8,8 @@
 // CHECK:           %[[INC:.*]] = arith.constant 1442695040888963407 : i64
 // CHECK:           %[[MUL:.*]] = arith.muli %[[SEED]], %[[MULTIPLIER]] : i64
 // CHECK:           %[[TEMP:.*]] = arith.addi %[[MUL]], %[[INC]] : i64
-// CHECK:           %[[CST127:.*]] = arith.constant 127 : i64
-// CHECK:           %[[NEXT_SEED:.*]] = arith.andi %[[TEMP]], %[[CST127]] : i64
+// CHECK:           %[[NEG_1:.*]] = arith.constant -1 : i64
+// CHECK:           %[[NEXT_SEED:.*]] = arith.andi %[[TEMP]], %[[NEG_1]] : i64
 // CHECK:           memref.store %[[NEXT_SEED]], %[[MEMREF]][] : memref<i64>
 // CHECK:           return %[[NEXT_SEED]] : i64
 module {


### PR DESCRIPTION
There seems to have been a typo in the implementation of `lowerGetNextSeed`. The LCG algorithm uses the recurrence relation $X_{n+1} = (aX_n + c) \mod m$ to generate the next seed. For the values of $a$ and $c$ used in the current implementation, $m$ is supposed to be $2^{64}$. See Donald Knuth's values for MMIX in https://en.wikipedia.org/wiki/Linear_congruential_generator .