### PR TITLE
Use delvewheel to package windows DLLs

### DIFF
--- a/build_tools/python_deploy/build_windows.ps1
+++ b/build_tools/python_deploy/build_windows.ps1
@@ -14,6 +14,7 @@ Write-Host "Installing Build Dependencies"
 python -m venv .\mlir_venv\
 .\mlir_venv\Scripts\Activate.PS1
 pip install -r .\requirements.txt
+pip install delvewheel
 Write-Host "Build Deps installation completed successfully"
 
 Write-Host "Building torch-mlir"
@@ -22,3 +23,7 @@ $env:TORCH_MLIR_ENABLE_LTC='0'
 python -m pip wheel -v -w  wheelhouse ./  -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html  -r whl-requirements.txt
 
 Write-Host "Build completed successfully"
+
+Write-Host "Fixing up wheel dependencies"
+delvewheel repair --add-path .\build\cmake_build\tools\torch-mlir\python_packages\torch_mlir\torch_mlir\_mlir_libs --add-dll TorchMLIRAggregateCAPI.dll --no-dll 'c10.dll;torch_python.dll;torch_cpu.dll' -v (get-item .\wheelhouse\torch_mlir*.whl).FullName
+Write-Host "All Done."


### PR DESCRIPTION
Use the delvewheel to package our windows whl. It is similar to auditwheel in Linux.

Test: Import and run the samples via torch-mlir on windows

Fixes https://github.com/llvm/torch-mlir/issues/1819