### PR TITLE
[TOSA] Add aten.cumsum tosa support

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -632,6 +632,8 @@ TOSA_PASS_SET = {
     "ArgmaxModule_with_dim",
     "_LogSoftmaxModuleStable_basic",
     "ElementwiseAtenWhereSelfModule_basic",
+    "CumsumStaticModule_basic",
+    "CumsumStaticNegativeDimModule_basic",
     "ElementwiseUnsqueezeBroadcastModule_basic",
     "MaskedFillScalarIntValueModule_basic",
     "MaskedFillScalarIntValueStaticModule_basic",


### PR DESCRIPTION
Find this issue when lower opt model: https://github.com/nod-ai/SHARK/issues/865

[opt_torchbackend.mlir](https://gist.github.com/AmosLewis/3faccdf32c91d30f21daed12bf7197b4#file-opt_torchbackend-mlir)

https://pytorch.org/docs/stable/generated/torch.cumsum.html

Related patch cumsum in TMTensor https://github.com/llvm/torch-mlir/pull/1320


```
func.func @torch.aten.to.dtype(%arg0: !torch.vtensor<[1,6],si64>) -> !torch.vtensor<[1,6],si64> {
  %int1 = torch.constant.int 1
  %none = torch.constant.none
  %0 =  torch.aten.cumsum %arg0, %int1, %none : !torch.vtensor<[1,6],si64>, !torch.int, !torch.none -> !torch.vtensor<[1,6],si64>
  return %0 : !torch.vtensor<[1,6],si64>
}
```

`torch-mlir-opt -convert-torch-to-tosa /tmp/cumsum.mlir`

```
module {
  func.func @torch.aten.to.dtype(%arg0: !torch.vtensor<[1,6],si64>) -> !torch.vtensor<[1,6],si64> {
    %0 = torch_c.to_builtin_tensor %arg0 : !torch.vtensor<[1,6],si64> -> tensor<1x6xi64>
    %int1 = torch.constant.int 1
    %none = torch.constant.none
    %1 = "tosa.slice"(%0) {size = array<i64: 1, 1>, start = array<i64: 0, 0>} : (tensor<1x6xi64>) -> tensor<1x1xi64>
    %2 = "tosa.reduce_sum"(%1) {axis = 1 : i64} : (tensor<1x1xi64>) -> tensor<1x1xi64>
    %3 = "tosa.slice"(%0) {size = array<i64: 1, 2>, start = array<i64: 0, 0>} : (tensor<1x6xi64>) -> tensor<1x2xi64>
    %4 = "tosa.reduce_sum"(%3) {axis = 1 : i64} : (tensor<1x2xi64>) -> tensor<1x1xi64>
    %5 = "tosa.slice"(%0) {size = array<i64: 1, 3>, start = array<i64: 0, 0>} : (tensor<1x6xi64>) -> tensor<1x3xi64>
    %6 = "tosa.reduce_sum"(%5) {axis = 1 : i64} : (tensor<1x3xi64>) -> tensor<1x1xi64>
    %7 = "tosa.slice"(%0) {size = array<i64: 1, 4>, start = array<i64: 0, 0>} : (tensor<1x6xi64>) -> tensor<1x4xi64>
    %8 = "tosa.reduce_sum"(%7) {axis = 1 : i64} : (tensor<1x4xi64>) -> tensor<1x1xi64>
    %9 = "tosa.slice"(%0) {size = array<i64: 1, 5>, start = array<i64: 0, 0>} : (tensor<1x6xi64>) -> tensor<1x5xi64>
    %10 = "tosa.reduce_sum"(%9) {axis = 1 : i64} : (tensor<1x5xi64>) -> tensor<1x1xi64>
    %11 = "tosa.slice"(%0) {size = array<i64: 1, 6>, start = array<i64: 0, 0>} : (tensor<1x6xi64>) -> tensor<1x6xi64>
    %12 = "tosa.reduce_sum"(%11) {axis = 1 : i64} : (tensor<1x6xi64>) -> tensor<1x1xi64>
    %13 = "tosa.concat"(%2, %4, %6, %8, %10, %12) {axis = 1 : i64} : (tensor<1x1xi64>, tensor<1x1xi64>, tensor<1x1xi64>, tensor<1x1xi64>, tensor<1x1xi64>, tensor<1x1xi64>) -> tensor<1x6xi64>
    %14 = torch_c.from_builtin_tensor %13 : tensor<1x6xi64> -> !torch.vtensor<[1,6],si64>
    return %14 : !torch.vtensor<[1,6],si64>
  }
}
```
