### PR TITLE
Add `torch-mlir-no-jit-importer` build case for mac os wheels

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -63,7 +63,7 @@ jobs:
       run: mkdir dist
     - name: Copy releases to publish to dist directory
       if: github.event.inputs.release_id != ''
-      run: cp build_tools/python_deploy/wheelhouse/torch_mlir-*.whl dist/
+      run: cp build_tools/python_deploy/wheelhouse/torch_mlir*.whl dist/
 
     # Wheels must be published from a linux environment.
     #
@@ -120,7 +120,7 @@ jobs:
       run: mkdir dist
     - name: Copy releases to publish to dist directory
       if: github.event.inputs.release_id != ''
-      run: cp build_tools/python_deploy/wheelhouse/torch_mlir-*.whl dist/
+      run: cp build_tools/python_deploy/wheelhouse/torch_mlir*.whl dist/
 
     # Wheels must be published from a linux environment.
     #
@@ -179,7 +179,7 @@ jobs:
       continue-on-error: true
     - name: Copy releases to publish to dist directory
       if: github.event.inputs.release_id != ''
-      run: cp ./wheelhouse/torch_mlir-*.whl dist/
+      run: cp ./wheelhouse/torch_mlir*.whl dist/
 
     # Wheels must be published from a linux environment.
     #

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -48,7 +48,7 @@ TM_PYTHON_VERSIONS="${TM_PYTHON_VERSIONS:-cp38-cp38 cp310-cp310 cp311-cp311}"
 # Location to store Release wheels
 TM_OUTPUT_DIR="${TM_OUTPUT_DIR:-${this_dir}/wheelhouse}"
 # What "packages to build"
-TM_PACKAGES="${TM_PACKAGES:-torch-mlir}"
+TM_PACKAGES="${TM_PACKAGES:-torch-mlir torch-mlir-no-jit}"
 # Use pre-built Pytorch
 TM_USE_PYTORCH_BINARY="${TM_USE_PYTORCH_BINARY:-ON}"
 # Skip running tests if you want quick iteration
@@ -80,6 +80,11 @@ function run_on_host() {
   mkdir -p "${TM_OUTPUT_DIR}"
   case "$package" in
     torch-mlir)
+      TM_CURRENT_DOCKER_IMAGE=${TM_RELEASE_DOCKER_IMAGE}
+      export USERID=0
+      export GROUPID=0
+      ;;
+    torch-mlir-no-jit)
       TM_CURRENT_DOCKER_IMAGE=${TM_RELEASE_DOCKER_IMAGE}
       export USERID=0
       export GROUPID=0
@@ -158,6 +163,12 @@ function run_in_docker() {
           #run_audit_wheel torch_mlir "$python_version"
 
           clean_build torch_mlir "$python_version"
+          ;;
+        torch-mlir-no-jit)
+          clean_wheels torch_mlir_no_jit "$python_version"
+          build_torch_mlir_no_jit
+          run_audit_wheel torch_mlir_no_jit "$python_version"
+          clean_build torch_mlir_no_jit "$python_version"
           ;;
         out-of-tree)
           setup_venv "$python_version"
@@ -365,6 +376,24 @@ function build_torch_mlir() {
 }
 
 function run_audit_wheel() {
+  local wheel_basename="$1"
+  local python_version="$2"
+  generic_wheel="/wheelhouse/${wheel_basename}-${TORCH_MLIR_PYTHON_PACKAGE_VERSION}-${python_version}-linux_x86_64.whl"
+  echo ":::: Auditwheel $generic_wheel"
+  auditwheel repair -w /wheelhouse "$generic_wheel"
+  rm "$generic_wheel"
+}
+
+function build_torch_mlir_no_jit() {
+  python -m pip install --no-cache-dir -r /main_checkout/torch-mlir/build-requirements.txt
+  CMAKE_GENERATOR=Ninja \
+  TORCH_MLIR_PYTHON_PACKAGE_VERSION=${TORCH_MLIR_PYTHON_PACKAGE_VERSION} \
+  TORCH_MLIR_ENABLE_JIT_IR_IMPORTER=0 \
+  TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS=1 \
+  python -m pip wheel -v -w /wheelhouse /main_checkout/torch-mlir
+}
+
+function run_audit_wheel_no_jit() {
   local wheel_basename="$1"
   local python_version="$2"
   generic_wheel="/wheelhouse/${wheel_basename}-${TORCH_MLIR_PYTHON_PACKAGE_VERSION}-${python_version}-linux_x86_64.whl"

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,6 @@ TORCH_MLIR_ENABLE_LTC_DEFAULT = True
 TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS = int(os.environ.get('TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS', False))
 if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS:
     import torch
-TORCH_MLIR_OUT_OF_TREE_BUILD_DEFAULT = False
-TORCH_MLIR_ENABLE_STABLEHLO_DEFAULT = True
 
 # Build phase discovery is unreliable. Just tell it what phases to run.
 class CustomBuild(_build):
@@ -68,11 +66,15 @@ class CMakeBuild(build_py):
         if not cmake_build_dir:
             cmake_build_dir = os.path.abspath(
                 os.path.join(target_dir, "..", "cmake_build"))
+        python_package_dir = os.path.join(cmake_build_dir,
+                                          "tools", "torch-mlir", "python_packages",
+                                          "torch_mlir")
         if not os.getenv("TORCH_MLIR_CMAKE_BUILD_DIR_ALREADY_BUILT"):
             src_dir = os.path.abspath(os.path.dirname(__file__))
+            llvm_dir = os.path.join(
+                src_dir, "externals", "llvm-project", "llvm")
+
             enable_ltc = int(os.environ.get('TORCH_MLIR_ENABLE_LTC', TORCH_MLIR_ENABLE_LTC_DEFAULT))
-            enable_out_of_tree_build = int(os.environ.get('TORCH_MLIR_OUT_OF_TREE_BUILD', TORCH_MLIR_OUT_OF_TREE_BUILD_DEFAULT))
-            enable_stablehlo = int(os.environ.get('TORCH_MLIR_ENABLE_STABLEHLO', TORCH_MLIR_ENABLE_STABLEHLO_DEFAULT))
 
             cmake_args = [
                 f"-DCMAKE_BUILD_TYPE=Release",
@@ -91,8 +93,6 @@ class CMakeBuild(build_py):
                 f"-DCMAKE_CXX_VISIBILITY_PRESET=hidden",
                 f"-DTORCH_MLIR_ENABLE_LTC={'ON' if enable_ltc else 'OFF'}",
                 f"-DTORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS={'ON' if TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS else 'OFF'}",
-                f"-DTORCH_MLIR_OUT_OF_TREE_BUILD={'ON' if enable_out_of_tree_build else 'OFF'}",
-                f"-DTORCH_MLIR_ENABLE_STABLEHLO={'ON' if enable_stablehlo else 'OFF'}",
             ]
 
             os.makedirs(cmake_build_dir, exist_ok=True)
@@ -106,12 +106,6 @@ class CMakeBuild(build_py):
             # delete the directory where we build native extensions to keep
             # this from happening but still take advantage of most of the
             # build cache.
-            if enable_out_of_tree_build:
-                python_package_dir = os.path.join(cmake_build_dir, "python_packages", "torch_mlir")
-            else:
-                python_package_dir = os.path.join(cmake_build_dir, "tools", "torch-mlir", "python_packages",
-                                                  "torch_mlir")
-
             mlir_libs_dir = os.path.join(python_package_dir, "torch_mlir", "_mlir_libs")
             if os.path.exists(mlir_libs_dir):
                 print(f"Removing _mlir_mlibs dir to force rebuild: {mlir_libs_dir}")
@@ -119,13 +113,7 @@ class CMakeBuild(build_py):
             else:
                 print(f"Not removing _mlir_libs dir (does not exist): {mlir_libs_dir}")
 
-            if enable_out_of_tree_build:
-                cmake_src_dir = src_dir
-            else:
-                cmake_src_dir = os.path.join(
-                    src_dir, "externals", "llvm-project", "llvm")
-
-            subprocess.check_call(["cmake", cmake_src_dir] +
+            subprocess.check_call(["cmake", llvm_dir] +
                                   cmake_args, cwd=cmake_build_dir)
             subprocess.check_call(["cmake",
                                    "--build",  ".",
@@ -158,7 +146,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 
 setup(
-    name="torch-mlir",
+    name="torch-mlir" if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS else "torch-mlir-no-jit",
     version=f"{PACKAGE_VERSION}",
     author="Sean Silva",
     author_email="silvasean@google.com",
@@ -173,7 +161,7 @@ setup(
     },
     ext_modules=[
         CMakeExtension("torch_mlir._mlir_libs._jit_ir_importer"),
-    ] if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS else [CMakeExtension("_")],
+    ] if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS else [CMakeExtension("torch_mlir._mlir_libs._torchMlir")],
     install_requires=["numpy", ] + (
         [f"torch=={torch.__version__}".split("+", 1)[0], ] if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS else []),
     zip_safe=False,


### PR DESCRIPTION
This PR adds a build case in the `build_macos_packages.sh` for `torch-mlir-no-jit-importer`. This is probably not the best way to factor this, which is why I didn't go ahead and add such cases to the other platforms/targets.