### PR TITLE
Make `getTensorRank` safe by changing return to `Optional<unsigned>`

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -47,8 +47,8 @@ Value convertTensorToDtype(PatternRewriter &rewriter, Location loc, Value input,
 bool isBuiltInType(Type type);
 
 // Helper funtion to get rank of `Base tensor type`.
-// -1 is returned if the tensorRank can't be determined.
-int getTensorRank(Value tensor);
+// llvm::None is returned if the tensorRank can't be determined.
+Optional<unsigned> getTensorRank(Value tensor);
 
 bool isViewLikeOp(Operation *op);
 

--- a/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
+++ b/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
@@ -279,7 +279,7 @@ public:
     // to i32 as required for the scatter op.
     // 2.) `values` is mapped to `updates` in scatter op.
     // 3.) `input` is mapped to `original` in scatter op.
-    if (getTensorRank(indexTensor) != 1)
+    if (*getTensorRank(indexTensor) != 1)
       return rewriter.notifyMatchFailure(
           op, "unimplemented: index tensor with rank != 1 is not supported");
     auto indexTensorType = indexTensor.getType().cast<BaseTensorType>();

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -137,7 +137,7 @@ static Value getScalarValue(Value input, Location loc,
   Value scalar = nullptr;
   if (auto valueTensorLiteralOp = input.getDefiningOp<ValueTensorLiteralOp>()) {
     if (valueTensorLiteralOp &&
-        getTensorRank(valueTensorLiteralOp.getResult()) == 0) {
+        *getTensorRank(valueTensorLiteralOp.getResult()) == 0) {
       auto tensorType =
           valueTensorLiteralOp.getValue().getType().cast<RankedTensorType>();
       if (tensorType.getElementType().isa<mlir::IntegerType>()) {

--- a/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
+++ b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
@@ -348,10 +348,12 @@ static void markDecomposedOpsAsIllegal(MLIRContext *context,
   target.addIllegalOp<AtenTOp>();
   target.addIllegalOp<Aten_LogSoftmaxBackwardDataOp>();
   target.addDynamicallyLegalOp<AtenMatmulOp>([](AtenMatmulOp op) {
-    int lhsRank = getTensorRank(op.getSelf());
-    int rhsRank = getTensorRank(op.getOther());
+    Optional<unsigned> lhsRank = getTensorRank(op.getSelf());
+    Optional<unsigned> rhsRank = getTensorRank(op.getOther());
+    if (!lhsRank || !rhsRank)
+      return false;
     // Make aten.matmul legal if the following condition is satisfied.
-    return (lhsRank != 2 || rhsRank != 2) && (lhsRank != 3 || rhsRank != 3);
+    return (*lhsRank != 2 || *rhsRank != 2) && (*lhsRank != 3 || *rhsRank != 3);
   });
   target.addIllegalOp<AtenAddcmulOp>();
   target.addIllegalOp<AtenAddcdivOp>();

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -139,15 +139,11 @@ bool Torch::isBuiltInType(Type type) {
   return isa<BuiltinDialect>(type.getDialect());
 }
 
-int Torch::getTensorRank(Value tensor) {
-  int tensorRank = -1;
+Optional<unsigned> Torch::getTensorRank(Value tensor) {
   BaseTensorType tensorType = tensor.getType().cast<BaseTensorType>();
-
-  if (tensorType.hasSizes()) {
-    ArrayRef<int64_t> tensorShape = tensorType.getSizes();
-    tensorRank = tensorShape.size();
-  }
-  return tensorRank;
+  if (!tensorType.hasSizes())
+    return llvm::None;
+  return tensorType.getSizes().size();
 }
 
 bool Torch::isViewLikeOp(Operation *op) {


### PR DESCRIPTION
Currently `getTensorRank` returns -1 if it was unable to get the rank of the tensor. However, not every use in the codebase was checking the return value, and in some cases, the return value was casted to unsigned leading to some infinte loops when an unranked tensor reached a decomposition.

This commit changes the return of `getTensorRank` to `Optional<unsigned>` to make it clear to the user that the function can fail.