### PR TITLE
build: match windows CI and Release build steps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ class CMakeBuild(build_py):
             cmake_args = [
                 f"-DCMAKE_BUILD_TYPE=Release",
                 f"-DPython3_EXECUTABLE={sys.executable}",
+                f"-DPython3_FIND_VIRTUALENV=ONLY",
                 f"-DLLVM_TARGETS_TO_BUILD=host",
                 f"-DMLIR_ENABLE_BINDINGS_PYTHON=ON",
                 f"-DLLVM_ENABLE_PROJECTS=mlir",


### PR DESCRIPTION
After a recent LLVM tag update, the Windows Release build failed even
though pre- and post-merge Windows CI builds passed.  This patch makes
the Windows Release build use the same flags as the Window CI build to
try and address the Release build failures in the future.

---

@powderluv This was the only difference I found between Windows CI and Windows Release builds.  I'm not sure if it will resolve the Release build issue, but it's worth a try.

The Release builds for all platforms completed successfully with this patch [https://github.com/llvm/torch-mlir/actions/runs/3823707248], but of course, the true impact of this patch will only be visible once we update the LLVM tag.