### PR TITLE
build: update llvm tag to 798fa4b4

### DIFF
--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorBase.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorBase.td
@@ -43,7 +43,6 @@ def TMTensor_Dialect : Dialect {
     to.
   }];
   let hasCanonicalizer = 1;
-  let emitAccessorPrefix = kEmitAccessorPrefix_Raw;
 }
 
 //===----------------------------------------------------------------------===//

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorInterfaces.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorInterfaces.td
@@ -25,7 +25,7 @@ def TMTensorInterface : OpInterface<"TMTensorOp"> {
         Return the input shape operands.
       }],
       /*retTy=*/"ValueRange",
-      /*methodName=*/"inputs",
+      /*methodName=*/"getInputs",
       /*args=*/(ins)
     >,
     // These special methods rely on `inputs` and `outputs` being defined by
@@ -39,7 +39,7 @@ def TMTensorInterface : OpInterface<"TMTensorOp"> {
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        return $_op.inputs().size();
+        return $_op.getInputs().size();
       }]
     >,
     // `outputs` must be defined by each op that wants to implement the
@@ -49,7 +49,7 @@ def TMTensorInterface : OpInterface<"TMTensorOp"> {
         Return the output shape operands.
       }],
       /*retTy=*/"ValueRange",
-      /*methodName=*/"outputs",
+      /*methodName=*/"getOutputs",
       /*args=*/(ins)
     >,
     InterfaceMethod<
@@ -61,7 +61,7 @@ def TMTensorInterface : OpInterface<"TMTensorOp"> {
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        return $_op.outputs().size();
+        return $_op.getOutputs().size();
       }]
     >,
     InterfaceMethod<

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.td
@@ -34,7 +34,7 @@ class TMTensor_Op<string mnemonic, list<Trait> traits = []> :
   let hasVerifier = 1;
   code extraTMTensorOpClassDeclaration = [{
     SmallVector<Value> getDestinationOperands(OpBuilder &b) {
-      SmallVector<Value> dest(outputs().begin(), outputs().end());
+      SmallVector<Value> dest(getOutputs().begin(), getOutputs().end());
       return dest;
     }
   }];

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorInterfaces.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorInterfaces.cpp
@@ -30,12 +30,12 @@ mlir::torch::TMTensor::detail::verifyTMTensorOpInterface(Operation *op) {
           "expected inputs and outputs to be RankedTensorType or scalar");
     }
 
-    if (op->getNumResults() != mtTensorOp.outputs().size()) {
+    if (op->getNumResults() != mtTensorOp.getOutputs().size()) {
       return mtTensorOp.emitOpError(
           "expected number of outputs to be same as the number of results");
     }
     for (auto en : llvm::enumerate(op->getResultTypes())) {
-      Type outputType = mtTensorOp.outputs()[en.index()].getType();
+      Type outputType = mtTensorOp.getOutputs()[en.index()].getType();
       if (en.value() != outputType) {
         return mtTensorOp.emitOpError("expected type of `outs` operand #")
                << en.index() << " " << outputType

--- a/include/torch-mlir/Dialect/Torch/IR/TorchBase.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchBase.td
@@ -37,7 +37,6 @@ def Torch_Dialect : Dialect {
   let hasRegionArgAttrVerify = 1;
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 0;
-  let emitAccessorPrefix = kEmitAccessorPrefix_Raw;
 
   let extraClassDeclaration = [{
     /// Parse a type registered to this dialect.

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
@@ -39,7 +39,7 @@ struct torch_constant_int_op_binder {
 
   bool match(Operation *op) {
     if (auto constantInt = dyn_cast<Torch::ConstantIntOp>(op)) {
-      *bind_value = constantInt.value().getSExtValue();
+      *bind_value = constantInt.getValue().getSExtValue();
       return true;
     }
     return false;
@@ -54,7 +54,7 @@ struct torch_constant_float_op_binder {
 
   bool match(Operation *op) {
     if (auto constantFloat = dyn_cast<Torch::ConstantFloatOp>(op)) {
-      *bind_value = constantFloat.value().convertToDouble();
+      *bind_value = constantFloat.getValue().convertToDouble();
       return true;
     }
     return false;
@@ -69,7 +69,7 @@ struct torch_constant_str_op_binder {
 
   bool match(Operation *op) {
     if (auto constantString = dyn_cast<Torch::ConstantStrOp>(op)) {
-      bind_value = constantString.value().str();
+      bind_value = constantString.getValue().str();
       return true;
     }
     return false;
@@ -84,7 +84,7 @@ struct torch_constant_device_op_binder {
 
   bool match(Operation *op) {
     if (auto constantDevice = dyn_cast<Torch::ConstantDeviceOp>(op)) {
-      bind_value = constantDevice.value().str();
+      bind_value = constantDevice.getValue().str();
       return true;
     }
     return false;
@@ -126,7 +126,7 @@ struct torch_constant_bool_op_binder {
 
   bool match(Operation *op) {
     if (auto constantBool = dyn_cast<Torch::ConstantBoolOp>(op)) {
-      *bind_value = constantBool.value();
+      *bind_value = constantBool.getValue();
       return true;
     }
     return false;
@@ -153,7 +153,7 @@ struct torch_list_of_constant_ints_op_binder {
     auto listConstruct = dyn_cast<Torch::PrimListConstructOp>(op);
     if (!listConstruct)
       return false;
-    for (Value value : listConstruct.elements()) {
+    for (Value value : listConstruct.getElements()) {
       int64_t num;
       if (matchPattern(value, m_TorchConstantInt(&num)))
         bind_values.push_back(num);
@@ -184,7 +184,7 @@ struct torch_list_of_constant_bools_op_binder {
     auto listConstruct = dyn_cast<Torch::PrimListConstructOp>(op);
     if (!listConstruct)
       return false;
-    for (Value value : listConstruct.elements()) {
+    for (Value value : listConstruct.getElements()) {
       bool num;
       if (matchPattern(value, m_TorchConstantBool(&num)))
         bind_values.push_back(num);
@@ -214,8 +214,8 @@ struct torch_tensor_size_int_op_binder {
 
   bool match(Operation *op) {
     if (auto atenSizeIntOp = dyn_cast<Torch::AtenSizeIntOp>(op)) {
-      if (atenSizeIntOp.self() == tensor) {
-        if (matchPattern(atenSizeIntOp.dim(), m_TorchConstantInt(dim)))
+      if (atenSizeIntOp.getSelf() == tensor) {
+        if (matchPattern(atenSizeIntOp.getDim(), m_TorchConstantInt(dim)))
           return true;
       }
     }

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -497,12 +497,12 @@ def Torch_PrimCallMethodOp : Torch_Op<"prim.CallMethod", []> {
   let arguments = (ins
     StrAttr:$name,
     Torch_NnModuleType:$receiver,
-    Variadic<AnyTorchType>:$operands
+    Variadic<AnyTorchType>:$methodOperands
   );
   let results = (outs AnyTorchType:$result);
 
   let assemblyFormat = [{
-    $receiver `[` $name `]` `(` $operands `)` attr-dict `:` qualified(type($receiver)) `,` functional-type($operands, $result)
+    $receiver `[` $name `]` `(` $methodOperands `)` attr-dict `:` qualified(type($receiver)) `,` functional-type($methodOperands, $result)
   }];
 }
 

--- a/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
@@ -75,13 +75,13 @@ public:
       return failure();
     Location loc = op->getLoc();
 
-    Value dimValue = op.dim();
+    Value dimValue = op.getDim();
     int64_t dim;
     if (!matchPattern(dimValue, m_TorchConstantInt(&dim)))
       return op.emitError("unimplemented: dim is not constant");
 
-    Value indices = adaptor.index();
-    Value self = adaptor.self();
+    Value indices = adaptor.getIndex();
+    Value self = adaptor.getSelf();
     RankedTensorType newResultTy =
         getTypeConverter()->convertType(op.getType()).cast<RankedTensorType>();
     int64_t rank = newResultTy.getRank();
@@ -120,8 +120,8 @@ public:
     if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
       return failure();
     Location loc = op->getLoc();
-    Value weight = adaptor.weight();
-    Value indices = adaptor.indices();
+    Value weight = adaptor.getWeight();
+    Value indices = adaptor.getIndices();
     RankedTensorType newResultType =
         typeConverter->convertType(op.getType()).cast<RankedTensorType>();
 
@@ -217,13 +217,13 @@ public:
       return failure();
     Location loc = op->getLoc();
     auto context = op->getContext();
-    Value weight = adaptor.weight();
-    Value indices = adaptor.indices();
-    Value offsets = adaptor.offsets();
-    Value scaleGradByFreq = op.scale_grad_by_freq();
-    Value mode = op.mode();
-    Value sparse = op.sparse();
-    Value includeLastOffset = op.include_last_offset();
+    Value weight = adaptor.getWeight();
+    Value indices = adaptor.getIndices();
+    Value offsets = adaptor.getOffsets();
+    Value scaleGradByFreq = op.getScaleGradByFreq();
+    Value mode = op.getMode();
+    Value sparse = op.getSparse();
+    Value includeLastOffset = op.getIncludeLastOffset();
 
     bool scaleGradByFreqBool;
     if (!matchPattern(scaleGradByFreq,
@@ -464,8 +464,8 @@ public:
       return failure();
 
     Location loc = op.getLoc();
-    Value input = adaptor.self();
-    Value indices = adaptor.index();
+    Value input = adaptor.getSelf();
+    Value indices = adaptor.getIndex();
     RankedTensorType inputType = input.getType().cast<RankedTensorType>();
     RankedTensorType resultType = getTypeConverter()
                                       ->convertType(op->getResult(0).getType())
@@ -474,7 +474,7 @@ public:
     unsigned inputRank = inputType.getRank();
 
     int64_t dimInt;
-    if (!matchPattern(op.dim(), m_TorchConstantInt(&dimInt)))
+    if (!matchPattern(op.getDim(), m_TorchConstantInt(&dimInt)))
       return op->emitError("unimplemented: dim is not constant");
 
     SmallVector<Value> resultShape = getTensorSizes(rewriter, loc, input);
@@ -545,8 +545,8 @@ public:
       return failure();
 
     Location loc = op.getLoc();
-    Value input = adaptor.self();
-    Value indices = op.indices();
+    Value input = adaptor.getSelf();
+    Value indices = op.getIndices();
     SmallVector<Value> indicesTuple;
     if (!getListConstructElements(indices, indicesTuple)) {
       return rewriter.notifyMatchFailure(
@@ -790,7 +790,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     Location loc = op->getLoc();
-    Value input = adaptor.self();
+    Value input = adaptor.getSelf();
 
     Type resultType = getTypeConverter()->convertType(op.getResult().getType());
     auto inputType = input.getType().cast<RankedTensorType>();
@@ -807,7 +807,7 @@ public:
     Value originalWidth = dims[hDimOffset + 1];
 
     SmallVector<Value, 2> outputSizeTorchInt;
-    if (!getListConstructElements(op.output_size(), outputSizeTorchInt))
+    if (!getListConstructElements(op.getOutputSize(), outputSizeTorchInt))
       return rewriter.notifyMatchFailure(
           op, "unimplemented: the output_size is not constructed from "
               "ListConstruct");
@@ -815,10 +815,10 @@ public:
     outputSizeIntValues = getTypeConvertedValues(
         rewriter, loc, getTypeConverter(), outputSizeTorchInt);
 
-    if (!op.scales_h().getType().isa<Torch::NoneType>()) {
+    if (!op.getScalesH().getType().isa<Torch::NoneType>()) {
       // Convert float values to int values.
       // int_value = (int64_t)ceil(float_value)
-      Value ceilVal = rewriter.create<math::CeilOp>(loc, adaptor.scales_h());
+      Value ceilVal = rewriter.create<math::CeilOp>(loc, adaptor.getScalesH());
       Value intVal =
           rewriter.create<arith::FPToSIOp>(loc, rewriter.getI64Type(), ceilVal);
       scaleFactorsInt.push_back(intVal);
@@ -828,10 +828,10 @@ public:
       scaleFactorsInt.push_back(scaleFactorVal);
     }
 
-    if (!op.scales_w().getType().isa<Torch::NoneType>()) {
+    if (!op.getScalesW().getType().isa<Torch::NoneType>()) {
       // Convert float values to int values.
       // int_value = (int64_t)ceil(float_value)
-      Value ceilVal = rewriter.create<math::CeilOp>(loc, adaptor.scales_w());
+      Value ceilVal = rewriter.create<math::CeilOp>(loc, adaptor.getScalesW());
       Value intVal =
           rewriter.create<arith::FPToSIOp>(loc, rewriter.getI64Type(), ceilVal);
       scaleFactorsInt.push_back(intVal);
@@ -951,7 +951,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     Location loc = op->getLoc();
-    Value gradOutput = adaptor.grad_output();
+    Value gradOutput = adaptor.getGradOutput();
 
     Type resultType = getTypeConverter()->convertType(op.getResult().getType());
     auto gradOutputType = gradOutput.getType().cast<RankedTensorType>();
@@ -964,7 +964,7 @@ public:
         castIndexVectorToInt64Vector(rewriter, loc, gradOutputSizeIndexValues);
 
     SmallVector<Value, 4> inputSizeTorchInt;
-    if (!getListConstructElements(op.input_size(), inputSizeTorchInt))
+    if (!getListConstructElements(op.getInputSize(), inputSizeTorchInt))
       return rewriter.notifyMatchFailure(
           op, "unimplemented: the input_size is not constructed from "
               "ListConstruct");
@@ -976,8 +976,8 @@ public:
     unsigned hDimOffset = 2;
 
     SmallVector<Value, 2> scaleFactorsFloatValues;
-    if (!op.scales_h().getType().isa<Torch::NoneType>()) {
-      scaleFactorsFloatValues.push_back(adaptor.scales_h());
+    if (!op.getScalesH().getType().isa<Torch::NoneType>()) {
+      scaleFactorsFloatValues.push_back(adaptor.getScalesH());
     } else {
       auto scaleFactorVal = rewriter.create<arith::DivFOp>(
           loc,
@@ -989,8 +989,8 @@ public:
       scaleFactorsFloatValues.push_back(scaleFactorVal);
     }
 
-    if (!op.scales_w().getType().isa<Torch::NoneType>()) {
-      scaleFactorsFloatValues.push_back(adaptor.scales_w());
+    if (!op.getScalesW().getType().isa<Torch::NoneType>()) {
+      scaleFactorsFloatValues.push_back(adaptor.getScalesW());
     } else {
       auto scaleFactorVal = rewriter.create<arith::DivFOp>(
           loc,

--- a/lib/Conversion/TorchToLinalg/Random.cpp
+++ b/lib/Conversion/TorchToLinalg/Random.cpp
@@ -41,7 +41,7 @@ public:
       return failure();
 
     bool train;
-    if (!matchPattern(op.train(), m_TorchConstantBool(&train)))
+    if (!matchPattern(op.getTrain(), m_TorchConstantBool(&train)))
       return rewriter.notifyMatchFailure(op,
                                          "Expected train to be constant bool.");
 
@@ -51,7 +51,7 @@ public:
                           ->convertType(op->getResult(0).getType())
                           .cast<RankedTensorType>();
     rewriter.replaceOpWithNewOp<tensor::CastOp>(op, resultType,
-                                                adaptor.input());
+                                                adaptor.getInput());
     return success();
   }
 };
@@ -123,10 +123,10 @@ public:
     if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
       return failure();
     Location loc = op.getLoc();
-    Value self = adaptor.self();
-    Value from = adaptor.from();
-    Value to = adaptor.to();
-    Value generator = adaptor.generator();
+    Value self = adaptor.getSelf();
+    Value from = adaptor.getFrom();
+    Value to = adaptor.getTo();
+    Value generator = adaptor.getGenerator();
     RankedTensorType resultType = self.getType().cast<RankedTensorType>();
     Type elemTy = resultType.getElementType();
 

--- a/lib/Conversion/TorchToMhlo/Pooling.cpp
+++ b/lib/Conversion/TorchToMhlo/Pooling.cpp
@@ -78,7 +78,7 @@ template <>
 LogicalResult ConvertAtenOp<AtenMaxPool2dOp>::matchAndRewrite(
     AtenMaxPool2dOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value input = adaptor.self();
+  Value input = adaptor.getSelf();
   auto inputTy = input.getType().cast<RankedTensorType>();
   auto inputElemTy = inputTy.getElementType();
 
@@ -93,23 +93,23 @@ LogicalResult ConvertAtenOp<AtenMaxPool2dOp>::matchAndRewrite(
   SmallVector<int64_t, 2> padding, kernelSize, stride, dilation;
   bool ceilMode = false;
 
-  if (!(matchPattern(op.kernel_size(),
+  if (!(matchPattern(op.getKernelSize(),
                      m_TorchListOfConstantInts(kernelSize)))) {
     return rewriter.notifyMatchFailure(
         op, "non-const int kernel size unsupported!");
   }
-  if (!(matchPattern(op.stride(), m_TorchListOfConstantInts(stride)))) {
+  if (!(matchPattern(op.getStride(), m_TorchListOfConstantInts(stride)))) {
     return rewriter.notifyMatchFailure(op, "non-const int stride unsupported!");
   }
-  if (!(matchPattern(op.padding(), m_TorchListOfConstantInts(padding)))) {
+  if (!(matchPattern(op.getPadding(), m_TorchListOfConstantInts(padding)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int padding unsupported!");
   }
-  if (!(matchPattern(op.dilation(), m_TorchListOfConstantInts(dilation)))) {
+  if (!(matchPattern(op.getDilation(), m_TorchListOfConstantInts(dilation)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int dilation unsupported!");
   }
-  if (!(matchPattern(op.ceil_mode(), m_TorchConstantBool(&ceilMode)))) {
+  if (!(matchPattern(op.getCeilMode(), m_TorchConstantBool(&ceilMode)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const bool ceil_mode unsupported!");
   }
@@ -181,7 +181,7 @@ template <>
 LogicalResult ConvertAtenOp<AtenMaxPool2dWithIndicesOp>::matchAndRewrite(
     AtenMaxPool2dWithIndicesOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value input = adaptor.self();
+  Value input = adaptor.getSelf();
   auto inputTy = input.getType().cast<RankedTensorType>();
   auto inputElemTy = inputTy.getElementType();
   auto inputShape = inputTy.getShape();
@@ -198,23 +198,23 @@ LogicalResult ConvertAtenOp<AtenMaxPool2dWithIndicesOp>::matchAndRewrite(
   SmallVector<int64_t, 2> padding, kernelSize, stride, dilation;
   bool ceilMode = false;
 
-  if (!(matchPattern(op.kernel_size(),
+  if (!(matchPattern(op.getKernelSize(),
                      m_TorchListOfConstantInts(kernelSize)))) {
     return rewriter.notifyMatchFailure(
         op, "non-const int kernel size unsupported!");
   }
-  if (!(matchPattern(op.stride(), m_TorchListOfConstantInts(stride)))) {
+  if (!(matchPattern(op.getStride(), m_TorchListOfConstantInts(stride)))) {
     return rewriter.notifyMatchFailure(op, "non-const int stride unsupported!");
   }
-  if (!(matchPattern(op.padding(), m_TorchListOfConstantInts(padding)))) {
+  if (!(matchPattern(op.getPadding(), m_TorchListOfConstantInts(padding)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int padding unsupported!");
   }
-  if (!(matchPattern(op.dilation(), m_TorchListOfConstantInts(dilation)))) {
+  if (!(matchPattern(op.getDilation(), m_TorchListOfConstantInts(dilation)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int dilation unsupported!");
   }
-  if (!(matchPattern(op.ceil_mode(), m_TorchConstantBool(&ceilMode)))) {
+  if (!(matchPattern(op.getCeilMode(), m_TorchConstantBool(&ceilMode)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const bool ceil_mode unsupported!");
   }
@@ -375,7 +375,7 @@ template <>
 LogicalResult ConvertAtenOp<AtenAvgPool2dOp>::matchAndRewrite(
     AtenAvgPool2dOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value input = adaptor.self();
+  Value input = adaptor.getSelf();
   auto inputTy = input.getType().cast<RankedTensorType>();
   auto inputElemTy = inputTy.getElementType();
   auto inputRank = inputTy.getRank();
@@ -391,28 +391,28 @@ LogicalResult ConvertAtenOp<AtenAvgPool2dOp>::matchAndRewrite(
   bool ceilMode = false;
   bool countIncludePad = true;
 
-  if (!(matchPattern(op.kernel_size(),
+  if (!(matchPattern(op.getKernelSize(),
                      m_TorchListOfConstantInts(kernelSize)))) {
     return rewriter.notifyMatchFailure(
         op, "non-const int kernel size unsupported!");
   }
-  if (!(matchPattern(op.stride(), m_TorchListOfConstantInts(stride)))) {
+  if (!(matchPattern(op.getStride(), m_TorchListOfConstantInts(stride)))) {
     return rewriter.notifyMatchFailure(op, "non-const int stride unsupported!");
   }
-  if (!(matchPattern(op.padding(), m_TorchListOfConstantInts(padding)))) {
+  if (!(matchPattern(op.getPadding(), m_TorchListOfConstantInts(padding)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const int padding unsupported!");
   }
-  if (!(matchPattern(op.ceil_mode(), m_TorchConstantBool(&ceilMode)))) {
+  if (!(matchPattern(op.getCeilMode(), m_TorchConstantBool(&ceilMode)))) {
     return rewriter.notifyMatchFailure(op,
                                        "non-const bool ceil_mode unsupported!");
   }
-  if (!(matchPattern(op.count_include_pad(),
+  if (!(matchPattern(op.getCountIncludePad(),
                      m_TorchConstantBool(&countIncludePad)))) {
     return rewriter.notifyMatchFailure(
         op, "non-const bool count_include_pad unsupported!");
   }
-  if (succeeded(checkNotNone(rewriter, op, op.divisor_override()))) {
+  if (succeeded(checkNotNone(rewriter, op, op.getDivisorOverride()))) {
     return rewriter.notifyMatchFailure(
         op, "only None divisor_override supported for now!");
   }

--- a/lib/Conversion/TorchToMhlo/Reduction.cpp
+++ b/lib/Conversion/TorchToMhlo/Reduction.cpp
@@ -192,7 +192,7 @@ template <>
 LogicalResult ConvertAtenReductionOp<AtenArgmaxOp>::matchAndRewrite(
     AtenArgmaxOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value input = adaptor.self();
+  Value input = adaptor.getSelf();
   auto inputTy = input.getType().template cast<RankedTensorType>();
   if (!inputTy) {
     return rewriter.notifyMatchFailure(op, "only Tensor types supported in MHLO");
@@ -212,7 +212,7 @@ LogicalResult ConvertAtenReductionOp<AtenArgmaxOp>::matchAndRewrite(
   }
 
   int64_t dim;
-  if (!matchPattern(op.dim(), m_TorchConstantInt(&dim))) {
+  if (!matchPattern(op.getDim(), m_TorchConstantInt(&dim))) {
     return rewriter.notifyMatchFailure(op, "non-int dim unsupported");
   }
   dim = toPositiveDim(dim, inputTy.getRank());
@@ -221,7 +221,7 @@ LogicalResult ConvertAtenReductionOp<AtenArgmaxOp>::matchAndRewrite(
   }
 
   bool keepDim = false;
-  if (!matchPattern(op.keepdim(), m_TorchConstantBool(&keepDim))) {
+  if (!matchPattern(op.getKeepdim(), m_TorchConstantBool(&keepDim))) {
     return rewriter.notifyMatchFailure(op, "non-bool keepdim unsupported");
   }
 
@@ -263,7 +263,7 @@ template <>
 LogicalResult ConvertAtenReductionOp<AtenMaxDimOp>::matchAndRewrite(
     AtenMaxDimOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value input = adaptor.self();
+  Value input = adaptor.getSelf();
   auto inputTy = input.getType().template dyn_cast<RankedTensorType>();
   if (!inputTy) {
     return rewriter.notifyMatchFailure(op, "only Tensor types supported in MHLO");
@@ -293,7 +293,7 @@ LogicalResult ConvertAtenReductionOp<AtenMaxDimOp>::matchAndRewrite(
   }
 
   int64_t dim;
-  if (!matchPattern(op.dim(), m_TorchConstantInt(&dim))) {
+  if (!matchPattern(op.getDim(), m_TorchConstantInt(&dim))) {
     return rewriter.notifyMatchFailure(op, "non-int dim unsupported");
   }
   dim = toPositiveDim(dim, inputTy.getRank());
@@ -301,7 +301,7 @@ LogicalResult ConvertAtenReductionOp<AtenMaxDimOp>::matchAndRewrite(
     return rewriter.notifyMatchFailure(op, "dim is not a valid dim");
   }
   bool keepDim = false;
-  if (!matchPattern(op.keepdim(), m_TorchConstantBool(&keepDim))) {
+  if (!matchPattern(op.getKeepdim(), m_TorchConstantBool(&keepDim))) {
     return rewriter.notifyMatchFailure(op, "non-bool keepdim unsupported");
   }
 
@@ -345,7 +345,7 @@ template <>
 LogicalResult ConvertAtenReductionOp<AtenSumOp>::matchAndRewrite(
     AtenSumOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value input = adaptor.self();
+  Value input = adaptor.getSelf();
   auto inputTy = input.getType().dyn_cast<RankedTensorType>();
   auto outTy = getTypeConverter()
                    ->convertType(op.getType())
@@ -413,7 +413,7 @@ template <>
 LogicalResult ConvertAtenReductionOp<AtenMaxOp>::matchAndRewrite(
     AtenMaxOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value input = adaptor.self();
+  Value input = adaptor.getSelf();
   auto inputTy = input.getType().dyn_cast<RankedTensorType>();
   if (!inputTy) {
     return rewriter.notifyMatchFailure(op, "only Tensor types supported in MHLO");
@@ -473,7 +473,7 @@ template <>
 LogicalResult ConvertAtenReductionOp<AtenSumDimIntListOp>::matchAndRewrite(
     AtenSumDimIntListOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value input = adaptor.self();
+  Value input = adaptor.getSelf();
   auto inputTy = input.getType().dyn_cast<RankedTensorType>();
   auto outTy = getTypeConverter()
                    ->convertType(op.getType())
@@ -503,7 +503,7 @@ LogicalResult ConvertAtenReductionOp<AtenSumDimIntListOp>::matchAndRewrite(
 
   SmallVector<int64_t> inputDims;
   SmallVector<int64_t> dims;
-  if (!matchPattern(op.dim(), m_TorchListOfConstantInts(inputDims))) {
+  if (!matchPattern(op.getDim(), m_TorchListOfConstantInts(inputDims))) {
     return rewriter.notifyMatchFailure(op, "non-int dim list unsupported");
   }
   if (inputDims.size() == 0) {
@@ -519,7 +519,7 @@ LogicalResult ConvertAtenReductionOp<AtenSumDimIntListOp>::matchAndRewrite(
   }
 
   bool keepDim = false;
-  if (!matchPattern(op.keepdim(), m_TorchConstantBool(&keepDim))) {
+  if (!matchPattern(op.getKeepdim(), m_TorchConstantBool(&keepDim))) {
     return rewriter.notifyMatchFailure(op, "non-bool keepdim unsupported");
   }
   Value initValue =
@@ -587,7 +587,7 @@ LogicalResult ConvertAtenReductionOp<AtenFrobeniusNormDimOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
   const TorchToMhloOptions &options = getOptions();
 
-  Value input = adaptor.self();
+  Value input = adaptor.getSelf();
   auto inputType = input.getType().dyn_cast<RankedTensorType>();
   if (!inputType) {
     return op.emitError(
@@ -601,7 +601,7 @@ LogicalResult ConvertAtenReductionOp<AtenFrobeniusNormDimOp>::matchAndRewrite(
   }
 
   SmallVector<int64_t> dims;
-  if (!matchPattern(op.dim(), m_TorchListOfConstantInts(dims))) {
+  if (!matchPattern(op.getDim(), m_TorchListOfConstantInts(dims))) {
     return rewriter.notifyMatchFailure(
         op, "non-const integer `dim` is not supported");
   }
@@ -618,7 +618,7 @@ LogicalResult ConvertAtenReductionOp<AtenFrobeniusNormDimOp>::matchAndRewrite(
   std::sort(dims.begin(), dims.end());
 
   bool keepDim = false;
-  if (!matchPattern(op.keepdim(), m_TorchConstantBool(&keepDim))) {
+  if (!matchPattern(op.getKeepdim(), m_TorchConstantBool(&keepDim))) {
     return rewriter.notifyMatchFailure(
         op, "non-const bool `keepdim` is not supported");
   }

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -41,7 +41,7 @@ public:
   LogicalResult
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value self = adaptor.self();
+    Value self = adaptor.getSelf();
     auto selfTy = self.getType().cast<TensorType>();
 
     if (!selfTy)
@@ -76,7 +76,7 @@ public:
         op,
         OpConversionPattern<AtenOpT>::getTypeConverter()->convertType(
             op.getType()),
-        adaptor.self());
+        adaptor.getSelf());
     return success();
   }
 };
@@ -91,9 +91,9 @@ public:
   LogicalResult
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value lhs = adaptor.self();
+    Value lhs = adaptor.getSelf();
     auto lhsTy = lhs.getType().cast<TensorType>();
-    Value rhs = adaptor.other();
+    Value rhs = adaptor.getOther();
     auto rhsTy = rhs.getType().cast<TensorType>();
 
     if (!lhsTy || !rhsTy)
@@ -220,9 +220,9 @@ public:
   LogicalResult
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value lhs = adaptor.self();
+    Value lhs = adaptor.getSelf();
     auto lhsType = lhs.getType().dyn_cast<TensorType>();
-    Value rhs = adaptor.other();
+    Value rhs = adaptor.getOther();
     auto rhsType = rhs.getType().dyn_cast<TensorType>();
 
     if (!lhsType)
@@ -247,7 +247,7 @@ public:
 
     Value rhsAsTensor;
     if (!rhsType) {
-      if (failed(torchScalarToTosaTensor(rewriter, op, op.other(), rhsAsTensor,
+      if (failed(torchScalarToTosaTensor(rewriter, op, op.getOther(), rhsAsTensor,
                                          outElemTy, {})))
         return rewriter.notifyMatchFailure(
             op, "Currently only scalar constants are supported for "
@@ -257,7 +257,7 @@ public:
 
     // Handle alpha.
     Value alphaTensor;
-    if (failed(torchAlphaToTosaTensor(rewriter, op.getOperation(), op.alpha(),
+    if (failed(torchAlphaToTosaTensor(rewriter, op.getOperation(), op.getAlpha(),
                                       alphaTensor, outElemTy,
                                       /*checkForUnity=*/false))) {
       return rewriter.notifyMatchFailure(
@@ -292,9 +292,9 @@ public:
   LogicalResult
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value lhs = adaptor.self();
+    Value lhs = adaptor.getSelf();
     auto lhsTy = lhs.getType().dyn_cast<TensorType>();
-    Value rhs = adaptor.other();
+    Value rhs = adaptor.getOther();
     auto rhsTy = rhs.getType().dyn_cast<TensorType>();
 
     if (!lhsTy)
@@ -316,7 +316,7 @@ public:
 
     Value rhsAsTensor;
     if (!rhsTy) {
-      if (failed(torchScalarToTosaTensor(rewriter, op, op.other(), rhsAsTensor,
+      if (failed(torchScalarToTosaTensor(rewriter, op, op.getOther(), rhsAsTensor,
                                          lhsElemTy, {})))
         return rewriter.notifyMatchFailure(
             op, "Currently only scalar constants are supported for "
@@ -357,7 +357,7 @@ public:
   LogicalResult
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value lhs = adaptor.self();
+    Value lhs = adaptor.getSelf();
     auto lhsType = lhs.getType().dyn_cast<TensorType>();
 
     if (!lhsType)
@@ -378,10 +378,10 @@ public:
       rhsTensor = lhs;
     } else {
       Value rhsAsTensor;
-      Value rhs = adaptor.other();
+      Value rhs = adaptor.getOther();
       auto rhsType = rhs.getType().dyn_cast<TensorType>();
       if (!rhsType) {
-        if (failed(torchScalarToTosaTensor(rewriter, op, op.other(),
+        if (failed(torchScalarToTosaTensor(rewriter, op, op.getOther(),
                                            rhsAsTensor, outElemTy, {}))) {
           return rewriter.notifyMatchFailure(
               op, "Currently only scalar constants are supported for "
@@ -420,9 +420,9 @@ public:
   LogicalResult
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value lhs = adaptor.self();
+    Value lhs = adaptor.getSelf();
     auto lhsTy = lhs.getType().dyn_cast<TensorType>();
-    Value rhs = adaptor.other();
+    Value rhs = adaptor.getOther();
     auto rhsTy = rhs.getType().dyn_cast<TensorType>();
 
     if (!lhsTy)
@@ -436,7 +436,7 @@ public:
 
     Value rhsAsTensor;
     if (!rhsTy) {
-      if (failed(torchScalarToTosaTensor(rewriter, op, op.other(), rhsAsTensor,
+      if (failed(torchScalarToTosaTensor(rewriter, op, op.getOther(), rhsAsTensor,
                                          lhsElemTy, {})))
         return rewriter.notifyMatchFailure(
             op, "Currently only scalar constants are supported for "
@@ -480,7 +480,7 @@ template <>
 LogicalResult ConvertAtenOp<AtenTanhOp>::matchAndRewrite(
     AtenTanhOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value self = adaptor.self();
+  Value self = adaptor.getSelf();
   auto selfTy = self.getType().cast<TensorType>();
   if (selfTy && selfTy.getElementType().isa<mlir::FloatType>()) {
     rewriter.replaceOpWithNewOp<tosa::TanhOp>(
@@ -497,7 +497,7 @@ template <>
 LogicalResult ConvertAtenOp<AtenSigmoidOp>::matchAndRewrite(
     AtenSigmoidOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value self = adaptor.self();
+  Value self = adaptor.getSelf();
   auto selfTy = self.getType().cast<TensorType>();
   if (selfTy && selfTy.getElementType().isa<mlir::FloatType>()) {
     rewriter.replaceOpWithNewOp<tosa::SigmoidOp>(
@@ -514,7 +514,7 @@ template <>
 LogicalResult ConvertAtenOp<AtenReluOp>::matchAndRewrite(
     AtenReluOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  Value self = adaptor.self();
+  Value self = adaptor.getSelf();
   auto selfTy = self.getType().cast<TensorType>();
 
   // Maps to tosa.clamp which has both int and fp limits.
@@ -565,7 +565,7 @@ public:
   LogicalResult
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value self = adaptor.self();
+    Value self = adaptor.getSelf();
     auto selfTy = self.getType().cast<TensorType>();
 
     if (!selfTy)
@@ -614,7 +614,7 @@ class ConvertAtenMultipleDimsReductionOp
                                           ElementsAttr &reduceDimsAttr,
                                           bool &keepDims) const override {
     SmallVector<int64_t, 4> reduceDims;
-    if (!matchPattern(op.dim(), m_TorchListOfConstantInts(reduceDims)))
+    if (!matchPattern(op.getDim(), m_TorchListOfConstantInts(reduceDims)))
       return rewriter.notifyMatchFailure(op,
                                          "non-const dim parameter unsupported");
     int64_t N = reduceDims.size();
@@ -623,7 +623,7 @@ class ConvertAtenMultipleDimsReductionOp
                                                llvm::makeArrayRef(reduceDims));
 
     keepDims = false;
-    if (!matchPattern(op.keepdim(), m_TorchConstantBool(&keepDims)))
+    if (!matchPattern(op.getKeepdim(), m_TorchConstantBool(&keepDims)))
       return rewriter.notifyMatchFailure(
           op, "non-const keepdim parameter unsupported");
 
@@ -645,7 +645,7 @@ class ConvertAtenOneDimReductionOp
                                           ElementsAttr &reduceDimsAttr,
                                           bool &keepDims) const override {
     int64_t reduceDim;
-    if (!matchPattern(op.dim(), m_TorchConstantInt(&reduceDim)))
+    if (!matchPattern(op.getDim(), m_TorchConstantInt(&reduceDim)))
       return rewriter.notifyMatchFailure(op,
                                          "non-const dim parameter unsupported");
     auto reduceDimsType = RankedTensorType::get({1}, rewriter.getI64Type());
@@ -653,7 +653,7 @@ class ConvertAtenOneDimReductionOp
                                                llvm::makeArrayRef({reduceDim}));
 
     keepDims = false;
-    if (!matchPattern(op.keepdim(), m_TorchConstantBool(&keepDims)))
+    if (!matchPattern(op.getKeepdim(), m_TorchConstantBool(&keepDims)))
       return rewriter.notifyMatchFailure(
           op, "non-const keepdim parameter unsupported");
 
@@ -674,7 +674,7 @@ public:
                                           ConversionPatternRewriter &rewriter,
                                           ElementsAttr &reduceDimsAttr,
                                           bool &keepDims) const override {
-    auto self = adaptor.self();
+    auto self = adaptor.getSelf();
     auto selfTy = self.getType().template cast<RankedTensorType>();
 
     // Select all dims to reduce
@@ -696,7 +696,7 @@ LogicalResult ConvertAtenOp<AtenArgmaxOp>::matchAndRewrite(
     AtenArgmaxOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
 
-  Value self = adaptor.self();
+  Value self = adaptor.getSelf();
   auto selfTy = self.getType().template cast<RankedTensorType>();
 
   if (!selfTy)
@@ -704,13 +704,13 @@ LogicalResult ConvertAtenOp<AtenArgmaxOp>::matchAndRewrite(
         op, "Only ranked tensor types supported in TOSA argmax");
 
   int64_t reduceDim;
-  if (!matchPattern(op.dim(), m_TorchConstantInt(&reduceDim))) {
+  if (!matchPattern(op.getDim(), m_TorchConstantInt(&reduceDim))) {
     // NoneType indicates reduce on all dims
     reduceDim = -1;
   }
 
   bool keepDim = false;
-  if (!matchPattern(op.keepdim(), m_TorchConstantBool(&keepDim)))
+  if (!matchPattern(op.getKeepdim(), m_TorchConstantBool(&keepDim)))
     return rewriter.notifyMatchFailure(
         op, "non-const keepdim parameter unsupported");
 
@@ -801,7 +801,7 @@ public:
   LogicalResult
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value self = adaptor.self();
+    Value self = adaptor.getSelf();
     auto selfTy = self.getType().template cast<RankedTensorType>();
 
     if (!selfTy)
@@ -846,7 +846,7 @@ class ConvertAtenSqueezeOneDimOp : public ConvertAtenSqueezeOp<AtenOpT> {
                         ConversionPatternRewriter &rewriter,
                         SmallVector<int64_t> &squeezedShape) const override {
     int64_t squeezeDim;
-    if (!matchPattern(op.dim(), m_TorchConstantInt(&squeezeDim)))
+    if (!matchPattern(op.getDim(), m_TorchConstantInt(&squeezeDim)))
       return rewriter.notifyMatchFailure(op,
                                          "non-const dim parameter unsupported");
 
@@ -896,7 +896,7 @@ LogicalResult ConvertAtenOp<AtenPowTensorScalarOp>::matchAndRewrite(
     AtenPowTensorScalarOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
 
-  Value self = adaptor.self();
+  Value self = adaptor.getSelf();
   auto selfTy = self.getType().template cast<RankedTensorType>();
 
   if (!selfTy)
@@ -908,7 +908,7 @@ LogicalResult ConvertAtenOp<AtenPowTensorScalarOp>::matchAndRewrite(
         op, "Only floating-point datatype legalization supported");
 
   Value expTensor;
-  Value expScalar = op.exponent();
+  Value expScalar = op.getExponent();
   if (failed(torchScalarToTosaTensor(rewriter, op, expScalar, expTensor,
                                      selfTy.getElementType(), {})))
     return rewriter.notifyMatchFailure(
@@ -1516,10 +1516,10 @@ public:
   LogicalResult readMatMulInputs(AtenOpT op, OpAdaptor adaptor,
                                  ConversionPatternRewriter &rewriter,
                                  Value &lhs, Value &rhs) const override {
-    lhs = adaptor.self();
+    lhs = adaptor.getSelf();
     auto lhsTy = lhs.getType().cast<RankedTensorType>();
 
-    rhs = adaptor.other();
+    rhs = adaptor.getOther();
     auto rhsTy = rhs.getType().cast<RankedTensorType>();
 
     if (!lhsTy || !rhsTy)
@@ -1540,10 +1540,10 @@ public:
                                  ConversionPatternRewriter &rewriter,
                                  Value &lhs, Value &rhs) const override {
 
-    lhs = adaptor.self();
+    lhs = adaptor.getSelf();
     auto lhsTy = lhs.getType().cast<RankedTensorType>();
 
-    rhs = adaptor.mat2();
+    rhs = adaptor.getMat2();
     auto rhsTy = rhs.getType().cast<RankedTensorType>();
 
     if (!lhsTy || !rhsTy)
@@ -1577,10 +1577,10 @@ public:
                                  ConversionPatternRewriter &rewriter,
                                  Value &lhs, Value &rhs) const override {
 
-    lhs = adaptor.input();
+    lhs = adaptor.getInput();
     auto lhsTy = lhs.getType().cast<RankedTensorType>();
 
-    rhs = adaptor.weight();
+    rhs = adaptor.getWeight();
     auto rhsTy = rhs.getType().cast<RankedTensorType>();
 
     if (!lhsTy || !rhsTy)
@@ -1615,7 +1615,7 @@ public:
       return rewriter.notifyMatchFailure(op, "Failed to read matmul inputs");
 
     // The aten.Linear op has a bias tensor that is added to the matmul output.
-    auto bias = adaptor.bias();
+    auto bias = adaptor.getBias();
     auto biasTy = bias.getType();
 
     // TOSA does not mandate that elementwise op tensors need to be ranked.
@@ -1689,11 +1689,11 @@ LogicalResult ConvertAtenOp<AtenRsubScalarOp>::matchAndRewrite(
     AtenRsubScalarOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
 
-  auto self = adaptor.self();
-  auto otherScalar = op.other();
-  auto alphaScalar = op.alpha();
+  auto self = adaptor.getSelf();
+  auto otherScalar = op.getOther();
+  auto alphaScalar = op.getAlpha();
 
-  auto selfTy = self.getType().template cast<RankedTensorType>();
+  auto selfTy = self.getType().cast<RankedTensorType>();
   if (!selfTy)
     return rewriter.notifyMatchFailure(
         op, "Only ranked tensor types supported in TOSA Rsub");
@@ -1731,11 +1731,11 @@ LogicalResult ConvertAtenOp<AtenConvolutionOp>::matchAndRewrite(
     AtenConvolutionOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
 
-  auto input = adaptor.input();
-  auto weight = adaptor.weight();
+  auto input = adaptor.getInput();
+  auto weight = adaptor.getWeight();
 
-  auto inputTy = input.getType().template cast<RankedTensorType>();
-  auto weightTy = weight.getType().template cast<RankedTensorType>();
+  auto inputTy = input.getType().cast<RankedTensorType>();
+  auto weightTy = weight.getType().cast<RankedTensorType>();
   auto outputTy = getTypeConverter()
                       ->convertType(op.getType())
                       .template cast<RankedTensorType>();
@@ -1759,8 +1759,8 @@ LogicalResult ConvertAtenOp<AtenConvolutionOp>::matchAndRewrite(
 
   // Bias is optional. TOSA mandates a zero tensor here, so construct one if
   // required.
-  auto bias = adaptor.bias();
-  if (adaptor.bias().getType().template isa<Torch::NoneType>()) {
+  auto bias = adaptor.getBias();
+  if (adaptor.getBias().getType().template isa<Torch::NoneType>()) {
     // TBD: This is only valid for quantized 8-bit. For 16-bit, the bias (and
     // accumulator) are 48-bit and not 32-bit, and requires the use of APInt to
     // define a 48-bit int.
@@ -1780,16 +1780,16 @@ LogicalResult ConvertAtenOp<AtenConvolutionOp>::matchAndRewrite(
       return rewriter.notifyMatchFailure(
           op, "Bias provided but not a ranked tensor");
   }
-  auto biasElemTy = inputElemTy.template isa<mlir::FloatType>()
+  auto biasElemTy = inputElemTy.isa<mlir::FloatType>()
                         ? inputElemTy
                         : rewriter.getI32Type();
 
   SmallVector<int64_t, 2> stride;
-  if (!matchPattern(adaptor.stride(), m_TorchListOfConstantInts(stride)))
+  if (!matchPattern(adaptor.getStride(), m_TorchListOfConstantInts(stride)))
     return rewriter.notifyMatchFailure(op, "non-const stride list unsupported");
 
   SmallVector<int64_t, 2> padding_2d;
-  if (!matchPattern(adaptor.padding(), m_TorchListOfConstantInts(padding_2d)))
+  if (!matchPattern(adaptor.getPadding(), m_TorchListOfConstantInts(padding_2d)))
     return rewriter.notifyMatchFailure(op,
                                        "non-const padding list unsupported");
   // TOSA uses 4D padding {t, b, l, r} while Torch defines 2D padding {t, l}.
@@ -1799,7 +1799,7 @@ LogicalResult ConvertAtenOp<AtenConvolutionOp>::matchAndRewrite(
       {padding_2d[0], padding_2d[0], padding_2d[1], padding_2d[1]});
 
   SmallVector<int64_t, 2> dilation;
-  if (!matchPattern(adaptor.dilation(), m_TorchListOfConstantInts(dilation)))
+  if (!matchPattern(adaptor.getDilation(), m_TorchListOfConstantInts(dilation)))
     return rewriter.notifyMatchFailure(op,
                                        "non-const dilation list unsupported");
 
@@ -1881,7 +1881,7 @@ LogicalResult ConvertAtenOp<AtenConvolutionOp>::matchAndRewrite(
           .getResult();
 
   Value rescaledResult = transposedOutput;
-  if (inputElemTy.template isa<quant::QuantizedType>()) {
+  if (inputElemTy.isa<quant::QuantizedType>()) {
     rescaledResult = tosa::buildRescaleOpConvOutput(
         rewriter, op, transposedOutput, inputTy, weightTy, outputTy);
   }
@@ -1897,16 +1897,16 @@ LogicalResult ConvertAtenOp<AtenReshapeOp>::matchAndRewrite(
     AtenReshapeOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
 
-  auto self = adaptor.self();
+  auto self = adaptor.getSelf();
 
-  auto selfTy = self.getType().template cast<RankedTensorType>();
+  auto selfTy = self.getType().cast<RankedTensorType>();
   if (!selfTy)
     return rewriter.notifyMatchFailure(
         op, "Only ranked tensor types supported in TOSA Reshape");
 
   // Check that at most one dimension is -1
   SmallVector<int64_t> newShape;
-  if (!matchPattern(op.shape(), m_TorchListOfConstantInts(newShape)))
+  if (!matchPattern(op.getShape(), m_TorchListOfConstantInts(newShape)))
     return rewriter.notifyMatchFailure(
         op, "Only constant shape supported in TOSA Reshape");
 
@@ -1983,7 +1983,7 @@ LogicalResult ConvertAtenOp<AtenBatchNormOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a ranked tensor output
-  if (!adaptor.input().getType().dyn_cast<RankedTensorType>())
+  if (!adaptor.getInput().getType().dyn_cast<RankedTensorType>())
     return rewriter.notifyMatchFailure(
         op, "Only ranked tensor types are supported");
 
@@ -1992,11 +1992,11 @@ LogicalResult ConvertAtenOp<AtenBatchNormOp>::matchAndRewrite(
   // Note: cudnn_enabled is not handled.
 
   // FIXME: Handle training and momentum.
-  if (op.momentum().getType().isa<Torch::NoneType>())
+  if (op.getMomentum().getType().isa<Torch::NoneType>())
     return rewriter.notifyMatchFailure(op, "Unsupported None for momentum");
 
-  auto meanType = adaptor.running_mean().getType().dyn_cast<TensorType>();
-  auto varianceType = adaptor.running_var().getType().dyn_cast<TensorType>();
+  auto meanType = adaptor.getRunningMean().getType().dyn_cast<TensorType>();
+  auto varianceType = adaptor.getRunningVar().getType().dyn_cast<TensorType>();
   if (!varianceType || !meanType)
     return rewriter.notifyMatchFailure(
         op, "Only ranked tensor types are supported");
@@ -2031,34 +2031,34 @@ LogicalResult ConvertAtenOp<AtenBatchNormOp>::matchAndRewrite(
   assert(meanType.getNumElements() != 0 && varianceType.getNumElements() != 0);
   if (failed(reshapeToNormInputDim(op.getOperation(), rewriter,
                                    getTypeConverter(), outType,
-                                   adaptor.running_mean(), meanVal)))
+                                   adaptor.getRunningMean(), meanVal)))
     return rewriter.notifyMatchFailure(op, "Failed to reshape running mean");
 
   if (failed(reshapeToNormInputDim(op.getOperation(), rewriter,
                                    getTypeConverter(), outType,
-                                   adaptor.running_var(), varianceVal)))
+                                   adaptor.getRunningVar(), varianceVal)))
     return rewriter.notifyMatchFailure(op,
                                        "Failed to reshape running variance");
 
   if (failed(reshapeToNormInputDim(op.getOperation(), rewriter,
                                    getTypeConverter(), outType,
-                                   adaptor.weight(), weightVal)))
+                                   adaptor.getWeight(), weightVal)))
     return rewriter.notifyMatchFailure(op, "Failed to reshape weight");
 
   if (failed(reshapeToNormInputDim(op.getOperation(), rewriter,
-                                   getTypeConverter(), outType, adaptor.bias(),
+                                   getTypeConverter(), outType, adaptor.getBias(),
                                    biasVal)))
     return rewriter.notifyMatchFailure(op, "Failed to reshape bias");
 
   double eps;
-  if (!matchPattern(op.eps(), m_TorchConstantFloat(&eps)))
+  if (!matchPattern(op.getEps(), m_TorchConstantFloat(&eps)))
     return rewriter.notifyMatchFailure(op, "eps must be a scalar constant");
 
   auto epsilonConst =
       mlir::tosa::getTosaConstTensorSingleF32(rewriter, op, eps);
 
   auto batchNorm =
-      computeBatchNorm(op, rewriter, outType, adaptor.input(), varianceVal,
+      computeBatchNorm(op, rewriter, outType, adaptor.getInput(), varianceVal,
                        epsilonConst, meanVal, weightVal, biasVal);
 
   rewriter.replaceOp(op, {batchNorm});
@@ -2079,11 +2079,11 @@ LogicalResult ConvertAtenOp<AtenNativeLayerNormOp>::matchAndRewrite(
   // eventually being reshaped for broadcasting.
 
   // Not a ranked tensor output
-  if (!adaptor.input().getType().dyn_cast<RankedTensorType>())
+  if (!adaptor.getInput().getType().dyn_cast<RankedTensorType>())
     return rewriter.notifyMatchFailure(
         op, "Only ranked tensor types are supported");
 
-  auto inputType = adaptor.input().getType().cast<RankedTensorType>();
+  auto inputType = adaptor.getInput().getType().cast<RankedTensorType>();
   if (inputType.getRank() > 4)
     return rewriter.notifyMatchFailure(op,
                                        "Only up to 4D tensors are supported");
@@ -2093,13 +2093,13 @@ LogicalResult ConvertAtenOp<AtenNativeLayerNormOp>::matchAndRewrite(
   // Note: cudnn_enabled is not handled.
 
   // FIXME: Handle the None cases for the optional parameters.
-  if (adaptor.weight().getType().isa<Torch::NoneType>())
+  if (adaptor.getWeight().getType().isa<Torch::NoneType>())
     return rewriter.notifyMatchFailure(op, "Unsupported None for weight");
-  if (adaptor.bias().getType().isa<Torch::NoneType>())
+  if (adaptor.getBias().getType().isa<Torch::NoneType>())
     return rewriter.notifyMatchFailure(op, "Unsupported None for bias");
 
-  auto weightType = adaptor.weight().getType().cast<RankedTensorType>();
-  auto biasType = adaptor.bias().getType().cast<RankedTensorType>();
+  auto weightType = adaptor.getWeight().getType().cast<RankedTensorType>();
+  auto biasType = adaptor.getBias().getType().cast<RankedTensorType>();
   int64_t inputRank = inputType.getRank();
   Type elemTy = inputType.getElementType();
   SmallVector<int64_t> inputTypeShape(
@@ -2107,7 +2107,7 @@ LogicalResult ConvertAtenOp<AtenNativeLayerNormOp>::matchAndRewrite(
 
   // Check if all the arguments meet the requirements.
   SmallVector<int64_t> normalizedShapeSizesInt;
-  if (!matchPattern(op.normalized_shape(),
+  if (!matchPattern(op.getNormalizedShape(),
                     m_TorchListOfConstantInts(normalizedShapeSizesInt))) {
     return rewriter.notifyMatchFailure(op, "Unimplemented normalized_shape not"
                                            "constructed from ListConstruct");
@@ -2175,14 +2175,14 @@ LogicalResult ConvertAtenOp<AtenNativeLayerNormOp>::matchAndRewrite(
       RankedTensorType::get(makeShapeLLVMCompatible(bcastOutShape), elemTy);
 
   // Compute mean.
-  Value sum = computeSumAndReshape(adaptor.input(), inputType, bcastOutType,
+  Value sum = computeSumAndReshape(adaptor.getInput(), inputType, bcastOutType,
                                    bcastOutShape);
   Value meanVal = rewriter.create<tosa::MulOp>(op.getLoc(), bcastOutType, sum,
                                                elemCntRcp, /*shift=*/0);
 
   // Compute variance.
   Value squareSumSub = rewriter.create<tosa::SubOp>(op.getLoc(), inputType,
-                                                    adaptor.input(), meanVal);
+                                                    adaptor.getInput(), meanVal);
   Value squareSum = rewriter.create<tosa::MulOp>(op.getLoc(), inputType,
                                                  squareSumSub, squareSumSub, 0);
 
@@ -2203,22 +2203,22 @@ LogicalResult ConvertAtenOp<AtenNativeLayerNormOp>::matchAndRewrite(
       makeShapeLLVMCompatible(weightAndBiasBcastShape), elemTy);
 
   Value weightVal = rewriter.create<tosa::ReshapeOp>(
-      op.getLoc(), weightAndMeanBcastType, adaptor.weight(),
+      op.getLoc(), weightAndMeanBcastType, adaptor.getWeight(),
       rewriter.getI64ArrayAttr(weightAndBiasBcastShape));
 
   Value biasVal = rewriter.create<tosa::ReshapeOp>(
-      op.getLoc(), weightAndMeanBcastType, adaptor.bias(),
+      op.getLoc(), weightAndMeanBcastType, adaptor.getBias(),
       rewriter.getI64ArrayAttr(weightAndBiasBcastShape));
 
   double eps;
-  if (!matchPattern(op.eps(), m_TorchConstantFloat(&eps)))
+  if (!matchPattern(op.getEps(), m_TorchConstantFloat(&eps)))
     return rewriter.notifyMatchFailure(op, "eps must be a scalar constant");
   auto epsilonConst =
       mlir::tosa::getTosaConstTensorSingleF32(rewriter, op, eps);
 
   // Compute layer norm.
   auto layerNorm =
-      computeBatchNorm(op, rewriter, outType, adaptor.input(), varianceVal,
+      computeBatchNorm(op, rewriter, outType, adaptor.getInput(), varianceVal,
                        epsilonConst, meanVal, weightVal, biasVal);
 
   rewriter.replaceOp(op, {layerNorm, meanVal, varianceVal});
@@ -2240,7 +2240,7 @@ LogicalResult ConvertAtenOp<ValueTensorLiteralOp>::matchAndRewrite(
   // element type. All tensors with element types other than integer can reuse
   // existing elements attribute.
   // TODO: what about unsigned integer?
-  if (auto elements = op.valueAttr().dyn_cast<DenseIntElementsAttr>()) {
+  if (auto elements = op.getValueAttr().dyn_cast<DenseIntElementsAttr>()) {
     if (elements.getElementType().isSignedInteger()) {
       Type builtinTensorElemTy = outputTy.getElementType();
       unsigned bitWidth = builtinTensorElemTy.getIntOrFloatBitWidth();
@@ -2252,7 +2252,7 @@ LogicalResult ConvertAtenOp<ValueTensorLiteralOp>::matchAndRewrite(
       return success();
     }
   }
-  rewriter.replaceOpWithNewOp<tosa::ConstOp>(op, outputTy, adaptor.value());
+  rewriter.replaceOpWithNewOp<tosa::ConstOp>(op, outputTy, adaptor.getValue());
   return success();
 }
 
@@ -2262,7 +2262,7 @@ LogicalResult ConvertAtenOp<AtenFlattenUsingIntsOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a ranked tensor type
-  auto selfType = adaptor.self().getType().dyn_cast<RankedTensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<RankedTensorType>();
   if (!selfType || !selfType.hasStaticShape())
     return rewriter.notifyMatchFailure(
         op,
@@ -2272,12 +2272,12 @@ LogicalResult ConvertAtenOp<AtenFlattenUsingIntsOp>::matchAndRewrite(
 
   int64_t start_dim, end_dim;
 
-  if (!matchPattern(op.start_dim(), m_TorchConstantInt(&start_dim)))
+  if (!matchPattern(op.getStartDim(), m_TorchConstantInt(&start_dim)))
     return rewriter.notifyMatchFailure(op,
                                        "start_dim must be a Scalar constant");
   start_dim = toPositiveDim(start_dim, selfRank);
 
-  if (!matchPattern(op.end_dim(), m_TorchConstantInt(&end_dim)))
+  if (!matchPattern(op.getEndDim(), m_TorchConstantInt(&end_dim)))
     return rewriter.notifyMatchFailure(op, "end_dim must be a Scalar constant");
   end_dim = toPositiveDim(end_dim, selfRank);
 
@@ -2310,7 +2310,7 @@ LogicalResult ConvertAtenOp<AtenFlattenUsingIntsOp>::matchAndRewrite(
   auto newType = RankedTensorType::get(makeShapeLLVMCompatible(newShape),
                                        selfType.getElementType());
   auto reshapeOp = rewriter.create<tosa::ReshapeOp>(
-      op.getLoc(), newType, adaptor.self(), rewriter.getI64ArrayAttr(newShape));
+      op.getLoc(), newType, adaptor.getSelf(), rewriter.getI64ArrayAttr(newShape));
 
   rewriter.replaceOpWithNewOp<tensor::CastOp>(
       op, getTypeConverter()->convertType(op.getType()), reshapeOp);
@@ -2324,14 +2324,14 @@ LogicalResult ConvertAtenOp<AtenPermuteOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a ranked tensor type
-  auto selfType = adaptor.self().getType().dyn_cast<RankedTensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<RankedTensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op,
         "Only ranked tensor types with static shapes are currently supported");
 
   SmallVector<int64_t> dimListInt;
-  if (!matchPattern(adaptor.dims(), m_TorchListOfConstantInts(dimListInt)))
+  if (!matchPattern(adaptor.getDims(), m_TorchListOfConstantInts(dimListInt)))
     return rewriter.notifyMatchFailure(
         op, "Only constant dimensions are currently supported");
 
@@ -2347,7 +2347,7 @@ LogicalResult ConvertAtenOp<AtenPermuteOp>::matchAndRewrite(
       rewriter, op.getOperation(), dimListInt, {selfRank});
 
   rewriter.replaceOpWithNewOp<tosa::TransposeOp>(
-      op, getTypeConverter()->convertType(op.getType()), adaptor.self(),
+      op, getTypeConverter()->convertType(op.getType()), adaptor.getSelf(),
       transposeDimsConst.value());
 
   return success();
@@ -2359,7 +2359,7 @@ LogicalResult ConvertAtenOp<AtenLog2Op>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op, "Only tensor types are currently supported");
@@ -2374,7 +2374,7 @@ LogicalResult ConvertAtenOp<AtenLog2Op>::matchAndRewrite(
 
   auto outType = getTypeConverter()->convertType(op.getType());
   auto logOp =
-      rewriter.create<tosa::LogOp>(op.getLoc(), outType, adaptor.self());
+      rewriter.create<tosa::LogOp>(op.getLoc(), outType, adaptor.getSelf());
   rewriter.replaceOpWithNewOp<tosa::MulOp>(op, outType, logOp, rcpOp,
                                            /*shift=*/0);
 
@@ -2387,7 +2387,7 @@ LogicalResult ConvertAtenOp<AtenThresholdOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op, "Only tensor types are currently supported");
@@ -2406,12 +2406,12 @@ LogicalResult ConvertAtenOp<AtenThresholdOp>::matchAndRewrite(
 
   SmallVector<int64_t> constTypeShape(selfType.getRank(), 1);
   Value threshold, value;
-  if (failed(torchScalarToTosaTensor(rewriter, op, op.threshold(), threshold,
+  if (failed(torchScalarToTosaTensor(rewriter, op, op.getThreshold(), threshold,
                                      selfElemTy, constTypeShape)))
     return rewriter.notifyMatchFailure(
         op, "Only scalar constant is supported for threshold");
 
-  if (failed(torchScalarToTosaTensor(rewriter, op, op.value(), value,
+  if (failed(torchScalarToTosaTensor(rewriter, op, op.getValue(), value,
                                      selfElemTy, constTypeShape)))
     return rewriter.notifyMatchFailure(
         op, "Only scalar constant is supported for value");
@@ -2423,10 +2423,10 @@ LogicalResult ConvertAtenOp<AtenThresholdOp>::matchAndRewrite(
   auto cmpOp = rewriter.create<tosa::GreaterOp>(
       op.getLoc(),
       RankedTensorType::get(selfType.getShape(), rewriter.getIntegerType(1)),
-      adaptor.self(), threshold);
+      adaptor.getSelf(), threshold);
 
   rewriter.replaceOpWithNewOp<tosa::SelectOp>(op, outType, cmpOp,
-                                              adaptor.self(), value);
+                                              adaptor.getSelf(), value);
 
   return success();
 }
@@ -2437,7 +2437,7 @@ LogicalResult ConvertAtenOp<AtenUnsqueezeOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType) {
     return rewriter.notifyMatchFailure(
         op, "Only tensor types are currently supported");
@@ -2451,7 +2451,7 @@ LogicalResult ConvertAtenOp<AtenUnsqueezeOp>::matchAndRewrite(
   }
 
   int64_t dim;
-  if (!matchPattern(op.dim(), m_TorchConstantInt(&dim)))
+  if (!matchPattern(op.getDim(), m_TorchConstantInt(&dim)))
     return rewriter.notifyMatchFailure(op, "dim must be a Scalar constant");
 
   dim = toPositiveDim(dim, selfRank);
@@ -2468,7 +2468,7 @@ LogicalResult ConvertAtenOp<AtenUnsqueezeOp>::matchAndRewrite(
   }
 
   rewriter.replaceOpWithNewOp<tosa::ReshapeOp>(
-      op, getTypeConverter()->convertType(op.getType()), adaptor.self(),
+      op, getTypeConverter()->convertType(op.getType()), adaptor.getSelf(),
       rewriter.getI64ArrayAttr(outShape));
 
   return success();
@@ -2480,14 +2480,14 @@ LogicalResult ConvertAtenOp<AtenContiguousOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op, "Only tensor types are currently supported");
 
   // FIXME: memory_format is not handled.
 
-  rewriter.replaceOp(op, adaptor.self());
+  rewriter.replaceOp(op, adaptor.getSelf());
 
   return success();
 }
@@ -2498,7 +2498,7 @@ LogicalResult ConvertAtenOp<AtenDropoutOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.input().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getInput().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op, "Only tensor types are currently supported");
@@ -2506,14 +2506,14 @@ LogicalResult ConvertAtenOp<AtenDropoutOp>::matchAndRewrite(
   // FIXME: train and p are not handled.
 
   bool train;
-  if (!matchPattern(op.train(), m_TorchConstantBool(&train)))
+  if (!matchPattern(op.getTrain(), m_TorchConstantBool(&train)))
     return rewriter.notifyMatchFailure(op, "train must be a Scalar constant");
 
   if (train)
     return rewriter.notifyMatchFailure(op, "train must be false");
 
   rewriter.replaceOpWithNewOp<tosa::CastOp>(
-      op, getTypeConverter()->convertType(op.getType()), adaptor.input());
+      op, getTypeConverter()->convertType(op.getType()), adaptor.getInput());
 
   return success();
 }
@@ -2524,7 +2524,7 @@ LogicalResult ConvertAtenOp<AtenViewOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op, "Only tensor types are currently supported");
@@ -2536,12 +2536,12 @@ LogicalResult ConvertAtenOp<AtenViewOp>::matchAndRewrite(
   }
 
   SmallVector<int64_t> outShape;
-  if (!matchPattern(op.size(), m_TorchListOfConstantInts(outShape)))
+  if (!matchPattern(op.getSize(), m_TorchListOfConstantInts(outShape)))
     return rewriter.notifyMatchFailure(op,
                                        "size must consist of Scalar constants");
 
   rewriter.replaceOpWithNewOp<tosa::ReshapeOp>(
-      op, getTypeConverter()->convertType(op.getType()), adaptor.self(),
+      op, getTypeConverter()->convertType(op.getType()), adaptor.getSelf(),
       rewriter.getI64ArrayAttr(outShape));
 
   return success();
@@ -2629,7 +2629,7 @@ LogicalResult ConvertAtenOp<AtenGeluOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op, "Only tensor types are currently supported");
@@ -2642,14 +2642,14 @@ LogicalResult ConvertAtenOp<AtenGeluOp>::matchAndRewrite(
 
   // TODO: Handle approximate.
   std::string approximate;
-  if (!matchPattern(op.approximate(), m_TorchConstantStr(approximate)) ||
+  if (!matchPattern(op.getApproximate(), m_TorchConstantStr(approximate)) ||
       approximate != "none") {
     return rewriter.notifyMatchFailure(op, "Unsupported value of approximate");
   }
 
-  Value cdf = buildUnitNormalCdf(rewriter, op, adaptor.self());
+  Value cdf = buildUnitNormalCdf(rewriter, op, adaptor.getSelf());
   rewriter.replaceOpWithNewOp<tosa::MulOp>(
-      op, getTypeConverter()->convertType(op.getType()), adaptor.self(), cdf,
+      op, getTypeConverter()->convertType(op.getType()), adaptor.getSelf(), cdf,
       /*shift=*/0);
 
   return success();
@@ -2662,7 +2662,7 @@ LogicalResult ConvertAtenOp<AtenGeluBackwardOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op, "Only tensor types are currently supported");
@@ -2675,7 +2675,7 @@ LogicalResult ConvertAtenOp<AtenGeluBackwardOp>::matchAndRewrite(
 
   // TODO: Handle approximate.
   std::string approximate;
-  if (!matchPattern(op.approximate(), m_TorchConstantStr(approximate)) ||
+  if (!matchPattern(op.getApproximate(), m_TorchConstantStr(approximate)) ||
       approximate != "none") {
     return rewriter.notifyMatchFailure(op, "Unsupported value of approximate");
   }
@@ -2692,20 +2692,20 @@ LogicalResult ConvertAtenOp<AtenGeluBackwardOp>::matchAndRewrite(
   Value negOneHalf =
       tosa::getConstTensor<float>(rewriter, op, -0.5, {}).value();
   Value inputSquared = rewriter.create<tosa::MulOp>(
-      loc, selfType, adaptor.self(), adaptor.self(), /*shift=*/0);
+      loc, selfType, adaptor.getSelf(), adaptor.getSelf(), /*shift=*/0);
   Value negHalfInputSquared = rewriter.create<tosa::MulOp>(
       loc, selfType, inputSquared, negOneHalf, /*shift=*/0);
   Value dinput =
       rewriter.create<tosa::ExpOp>(loc, selfType, negHalfInputSquared);
-  Value cdf = buildUnitNormalCdf(rewriter, op, adaptor.self());
+  Value cdf = buildUnitNormalCdf(rewriter, op, adaptor.getSelf());
   Value dinputInput = rewriter.create<tosa::MulOp>(loc, selfType, dinput,
-                                                   adaptor.self(), /*shift=*/0);
+                                                   adaptor.getSelf(), /*shift=*/0);
   Value dinputInputAlpha = rewriter.create<tosa::MulOp>(
       loc, selfType, dinputInput, kAlphaHalf, /*shift=*/0);
   Value cdfExt =
       rewriter.create<tosa::AddOp>(loc, selfType, dinputInputAlpha, cdf);
   rewriter.replaceOpWithNewOp<tosa::MulOp>(
-      op, getTypeConverter()->convertType(op.getType()), adaptor.grad_output(),
+      op, getTypeConverter()->convertType(op.getType()), adaptor.getGradOutput(),
       cdfExt,
       /*shift=*/0);
 
@@ -2717,8 +2717,8 @@ LogicalResult ConvertAtenOp<AtenEmbeddingOp>::matchAndRewrite(
     AtenEmbeddingOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
 
-  Value weight = adaptor.weight();
-  Value indices = adaptor.indices();
+  Value weight = adaptor.getWeight();
+  Value indices = adaptor.getIndices();
   RankedTensorType outType =
       typeConverter->convertType(op.getType()).cast<RankedTensorType>();
 
@@ -2736,12 +2736,12 @@ LogicalResult ConvertAtenOp<AtenEmbeddingOp>::matchAndRewrite(
 
   // FIXME: padding_idx, scale_grad_by_freq and sparse are not handled yet.
   int64_t paddingIdx;
-  if (!matchPattern(op.padding_idx(), m_TorchConstantInt(&paddingIdx)))
+  if (!matchPattern(op.getPaddingIdx(), m_TorchConstantInt(&paddingIdx)))
     return rewriter.notifyMatchFailure(
         op, "only supports constant int padding_idx for embedding op");
 
   bool scaleGradByFreq;
-  if (!matchPattern(op.scale_grad_by_freq(),
+  if (!matchPattern(op.getScaleGradByFreq(),
                     m_TorchConstantBool(&scaleGradByFreq)))
     return rewriter.notifyMatchFailure(
         op, "only supports constant bool scale_grad_by_freq for embedding op");
@@ -2751,7 +2751,7 @@ LogicalResult ConvertAtenOp<AtenEmbeddingOp>::matchAndRewrite(
         "only supports scale_grad_by_freq equals to False for embedding op");
 
   bool isSparse;
-  if (!matchPattern(op.sparse(), m_TorchConstantBool(&isSparse)))
+  if (!matchPattern(op.getSparse(), m_TorchConstantBool(&isSparse)))
     return rewriter.notifyMatchFailure(
         op, "only supports constant bool sparse for embedding op");
   if (isSparse)
@@ -2819,16 +2819,16 @@ LogicalResult ConvertAtenOp<AtenTransposeIntOp>::matchAndRewrite(
     AtenTransposeIntOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
 
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(op, "Only tensor types are supported");
 
   // Only statically resolvable values are currently supported
   int64_t dim0, dim1;
-  if (!matchPattern(op.dim0(), m_TorchConstantInt(&dim0)))
+  if (!matchPattern(op.getDim0(), m_TorchConstantInt(&dim0)))
     return rewriter.notifyMatchFailure(op, "dim0 must be a Scalar constant");
 
-  if (!matchPattern(op.dim1(), m_TorchConstantInt(&dim1)))
+  if (!matchPattern(op.getDim1(), m_TorchConstantInt(&dim1)))
     return rewriter.notifyMatchFailure(op, "dim1 must be a Scalar constant");
 
   dim0 = toPositiveDim(dim0, selfType.getRank());
@@ -2850,7 +2850,7 @@ LogicalResult ConvertAtenOp<AtenTransposeIntOp>::matchAndRewrite(
       rewriter, op.getOperation(), transposeDims, {selfType.getRank()});
 
   rewriter.replaceOpWithNewOp<tosa::TransposeOp>(
-      op, getTypeConverter()->convertType(op.getType()), adaptor.self(),
+      op, getTypeConverter()->convertType(op.getType()), adaptor.getSelf(),
       transposeDimsConst.value());
 
   return success();
@@ -2861,7 +2861,7 @@ LogicalResult ConvertAtenOp<AtenMaxDimOp>::matchAndRewrite(
     AtenMaxDimOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
 
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(op, "Only tensor types are supported");
 
@@ -2875,7 +2875,7 @@ LogicalResult ConvertAtenOp<AtenMaxDimOp>::matchAndRewrite(
 
   // Only statically deducible values are currently supported
   int64_t dim;
-  if (!matchPattern(op.dim(), m_TorchConstantInt(&dim)))
+  if (!matchPattern(op.getDim(), m_TorchConstantInt(&dim)))
     return rewriter.notifyMatchFailure(op, "dim must be a Scalar constant");
 
   dim = toPositiveDim(dim, selfType.getRank());
@@ -2884,7 +2884,7 @@ LogicalResult ConvertAtenOp<AtenMaxDimOp>::matchAndRewrite(
     return rewriter.notifyMatchFailure(op, "dim must be less than tensor rank");
 
   bool keepDim;
-  if (!matchPattern(op.keepdim(), m_TorchConstantBool(&keepDim)))
+  if (!matchPattern(op.getKeepdim(), m_TorchConstantBool(&keepDim)))
     return rewriter.notifyMatchFailure(op, "keepdim must be a Scalar constant");
 
   SmallVector<int64_t> reducedShape, prunedShape;
@@ -2904,12 +2904,12 @@ LogicalResult ConvertAtenOp<AtenMaxDimOp>::matchAndRewrite(
   Value reduceMax = rewriter.create<tosa::ReduceMaxOp>(
       op->getLoc(),
       RankedTensorType::get(makeShapeLLVMCompatible(reducedShape), selfElemType),
-      adaptor.self(), dimAttr);
+      adaptor.getSelf(), dimAttr);
 
   Value argMax = rewriter.create<tosa::ArgMaxOp>(
       op->getLoc(),
       RankedTensorType::get(makeShapeLLVMCompatible(prunedShape), indicesElemType),
-      adaptor.self(), dimAttr);
+      adaptor.getSelf(), dimAttr);
 
   if (argMax.getType() != indicesType) {
     argMax = rewriter.create<tosa::ReshapeOp>(
@@ -2934,14 +2934,14 @@ LogicalResult ConvertAtenOp<AtenSliceTensorOp>::matchAndRewrite(
     AtenSliceTensorOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
 
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType || !selfType.hasStaticShape())
     return rewriter.notifyMatchFailure(
         op, "Only tensor types with static shape are supported");
 
   // Only statically deducible values are currently supported
   int64_t dim;
-  if (!matchPattern(op.dim(), m_TorchConstantInt(&dim)))
+  if (!matchPattern(op.getDim(), m_TorchConstantInt(&dim)))
     return rewriter.notifyMatchFailure(op, "dim must be a Scalar constant");
 
   dim = toPositiveDim(dim, selfType.getRank());
@@ -2950,14 +2950,14 @@ LogicalResult ConvertAtenOp<AtenSliceTensorOp>::matchAndRewrite(
     return rewriter.notifyMatchFailure(op, "dim must less than tensor rank");
 
   int64_t start;
-  if (!matchPattern(op.start(), m_TorchConstantInt(&start)))
+  if (!matchPattern(op.getStart(), m_TorchConstantInt(&start)))
     return rewriter.notifyMatchFailure(op, "start must be a Scalar constant");
 
   if (start < 0)
     return rewriter.notifyMatchFailure(op, "Currently unsupported: start < 0");
 
   int64_t end;
-  if (!matchPattern(op.end(), m_TorchConstantInt(&end)))
+  if (!matchPattern(op.getEnd(), m_TorchConstantInt(&end)))
     return rewriter.notifyMatchFailure(op, "end must be a Scalar constant");
 
   // FIXME: add support for start/end < 0 and end < start
@@ -2966,7 +2966,7 @@ LogicalResult ConvertAtenOp<AtenSliceTensorOp>::matchAndRewrite(
                                        "Currently unsupported: end < start");
 
   int64_t step;
-  if (!matchPattern(op.step(), m_TorchConstantInt(&step)))
+  if (!matchPattern(op.getStep(), m_TorchConstantInt(&step)))
     return rewriter.notifyMatchFailure(op, "step must be a Scalar constant");
 
   if (step != 1)
@@ -2981,7 +2981,7 @@ LogicalResult ConvertAtenOp<AtenSliceTensorOp>::matchAndRewrite(
   sizeSlice[dim] = end - start;
 
   rewriter.replaceOpWithNewOp<tosa::SliceOp>(
-      op, getTypeConverter()->convertType(op.getType()), adaptor.self(),
+      op, getTypeConverter()->convertType(op.getType()), adaptor.getSelf(),
       rewriter.getI64ArrayAttr(startSlice),
       rewriter.getI64ArrayAttr(sizeSlice));
 
@@ -2994,7 +2994,7 @@ LogicalResult ConvertAtenOp<AtenBroadcastToOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType || !selfType.hasStaticShape())
     return rewriter.notifyMatchFailure(
         op, "Only tensor types with static shape are supported");
@@ -3006,7 +3006,7 @@ LogicalResult ConvertAtenOp<AtenBroadcastToOp>::matchAndRewrite(
   }
 
   SmallVector<int64_t> outShape;
-  if (!matchPattern(op.size(), m_TorchListOfConstantInts(outShape)))
+  if (!matchPattern(op.getSize(), m_TorchListOfConstantInts(outShape)))
     return rewriter.notifyMatchFailure(op,
                                        "size must consist of Scalar constants");
 
@@ -3028,7 +3028,7 @@ LogicalResult ConvertAtenOp<AtenBroadcastToOp>::matchAndRewrite(
     }
     // If we reach here, then it means the given case is handled by implicit
     // broadcasting done by tosa.
-    op.replaceAllUsesWith(op.self());
+    op.replaceAllUsesWith(op.getSelf());
     rewriter.eraseOp(op);
     return success();
   }
@@ -3044,18 +3044,18 @@ LogicalResult ConvertAtenOp<AtenWhereSelfOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op, "Only tensor types input are currently supported");
-  auto condType = adaptor.condition().getType().dyn_cast<TensorType>();
+  auto condType = adaptor.getCondition().getType().dyn_cast<TensorType>();
   if (!condType)
     return rewriter.notifyMatchFailure(
         op, "Only tensor types condition are currently supported");
 
   auto outType = getTypeConverter()->convertType(op.getType());
-  rewriter.replaceOpWithNewOp<tosa::SelectOp>(op, outType, adaptor.condition(),
-                                              adaptor.self(), adaptor.other());
+  rewriter.replaceOpWithNewOp<tosa::SelectOp>(op, outType, adaptor.getCondition(),
+                                              adaptor.getSelf(), adaptor.getOther());
 
   return success();
 }
@@ -3066,17 +3066,17 @@ LogicalResult ConvertAtenOp<AtenClampOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType)
     return rewriter.notifyMatchFailure(
         op, "only tensor types input are currently supported");
 
   int64_t int_min, int_max;
-  if (!matchPattern(op.min(), m_TorchConstantInt(&int_min)))
+  if (!matchPattern(op.getMin(), m_TorchConstantInt(&int_min)))
     return rewriter.notifyMatchFailure(
         op, "unimplemented: value `int_min` should be a torch constant int");
 
-  if (!matchPattern(op.max(), m_TorchConstantInt(&int_max)))
+  if (!matchPattern(op.getMax(), m_TorchConstantInt(&int_max)))
     return rewriter.notifyMatchFailure(
         op, "unimplemented: value `int_max` should be a torch constant int");
 
@@ -3087,7 +3087,7 @@ LogicalResult ConvertAtenOp<AtenClampOp>::matchAndRewrite(
 
   auto outType = getTypeConverter()->convertType(op.getType());
   rewriter.replaceOpWithNewOp<tosa::ClampOp>(
-      op, outType, adaptor.self(), min_int, max_int, min_fp, max_fp);
+      op, outType, adaptor.getSelf(), min_int, max_int, min_fp, max_fp);
 
   return success();
 }
@@ -3108,23 +3108,23 @@ LogicalResult ConvertAtenOp<AtenArangeStartStepOp>::matchAndRewrite(
   // TODO: Add support for pin_memory features.
   // The pin_memory should be either `False` or `none`.
   bool pinMemory;
-  if (!op.pin_memory().getType().isa<Torch::NoneType>() &&
-      (!matchPattern(op.pin_memory(), m_TorchConstantBool(&pinMemory)) ||
+  if (!op.getPinMemory().getType().isa<Torch::NoneType>() &&
+      (!matchPattern(op.getPinMemory(), m_TorchConstantBool(&pinMemory)) ||
        pinMemory)) {
     return rewriter.notifyMatchFailure(
         op, "unimplemented: pin_memory must be either None or false");
   }
 
   int64_t start, step, end;
-  if (!matchPattern(op.start(), m_TorchConstantInt(&start)))
+  if (!matchPattern(op.getStart(), m_TorchConstantInt(&start)))
     return rewriter.notifyMatchFailure(
         op, "unimplemented: value `start` should be a torch constant int");
 
-  if (!matchPattern(op.end(), m_TorchConstantInt(&end)))
+  if (!matchPattern(op.getEnd(), m_TorchConstantInt(&end)))
     return rewriter.notifyMatchFailure(
         op, "unimplemented: value `end` should be a torch constant int");
 
-  if (!matchPattern(op.step(), m_TorchConstantInt(&step)))
+  if (!matchPattern(op.getStep(), m_TorchConstantInt(&step)))
     return rewriter.notifyMatchFailure(
         op, "unimplemented: value `step` should be a torch constant int");
 
@@ -3156,7 +3156,7 @@ LogicalResult ConvertAtenOp<PrimNumToTensorScalarOp>::matchAndRewrite(
   // type result tensor has to be of type `f64` which is not supported in the
   // tosa.
   int64_t initValue;
-  if (!matchPattern(op.a(), m_TorchConstantInt(&initValue)))
+  if (!matchPattern(op.getA(), m_TorchConstantInt(&initValue)))
     return rewriter.notifyMatchFailure(
         op, "unimplemented: input should be a torch constant int");
 
@@ -3171,8 +3171,8 @@ LogicalResult ConvertAtenOp<AtenCopyOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
-  auto srcType = adaptor.src().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
+  auto srcType = adaptor.getSrc().getType().dyn_cast<TensorType>();
   if (!selfType || !selfType.hasStaticShape())
     return rewriter.notifyMatchFailure(
         op, "Only tensor types with static shape are supported");
@@ -3183,7 +3183,7 @@ LogicalResult ConvertAtenOp<AtenCopyOp>::matchAndRewrite(
 
   // The non_blocking should be a constant `False`.
   bool nonBlocking;
-  if (!matchPattern(op.non_blocking(), m_TorchConstantBool(&nonBlocking))) {
+  if (!matchPattern(op.getNonBlocking(), m_TorchConstantBool(&nonBlocking))) {
     return rewriter.notifyMatchFailure(
         op, "unimplemented: non_blocking must be a constant");
   } else if (nonBlocking) {
@@ -3199,7 +3199,7 @@ LogicalResult ConvertAtenOp<AtenCopyOp>::matchAndRewrite(
     // broadcasting done by tosa.
     Value result;
     if (failed(tosa::tosaCastTensorToType(
-            rewriter, op, adaptor.src(),
+            rewriter, op, adaptor.getSrc(),
             getTypeConverter()->convertType(op.getType()), result)))
       return rewriter.notifyMatchFailure(
           op, "unimplemented: cast to result type not supported");
@@ -3217,14 +3217,14 @@ LogicalResult ConvertAtenOp<AtenToDtypeOp>::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
 
   // Not a tensor type.
-  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  auto selfType = adaptor.getSelf().getType().dyn_cast<TensorType>();
   if (!selfType || !selfType.hasStaticShape())
     return rewriter.notifyMatchFailure(
         op, "Only tensor types with static shape are supported");
 
   // The non_blocking arg should be a constant `False`.
   bool nonBlocking;
-  if (!matchPattern(op.non_blocking(), m_TorchConstantBool(&nonBlocking))) {
+  if (!matchPattern(op.getNonBlocking(), m_TorchConstantBool(&nonBlocking))) {
     return rewriter.notifyMatchFailure(
         op, "unimplemented: non_blocking arg must be a constant");
   } else if (nonBlocking) {
@@ -3234,7 +3234,7 @@ LogicalResult ConvertAtenOp<AtenToDtypeOp>::matchAndRewrite(
 
   // The copy arg should be a constant `False`.
   bool copy;
-  if (!matchPattern(op.copy(), m_TorchConstantBool(&copy))) {
+  if (!matchPattern(op.getCopy(), m_TorchConstantBool(&copy))) {
     return rewriter.notifyMatchFailure(
         op, "unimplemented: copy arg must be a constant");
   } else if (copy) {
@@ -3243,9 +3243,9 @@ LogicalResult ConvertAtenOp<AtenToDtypeOp>::matchAndRewrite(
   }
 
   // Only `none`, `contiguous` and `preserve` memory_format is supported.
-  if (!op.memory_format().getType().isa<Torch::NoneType>()) {
+  if (!op.getMemoryFormat().getType().isa<Torch::NoneType>()) {
     int64_t memoryFormat;
-    if (!matchPattern(op.memory_format(), m_TorchConstantInt(&memoryFormat)))
+    if (!matchPattern(op.getMemoryFormat(), m_TorchConstantInt(&memoryFormat)))
       return rewriter.notifyMatchFailure(
           op, "unimplemented: the memory format should be specified in "
               "an integer constant");
@@ -3261,7 +3261,7 @@ LogicalResult ConvertAtenOp<AtenToDtypeOp>::matchAndRewrite(
                       .cast<RankedTensorType>();
 
   Value result;
-  if (failed(tosa::tosaCastTensorToType(rewriter, op, adaptor.self(), resultTy,
+  if (failed(tosa::tosaCastTensorToType(rewriter, op, adaptor.getSelf(), resultTy,
                                         result)))
     return rewriter.notifyMatchFailure(op, "conversion to result type failed");
 
@@ -3395,7 +3395,7 @@ public:
                               ConversionPatternRewriter &rewriter, Value &input,
                               ArrayAttr &kernel, ArrayAttr &stride,
                               ArrayAttr &pad, Type &outputTy) const override {
-    auto inputXchw = adaptor.self();
+    auto inputXchw = adaptor.getSelf();
     auto inputTy = inputXchw.getType().template cast<RankedTensorType>();
     if (!inputTy)
       return rewriter.notifyMatchFailure(
@@ -3414,7 +3414,7 @@ public:
     int64_t inputWDim = inputShape[inputRank - 1];
 
     SmallVector<int64_t> outputSize;
-    if (!matchPattern(op.output_size(), m_TorchListOfConstantInts(outputSize)))
+    if (!matchPattern(op.getOutputSize(), m_TorchListOfConstantInts(outputSize)))
       return rewriter.notifyMatchFailure(
           op, "Non-const output_size for adaptive pooling unsupported.");
 
@@ -3511,14 +3511,14 @@ static LogicalResult getOutputTypeAndPoolingParameters(
         op, "NCHW->NHWC transpose requires 3D or 4D tensor");
 
   SmallVector<int64_t, 2> kernelSizeInts, strideInts, paddingInts;
-  if (!matchPattern(op.kernel_size(),
+  if (!matchPattern(op.getKernelSize(),
                     m_TorchListOfConstantInts(kernelSizeInts)))
     return rewriter.notifyMatchFailure(
         op, "Non-const kernel_size for pooling op unsupported");
-  if (!matchPattern(op.stride(), m_TorchListOfConstantInts(strideInts)))
+  if (!matchPattern(op.getStride(), m_TorchListOfConstantInts(strideInts)))
     return rewriter.notifyMatchFailure(
         op, "Non-const stride for pooling op unsupported");
-  if (!matchPattern(op.padding(), m_TorchListOfConstantInts(paddingInts)))
+  if (!matchPattern(op.getPadding(), m_TorchListOfConstantInts(paddingInts)))
     return rewriter.notifyMatchFailure(
         op, "Non-const padding factor for pooling op unsupported");
 
@@ -3529,7 +3529,7 @@ static LogicalResult getOutputTypeAndPoolingParameters(
 
   // FIXME: add ceil_mode support.
   bool ceilMode;
-  if (!matchPattern(op.ceil_mode(), m_TorchConstantBool(&ceilMode)))
+  if (!matchPattern(op.getCeilMode(), m_TorchConstantBool(&ceilMode)))
     return rewriter.notifyMatchFailure(
         op, "only support constant bool ceil_mode for pooling op");
   if (ceilMode)
@@ -3552,7 +3552,7 @@ public:
                               ArrayAttr &kernel, ArrayAttr &stride,
                               ArrayAttr &pad, Type &outputTy) const override {
     SmallVector<int64_t, 2> dilationArray;
-    if (!matchPattern(op.dilation(), m_TorchListOfConstantInts(dilationArray)))
+    if (!matchPattern(op.getDilation(), m_TorchListOfConstantInts(dilationArray)))
       return rewriter.notifyMatchFailure(
           op, "Non-const dilation for pooling op unsupported.");
     // TOSA pooling only supports unit dilation.
@@ -3562,14 +3562,14 @@ public:
 
     if (failed(getOutputTypeAndPoolingParameters<AtenMaxPool2dOp,
                                                  tosa::MaxPool2dOp>(
-            op, rewriter, adaptor.self(), dilationArray, outputTy, kernel,
+            op, rewriter, adaptor.getSelf(), dilationArray, outputTy, kernel,
             stride, pad)))
       return rewriter.notifyMatchFailure(
           op, "invalid pooling parameters or input type");
 
     // Transpose to xHWC
     input = ConvertAtenPoolingBaseOp<AtenMaxPool2dOp, tosa::MaxPool2dOp>::
-        transposePoolingInputToHwc(op, rewriter, adaptor.self());
+        transposePoolingInputToHwc(op, rewriter, adaptor.getSelf());
 
     return success();
   }
@@ -3587,14 +3587,14 @@ public:
     SmallVector<int64_t, 2> dilationArray{1, 1};
     if (failed(getOutputTypeAndPoolingParameters<AtenAvgPool2dOp,
                                                  tosa::AvgPool2dOp>(
-            op, rewriter, adaptor.self(), dilationArray, outputTy, kernel,
+            op, rewriter, adaptor.getSelf(), dilationArray, outputTy, kernel,
             stride, pad)))
       return rewriter.notifyMatchFailure(
           op, "invalid pooling parameters or input type");
 
     // Transpose to xHWC
     input = ConvertAtenPoolingBaseOp<AtenAvgPool2dOp, tosa::AvgPool2dOp>::
-        transposePoolingInputToHwc(op, rewriter, adaptor.self());
+        transposePoolingInputToHwc(op, rewriter, adaptor.getSelf());
 
     return success();
   }
@@ -3625,20 +3625,20 @@ public:
 
     // FIXME: Handle layout, device and pin_memory. Assume dtype has been
     // processed to set output type correctly?
-    if (!op.layout().getType().template isa<Torch::NoneType>())
+    if (!op.getLayout().getType().template isa<Torch::NoneType>())
       return rewriter.notifyMatchFailure(op,
                                          "Only default layout is supported");
 
     bool pinMemory;
-    if (!op.pin_memory().getType().template isa<Torch::NoneType>() &&
-        (!matchPattern(op.pin_memory(), m_TorchConstantBool(&pinMemory)) ||
+    if (!op.getPinMemory().getType().template isa<Torch::NoneType>() &&
+        (!matchPattern(op.getPinMemory(), m_TorchConstantBool(&pinMemory)) ||
          pinMemory)) {
       return rewriter.notifyMatchFailure(
           op, "Unsupported pin_memory, should be either None or false");
     }
 
     SmallVector<int64_t> shape;
-    if (!matchPattern(op.size(), m_TorchListOfConstantInts(shape))) {
+    if (!matchPattern(op.getSize(), m_TorchListOfConstantInts(shape))) {
       return rewriter.notifyMatchFailure(
           op, "Shape must be a list of Scalar constants");
     }
@@ -3680,7 +3680,7 @@ public:
     }
     Value constOp;
     if (failed(torchScalarToTosaTensor(
-            rewriter, op, op.value(), constOp, outElemTy,
+            rewriter, op, op.getValue(), constOp, outElemTy,
             makeShapeTorchCompatible(outType.getShape()))))
       return rewriter.notifyMatchFailure(
           op, "Supplied value must be a Scalar constant");
@@ -3701,8 +3701,8 @@ public:
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     int64_t memoryFormat;
-    if (!op.memory_format().getType().template isa<Torch::NoneType>() &&
-        (!matchPattern(op.memory_format(), m_TorchConstantInt(&memoryFormat)) ||
+    if (!op.getMemoryFormat().getType().template isa<Torch::NoneType>() &&
+        (!matchPattern(op.getMemoryFormat(), m_TorchConstantInt(&memoryFormat)) ||
          memoryFormat != torch_upstream::MemoryFormat::Contiguous)) {
       return op.emitError(
           "unimplemented: only default memory format is supported");
@@ -3710,7 +3710,7 @@ public:
     auto outType = OpConversionPattern<AtenOpT>::getTypeConverter()
                        ->convertType(op.getType())
                        .template dyn_cast<TensorType>();
-    rewriter.replaceOpWithNewOp<tosa::CastOp>(op, outType, adaptor.self());
+    rewriter.replaceOpWithNewOp<tosa::CastOp>(op, outType, adaptor.getSelf());
 
     return success();
   }

--- a/lib/Dialect/Torch/Transforms/DropShapeCalculations.cpp
+++ b/lib/Dialect/Torch/Transforms/DropShapeCalculations.cpp
@@ -33,7 +33,7 @@ public:
   LogicalResult
   matchAndRewrite(ShapeCalculateOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Block *block = &op.body().front();
+    Block *block = &op.getBody().front();
     Operation *terminator = block->getTerminator();
     ValueRange results = terminator->getOperands();
     rewriter.mergeBlockBefore(block, op);

--- a/lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp
+++ b/lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp
@@ -114,7 +114,7 @@ private:
       llvm::StringMap<SlotOp> nameToSlot;
       auto &slotNameToSlots = moduleClassNameToSlots[moduleOp.getClassName()];
       for (auto slotOp : moduleOp.getOps<SlotOp>())
-        slotNameToSlots[slotOp.name()].push_back(slotOp);
+        slotNameToSlots[slotOp.getName()].push_back(slotOp);
     });
 
     // Find all the module slots that are accessed through `PrimGetAttrOp` or
@@ -126,12 +126,12 @@ private:
       Value module;
       StringRef slotName;
       if (auto getAttrOp = llvm::dyn_cast<PrimGetAttrOp>(op)) {
-        module = getAttrOp.receiver();
-        slotName = getAttrOp.name();
+        module = getAttrOp.getReceiver();
+        slotName = getAttrOp.getName();
       } else {
         auto setAttrOp = cast<PrimSetAttrOp>(op);
-        module = setAttrOp.receiver();
-        slotName = setAttrOp.name();
+        module = setAttrOp.getReceiver();
+        slotName = setAttrOp.getName();
       }
 
       auto moduleType = module.getType().cast<NnModuleType>();
@@ -168,31 +168,31 @@ private:
          llvm::zip(nnModule.getOps<SlotOp>(), classType.getOps<AttrOp>())) {
       auto slot = std::get<0>(t);
       auto attr = std::get<1>(t);
-      nameStack.push_back(attr.name().str());
-      if (attr.type().isa<NnModuleType>()) {
+      nameStack.push_back(attr.getName().str());
+      if (attr.getType().isa<NnModuleType>()) {
         if (failed(
-                recursivelyTraverse(slot.value().getDefiningOp<NnModuleOp>())))
+                recursivelyTraverse(slot.getValue().getDefiningOp<NnModuleOp>())))
           return failure();
       } else if (usedSlots.find(slot) != usedSlots.end()) {
         // Only create the GlobalSlotOp if the slot is used at all.
         std::string linkageName = llvm::join(nameStack, ".");
         auto globalSlot = globalSlotBuilder.create<GlobalSlotOp>(
             slot.getLoc(), linkageName,
-            /*sym_visibility=*/nullptr, attr.type());
-        if (attr.isPrivate())
+            /*sym_visibility=*/nullptr, attr.getType());
+        if (attr.getIsPrivate())
           globalSlot.setVisibility(SymbolTable::Visibility::Private);
         assert(slotToGlobalSlot.find(slot) == slotToGlobalSlot.end());
         slotToGlobalSlot[slot] = globalSlot;
-        slotLinkageInfo[slot] = LinkageInfo{linkageName, attr.isPrivate()};
-        globalSlotInitialValues[globalSlot.sym_nameAttr()] = slot.value();
+        slotLinkageInfo[slot] = LinkageInfo{linkageName, attr.getIsPrivate()};
+        globalSlotInitialValues[globalSlot.getSymNameAttr()] = slot.getValue();
       }
       nameStack.pop_back();
     }
     for (auto method : classType.getOps<MethodOp>()) {
-      nameStack.push_back(method.name().str());
+      nameStack.push_back(method.getName().str());
       funcLinkageInfo[{nnModule,
-                       symbolTable.lookup<func::FuncOp>(method.function())}] =
-          LinkageInfo{llvm::join(nameStack, "."), method.isPrivate()};
+                       symbolTable.lookup<func::FuncOp>(method.getFunction())}] =
+          LinkageInfo{llvm::join(nameStack, "."), method.getIsPrivate()};
       nameStack.pop_back();
     }
     return success();
@@ -235,7 +235,7 @@ createGlobalSlotModuleInitializer(ModuleOp module, SymbolTable &symbolTable,
   auto builder = OpBuilder::atBlockBegin(module.getBody());
   auto moduleInitializer =
       builder.create<GlobalSlotModuleInitializerOp>(module.getLoc());
-  Block *body = builder.createBlock(&moduleInitializer.initializer());
+  Block *body = builder.createBlock(&moduleInitializer.getInitializer());
   builder.setInsertionPointToEnd(body);
   SmallVector<Operation *> opsToMove;
   for (Operation &op : *module.getBody()) {
@@ -335,11 +335,11 @@ static LogicalResult analyzeInstances(func::FuncOp func,
   auto walkResult = func.walk([&](PrimGetAttrOp op) {
     if (!op.getType().isa<NnModuleType>())
       return WalkResult::advance();
-    auto instance = mapping.lookupOrNull(op.receiver());
+    auto instance = mapping.lookupOrNull(op.getReceiver());
     assert(instance && "verifyFuncConformsToSubset should ensure this");
     for (auto slot : instance.getDefiningOp<NnModuleOp>().getOps<SlotOp>()) {
-      if (slot.name() == op.name()) {
-        mapping.map(op, slot.value());
+      if (slot.getName() == op.getName()) {
+        mapping.map(op, slot.getValue());
         break;
       }
     }
@@ -442,7 +442,7 @@ static LogicalResult verifyNnModuleValueUses(Value value) {
     if (isa<func::CallOp, PrimGetAttrOp>(op))
       continue;
     // Only allow `value` as the receiver.
-    if (isa<PrimSetAttrOp>(op) && cast<PrimSetAttrOp>(op).value() != value)
+    if (isa<PrimSetAttrOp>(op) && cast<PrimSetAttrOp>(op).getValue() != value)
       continue;
     // TODO: Improve this based on real user use cases.
     // This is a diagnostic that users will hit if they do not conform to
@@ -479,9 +479,9 @@ verifyPublicMonomorphizations(ModuleOp module, SymbolTable &symbolTable,
   bool sawError = false;
   for (auto classType : module.getOps<ClassTypeOp>()) {
     for (auto method : classType.getOps<MethodOp>()) {
-      if (!method.isPrivate()) {
+      if (!method.getIsPrivate()) {
         if (numMonomorphizations[symbolTable.lookup<func::FuncOp>(
-                method.function())] > 1) {
+                method.getFunction())] > 1) {
           method.emitError()
               << "public function with multiple monomorphizations";
           sawError = true;
@@ -501,29 +501,29 @@ static LogicalResult rewriteMonomorphizedFuncClone(
 
   SmallVector<Operation *> toErase;
   auto handlePrimSetAttr = [&](PrimSetAttrOp op) {
-    auto instance = mapping.lookup(op.receiver()).getDefiningOp<NnModuleOp>();
+    auto instance = mapping.lookup(op.getReceiver()).getDefiningOp<NnModuleOp>();
     SlotOp affectedSlot;
     for (auto slot : instance.getOps<SlotOp>()) {
-      if (slot.name() == op.name())
+      if (slot.getName() == op.getName())
         affectedSlot = slot;
     }
     OpBuilder(op).create<GlobalSlotSetOp>(
-        op.getLoc(), objectGraphInfo.getGlobalSlotFor(affectedSlot).sym_name(),
-        op.value());
+        op.getLoc(), objectGraphInfo.getGlobalSlotFor(affectedSlot).getSymName(),
+        op.getValue());
     toErase.push_back(op);
     return WalkResult::advance();
   };
   auto handlePrimGetAttr = [&](PrimGetAttrOp op) {
     if (!op.getType().isa<NnModuleType>()) {
-      auto instance = mapping.lookup(op.receiver()).getDefiningOp<NnModuleOp>();
+      auto instance = mapping.lookup(op.getReceiver()).getDefiningOp<NnModuleOp>();
       SlotOp affectedSlot;
       for (auto slot : instance.getOps<SlotOp>()) {
-        if (slot.name() == op.name())
+        if (slot.getName() == op.getName())
           affectedSlot = slot;
       }
       auto newOp = OpBuilder(op).create<GlobalSlotGetOp>(
           op.getLoc(), op.getType(),
-          objectGraphInfo.getGlobalSlotFor(affectedSlot).sym_name());
+          objectGraphInfo.getGlobalSlotFor(affectedSlot).getSymName());
       op.replaceAllUsesWith(&*newOp);
     }
     toErase.push_back(op);

--- a/lib/Dialect/Torch/Transforms/PrepareForGlobalizeObjectGraph.cpp
+++ b/lib/Dialect/Torch/Transforms/PrepareForGlobalizeObjectGraph.cpp
@@ -31,12 +31,12 @@ public:
   LogicalResult matchAndRewrite(PrimCallMethodOp op,
                                 PatternRewriter &rewriter) const override {
     auto classType = symbolTable.lookup<ClassTypeOp>(
-        op.receiver().getType().cast<NnModuleType>().getClassName());
+        op.getReceiver().getType().cast<NnModuleType>().getClassName());
     assert(classType && "malformed module -- missing ClassTypeOp");
     func::FuncOp func;
     for (auto method : classType.getOps<MethodOp>()) {
-      if (method.name() == op.name()) {
-        func = symbolTable.lookup<func::FuncOp>(method.function());
+      if (method.getName() == op.getName()) {
+        func = symbolTable.lookup<func::FuncOp>(method.getFunction());
         break;
       }
     }

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -38,7 +38,7 @@ bool Torch::getListConstructElements(Value v, SmallVectorImpl<Value> &elems) {
   auto listConstruct = v.getDefiningOp<PrimListConstructOp>();
   if (!listConstruct)
     return false;
-  elems = llvm::to_vector<4>(listConstruct.elements());
+  elems = llvm::to_vector<4>(listConstruct.getElements());
   return true;
 }
 

--- a/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -147,7 +147,9 @@ LOWERING_PIPELINE = "builtin.module(" + ",".join([
     # Handle some complex mlir::math ops (e.g. atan2)
     "convert-math-to-libm",
     "convert-linalg-to-llvm",
+    "expand-strided-metadata",
     "convert-memref-to-llvm",
+    "lower-affine",
     "func.func(convert-arith-to-llvm)",
     "convert-func-to-llvm",
     "convert-cf-to-llvm",


### PR DESCRIPTION
- Support for non-prefixed accessors has been removed. See:
  https://reviews.llvm.org/D136727
- Rename `operands` to `methodOperands` in `prim.CallMethod` since the
  name `operands` overlaps with a builtin method name. See:
  https://reviews.llvm.org/D136727
- Add passes in refbackend to lower memref.subview. See:
  https://reviews.llvm.org/D136377
- Replace `CopyToValueTensorOps` first in `RewriteViewLikeSubgraph` in
  maximize-value-semantics.

  The current implementation of the `RewriteViewLikeSubgraph` pass in
  maximize-value-semantics creates temporarily invalid IR. In
  particular, given a forward slice starting from a
  `CopyToNonValueTensorOp` and ending in `CopyToValueTensorOp`s, the
  pass first replaces all uses of the `CopyToNonValueTensorOp` with
  its operand, which results in all the `CopyToValueTensorOp` users
  having their operand have type `!torch.vtensor`, which is invalid.

  The correct way to do things is to first replace all the
  `CopyToValueTensorOp`s with their operand, and then replace all uses
  of the `CopyToNonValueTensorOp` with its operand.

  This only started failing now because the generated accessor
  `getOperand` for the `CopyToValueTensorOp` now returns a
  `TypedValue<NonValueTensorType>`, which has an assert checking that
  the value returned is of the expected type.