### PR TITLE
Fix the error of type casting in dynamo example

### DIFF
--- a/examples/torchdynamo_resnet18.py
+++ b/examples/torchdynamo_resnet18.py
@@ -91,4 +91,4 @@ resnet18 = models.resnet18(pretrained=True)
 resnet18.train(False)
 dynamo_callable = dynamo.optimize(refbackend_torchdynamo_backend)(resnet18)
 
-predictions(resnet18.forward, lambda x: dynamo_callable(torch.from_numpy(x)).numpy(), img, labels)
+predictions(resnet18.forward, lambda x: dynamo_callable(torch.from_numpy(x)).detach().numpy(), img, labels)


### PR DESCRIPTION
Fix following error for dynamo example:
`
Traceback (most recent call last):
  File "/root/github/torch-mlir/examples/torchdynamo_resnet18.py", line 94, in <module>
    predictions(resnet18.forward, lambda x: dynamo_callable(torch.from_numpy(x)).numpy(), img, labels)
  File "/root/github/torch-mlir/examples/torchdynamo_resnet18.py", line 61, in predictions
    prediction = top3_possibilities(torch.from_numpy(jit_func(img.numpy())))
  File "/root/github/torch-mlir/examples/torchdynamo_resnet18.py", line 94, in <lambda>
    predictions(resnet18.forward, lambda x: dynamo_callable(torch.from_numpy(x)).numpy(), img, labels)
RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.
`