### PR TITLE
[MHLO] Support cumsum op in mhlo backend

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -107,6 +107,8 @@ MHLO_PASS_SET = {
     "BroadcastToModule_basic",
     "BroadcastToSameRankStaticModule_basic",
     "BroadcastZeroRankInputStaticModule_basic",
+    "CumsumStaticModule_basic",
+    "CumsumStaticNegativeDimModule_basic",
     "ElementwiseAtenLogicalAndOpPromoteBroadcastStaticShapeModule_basic",
     "ElementwiseAtenLogicalNotOpModule_basic",
     "ElementwiseAtenLogicalNotOpPromoteModule_basic",

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -3035,6 +3035,23 @@ class CumsumStaticModule(torch.nn.Module):
 def CumsumStaticModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 7, 4))
 
+class CumsumStaticNegativeDimModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([2, 7, 4], torch.float32, True),
+    ])
+    def forward(self, val):
+        return torch.ops.aten.cumsum(val, dim=-1)
+
+@register_test_case(module_factory=lambda: CumsumStaticNegativeDimModule())
+def CumsumStaticNegativeDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 7, 4))
+
 # ==============================================================================
 
 class AtenToDeviceModule(torch.nn.Module):


### PR DESCRIPTION
This PR supports lowering `aten.cumsum` op to the MHLO backend. The static-shape cumsum e2e test has passed in MHLO config.