### PR TITLE
Allow running DecomposeComplexOps more than once

### DIFF
--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -28,30 +28,27 @@ func.func @matmul_decompose_3d(%arg0: !torch.vtensor<[?,?,?],f32>, %arg1: !torch
 // -----
 // CHECK-LABEL:   func @torch.aten.adaptive_avg_pool2d$non_unit_output_size(
 // CHECK-SAME:                  %[[SELF:.*]]: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
-// CHECK:           %[[CST7:.*]] = torch.constant.int 7
-// CHECK:           %[[OUTPUT_SIZE:.*]] = torch.prim.ListConstruct %[[CST7]], %[[CST7]] : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:           %[[CST2:.*]] = torch.constant.int 2
+// CHECK-DAG:       %[[CST0:.*]] = torch.constant.int 0
+// CHECK-DAG:       %[[CST1:.*]] = torch.constant.int 1
+// CHECK-DAG:       %[[CST2:.*]] = torch.constant.int 2
+// CHECK-DAG:       %[[CST3:.*]] = torch.constant.int 3
+// CHECK-DAG:       %[[CST6:.*]] = torch.constant.int 6
+// CHECK-DAG:       %[[CST7:.*]] = torch.constant.int 7
+// CHECK-DAG:       %[[FALSE:.*]] = torch.constant.bool false
+// CHECK-DAG:       %[[TRUE:.*]] = torch.constant.bool true
+// CHECK-DAG:       %[[NONE:.*]] = torch.constant.none
 // CHECK:           %[[DIM2:.*]] = torch.aten.size.int %[[SELF]], %[[CST2]] : !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.int
-// CHECK:           %[[CST3:.*]] = torch.constant.int 3
 // CHECK:           %[[DIM3:.*]] = torch.aten.size.int %[[SELF]], %[[CST3]] : !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.int
-// CHECK:           %[[CST1:.*]] = torch.constant.int 1
-// CHECK:           %[[CST0:.*]] = torch.constant.int 0
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[TRUE:.*]] = torch.constant.bool true
-// CHECK:           %[[NONE:.*]] = torch.constant.none
 // CHECK:           %[[COND1:.*]] = torch.aten.eq.int %[[DIM2]], %[[CST7]] : !torch.int, !torch.int -> !torch.bool
 // CHECK:           torch.runtime.assert %[[COND1]], "unimplemented: only support cases where input and output size are equal for non-unit output size"
-// CHECK:           %[[T1:.*]] = torch.aten.sub.int %[[CST7]], %[[CST1]] : !torch.int, !torch.int -> !torch.int
-// CHECK:           %[[T2:.*]] = torch.aten.sub.int %[[DIM2]], %[[T1]] : !torch.int, !torch.int -> !torch.int
+// CHECK:           %[[T1:.*]] = torch.aten.sub.int %[[DIM2]], %[[CST6]] : !torch.int, !torch.int -> !torch.int
 // CHECK:           %[[COND2:.*]] = torch.aten.eq.int %[[DIM3]], %[[CST7]] : !torch.int, !torch.int -> !torch.bool
 // CHECK:           torch.runtime.assert %[[COND2]], "unimplemented: only support cases where input and output size are equal for non-unit output size"
-// CHECK:           %[[T3:.*]] = torch.aten.sub.int %[[CST7]], %[[CST1]] : !torch.int, !torch.int -> !torch.int
-// CHECK:           %[[T4:.*]] = torch.aten.sub.int %[[DIM3]], %[[T3]] : !torch.int, !torch.int -> !torch.int
-// CHECK:           %[[T5:.*]] = torch.prim.ListConstruct %[[T2]], %[[T4]] : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:           %[[T6:.*]] = torch.prim.ListConstruct %[[CST1]], %[[CST1]] : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:           %[[T7:.*]]  = torch.prim.ListConstruct %[[CST0]], %[[CST0]] : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:           %[[OUT:.*]] = torch.aten.avg_pool2d %[[SELF]], %[[T5]], %[[T6]], %[[T7]], %[[FALSE]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[?,?,?,?],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?,?],f32>
-// CHECK:           return %[[OUT]] : !torch.vtensor<[?,?,?,?],f32>
+// CHECK:           %[[T2:.*]] = torch.aten.sub.int %[[DIM3]], %[[CST6]] : !torch.int, !torch.int -> !torch.int
+// CHECK:           %[[KERNEL_SIZE:.*]] = torch.prim.ListConstruct %[[T1]], %[[T2]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[STRIDE:.*]] = torch.prim.ListConstruct %[[CST1]], %[[CST1]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[PADDING:.*]]  = torch.prim.ListConstruct %[[CST0]], %[[CST0]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[AVG_POOL:.*]] = torch.aten.avg_pool2d %[[SELF]], %[[KERNEL_SIZE]], %[[STRIDE]], %[[PADDING]], %[[FALSE]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[?,?,?,?],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?,?],f32>
 func.func @torch.aten.adaptive_avg_pool2d$non_unit_output_size(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
   %int7 = torch.constant.int 7
   %output_size = torch.prim.ListConstruct %int7, %int7 : (!torch.int, !torch.int) -> !torch.list<int>
@@ -63,22 +60,19 @@ func.func @torch.aten.adaptive_avg_pool2d$non_unit_output_size(%arg0: !torch.vte
 
 // CHECK-LABEL:   func.func @torch.aten.adaptive_avg_pool2d$unit_output_size(
 // CHECK-SAME:                                                               %[[SELF:.*]]: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
-// CHECK:           %[[CST_1:.*]] = torch.constant.int 1
-// CHECK:           %[[OUTPUT_SIZE:.*]] = torch.prim.ListConstruct %[[CST_1]], %[[CST_1]] : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:           %[[CST_2:.*]] = torch.constant.int 2
-// CHECK:           %[[DIM_2:.*]] = torch.aten.size.int %[[SELF]], %[[CST_2]] : !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.int
-// CHECK:           %[[CST_3:.*]] = torch.constant.int 3
-// CHECK:           %[[DIM_3:.*]] = torch.aten.size.int %[[SELF]], %[[CST_3]] : !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.int
-// CHECK:           %[[CST_1_1:.*]] = torch.constant.int 1
-// CHECK:           %[[CST_0:.*]] = torch.constant.int 0
-// CHECK:           %[[CEIL_MODE:.*]] = torch.constant.bool false
-// CHECK:           %[[COUNT_INCLUDE_PAD:.*]] = torch.constant.bool true
-// CHECK:           %[[DIVISOR_OVERRIDE:.*]] = torch.constant.none
-// CHECK:           %[[KERNEL_SIZE:.*]] = torch.prim.ListConstruct %[[DIM_2]], %[[DIM_3]] : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:           %[[STRIDE:.*]] = torch.prim.ListConstruct %[[CST_1_1]], %[[CST_1_1]] : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:           %[[PADDING:.*]] = torch.prim.ListConstruct %[[CST_0]], %[[CST_0]] : (!torch.int, !torch.int) -> !torch.list<int>
-// CHECK:           %[[OUT:.*]] = torch.aten.avg_pool2d %[[SELF]], %[[KERNEL_SIZE]], %[[STRIDE]], %[[PADDING]], %[[CEIL_MODE]], %[[COUNT_INCLUDE_PAD]], %[[DIVISOR_OVERRIDE]] : !torch.vtensor<[?,?,?,?],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?,?],f32>
-// CHECK:           return %[[OUT]] : !torch.vtensor<[?,?,?,?],f32>
+// CHECK-DAG:       %[[CST0:.*]] = torch.constant.int 0
+// CHECK-DAG:       %[[CST1:.*]] = torch.constant.int 1
+// CHECK-DAG:       %[[CST2:.*]] = torch.constant.int 2
+// CHECK-DAG:       %[[CST3:.*]] = torch.constant.int 3
+// CHECK-DAG:       %[[FALSE:.*]] = torch.constant.bool false
+// CHECK-DAG:       %[[TRUE:.*]] = torch.constant.bool true
+// CHECK-DAG:       %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[DIM2:.*]] = torch.aten.size.int %[[SELF]], %[[CST2]] : !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.int
+// CHECK:           %[[DIM3:.*]] = torch.aten.size.int %[[SELF]], %[[CST3]] : !torch.vtensor<[?,?,?,?],f32>, !torch.int -> !torch.int
+// CHECK:           %[[KERNEL_SIZE:.*]] = torch.prim.ListConstruct %[[DIM2]], %[[DIM3]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[STRIDE:.*]] = torch.prim.ListConstruct %[[CST1]], %[[CST1]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[PADDING:.*]] = torch.prim.ListConstruct %[[CST0]], %[[CST0]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[AVG_POOL:.*]] = torch.aten.avg_pool2d %[[SELF]], %[[KERNEL_SIZE]], %[[STRIDE]], %[[PADDING]], %[[FALSE]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[?,?,?,?],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?,?],f32>
 func.func @torch.aten.adaptive_avg_pool2d$unit_output_size(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
   %int1 = torch.constant.int 1
   %output_size = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>

--- a/test/Dialect/Torch/lower-to-backend-contract-error.mlir
+++ b/test/Dialect/Torch/lower-to-backend-contract-error.mlir
@@ -44,6 +44,16 @@ func.func @f(%arg0: !torch.any) {
 
 // -----
 
+// Decomposition of `aten.t` fails if `inputRank > 2`
+func.func @f(%arg0: !torch.vtensor<[?,?,?],f32>) -> !torch.vtensor<[?,?,?],f32> {
+  // expected-error @+2 {{found an op that was marked as backend illegal}}
+  // expected-note @+1 {{this is likely due to}}
+  %t = torch.aten.t %arg0 : !torch.vtensor<[?,?,?],f32> -> !torch.vtensor<[?,?,?],f32>
+  return %t : !torch.vtensor<[?,?,?],f32>
+}
+
+// -----
+
 // Test case: checking of op results.
 // TODO: In theory we could diagnose every single value, but for now we bail out on the first one.
 


### PR DESCRIPTION
The current implementation of `DecomposeComplexOps` fails if an op expected to be decomposed does not get decomposed in the first iteration of the `createTorchSimplificationPipeline` in `LowerToBackendContractPass`. However, some graphs require multiple iterations of `createTorchSimplificationPipeline` to fully propagate all statically knowable information, such as dtypes and shapes, to the entire graph, sometimes resulting in the need to run `DecomposeComplexOps` more than once.

This commit changes `DecomposeComplexOps` to use a greedy algorithm for pattern application and moves the legalization check of ops to the `LowerToBackendContractPass` to allow for the `DecomposeComplexOps` to run more than once.