### PR TITLE
Fix RuntimeError while running examples/eager_mode.py

### DIFF
--- a/python/torch_mlir_e2e_test/eager_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/eager_backends/refbackend.py
@@ -88,4 +88,4 @@ class EagerModeRefBackend(TorchMLIREagerBackend):
         return torch.from_numpy(e).clone()
 
     def transfer_from_torch_to_device(self, tensor: torch.Tensor) -> np.ndarray:
-        return tensor.numpy()
+        return tensor.detach().numpy()


### PR DESCRIPTION
While running the example I am getting this error -
Traceback (most recent call last):
  File "/home/mcw/shivam/mlir/torch-mlir/examples/eager_mode.py", line 23, in <module>
    a = TorchMLIRTensor(torch_a)
  File "/home/mcw/shivam/mlir/torch-mlir/mlir_venv/lib/python3.9/site-packages/torch_mlir/eager_mode/torch_mlir_tensor.py", line 102, in __new__
    r.elem = backend.transfer_from_torch_to_device(elem)
  File "/home/mcw/shivam/mlir/torch-mlir/mlir_venv/lib/python3.9/site-packages/torch_mlir_e2e_test/eager_backends/refbackend.py", line 91, in transfer_from_torch_to_device
    return tensor.numpy()
RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.

This PR is simple fix of that.