### PR TITLE
[MHLO] Evaluate RuntimeAssertOp at compile time

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -83,6 +83,7 @@ TORCHDYNAMO_XFAIL_SET = {
 }
 
 MHLO_PASS_SET = {
+    "AdaptiveAvgPool2dNonUnitOutputSizeStaticModule_basic",
     "ArangeDtypeFloatModule_basic",
     "ArangeDtypeIntModule_basic",
     "ArangeFalsePinMemoryModule_basic",

--- a/test/Conversion/TorchToMhlo/basic.mlir
+++ b/test/Conversion/TorchToMhlo/basic.mlir
@@ -296,3 +296,14 @@ func.func @torch.aten.cat(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtenso
   %1 = torch.aten.cat %0, %int0 : !torch.list<vtensor>, !torch.int -> !torch.vtensor<[?,?],f32>
   return %1 : !torch.vtensor<[?,?],f32>
 }
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.runtime.assert(
+// CHECK-SAME:                                    %[[ARG_0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK:           return %[[ARG_0]] : !torch.vtensor<[?,?],f32>
+func.func @torch.runtime.assert(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %true = torch.constant.bool true
+  torch.runtime.assert %true, "this should not fail"
+  return %arg0: !torch.vtensor<[?,?],f32>
+}


### PR DESCRIPTION
[MHLO] Evaluate RuntimeAssertOp at compile time, since MHLO doesn't support runtime assertion.

It further enabled `aten.std.correction` op to be lowered to MHLO, and made one of the MHLO tests pass.
