### PR TITLE
CI: miscellaneous fixes for Release builds

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Get torch-mlir
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
     - uses: ./.github/actions/setup-build
@@ -72,7 +72,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Get torch-mlir
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
     - uses: ./.github/actions/setup-build
@@ -129,7 +129,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Get torch-mlir
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
     - uses: ./.github/actions/setup-build

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,12 @@
+-r pytorch-requirements.txt
+
+numpy
+pybind11
+wheel
+setuptools
+cmake
+ninja
+
+# Workaround for what should be a torch dep
+# See discussion in #1174
+pyyaml

--- a/build_tools/python_deploy/build_windows.ps1
+++ b/build_tools/python_deploy/build_windows.ps1
@@ -12,7 +12,7 @@
 
 Write-Host "Installing Build Dependencies"
 python -m venv .\mlir_venv\
-.\mlir_venv\Scripts\activate
+.\mlir_venv\Scripts\Activate.PS1
 pip install -r .\requirements.txt
 Write-Host "Build Deps installation completed successfully"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,4 @@
--r pytorch-requirements.txt
-
-numpy
-
-# Build requirements.
-pybind11
-wheel
-setuptools
-cmake
-ninja
-
-# Workaround for what should be a torch dep
-# See discussion in #1174
-pyyaml
+-r build-requirements.txt
 
 # Test Requirements
 pillow

--- a/utils/bazel/docker/Dockerfile
+++ b/utils/bazel/docker/Dockerfile
@@ -28,6 +28,7 @@ RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSIO
 
 # Install torch-mlir requirements
 COPY requirements.txt /opt/app/requirements.txt
+COPY build-requirements.txt /opt/app/build-requirements.txt
 COPY pytorch-requirements.txt /opt/app/pytorch-requirements.txt
 WORKDIR /opt/app
 RUN python3 -m pip install --upgrade pip

--- a/whl-requirements.txt
+++ b/whl-requirements.txt
@@ -1,10 +1,4 @@
--f pytorch-requirements.txt
+-f build-requirements.txt
 
-setuptools>=42
-wheel
-cmake==3.22.2
-ninja==1.10.2
+# Packaging requirements.
 packaging
-pybind11>=2.6.0,!=2.7.0
-PyYAML
-numpy


### PR DESCRIPTION
 - Use v3 of actions/checkout, since the version we use (v2) uses
   Node.js 12, which is deprecated by GitHub.

 - Source the PowerShell venv sctipt (instead of the bash sript) since
   the calling script is a PowerShell script.  Without this, the build
   doesn't use venv at all.

 - Make the build dependencies in whl-requirements.txt (used by
   setup.py) match those in requirements.txt.  To that end, this patch
   creates a build-requirements.txt that is referenced by
   requirements.txt and whl-requirements.txt.