### PR TITLE
[MLIR][TORCH] Refix differentiable view

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -19,7 +19,6 @@ EAGER_MODE_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS | {
     # These tests pass in the regular RefBackend flow, so it's unclear
     # why they fail here.
     "Matmul_vecmat",
-    "BatchMlpLayerModule_basic",
     "UpSampleNearest2dDynamicFactor_basic",
 }
 

--- a/python/torch_mlir/eager_mode/torch_mlir_tensor.py
+++ b/python/torch_mlir/eager_mode/torch_mlir_tensor.py
@@ -128,10 +128,10 @@ class TorchMLIRTensor(torch.Tensor):
                 else:
                     raise RuntimeError(f"op {func} has no name")
 
+                requires_grad = requires_grad and "view" not in op_name
+
                 if UNSUPPORTED_OPS.match(op_name):
                     raise UnsupportedByTorchMlirEagerMode(op_name)
-
-                requires_grad = requires_grad and "view" not in op_name
 
                 if not hasattr(func, "_schema"):
                     raise RuntimeError(f"op {func} has no schema.")


### PR DESCRIPTION
[Re]fix https://github.com/llvm/torch-mlir/issues/1618 by stripping `requires_grad` from results of view ops (before the exception is thrown...)

