### PR TITLE
Implement quantize_per_tensor and int_repr with their lowering to linalg

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -12,7 +12,10 @@
 
 from torch_mlir_e2e_test.test_suite import COMMON_TORCH_MLIR_LOWERING_XFAILS
 
-LINALG_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS
+LINALG_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS.union({
+    # TODO ERROR: dtype (torch.int8) is not equal to golden dtype (torch.uint8)
+    "Quantize_uint8"
+})
 
 TORCHDYNAMO_XFAIL_SET = {
     #### General TorchDynamo/PyTorch errors
@@ -43,6 +46,10 @@ TORCHDYNAMO_XFAIL_SET = {
     # TODO: This is due to returning a scalar float as output from the test.
     # We should probably just standardize all tests to return tensors.
     "DivIntModule_basic",
+
+    # NotImplementedError: could not find kernel for aten.quantize_per_tensor.default at dispatch key DispatchKey.Meta
+    "Quantize_int8",
+    "Quantize_uint8",
 
     #### Torch-MLIR internal compiler errors
 
@@ -735,6 +742,8 @@ LTC_XFAIL_SET = {
     "DivIntModule_basic",
     "NeFloatIntModule_basic",
     "NeIntModule_basic",
+    "Quantize_int8",
+    "Quantize_uint8",
     "QuantizedMLP_basic",
     "RandLikeDtypeModule_basic",
     "RandLikeModule_basic",

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -3512,6 +3512,55 @@ def Torch_AtenPreluOp : Torch_Op<"aten.prelu", [
   }];
 }
 
+def Torch_AtenQuantizePerTensorOp : Torch_Op<"aten.quantize_per_tensor", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::quantize_per_tensor : (Tensor, float, int, int) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    Torch_FloatType:$scale,
+    Torch_IntType:$zero_point,
+    Torch_IntType:$dtype
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenQuantizePerTensorOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 4, 1);
+    }
+    void AtenQuantizePerTensorOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 4, 1);
+    }
+  }];
+}
+
+def Torch_AtenIntReprOp : Torch_Op<"aten.int_repr", [
+    AllowsTypeRefinement,
+    HasValueSemantics,
+    ReadOnly
+  ]> {
+  let summary = "Generated op for `aten::int_repr : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = [{
+    ParseResult AtenIntReprOp::parse(OpAsmParser &parser, OperationState &result) {
+      return parseDefaultTorchOp(parser, result, 1, 1);
+    }
+    void AtenIntReprOp::print(OpAsmPrinter &printer) {
+      printDefaultTorchOp(printer, *this, 1, 1);
+    }
+  }];
+}
+
 def Torch_AtenUniformOp : Torch_Op<"aten.uniform", [
     AllowsTypeRefinement,
     HasValueSemantics,

--- a/lib/Dialect/Torch/IR/TorchTypes.cpp
+++ b/lib/Dialect/Torch/IR/TorchTypes.cpp
@@ -372,6 +372,10 @@ static Type convertDtypeToBuiltinElementType(MLIRContext *context, Type dtype) {
   } else if (auto integerType = dtype.dyn_cast<IntegerType>()) {
     return IntegerType::get(context, integerType.getWidth(),
                             IntegerType::Signless);
+  } else if (auto integerType = dtype.dyn_cast<QInt8Type>()) {
+    return IntegerType::get(context, 8, IntegerType::Signless);
+  } else if (auto integerType = dtype.dyn_cast<QUInt8Type>()) {
+    return IntegerType::get(context, 8, IntegerType::Signless);
   }
   emitError(UnknownLoc::get(context))
       << "unimplemented: conversion of dtype " << dtype

--- a/lib/Dialect/Torch/Transforms/AbstractInterpLibrary.cpp
+++ b/lib/Dialect/Torch/Transforms/AbstractInterpLibrary.cpp
@@ -7486,6 +7486,14 @@ StringRef mlir::torch::Torch::getAbstractInterpLibrary() {
 "    %4 = call @__torch__.torch_mlir.dialects.torch.importer.jit_ir.build_tools.library_generator.promote_dtypes(%0, %3) : (!torch.list<optional<int>>, !torch.list<int>) -> !torch.int\n"
 "    return %4 : !torch.int\n"
 "  }\n"
+"  func.func @\"__torch_mlir_shape_fn.aten.quantize_per_tensor\"(%arg0: !torch.list<int>, %arg1: !torch.float, %arg2: !torch.int, %arg3: !torch.int) -> !torch.list<int> {\n"
+"    %0 = call @__torch__.torch.jit._shape_functions.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>\n"
+"    return %0 : !torch.list<int>\n"
+"  }\n"
+"  func.func @\"__torch_mlir_shape_fn.aten.int_repr\"(%arg0: !torch.list<int>) -> !torch.list<int> {\n"
+"    %0 = call @__torch__.torch.jit._shape_functions.unary(%arg0) : (!torch.list<int>) -> !torch.list<int>\n"
+"    return %0 : !torch.list<int>\n"
+"  }\n"
 "}\n"
 "";
   // clang-format on

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -110,6 +110,10 @@ Type Torch::getTypeForScalarType(
     return mlir::ComplexType::get(Float64Type::get(context));
   case torch_upstream::ScalarType::ComplexDouble:
     return mlir::ComplexType::get(Float128Type::get(context));
+  case torch_upstream::ScalarType::QInt8:
+    return Torch::QInt8Type::get(context);
+  case torch_upstream::ScalarType::QUInt8:
+    return Torch::QUInt8Type::get(context);
   default:
     llvm::report_fatal_error("unhandled type for getTypeForScalarType");
   }

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/abstract_interp_lib_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/abstract_interp_lib_gen.py
@@ -1090,6 +1090,13 @@ def aten〇add〡dtype(a: Union[int, float], b: Union[int, float]) -> int:
     dtypes = [get_dtype_of_scalar(a), get_dtype_of_scalar(b)]
     return promote_dtypes(ranks, dtypes)
 
+
+def aten〇quantize_per_tensor〡shape(self: List[int], scale: float, zero_point: int, dtype: int) -> List[int]:
+    return upstream_shape_functions.unary(self)
+
+def aten〇int_repr〡shape(self: List[int]) -> List[int]:
+    return upstream_shape_functions.unary(self)
+
 def _maybe_import_op_extensions(args: argparse.Namespace):
     extension_string = str.strip(args.pytorch_op_extensions)
     if len(extension_string) > 0:

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -325,6 +325,8 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::floor_divide : (Tensor, Tensor) -> (Tensor)")
     emit("aten::softplus : (Tensor, Scalar, Scalar) -> (Tensor)")
     emit("aten::prelu : (Tensor, Tensor) -> (Tensor)")
+    emit("aten::quantize_per_tensor : (Tensor, float, int, int) -> (Tensor)")
+    emit("aten::int_repr : (Tensor) -> (Tensor)")
 
     # Random number generation
     emit_with_mutating_variants("aten::uniform : (Tensor, float, float, Generator?) -> (Tensor)")

--- a/python/torch_mlir_e2e_test/test_suite/__init__.py
+++ b/python/torch_mlir_e2e_test/test_suite/__init__.py
@@ -20,6 +20,7 @@ def register_all_tests():
     from . import conv
     from . import norm_like
     from . import quantized_models
+    from . import quantize
     from . import elementwise
     from . import type_promotion
     from . import type_conversion

--- a/python/torch_mlir_e2e_test/test_suite/quantize.py
+++ b/python/torch_mlir_e2e_test/test_suite/quantize.py
@@ -1,0 +1,48 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.framework import TestUtils
+from torch_mlir_e2e_test.registry import register_test_case
+from torch_mlir_e2e_test.annotations import annotate_args, export
+
+# ==============================================================================
+
+
+class QuantizeInt8(torch.nn.Module):
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        y = torch.int_repr(torch.quantize_per_tensor(x, 1.0, 0, torch.qint8))
+        y2 = torch.int_repr(torch.quantize_per_tensor(x, 2.0, -100, torch.qint8))
+        return y, y2
+
+@register_test_case(module_factory=lambda: QuantizeInt8())
+def Quantize_int8(module, tu: TestUtils):
+    module.forward(tu.rand(3, 5, low=-10, high=10))
+    module.forward(torch.FloatTensor([[-129, -128, -127], [126, 127, 128]]))
+    module.forward(torch.FloatTensor([[-1.5, -0.5], [0.5, 1.5]]))
+
+class QuantizeUInt8(torch.nn.Module):
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        y = torch.int_repr(torch.quantize_per_tensor(x, 1.0, 0, torch.quint8))
+        y2 = torch.int_repr(torch.quantize_per_tensor(x, 2.0, 3, torch.quint8))
+        return y, y2
+
+
+@register_test_case(module_factory=lambda: QuantizeUInt8())
+def Quantize_uint8(module, tu: TestUtils):
+    module.forward(tu.rand(3, 5, low=-10, high=10))
+    module.forward(torch.FloatTensor([[-1, 0, 1], [254, 255, 256]]))
+    module.forward(torch.FloatTensor([[-1.5, -0.5], [0.5, 1.5]]))


### PR DESCRIPTION
This PR adds support for `quantize_per_tensor` and `int_repr` and their lowering to Linalg.
The use case is to support the pattern `int_repr(quantize_per_tensor(x, scale, zero_point, type))`, which is used by the brevitas quantizer.

While working on this PR, I discovered two issues that make lowering `quantize_per_tensor` fail for `quint8` and `qint32`. `qint8` works and is the value of this PR.
(1) For uint8, I get `ERROR: dtype (torch.int8) is not equal to golden dtype (torch.uint8)` in the e2e test. It's unclear to me why this happens and how to fix. After learning more about it, I will fix it in a follow-up PR.
(2) qint32 doesn't even have a type representation in `TorchTypes.td` yet.

The strategy to lower `quantize_per_tensor` is to do `cast(clamp(round(input/scale + zero_point))` into an integer type.
Doing that, `int_repr` becomes a no-op. When we want to implement other operators that work on quantized types (like qint8),
we will also need to carry the side-channel information scale and zero_point to them. For `int_repr`, this is not needed because it doesn't use that information.

*Details*:
With this PR from
```
  def forward(self, x):
   return torch.int_repr(torch.quantize_per_tensor(x, 0.5, 0, torch.qint8))
```
we first get
```
module attributes {torch.debug_module_name = "TestModule"} {
  func.func @forward(%arg0: !torch.vtensor<[3],f32>, %arg1: !torch.vtensor<[3],f32>) -> !torch.vtensor<[3],si8> {
    %float5.000000e-01 = torch.constant.float 5.000000e-01
    %int0 = torch.constant.int 0
    %int12 = torch.constant.int 12
    %0 = torch.aten.quantize_per_tensor %arg0, %float5.000000e-01, %int0, %int12 : !torch.vtensor<[3],f32>, !torch.float, !torch.int, !torch.int -> !torch.vtensor<[3],!torch.qint8>
    %1 = torch.aten.int_repr %0 : !torch.vtensor<[3],!torch.qint8> -> !torch.vtensor<[3],si8>
    return %1 : !torch.vtensor<[3],si8>
  }
}
```
and then lower that into
```
 #map = affine_map<(d0) -> (d0)>
module attributes {torch.debug_module_name = "TestModule"} {
  ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>
  func.func @forward(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> tensor<3xi8> {
    %cst = arith.constant 0.000000e+00 : f32
    %cst_0 = arith.constant 2.550000e+02 : f32
    %0 = tensor.empty() : tensor<3xi8>
    %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%arg0 : tensor<3xf32>) outs(%0 : tensor<3xi8>) {
    ^bb0(%in: f32, %out: i8):
      %2 = arith.addf %in, %cst : f32
      %3 = math.roundeven %2 : f32
      %4 = arith.maxf %3, %cst : f32
      %5 = arith.minf %4, %cst_0 : f32
      %6 = arith.fptoui %5 : f32 to i8
      linalg.yield %6 : i8
    } -> tensor<3xi8>
    return %1 : tensor<3xi8>
  }
}
```