### PR TITLE
[cleanup] Remove disabled e2e test

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/vision_models.py
+++ b/python/torch_mlir_e2e_test/test_suite/vision_models.py
@@ -84,28 +84,6 @@ class IouOfModule(torch.nn.Module):
 def IouOfModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1024, 4), tu.rand(1024, 4))
 
-class MobilenetV2Module(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-        # Reset seed to make model deterministic.
-        torch.manual_seed(0)
-        self.mobilenetv2 = models.mobilenet_v2()
-        self.train(False)
-
-    @export
-    @annotate_args([
-        None,
-        ([-1, 3, -1, -1], torch.float32, True),
-    ])
-    def forward(self, img):
-        return self.mobilenetv2.forward(img)
-
-# TODO (cathyzhyi) The runtime assertion for conv2d with group != 1 is exposed
-# after aten.hardtanh is implemented. Reenable once the the runtime assertion
-# is fixed.
-#@register_test_case(module_factory=lambda: MobilenetV2Module())
-def MobilenetV2Module_basic(module, tu: TestUtils):
-    module.forward(tu.rand(1, 3, 224, 224))
 
 class MobilenetV3Module(torch.nn.Module):
     def __init__(self):


### PR DESCRIPTION
This test has been disabled a long time, and since RefBackend is so slow we don't want to add this unnecessarily. I believe it is covered by downstream testing such as the Shark Tank.