### PR TITLE
CI: install `unzip` before using it

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -36,6 +36,7 @@ jobs:
 
         cd ${GITHUB_WORKSPACE}
         python -m pip install wheel
+        sudo apt-get install unzip
 
         # Fetch the most recent nightly torchvision release
         VISION_RELEASE=$(python -m pip index versions -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html --pre torchvision | grep "Available versions" | tr ' ' '\n' | grep "^[0-9]" | sort --version-sort --reverse | head -n1 | tr -d ',' | sed 's/\([^+]*\).*/\1/')


### PR DESCRIPTION
The RollPyTorch action needs the `unzip` command to peek into WHL files
for fetching metadata.  This patch makes sure that the command is
installed before referencing it.