### PR TITLE
Adding stablehlo dialects support for torch-mlir-opt tool

### DIFF
--- a/tools/torch-mlir-opt/torch-mlir-opt.cpp
+++ b/tools/torch-mlir-opt/torch-mlir-opt.cpp
@@ -11,7 +11,10 @@
 #include "mlir/InitAllPasses.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "torch-mlir/InitAll.h"
+
+#ifdef TORCH_MLIR_ENABLE_STABLEHLO
 #include "stablehlo/dialect/Register.h"
+#endif
 
 using namespace mlir;
 
@@ -22,8 +25,10 @@ int main(int argc, char **argv) {
   DialectRegistry registry;
   registerAllDialects(registry);
   mlir::torch::registerAllDialects(registry);
-  mlir::stablehlo::registerAllDialects(registry);
   
+#ifdef TORCH_MLIR_ENABLE_STABLEHLO
+  mlir::stablehlo::registerAllDialects(registry);
+#endif  
   return mlir::asMainReturnCode(
       mlir::MlirOptMain(argc, argv, "MLIR modular optimizer driver\n", registry,
                         /*preloadDialectsInContext=*/false));

--- a/tools/torch-mlir-opt/torch-mlir-opt.cpp
+++ b/tools/torch-mlir-opt/torch-mlir-opt.cpp
@@ -11,6 +11,7 @@
 #include "mlir/InitAllPasses.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "torch-mlir/InitAll.h"
+#include "stablehlo/dialect/Register.h"
 
 using namespace mlir;
 
@@ -21,7 +22,8 @@ int main(int argc, char **argv) {
   DialectRegistry registry;
   registerAllDialects(registry);
   mlir::torch::registerAllDialects(registry);
-
+  mlir::stablehlo::registerAllDialects(registry);
+  
   return mlir::asMainReturnCode(
       mlir::MlirOptMain(argc, argv, "MLIR modular optimizer driver\n", registry,
                         /*preloadDialectsInContext=*/false));


### PR DESCRIPTION
I tried to use following commad to debug my program:

> ./torch-mlir/build/bin/torch-mlir-opt --chlo-legalize-to-hlo ./xxx-chlo.mlir

It showed torch-mlir-opt tool didn't support chlo dialect:

`error: Dialect 'chlo' not found for custom op 'chlo.broadcast_add'`

This PR tries to add stablehlo dialects support for this tool.