### PR TITLE
CI: clear workspace directory before checkout

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -14,11 +14,13 @@ jobs:
     if: github.repository == 'llvm/torch-mlir'
 
     steps:
-    
-    - name: chown $GITHUB_WORKSPACE
+
+    - name: Prepare workspace
       run: |
-        sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-          
+        # Clear the workspace directory so that we don't run into errors about
+        # existing lock files.
+        rm -rf $GITHUB_WORKSPACE/*
+
     - name: Get torch-mlir
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Prepare workspace
+      run: |
+        # Clear the workspace directory so that we don't run into errors about
+        # existing lock files.
+        rm -rf $GITHUB_WORKSPACE/*
+
     - name: Checkout torch-mlir
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -52,10 +52,12 @@ jobs:
 
     steps:
     
-    - name: chown $GITHUB_WORKSPACE
+    - name: Prepare workspace
       if: ${{ matrix.os-arch == 'ubuntu-x86_64' }}
       run: |
-        sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+        # Clear the workspace directory so that we don't run into errors about
+        # existing lock files.
+        rm -rf $GITHUB_WORKSPACE/*
     
     - name: Checkout torch-mlir
       uses: actions/checkout@v3

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -15,11 +15,13 @@ jobs:
     name: Manylinux Build
     runs-on: a100
     steps:
-    
-    - name: chown $GITHUB_WORKSPACE
+
+    - name: Prepare workspace
       run: |
-        sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-        
+        # Clear the workspace directory so that we don't run into errors about
+        # existing lock files.
+        rm -rf $GITHUB_WORKSPACE/*
+
     - name: Get torch-mlir
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/gh-pages-releases.yml
+++ b/.github/workflows/gh-pages-releases.yml
@@ -13,8 +13,13 @@ jobs:
     if: github.repository == 'llvm/torch-mlir'
 
     steps:
+      - name: Prepare workspace
+        run: |
+          # Clear the workspace directory so that we don't run into errors about
+          # existing lock files.
+          rm -rf $GITHUB_WORKSPACE/*
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
       - name: Run scrape releases script

--- a/.github/workflows/oneshotSnapshotPackage.yml
+++ b/.github/workflows/oneshotSnapshotPackage.yml
@@ -10,8 +10,14 @@ jobs:
     # Don't run this in everyone's forks.
     if: github.repository == 'llvm/torch-mlir'
     steps:
+      - name: Prepare workspace
+        run: |
+          # Clear the workspace directory so that we don't run into errors about
+          # existing lock files.
+          rm -rf $GITHUB_WORKSPACE/*
+
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
 

--- a/.github/workflows/releaseSnapshotPackage.yml
+++ b/.github/workflows/releaseSnapshotPackage.yml
@@ -13,8 +13,15 @@ jobs:
     # Don't run this in everyone's forks.
     if: github.repository == 'llvm/torch-mlir'
     steps:
+
+      - name: Prepare workspace
+        run: |
+          # Clear the workspace directory so that we don't run into errors about
+          # existing lock files.
+          rm -rf $GITHUB_WORKSPACE/*
+
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
 


### PR DESCRIPTION
We have recently started seeing errors like:

```
  Synchronizing submodule url for 'externals/llvm-project'
  Synchronizing submodule url for 'externals/mlir-hlo'
  /usr/bin/git -c protocol.version=2 submodule update --init --force --depth=1
  Error: fatal: Unable to create '/home/anush/actions-runner/_work/torch-mlir/torch-mlir/.git/modules/externals/llvm-project/index.lock': File exists.
```

As a workaround, this patch removes the workspace directory before the
checkout step.