### PR TITLE
Pass op legality info to verifyBackendContractPass

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
@@ -120,7 +120,9 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createLowerToBackendContractPass(int maxIterations, bool decompose,
                                  ArrayRef<std::string> backendLegalOps);
 
-std::unique_ptr<OperationPass<ModuleOp>> createVerifyBackendContractPass();
+std::unique_ptr<OperationPass<ModuleOp>>
+createVerifyBackendContractPass(bool decompose,
+                                ArrayRef<std::string> backendLegalOps);
 
 StringRef getAbstractInterpLibrary();
 

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -346,13 +346,21 @@ def LowerToBackendContract
 def VerifyBackendContract
     : Pass<"torch-verify-backend-contract", "ModuleOp"> {
   let summary = "Check that program satisfies backend contract.";
-  let constructor =
-    "mlir::torch::Torch::createVerifyBackendContractPass()";
+  let constructor = [{
+    mlir::torch::Torch::createVerifyBackendContractPass(
+      /*decompose=*/true, /*backendLegalOps=*/{})
+  }];
   let description = [{
     This pass performs a set of inspections to check that program satisfies backend
     contract. In case of check failure it prints out the error message and returns
     `signalPassFailure()` status.
   }];
+  let options = [
+    Option<"decompose", "decompose", "bool", /*default=*/"true",
+           "Decompose ops.">,
+    ListOption<"backendLegalOps", "backend-legal-ops", "std::string",
+               "List of ops to be considered legal for the backend.">
+  ];
 }
 
 #endif // TORCHMLIR_TORCH_PASSES

--- a/test/Dialect/Torch/verify-backend-contract-error.mlir
+++ b/test/Dialect/Torch/verify-backend-contract-error.mlir
@@ -1,0 +1,7 @@
+// RUN: torch-mlir-opt -torch-verify-backend-contract -split-input-file -verify-diagnostics %s
+func.func @f(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  // expected-error @+2 {{found an op that was marked as backend illegal}}
+  // expected-note @+1 {{this is likely due to}}
+  %t = torch.aten.t %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  return %t : !torch.vtensor<[?,?],f32>
+}


### PR DESCRIPTION
In order to verify if a given IR satisfies the backend contract, the verifier needs to know if decompositions took place, and if so, which ops were decomposed and which were not.

This commit adds two arguments to `verifyBackendContractPass` to specify if decompositions took place and which ops to consider backend legal, similar to the arguments of `LowerToBackendContractPass`.