### PR TITLE
Enable VerifyBackendContract in LTC backend

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
@@ -121,7 +121,7 @@ createLowerToBackendContractPass(int maxIterations, bool decompose,
                                  ArrayRef<std::string> backendLegalOps);
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createVerifyBackendContractPass();
+createVerifyBackendContractNoDecompositionsPass();
 
 StringRef getAbstractInterpLibrary();
 

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.h
@@ -121,8 +121,7 @@ createLowerToBackendContractPass(int maxIterations, bool decompose,
                                  ArrayRef<std::string> backendLegalOps);
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createVerifyBackendContractPass(bool decompose,
-                                ArrayRef<std::string> backendLegalOps);
+createVerifyBackendContractPass();
 
 StringRef getAbstractInterpLibrary();
 

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -348,7 +348,7 @@ def VerifyBackendContract
   let summary = "Check that program satisfies backend contract.";
   let constructor = [{
     mlir::torch::Torch::createVerifyBackendContractPass(
-      /*decompose=*/true, /*backendLegalOps=*/{})
+      /*decompose=*/false, /*backendLegalOps=*/{})
   }];
   let description = [{
     This pass performs a set of inspections to check that program satisfies backend
@@ -356,7 +356,7 @@ def VerifyBackendContract
     `signalPassFailure()` status.
   }];
   let options = [
-    Option<"decompose", "decompose", "bool", /*default=*/"true",
+    Option<"decompose", "decompose", "bool", /*default=*/"false",
            "Decompose ops.">,
     ListOption<"backendLegalOps", "backend-legal-ops", "std::string",
                "List of ops to be considered legal for the backend.">

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -343,16 +343,16 @@ def LowerToBackendContract
   let dependentDialects = ["func::FuncDialect"];
 }
 
-def VerifyBackendContract
-    : Pass<"torch-verify-backend-contract", "ModuleOp"> {
+def VerifyBackendContractNoDecompositions
+    : Pass<"torch-verify-backend-contract-no-decompositions", "ModuleOp"> {
   let summary = "Check that program satisfies backend contract.";
   let constructor = [{
-    mlir::torch::Torch::createVerifyBackendContractPass()
+    mlir::torch::Torch::createVerifyBackendContractNoDecompositionsPass()
   }];
   let description = [{
     This pass performs a set of inspections to check that program satisfies backend
-    contract. In case of check failure it prints out the error message and returns
-    `signalPassFailure()` status.
+    contract assuming that no decompositions were applied. In case of check failure
+    it prints out the error message and returns `signalPassFailure()` status.
   }];
 }
 

--- a/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/Torch/Transforms/Passes.td
@@ -347,20 +347,13 @@ def VerifyBackendContract
     : Pass<"torch-verify-backend-contract", "ModuleOp"> {
   let summary = "Check that program satisfies backend contract.";
   let constructor = [{
-    mlir::torch::Torch::createVerifyBackendContractPass(
-      /*decompose=*/false, /*backendLegalOps=*/{})
+    mlir::torch::Torch::createVerifyBackendContractPass()
   }];
   let description = [{
     This pass performs a set of inspections to check that program satisfies backend
     contract. In case of check failure it prints out the error message and returns
     `signalPassFailure()` status.
   }];
-  let options = [
-    Option<"decompose", "decompose", "bool", /*default=*/"false",
-           "Decompose ops.">,
-    ListOption<"backendLegalOps", "backend-legal-ops", "std::string",
-               "List of ops to be considered legal for the backend.">
-  ];
 }
 
 #endif // TORCHMLIR_TORCH_PASSES

--- a/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
+++ b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
@@ -289,15 +289,12 @@ class VerifyBackendContractPass
     : public VerifyBackendContractBase<VerifyBackendContractPass> {
 public:
   VerifyBackendContractPass() = default;
-  VerifyBackendContractPass(bool decompose,
-                            ArrayRef<std::string> backendLegalOps) {
-    this->decompose = decompose;
-    this->backendLegalOps = backendLegalOps;
-  }
+
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ConversionTarget target =
-        getBackendContractTarget(context, decompose, backendLegalOps);
+        getBackendContractTarget(context, /*decompose*/false,
+                                 /*backendLegalOps*/{});
 
     if (!satisfiesBackendContract(getOperation(), target,
                                   /*actuallyEmitDiagnostics=*/true)) {
@@ -315,10 +312,8 @@ mlir::torch::Torch::createLowerToBackendContractPass(
 }
 
 std::unique_ptr<OperationPass<ModuleOp>>
-mlir::torch::Torch::createVerifyBackendContractPass(
-    bool decompose, ArrayRef<std::string> backendLegalOps) {
-  return std::make_unique<VerifyBackendContractPass>(decompose,
-                                                     backendLegalOps);
+mlir::torch::Torch::createVerifyBackendContractPass() {
+  return std::make_unique<VerifyBackendContractPass>();
 }
 
 // The backend contract guarantees that ops with decompositions available will

--- a/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
+++ b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
@@ -285,10 +285,10 @@ public:
   }
 };
 
-class VerifyBackendContractPass
-    : public VerifyBackendContractBase<VerifyBackendContractPass> {
+class VerifyBackendContractNoDecompositionsPass
+    : public VerifyBackendContractNoDecompositionsBase<VerifyBackendContractNoDecompositionsPass> {
 public:
-  VerifyBackendContractPass() = default;
+  VerifyBackendContractNoDecompositionsPass() = default;
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
@@ -312,8 +312,8 @@ mlir::torch::Torch::createLowerToBackendContractPass(
 }
 
 std::unique_ptr<OperationPass<ModuleOp>>
-mlir::torch::Torch::createVerifyBackendContractPass() {
-  return std::make_unique<VerifyBackendContractPass>();
+mlir::torch::Torch::createVerifyBackendContractNoDecompositionsPass() {
+  return std::make_unique<VerifyBackendContractNoDecompositionsPass>();
 }
 
 // The backend contract guarantees that ops with decompositions available will

--- a/python/torch_mlir/csrc/base_lazy_backend/CMakeLists.txt
+++ b/python/torch_mlir/csrc/base_lazy_backend/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(torch_mlir_ltc_backend SHARED
   mlir_node.cpp
   ops/device_data.cpp
   ops/generic.cpp
+  utils/jit_utils.cpp
   utils/tensor_utils.cpp
 )
 target_compile_features(torch_mlir_ltc_backend PRIVATE cxx_std_17)

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -162,7 +162,7 @@ ComputationPtr TorchMlirLoweringContext::Build() {
   auto pass_manager = mlirPassManagerCreate(mlir_context_);
   mlirPassManagerAddOwnedPass(
     pass_manager,
-    mlirCreateVerifyBackendContract()
+    mlirCreateVerifyBackendContractNoDecompositions()
   );
 
   MlirLogicalResult result = mlirPassManagerRun(

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -14,7 +14,6 @@
 
 #include <torch/csrc/jit/api/compilation_unit.h>
 #include <torch/csrc/jit/passes/refine_tuple_types.h>
-#include <torch/csrc/jit/passes/convert_scalar_implicit.h>
 #include <torch/csrc/lazy/core/lazy_graph_executor.h>
 #include "torch-mlir-c/Registration.h"
 #include "torch-mlir-c/Transforms.h"
@@ -27,6 +26,7 @@
 #include "mlir_node.h"
 #include "utils/debug.h"
 #include "utils/exception.h"
+#include "utils/jit_utils.h"
 #include "utils/string_utils.h"
 #include "utils/sys_utils.h"
 

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h
@@ -73,7 +73,7 @@ public:
   // embedded builder (returned by the builder() API).
   torch::lazy::ComputationPtr Build() override;
 
-  virtual torch::lazy::ComputationPtr CreateComputation(MlirOperation func_op);
+  virtual torch::lazy::ComputationPtr CreateComputation(MlirModule module_op);
 
   // Retrieves the lowered operation for an output. If the requested output is
   // not available yet, the graph behind the output's Node is lowered, and the
@@ -123,7 +123,7 @@ public:
   using InputOutputAlias = TorchMlirLoweringContext::InputOutputAlias;
 
   TorchMlirComputation(
-      MlirOperation func_op, MlirContext mlir_context,
+      MlirModule module_op, MlirContext mlir_context,
       const std::shared_ptr<torch::jit::Graph>& graph,
       std::unordered_map<int, std::string> parameters_map,
       InputOutputAliases input_output_aliases);
@@ -142,6 +142,8 @@ public:
 
   MlirOperation func_op() const;
 
+  MlirModule module_op() const;
+
   MlirContext mlir_context() const;
 
   virtual const std::string debug_string() const;
@@ -155,7 +157,7 @@ protected:
   std::vector<Shape> parameter_shapes_;
   Shape result_shape_;
 
-  MlirOperation func_op_;
+  MlirModule module_op_;
   MlirContext mlir_context_;
   std::shared_ptr<torch::jit::Graph> graph_;
   InputOutputAliases input_output_aliases_;

--- a/python/torch_mlir/csrc/base_lazy_backend/utils/jit_utils.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/utils/jit_utils.cpp
@@ -1,0 +1,45 @@
+#include "jit_utils.h"
+
+#include <torch/csrc/jit/runtime/graph_iterator.h>
+
+#include <ATen/core/type_factory.h>
+
+namespace torch {
+namespace jit {
+
+void ConvertScalarImplicit(std::shared_ptr<Graph>& graph) {
+  DepthFirstGraphNodeIterator it(graph);
+  for (auto* node = it.next(); node != nullptr; node = it.next()) {
+    if (node->kind() != c10::aten::ScalarImplicit) {
+      continue;
+    }
+
+    auto input = node->input(0);
+    auto scalar_type = input->type()->cast<c10::TensorType>()->scalarType();
+    TORCH_CHECK(scalar_type, "scalar type is not defined for input value");
+
+    NodeKind node_type;
+    TypePtr output_type;
+    if (c10::isIntegralType(*scalar_type, false)) {
+      node_type = c10::aten::IntImplicit;
+      output_type = IntType::get();
+    } else if (c10::isFloatingType(*scalar_type)) {
+      node_type = c10::aten::FloatImplicit;
+      output_type = FloatType::get();
+    } else {
+      throw std::runtime_error(
+        "Expected isIntegralType or isFloatingType");
+    }
+
+    Value * output = graph
+        ->create(node_type, {input})
+        ->insertBefore(node)
+        ->output()
+        ->setType(output_type);
+    node->output()->replaceAllUsesWith(output);
+    node->destroy();
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/python/torch_mlir/csrc/base_lazy_backend/utils/jit_utils.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/utils/jit_utils.h
@@ -1,0 +1,10 @@
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+// Convert ScalarImplicit to IntImplicit or FloatImplicit.
+TORCH_API void ConvertScalarImplicit(std::shared_ptr<Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/test/Dialect/Torch/verify-backend-contract-error.mlir
+++ b/test/Dialect/Torch/verify-backend-contract-error.mlir
@@ -1,7 +1,7 @@
-// RUN: torch-mlir-opt -torch-verify-backend-contract -split-input-file -verify-diagnostics %s
-func.func @f(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
-  // expected-error @+2 {{found an op that was marked as backend illegal}}
-  // expected-note @+1 {{this is likely due to}}
-  %t = torch.aten.t %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
-  return %t : !torch.vtensor<[?,?],f32>
+// RUN: torch-mlir-opt -torch-verify-backend-contract-no-decompositions -split-input-file -verify-diagnostics %s
+func.func @f(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor {
+  // expected-error @below {{unsupported by backend contract: tensor with unknown rank}}
+  // expected-note @below {{this is likely due to a missing transfer function}}
+  %t = torch.aten.t %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor
+  return %t : !torch.vtensor
 }


### PR DESCRIPTION
### Description
In this PR I enable `VerifyBackendContract` pass as a part of LTC backend contract to check that MLIR satisfies backend requirements. See https://github.com/llvm/torch-mlir/issues/1460 for more details.

### Changes
* Update `TorchMlirLoweringContext::Build` with `VerifyBackendContract` pass execution.
* Updated `TorchMlirComputation` to accept `MlirModule`.
* Removed useless `VerifyBackendContract` pass parametrization.

This PR depends on changes in PyTorch https://github.com/pytorch/pytorch/pull/92095 so once they land I will mark this PR as ready for review. 