### PR TITLE
[TOSA] Fix broadcast_to input and output different shape support

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -679,6 +679,10 @@ TOSA_PASS_SET = {
     "HardsigmoidRandomModule_basic",
     "HardswishModule_basic",
     "HardswishRandomModule_basic",
+    "FullLikeModuleInt2DStatic_basic",
+    "FullModuleInt3D_basic",
+    "FullModuleFloat2D_basic",
+    "RepeatModule_basic"
 }
 
 LTC_XFAIL_SET = {


### PR DESCRIPTION
Find this in OPT model : https://github.com/nod-ai/SHARK/issues/865

If you have an elementwise op, those support implicit broadcasting, so you could choose one that shouldn't affect the result and use that. It's a bit tricky with FP to find that right op.
In TOSA, elementwise ops like ADD are defined to broadcast where needed along axis of size 1. You could add a constant tensor of 0 to your tensor with the right shape [1,1,128,1], and that should get a result tensor of [1,1,128,128].

https://gist.github.com/AmosLewis/2890afedc18b40f2860fc9605bf272e0

```
func.func @torch.aten.broadcast_to(%arg0: !torch.vtensor<[1,1,1,128],i1>) -> !torch.vtensor<[1,1,128,128],i1> {
  %int1 = torch.constant.int 1
  %int128 = torch.constant.int 128
  %1 = torch.prim.ListConstruct %int1, %int1, %int128, %int128 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
  %0 = torch.aten.broadcast_to %arg0, %1 : !torch.vtensor<[1,1,1,128],i1>, !torch.list<int> -> !torch.vtensor<[1,1,128,128],i1>
  return %0 : !torch.vtensor<[1,1,128,128],i1>
}
```

```
module {
  func.func @torch.aten.broadcast_to(%arg0: !torch.vtensor<[1,1,1,128],i1>) -> !torch.vtensor<[1,1,128,128],i1> {
    %0 = torch_c.to_builtin_tensor %arg0 : !torch.vtensor<[1,1,1,128],i1> -> tensor<1x1x1x128xi1>
    %int1 = torch.constant.int 1
    %int128 = torch.constant.int 128
    %1 = torch.prim.ListConstruct %int1, %int1, %int128, %int128 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
    %2 = "tosa.const"() {value = dense<0> : tensor<1x1x128x128xi64>} : () -> tensor<1x1x128x128xi64>
    %3 = "tosa.add"(%0, %2) : (tensor<1x1x1x128xi1>, tensor<1x1x128x128xi64>) -> tensor<1x1x128x128xi1>
    %4 = torch_c.from_builtin_tensor %3 : tensor<1x1x128x128xi1> -> !torch.vtensor<[1,1,128,128],i1>
    return %4 : !torch.vtensor<[1,1,128,128],i1>
  }
}
```