### PR TITLE
[TCP] Enable CI (with TCP enabled) for PRs to `mlir-tcp` branch

### DIFF
--- a/.github/workflows/bazelBuildAndTestTcp.yml
+++ b/.github/workflows/bazelBuildAndTestTcp.yml
@@ -1,0 +1,108 @@
+name: Bazel Build and Test (TCP)
+
+on:
+  pull_request:
+    branches: [ mlir-tcp ]
+  push:
+    branches: [ mlir-tcp ]
+  workflow_dispatch:
+
+# Ensure that only a single job or workflow using the same
+# concurrency group will run at a time. This would cancel
+# any in-progress jobs in the same github workflow and github
+# ref (e.g. refs/heads/main or refs/pull/<pr_number>/merge).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  ubuntu-build:
+    name: ubuntu-x86_64
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout torch-mlir
+      uses: actions/checkout@v3
+      with:
+        submodules: 'true'
+
+    # Continually update cache even if there's a "hit" during
+    # restore to avoid the cache going stale over time
+    # https://github.com/actions/cache/blob/main/workarounds.md#update-a-cache
+    - name: Setup cache for bazel
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/bazel
+        key: torch_mlir-bazel-build-cache-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          torch_mlir-bazel-build-cache-${{ runner.os }}
+
+    # Change bazel cache directory to root ownership
+    # to allow writing to it from within the docker container.
+    # If no cache hits, this directory is not present
+    # so don't run chown (will error otherwise).
+    - name: Set bazel cache permissions
+      run: |
+        if [ -d "${HOME}/.cache/bazel" ]; then
+          sudo chown -R root:root "${HOME}/.cache/bazel"
+        fi
+
+    - name: Build docker image
+      run: |
+        docker build -f utils/bazel/docker/Dockerfile \
+                     -t torch-mlir:ci \
+                     .
+
+    - name: Bazel build torch-mlir
+      run: |
+        docker run --rm \
+                   -v "$(pwd)":"/opt/src/torch-mlir" \
+                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   torch-mlir:ci \
+                   bazel build @torch-mlir//:torch-mlir-opt
+
+    - name: Bazel test torch-mlir (lit tests)
+      run: |
+        docker run --rm \
+                   -v "$(pwd)":"/opt/src/torch-mlir" \
+                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   torch-mlir:ci \
+                   bazel test @torch-mlir//test/...
+
+    - name: Bazel build torch-mlir-dialects
+      run: |
+        docker run --rm \
+                   -v "$(pwd)":"/opt/src/torch-mlir" \
+                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   torch-mlir:ci \
+                   bazel build @torch-mlir//:torch-mlir-dialects-opt
+
+    - name: Bazel test torch-mlir-dialects (lit tests)
+      run: |
+        docker run --rm \
+                   -v "$(pwd)":"/opt/src/torch-mlir" \
+                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   torch-mlir:ci \
+                   bazel test @torch-mlir//externals/llvm-external-projects/torch-mlir-dialects/test/...
+
+    - name: Verify buildifier was run (bazel lint)
+      run: |
+        docker run --rm \
+                   -v "$(pwd)":"/opt/src/torch-mlir" \
+                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   torch-mlir:ci \
+                   bazel run @torch-mlir//:buildifier
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "Please 'bazel run @torch-mlir//:buildifier' and commit changes."
+          exit 1
+        fi
+
+    # Switch back bazel cache directory to user ownership
+    # to allow GHA post-cache step to save cache without
+    # permissions issue.
+    - name: Switch bazel cache permissions
+      run: |
+        if [ -d "${HOME}/.cache/bazel" ]; then
+          sudo chown -R "$USER":"$USER" "${HOME}/.cache/bazel"
+        fi

--- a/.github/workflows/buildAndTestTcp.yml
+++ b/.github/workflows/buildAndTestTcp.yml
@@ -1,0 +1,82 @@
+name: Build and Test (TCP)
+
+on:
+  pull_request:
+    branches: [ mlir-tcp ]
+  push:
+    branches: [ mlir-tcp ]
+  workflow_dispatch:
+
+# Ensure that only a single job or workflow using the same
+# concurrency group will run at a time. This would cancel
+# any in-progress jobs in the same github workflow and github
+# ref (e.g. refs/heads/main or refs/pull/<pr_number>/merge).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+# Provisioned Jobs:
+# ubuntu/docker - x86_64 - llvm in-tree     - pytorch binary - build+test    # most used dev flow and fastest signal
+jobs:
+  build-test:
+    strategy:
+      fail-fast: true
+      matrix:
+        os-arch: [ubuntu-x86_64, macos-arm64, windows-x86_64]
+        llvm-build: [in-tree, out-of-tree]
+        torch-binary: [ON, OFF]
+        exclude:
+          # Exclude pytorch source
+          - torch-binary: OFF
+          # Exclude llvm out-of-tree
+          - llvm-build: out-of-tree
+          # Exclude macos-arm64
+          - os-arch: macos-arm64
+          # Exclude windows-x86_64
+          - os-arch: windows-x86_64
+        include:
+          # Specify OS versions
+          - os-arch: ubuntu-x86_64
+            os: a100
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout torch-mlir
+      uses: actions/checkout@v3
+      with:
+        submodules: 'true'
+
+    - name: Fetch PyTorch commit hash
+      if: ${{ matrix.os-arch != 'windows-x86_64' }}
+      run: |
+        PT_HASH="$(cat ${GITHUB_WORKSPACE}/pytorch-hash.txt)"
+        echo "PT_HASH=${PT_HASH}" >> ${GITHUB_ENV}
+
+    - name: Setup ccache
+      uses: ./.github/actions/setup-build
+      with:
+        cache-suffix: 'build-${{ matrix.llvm-build }}'
+
+    - name: Cache PyTorch Build
+      if: matrix.os-arch != 'windows-x86_64'
+      id: cache-pytorch
+      uses: ashay/cache@v1
+      with:
+        path: ${{ github.workspace }}/build_tools/python_deploy/wheelhouse
+        key: ${{ runner.os }}-pytorch-${{ env.PT_HASH }}
+        save: ${{ github.ref_name == 'main' && matrix.torch-binary == 'OFF' }}
+
+    - name: Build and Test os-arch='ubuntu-x86_64' llvm-build='${{ matrix.llvm-build }}' torch-binary='${{ matrix.torch-binary }}'
+      if: ${{ matrix.os-arch == 'ubuntu-x86_64' }}
+      run: |
+        cd $GITHUB_WORKSPACE
+        TORCH_MLIR_SRC_PYTORCH_BRANCH="$(cat pytorch-hash.txt)" \
+        TM_PACKAGES="${{ matrix.llvm-build }}" \
+        TM_USE_PYTORCH_BINARY="${{ matrix.torch-binary }}" \
+        TM_PYTORCH_INSTALL_WITHOUT_REBUILD="${{ steps.cache-pytorch.outputs.cache-hit }}" \
+        ./build_tools/python_deploy/build_linux_packages.sh
+
+    - name: Print ccache configuration and statistics
+      shell: bash
+      run: ccache --show-config --show-stats --print-stats


### PR DESCRIPTION
Initially proposed [here](https://github.com/llvm/torch-mlir/pull/1878#issuecomment-1440834604). 

Idea is that all PRs landing to `mlir-tcp` branch will be gated by CI.

To minimize any likely overhead on GHA runners, we only enable 2 workflows:
* CMake (linux, PyTorch binary, in-tree)
* Bazel

Also, removes email notifications from mlir-tcp branches as suggested [here](https://github.com/llvm/torch-mlir/pull/1878#issuecomment-1442324391).

