### PR TITLE
Fix multiprocessing for `--config=torchdynamo`

### DIFF
--- a/python/torch_mlir_e2e_test/framework.py
+++ b/python/torch_mlir_e2e_test/framework.py
@@ -84,7 +84,7 @@ def clone_torch_script_value(v: TorchScriptValue):
 def clone_trace(trace: Trace) -> Trace:
     return [
         TraceItem(symbol=item.symbol,
-                  inputs=item.inputs,
+                  inputs=clone_torch_script_value(item.inputs),
                   output=clone_torch_script_value(item.output))
         for item in trace
     ]
@@ -312,7 +312,7 @@ def compile_and_run_test(test: Test, config: TestConfig, verbose=False) -> Any:
                       compilation_error=None,
                       runtime_error=None,
                       trace=clone_trace(trace),
-                      golden_trace=golden_trace)
+                      golden_trace=clone_trace(golden_trace))
 
 
 def run_tests(tests: List[Test], config: TestConfig, sequential=False, verbose=False) -> List[TestResult]:


### PR DESCRIPTION
For reasons that I haven't yet fully tracked down, the TorchDynamo TestConfig seems to result in tensors that cannot be pickled. They seem to be holding some sort of weak handles to a `torch.fx.graph.Graph`.

Here is the object structure that leads to the unpickleable object:
```
(<function _rebuild_tensor_v2 at 0x7f56346d56c0>, <class 'torch.Tensor'>, ( 1.0...
{<object object at 0x7f557529e6b0>: <WeakKeyDictionary at 0x7f556a3efbb0>}
{'data': {<weakref at 0x7f5615372ed0; to 'PythonKeyTracer' at 0x7f556a3ee5c0>: _...
<class 'torch.fx.graph.Graph'>
<class 'torch._ops.OpOverloadPacket'>
TypeError("cannot pickle 'torch._C.FunctionSchema' object")
```

Upstream bug filed: https://github.com/pytorch/pytorch/issues/89626