### PR TITLE
[torchdynamo] Initial TorchDynamo support

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -273,6 +273,9 @@ function test_in_tree() {
 
   echo ":::: Run Lazy Tensor Core e2e integration tests"
   python -m e2e_testing.main --config=lazy_tensor_core -v
+
+  echo ":::: Run TorchDynamo e2e integration tests"
+  python -m e2e_testing.main --config=torchdynamo -v
 }
 
 function setup_venv() {

--- a/e2e_testing/main.py
+++ b/e2e_testing/main.py
@@ -20,21 +20,22 @@ from torch_mlir_e2e_test.configs import (
     NativeTorchTestConfig,
     TorchScriptTestConfig,
     TosaBackendTestConfig,
-    EagerModeTestConfig
+    EagerModeTestConfig,
+    TorchDynamoTestConfig,
 )
 
 from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import RefBackendLinalgOnTensorsBackend
 from torch_mlir_e2e_test.mhlo_backends.linalg_on_tensors import LinalgOnTensorsMhloBackend
 from torch_mlir_e2e_test.tosa_backends.linalg_on_tensors import LinalgOnTensorsTosaBackend
 
-from .xfail_sets import REFBACKEND_XFAIL_SET, MHLO_PASS_SET, TOSA_PASS_SET, EAGER_MODE_XFAIL_SET, LTC_XFAIL_SET
+from .xfail_sets import REFBACKEND_XFAIL_SET, MHLO_PASS_SET, TOSA_PASS_SET, EAGER_MODE_XFAIL_SET, LTC_XFAIL_SET, TORCHDYNAMO_XFAIL_SET
 
 # Import tests to register them in the global registry.
 from torch_mlir_e2e_test.test_suite import register_all_tests
 register_all_tests()
 
 def _get_argparse():
-    config_choices = ['native_torch', 'torchscript', 'refbackend', 'mhlo', 'tosa', 'eager_mode', 'lazy_tensor_core']
+    config_choices = ['native_torch', 'torchscript', 'refbackend', 'mhlo', 'tosa', 'eager_mode', 'lazy_tensor_core', 'torchdynamo']
     parser = argparse.ArgumentParser(description='Run torchscript e2e tests.')
     parser.add_argument('-c', '--config',
         choices=config_choices,
@@ -47,7 +48,8 @@ Meaning of options:
 "native_torch": run the torch.nn.Module as-is without compiling (useful for verifying model is deterministic; ALL tests should pass in this configuration).
 "torchscript": compile the model to a torch.jit.ScriptModule, and then run that as-is (useful for verifying TorchScript is modeling the program correctly).
 "eager_mode": run through torch-mlir's eager mode frontend, using RefBackend for execution.
-"lazy_tensor_core": run the model through the Lazy Tensor Core frontend and execute the traced graph. 
+"lazy_tensor_core": run the model through the Lazy Tensor Core frontend and execute the traced graph.
+"torchdynamo": run the model through the TorchDynamo frontend and execute the graph using RefBackend.
 ''')
     parser.add_argument('-f', '--filter', default='.*', help='''
 Regular expression specifying which tests to include in this run.
@@ -95,6 +97,9 @@ def main():
     elif args.config == 'lazy_tensor_core':
         config = LazyTensorCoreTestConfig()
         xfail_set = LTC_XFAIL_SET
+    elif args.config == 'torchdynamo':
+        config = TorchDynamoTestConfig()
+        xfail_set = TORCHDYNAMO_XFAIL_SET
 
     do_not_attempt = set(args.crashing_tests_to_not_attempt_to_run_and_a_bug_is_filed or [])
     available_tests = [test for test in GLOBAL_TEST_REGISTRY if test.unique_name not in do_not_attempt]

--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -23,6 +23,110 @@ EAGER_MODE_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS | {
     "UpSampleNearest2dDynamicFactor_basic",
 }
 
+TORCHDYNAMO_XFAIL_SET = {
+    #### General TorchDynamo/PyTorch errors
+
+    # https://github.com/pytorch/torchdynamo/issues/1891
+    # AssertionError: torch.* op returned non-Tensor bool call_function aten.Bool
+    "AllBoolFalseModule_basic",
+    "AllBoolTrueModule_basic",
+    "AnyBoolFalseModule_basic",
+    "AnyBoolTrueModule_basic",
+    "BoolFloatFalseModule_basic",
+    "BoolFloatTrueModule_basic",
+    "BoolFloatConstantModule_basic",
+    "BoolIntFalseModule_basic",
+    "BoolIntTrueModule_basic",
+    "BoolIntConstantModule_basic",
+    "CeilFloatModule_basic",
+    "ContainsIntList_False",
+    "ContainsIntList_True",
+    "GeIntModule_basic",
+    "LenStrModule_basic",
+    "SqrtIntConstantModule_basic",
+    "SqrtIntModule_basic",
+    "NumelModule_basic",
+    "NumelZeroRankModule_basic",
+
+    # RecursionError: maximum recursion depth exceeded
+    # RuntimeError: Failed running call_function aten.lift_fresh_copy(...
+    "LiftFreshCopyModule_basic",
+    # torch._subclasses.fake_tensor.DynamicOutputShapeException: aten.bincount.default
+    # RuntimeError: Failed running call_function aten.bincount(...
+    "BincountMinlengthModule_basic",
+    "BincountModule_basic",
+    "BincountStaticSizeModule_basic",
+    # TypeError: new_empty(): argument 'size' (position 1) must be tuple of ints, but found element of type NoneType at pos 0
+    # RuntimeError: Failed running call_function aten.convolution_backward(...
+    "ConvolutionBackwardModule2DPadded_basic",
+    "ConvolutionBackwardModule2D_basic",
+    # RuntimeError: Index tensor must have the same number of dimensions as self tensor
+    # RuntimeError: Failed running call_function aten.nll_loss_backward(...
+    "NllLossModuleBackward1DMeanWeight_basic",
+    "NllLossModuleBackward1DMean_basic",
+    "NllLossModuleBackward1DSumWeight_basic",
+    "NllLossModuleBackward1DSum_basic",
+    "NllLossModuleBackward1DWeight_basic",
+    "NllLossModuleBackward1D_basic",
+    # torch._subclasses.fake_tensor.DataDependentOutputException: aten._local_scalar_dense.default
+    # RuntimeError: Failed running call_module self_quantize(...
+    "QuantizedMLP_basic",
+    "ScalarImplicitFloatModule_basic",
+    "ScalarImplicitIntModule_basic",
+    # Decomposition assertion:
+    # assert device is not None or dtype is not None or memory_format is not None
+    "ToCopyModule_basic",
+    # TypeError: expected np.ndarray (got float)
+    "DivIntModule_basic",
+
+    #### Torch-MLIR internal compiler errors
+
+    # These are probably due to slightly different ops being recorded by
+    # torchdynamo vs. torchscript.
+
+    # error: unsupported by backend contract: tensor with unknown rank
+    "UpSampleNearest2dDynamicFactor_basic",
+    "AdaptiveAvgPool2dNonUnitOutputSizeDynamicModule_basic",
+    "AdaptiveAvgPool2dNonUnitOutputSizeStaticModule_basic",
+    "AtenEmbeddingBagSumExample_basic",
+    "BernoulliModule_basic",
+    "DropoutTrainModule_basic",
+    "ElementwiseWhereScalarModule_basic",
+    "ElementwiseWhereScalarOtherModule_basic",
+    "ElementwiseWhereScalarSelfModule_basic",
+    "IndexPutImpl1DFloatAccumulateModule_basic",
+    "IndexPutImpl1DFloatNonAccumulateModule_basic",
+    "IndexPutImpl1DIntAccumulateModule_basic",
+    "IndexPutImpl1DIntNonAccumulateModule_basic",
+    "IndexPutImpl2DFloatAccumulateModule_basic",
+    "IndexPutImpl2DFloatNonAccumulateModule_basic",
+    "IndexPutImpl3DFloatAccumulateModule_basic",
+    "IndexPutImpl3DFloatNonAccumulateModule_basic",
+    "Matmul_dot",
+    "Matmul_vecmat",
+    "StdBiasedModule_basic",
+    "StdDimBiasedModule_basic",
+    "StdDimEmptyDimModule_basic",
+    "StdDimKeepDimFalseModule_basic",
+    "StdDimKeepDimTrueModule_basic",
+    "StdDimNoneDimModule_basic",
+    "StdUnbiasedModule_basic",
+    "UniformModule_basic",
+    "UniformStaticModule_basic",
+    # https://github.com/llvm/torch-mlir/issues/1611
+    # error: 'tensor.cast' op operand type 'tensor<0xi64>' and result type 'tensor<18xi64>' are cast incompatible
+    "Aten_EmbeddingBagExample_basic",
+    # error: failed to legalize operation 'torch.valsem.aten.bernoulli.float' that was explicitly marked illegal
+    "BernoulliFloatModule_basic",
+    # error: failed to legalize operation 'torch.aten.bernoulli.Tensor' that was explicitly marked illegal
+    "BernoulliTensorModule_basic",
+    # error: failed to legalize operation 'torch.aten.view' that was explicitly marked illegal
+    "ElementwiseFlattenBroadcastModule_basic",
+    "FlattenRank0Module_basic",
+    # error: failed to materialize conversion for result #0 of operation 'torch.aten.t' that remained live after conversion
+    "TModuleRank1_basic",
+}
+
 MHLO_PASS_SET = {
     "ArangeDtypeFloatModule_basic",
     "ArangeDtypeIntModule_basic",

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -51,6 +51,7 @@ declare_mlir_python_sources(TorchMLIRPythonSources.TopLevel
   SOURCES
     __init__.py
     compiler_utils.py
+    dynamo.py
 )
 
 declare_mlir_python_sources(TorchMLIRPythonSources.Dialects

--- a/python/torch_mlir/dynamo.py
+++ b/python/torch_mlir/dynamo.py
@@ -1,0 +1,66 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+from typing import List
+
+import torch
+from torch.fx.experimental.proxy_tensor import make_fx
+from functorch._src.compile_utils import strip_overloads
+
+
+import warnings
+# https://github.com/pytorch/pytorch/issues/89064
+warnings.filterwarnings("ignore", module="torch.jit._check")
+
+
+def _unwrap_single_tuple_return(fx_g: torch.fx.GraphModule) -> bool:
+    """Canonicalize single-element tuple returns to just the element.
+
+    Returns:
+        True if unwrapping took place, and false otherwise.
+    """
+    did_unwrap = False
+    for node in fx_g.graph.nodes:
+        if node.op == "output":
+            assert len(
+                node.args) == 1, "Output node must have a single argument"
+            node_arg = node.args[0]
+            if isinstance(node_arg, tuple):
+                if len(node_arg) == 1:
+                    node.args = (node_arg[0],)
+                    did_unwrap = True
+                    break
+
+    if did_unwrap:
+        fx_g.graph.lint()
+        fx_g.recompile()
+    return did_unwrap
+
+
+def make_simple_dynamo_backend(user_backend):
+    """Wrapper for functions intended to be used as TorchDynamo backends.
+
+    This function simplifies a few of the steps that are required to make
+    TorchDynamo work with Torch-MLIR.
+
+    Args:
+        user_backend: A function with the signature used by ordinary
+            TorchDynamo backends. But the torch.fx.GraphModule passed to it
+            will be normalized for consumption by `torch_mlir.compile`.
+    Returns:
+        A function with the signature used by TorchDynamo backends.
+    """
+    def wrapper_backend(fx_graph: torch.fx.GraphModule,
+                        example_inputs: List[torch.Tensor]):
+        did_unwrap = _unwrap_single_tuple_return(fx_graph)
+        dispatcher_ops = make_fx(fx_graph)(*example_inputs)
+        strip_overloads(dispatcher_ops)
+        user_callable = user_backend(dispatcher_ops, example_inputs)
+
+        def dynamo_callable(*inputs):
+            result = user_callable(*inputs)
+            return (result,) if did_unwrap else result
+        return dynamo_callable
+    return wrapper_backend

--- a/python/torch_mlir_e2e_test/configs/__init__.py
+++ b/python/torch_mlir_e2e_test/configs/__init__.py
@@ -10,3 +10,4 @@ from .torchscript import TorchScriptTestConfig
 from .mhlo_backend import MhloBackendTestConfig
 from .tosa_backend import TosaBackendTestConfig
 from .eager_mode import EagerModeTestConfig
+from .torchdynamo import TorchDynamoTestConfig

--- a/python/torch_mlir_e2e_test/configs/torchdynamo.py
+++ b/python/torch_mlir_e2e_test/configs/torchdynamo.py
@@ -1,0 +1,75 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+from typing import List
+
+import torch
+import torch._dynamo as dynamo
+import torch_mlir
+import torch_mlir.dynamo
+from torch_mlir.dynamo import make_simple_dynamo_backend
+from torch_mlir_e2e_test.linalg_on_tensors_backends import refbackend
+
+from torch_mlir_e2e_test.framework import TestConfig, Trace, TraceItem
+
+
+@make_simple_dynamo_backend
+def refbackend_torchdynamo_backend(fx_graph: torch.fx.GraphModule,
+                                   example_inputs: List[torch.Tensor]):
+    # Use the LinalgOnTensors backend, since it is the most complete.
+    # In theory we could mix and match TorchDynamo with the other backends,
+    # since they all lower through the same backend contract.
+    # For now, testing-wise, it doesn't make sense to test those configurations.
+    # We really just want to check the TorchDynamo frontend.
+    #
+    # Longer-term we will need to do something more sophisticated here.
+    # As per the long-term roadmap:
+    # https://github.com/llvm/torch-mlir/blob/main/docs/long_term_roadmap.md#refactoring-the-frontend
+    # We will eventually have a configuration that uses new PyTorch infra and
+    # skips the entire "frontend" part. We currently don't have any code
+    # for that right now since it is still very early stages, but eventually
+    # this Config should test that path (and maybe the current behavior can
+    # be moved to a `legacy_frontend_via_torchdynamo` config).
+    mlir_module = torch_mlir.compile(
+        fx_graph, example_inputs, output_type="linalg-on-tensors")
+    backend = refbackend.RefBackendLinalgOnTensorsBackend()
+    compiled = backend.compile(mlir_module)
+    loaded = backend.load(compiled)
+
+    def compiled_callable(*inputs):
+        inputs = [x.numpy() for x in inputs]
+        result = loaded.forward(*inputs)
+        if not isinstance(result, tuple):
+            result = torch.from_numpy(result)
+        else:
+            result = tuple(torch.from_numpy(x) for x in result)
+        return result
+    return compiled_callable
+
+
+@dynamo.optimize(refbackend_torchdynamo_backend)
+def f(method, *inputs):
+    return method(*inputs)
+
+class TorchDynamoTestConfig(TestConfig):
+    """TestConfig that runs the torch.nn.Module with TorchDynamo"""
+
+    def __init__(self):
+        super().__init__()
+
+    def compile(self, program: torch.nn.Module) -> torch.nn.Module:
+        return program
+
+    def run(self, artifact: torch.nn.Module, trace: Trace) -> Trace:
+        # TODO: Deepcopy the torch.nn.Module, so that if the program is
+        # stateful then it does not mutate the original compiled program.
+        result: Trace = []
+        for item in trace:
+            output = f(getattr(artifact, item.symbol), *item.inputs)
+            result.append(
+                TraceItem(symbol=item.symbol,
+                          inputs=item.inputs,
+                          output=output))
+        return result


### PR DESCRIPTION
This adds a basic e2e Config for TorchDynamo using Linalg-on-Tensors/RefBackend.
But TorchDynamo is pretty orthogonal to
various other pieces, so it should compose nicely with variations like:
- Switching out all the backends (Linalg-on-Tensors, TOSA, MHLO)
- PyTorch functionalization and decompositions
- Taking the example inputs and compiling with all dynamic or all static shapes without duplicating tests.

This adds it to the CI, but there are still a lot of XFAIL's.

This also adds a helper `from torch_mlir.dynamo import make_simple_dynamo_backend` which simplifies some of the steps for making a Torch-MLIR-based TorchDynamo backend. We include "simple" in the name because we are going to be exploring various things next from the long-term roadmap.

The next steps are:
- Burn down all the XFAIL's.
- Start working on the pieces from the [long-term roadmap](https://github.com/llvm/torch-mlir/blob/main/docs/long_term_roadmap.md).
  - Add functionalization/decompositions into the TorchDynamo flow and remove reliance on the current Torch-MLIR "frontend".
  - Write a pure-Python direct FX->MLIR importer.
  - Hook up the new PyTorch symbolic shape stuff.
  - Explore PrimTorch decompositions for simplifying backends.