### PR TITLE
[Tcp] Add group, isolated_group, and yield ops

### DIFF
--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpBase.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpBase.td
@@ -33,6 +33,7 @@ def Tcp_Dialect : Dialect {
 
 def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, AnyComplex]>;
 def Tcp_Tensor : RankedTensorOf<[Tcp_Scalar]>;
+def Tcp_TensorOrScalar : AnyTypeOf<[Tcp_Tensor, Tcp_Scalar]>;
 
 def Tcp_FloatTensor : RankedTensorOf<[AnyFloat]>;
 def Tcp_FloatOrIntTensor : RankedTensorOf<[AnyFloat, AnySignlessInteger]>;

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.h
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.h
@@ -10,6 +10,7 @@
 #ifndef TORCH_MLIR_DIALECTS_DIALECT_TCP_IR_TCPOPS_H_
 #define TORCH_MLIR_DIALECTS_DIALECT_TCP_IR_TCPOPS_H_
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.td
@@ -191,4 +191,95 @@ def Tcp_BroadcastOp : Tcp_Op<"broadcast", [
   let hasVerifier = 1;
 }
 
+def Tcp_YieldOp : Tcp_Op<"yield", [Terminator, Pure]> {
+  let summary = "Yields values from regions in Tcp";
+
+  let description = [{
+    Terminates and yields values from regions in Tcp.
+
+    The values that are yielded should correspond to the parent operation's
+    results.
+  }];
+
+  let arguments = (ins
+    Variadic<Tcp_TensorOrScalar>:$ins
+  );
+
+  let builders = [
+    OpBuilder<(ins), [{ }]>,
+  ];
+
+  let assemblyFormat = "$ins attr-dict `:` type($ins)";
+}
+
+def Tcp_GroupOp : Tcp_Op<"group", [
+          AffineScope,
+          ParentOneOf<["func::FuncOp", "tcp::GroupOp", "tcp::IsolatedGroupOp"]>,
+          SingleBlockImplicitTerminator<"tcp::YieldOp">]> {
+  let summary = "Groups ops into a region that is not isolated from above";
+
+  let description = [{
+    Provides a way to group ops into a region that is not isolated from above.
+
+    Since this is not isolated from above, ops inside this region can refer to
+    values in the outer scopes. So, this op does not have any input parameters.
+
+    This op must not include control flow ops in its region. However, it can
+    be present within regions that are inside control flow ops.
+
+    The enclosed region will terminate with a `tcp.yield` op. This ops results
+    should correspond to the values that are yielded by the terminating op.
+  }];
+
+  let results = (outs
+    Variadic<Tcp_TensorOrScalar>:$outs
+  );
+
+  let regions = (region
+    SizedRegion<1>:$body
+  );
+
+  let assemblyFormat = "attr-dict-with-keyword $body `:` type($outs)";
+
+  let hasVerifier = 1;
+}
+
+def Tcp_IsolatedGroupOp : Tcp_Op<"isolated_group", [
+          AffineScope,
+          IsolatedFromAbove,
+          ParentOneOf<["func::FuncOp", "tcp::GroupOp", "tcp::IsolatedGroupOp"]>,
+          SingleBlockImplicitTerminator<"tcp::YieldOp">]> {
+  let summary = "Groups ops into a region that is isolated from above";
+
+  let description = [{
+    Provides a way to group ops into a region that is isolated from above.
+
+    Since the enclosed region is isolated from above, any use of values from
+    outer scopes requires passing that value as an input parameter to this op
+    and using that parameter instead.
+
+    This op must not include control flow ops in its region. However, it can
+    be present within regions that are inside control flow ops.
+
+    The enclosed region will terminate with a `tcp.yield` op. This ops results
+    should correspond to the values that are yielded by the terminating op.
+  }];
+
+  let arguments = (ins
+    Variadic<Tcp_TensorOrScalar>:$ins
+  );
+
+  let results = (outs
+    Variadic<Tcp_TensorOrScalar>:$outs
+  );
+
+  let regions = (region
+    SizedRegion<1>:$body
+  );
+
+  let assemblyFormat = "$ins attr-dict-with-keyword $body `:` type($ins) `->` type($outs)";
+
+  let hasVerifier = 1;
+}
+
 #endif // TORCH_MLIR_DIALECT_TCP_OPS

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/IR/TcpOps.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/IR/TcpOps.cpp
@@ -65,4 +65,48 @@ LogicalResult BroadcastOp::verify() {
   return success();
 }
 
+LogicalResult GroupOp::verify() {
+  auto &groupBlock = getBody().front();
+  if (groupBlock.empty() ||
+      !groupBlock.back().mightHaveTrait<OpTrait::IsTerminator>())
+    return emitOpError(
+        "failed to verify that op region ends with a terminator");
+
+  auto yieldOp = getBody().front().getTerminator();
+  if (yieldOp->getNumOperands() != getNumResults())
+    return emitOpError("failed to verify that the number of yielded values is "
+                       "same as the number of results");
+
+  for (unsigned i = 0; i < getNumResults(); ++i) {
+    if (yieldOp->getOperand(i).getType() != getResult(i).getType())
+      return emitOpError()
+             << "failed to verify that the type of operand #" << i
+             << " of terminator matches the corresponding result type";
+  }
+
+  return success();
+}
+
+LogicalResult IsolatedGroupOp::verify() {
+  auto &groupBlock = getBody().front();
+  if (groupBlock.empty() ||
+      !groupBlock.back().mightHaveTrait<OpTrait::IsTerminator>())
+    return emitOpError(
+        "failed to verify that op region ends with a terminator");
+
+  auto yieldOp = getBody().front().getTerminator();
+  if (yieldOp->getNumOperands() != getNumResults())
+    return emitOpError("failed to verify that the number of yielded values is "
+                       "same as the number of results");
+
+  for (unsigned i = 0; i < getNumResults(); ++i) {
+    if (yieldOp->getOperand(i).getType() != getResult(i).getType())
+      return emitOpError()
+             << "failed to verify that the type of operand #" << i
+             << " of terminator matches the corresponding result type";
+  }
+
+  return success();
+}
+
 } // namespace mlir::tcp

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/misc.mlir
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/misc.mlir
@@ -62,3 +62,122 @@ func.func @test_broadcast_axes_w_duplicates(%arg0 : tensor<?x1x?x1xf32>, %arg1 :
   %0 = "tcp.broadcast"(%arg0, %arg1, %arg2) {axes = [1, 1]} : (tensor<?x1x?x1xf32>, index, index) -> tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @test_group(
+// CHECK-SAME:          %[[ARG0:.*]]: tensor<?x?xf32>,
+// CHECK-SAME:          %[[ARG1:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[GROUP:.*]] = tcp.group {
+// CHECK:            %[[ADD:.*]] = tcp.add %[[ARG0]], %[[ARG1]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:            %[[TANH:.*]] = tcp.tanh %[[ADD]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:            tcp.yield %[[TANH]] : tensor<?x?xf32>
+// CHECK:         } : tensor<?x?xf32>
+// CHECK:         return %[[GROUP]] : tensor<?x?xf32>
+func.func @test_group(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %10 = "tcp.group" () ({
+    ^bb0() :
+      %2 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+      tcp.yield %3 : tensor<?x?xf32>
+  }) : () -> tensor<?x?xf32>
+  return %10 : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @test_group_no_yield(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  // expected-error @+1 {{'tcp.group' op failed to verify that op region ends with a terminator}}
+  %10 = "tcp.group" () ({
+    ^bb0() :
+      %2 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+  }) : () -> tensor<?x?xf32>
+  return %10 : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @test_group_incorrect_yield_args(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  // expected-error @+1 {{'tcp.group' op failed to verify that the number of yielded values is same as the number of results}}
+  %10 = "tcp.group" () ({
+    ^bb0() :
+      %2 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+      tcp.yield %2, %3 : tensor<?x?xf32>, tensor<?x?xf32>
+  }) : () -> tensor<?x?xf32>
+  return %10 : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @test_group_incorrect_yield_arg_type(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?xf32> {
+  // expected-error @+1 {{'tcp.group' op failed to verify that the type of operand #0 of terminator matches the corresponding result type}}
+  %10 = "tcp.group" () ({
+    ^bb0() :
+      %2 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+      tcp.yield %3 : tensor<?x?xf32>
+  }) : () -> tensor<?xf32>
+  return %10 : tensor<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_isolated_group(
+// CHECK-SAME:          %[[ARG0:.*]]: tensor<?x?xf32>,
+// CHECK-SAME:          %[[ARG1:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[IGROUP:.*]] = tcp.isolated_group %[[ARG0]], %[[ARG1]] {
+// CHECK:         ^bb0(%[[BBARG0:.*]]: tensor<?x?xf32>, %[[BBARG1:.*]]: tensor<?x?xf32>):
+// CHECK:            %[[ADD:.*]] = tcp.add %[[BBARG0]], %[[BBARG1]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:            %[[TANH:.*]] = tcp.tanh %[[ADD]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:            tcp.yield %[[TANH]] : tensor<?x?xf32>
+// CHECK:         } : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:         return %[[IGROUP]] : tensor<?x?xf32>
+func.func @test_isolated_group(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %10 = "tcp.isolated_group" (%arg0, %arg1) ({
+    ^bb0(%0 : tensor<?x?xf32>, %1 : tensor<?x?xf32>) :
+      %2 = tcp.add %0, %1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+      tcp.yield %3 : tensor<?x?xf32>
+  }) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %10 : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @test_isolated_group_no_yield(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  // expected-error @+1 {{'tcp.isolated_group' op failed to verify that op region ends with a terminator}}
+  %10 = "tcp.isolated_group" (%arg0, %arg1) ({
+    ^bb0(%0 : tensor<?x?xf32>, %1 : tensor<?x?xf32>) :
+      %2 = tcp.add %0, %1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+  }) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %10 : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @test_isolated_group_incorrect_yield_args(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  // expected-error @+1 {{'tcp.isolated_group' op failed to verify that the number of yielded values is same as the number of results}}
+  %10 = "tcp.isolated_group" (%arg0, %arg1) ({
+    ^bb0(%0 : tensor<?x?xf32>, %1 : tensor<?x?xf32>) :
+      %2 = tcp.add %0, %1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+      tcp.yield %2, %3 : tensor<?x?xf32>, tensor<?x?xf32>
+  }) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %10 : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @test_isolated_group_incorrect_yield_arg_type(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?xf32> {
+  // expected-error @+1 {{'tcp.isolated_group' op failed to verify that the type of operand #0 of terminator matches the corresponding result type}}
+  %10 = "tcp.isolated_group" (%arg0, %arg1) ({
+    ^bb0(%0 : tensor<?x?xf32>, %1 : tensor<?x?xf32>) :
+      %2 = tcp.add %0, %1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+      tcp.yield %3 : tensor<?x?xf32>
+  }) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?xf32>
+  return %10 : tensor<?xf32>
+}


### PR DESCRIPTION
This PR adds grouping ops `tcp.group`, `tcp.isolated_group` and a `tcp.yield` op.