### PR TITLE
Remove deprecated np.bool

### DIFF
--- a/python/torch_mlir_e2e_test/eager_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/eager_backends/refbackend.py
@@ -24,7 +24,6 @@ from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import (
 )
 
 NUMPY_TO_TORCH_DTYPE_DICT = {
-    np.bool: torch.bool,
     np.bool_: torch.bool,
     np.uint8: torch.uint8,
     np.int8: torch.int8,


### PR DESCRIPTION
`np.bool is bool` and will never be returned as a dtype of an `np.ndarray`, so we don't need to handle it here.

```
>>> a = np.ndarray([1], dtype=bool)
>>> a.dtype.type is np.bool_
True
```

More info here:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations