### PR TITLE
Fix decomposition of aten.linear wrt input rank

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -209,6 +209,7 @@ MHLO_PASS_SET = {
     "LayerNormModule_basic",
     "LayerNormNormalizeOverAllDimsModule_basic",
     "LeakyReluBackwardStaticModule_basic",
+    "Linear1DModule_basic",
     "MatmulBroadcastBatchDim_basic",
     "MatmulSingleDynamicBatchDim_basic",
     "Matmul_3d",

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -2490,14 +2490,14 @@ public:
     Value bias = op.getBias();
 
     BaseTensorType inputType = input.getType().cast<BaseTensorType>();
-    if (!inputType.hasSizes() || inputType.getSizes().size() < 2)
+    if (!inputType.hasSizes() || inputType.getSizes().size() < 1)
       return rewriter.notifyMatchFailure(
-          op, "expected input to be rank 2 or greater");
+          op, "expected input to be rank 1 or greater");
 
     BaseTensorType weightType = weight.getType().cast<BaseTensorType>();
-    // `weight` must be a rank 2 matrix.
-    if (!weightType.hasSizes() || weightType.getSizes().size() != 2)
-      return rewriter.notifyMatchFailure(op, "expected weight to be a rank 2");
+    // `weight` must be either a rank 1 or 2 matrix.
+    if (!weightType.hasSizes() || weightType.getSizes().size() >= 2)
+      return rewriter.notifyMatchFailure(op, "expected weight to be either a rank 1 or 2");
 
     SmallVector<int64_t> transposeShape =
         llvm::to_vector(llvm::reverse(weightType.getSizes()));

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -3145,3 +3145,22 @@ class SortIntListReverse(torch.nn.Module):
 @register_test_case(module_factory=lambda: SortIntListReverse())
 def SortIntListReverse_basic(module, tu: TestUtils):
     module.forward()
+
+
+class Linear1DModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+    ])
+    def forward(self, x, weight):
+        return torch.ops.aten.linear(x, weight)
+
+@register_test_case(module_factory=lambda: Linear1DModule())
+def Linear1DModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1), tu.rand(1))


### PR DESCRIPTION
This fix Failed to legalize operation 'torch.aten.linear' that was explicitly marked illegal #1076. 

As per the comment of @ramiro050  here - https://github.com/llvm/torch-mlir/issues/1076#issuecomment-1255578687 -

To match the [op documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.linear.html?highlight=linear), which allows any tensor with rank >= 1, change the expected input tensor rank here - https://github.com/llvm/torch-mlir/blob/4ef6e69ed49f309aa70ea40f12bf7488cd8e3434/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp#L2078.