### PR TITLE
Add `report_fatal_error` to `getTypeForScalarType`

### DIFF
--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -96,7 +96,7 @@ Type Torch::getTypeForScalarType(
   case torch_upstream::ScalarType::Char:
     return mlir::IntegerType::get(context, 8, signedness);
   default:
-    return Type();
+    llvm::report_fatal_error("unhandled type for getTypeForScalarType");
   }
 }
 


### PR DESCRIPTION
Functions like `getTypeForScalarType` that do a mapping from one set of types to another should not fail, and if they do it should be obvious to the developer that that function has an unhandled case.

Instead of silently failing when encountering an unsupported type, this commit adds a `report_fatal_error` at the end, similar to other type translation functions in this file.