### PR TITLE
[TORCH] Improve type refinement for aten.cat.

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -275,6 +275,7 @@ STABLEHLO_PASS_SET = {
     "FlattenStaticModule_basic",
     "FlattenRank0Module_basic",
     "TensorsConcatNegativeDimModule_basic",
+    "TensorsConcatPromoteDTypeModule_basic",
     "LiftFreshCopyModule_basic",
     "Mlp2LayerModuleNoBias_basic",
     "NumelModule_basic",

--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -797,6 +797,7 @@ LTC_XFAIL_SET = {
     "SubFloatModule_basic",
     "SubIntModule_basic",
     "TensorsConcatNegativeDimModule_basic",
+    "TensorsConcatPromoteDTypeModule_basic",
     "TensorToBoolZeroRank_basic",
     "TensorToBool_basic",
     "TensorToFloatZeroRank_basic",

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -1427,7 +1427,7 @@ void TypeAnalysis::visitAtenCatOp(AtenCatOp op,
     return;
   }
 
-  SmallVector<ValueKnowledge*, 4> tensors = llvm::to_vector<4>(
+  SmallVector<ValueKnowledge*> tensors = llvm::to_vector(
       llvm::map_range(listConstruct.getElements(), [&](Value v) -> ValueKnowledge* {
         return &getLatticeElement(v)->getValue();
       }));

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -70,7 +70,6 @@
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
 #include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
-#include <iostream>
 
 using namespace mlir;
 using namespace mlir::torch;
@@ -599,9 +598,6 @@ static Type getPromotedResultType(MLIRContext *context,
   assert(tensors.size() == rankIsNonZero.size());
   for (auto t : llvm::zip(tensors, rankIsNonZero)) {
     const ValueKnowledge *tensor = std::get<0>(t);
-    std::cout << "Step i: " << std::flush;
-    tensor->print(llvm::outs());
-    std::cout << std::endl;
     std::optional<bool> rankIsNonZero = std::get<1>(t);
     if (!tensor->dtype)
       return Type();

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -639,9 +639,9 @@ class TensorsConcatPromoteDTypeModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: TensorsConcatPromoteDTypeModule())
 def TensorsConcatPromoteDTypeModule_basic(module, tu: TestUtils):
-    module.forward(tu.randint(0, 2, (2, 2, 4)).bool(),
-                   tu.randint(0, 100, (2, 1, 4)).int(),
-                   tu.randint(0, 100, (2, 3, 4)).long())
+    module.forward(tu.randint(2, 2, 4, low=0, high=2).bool(),
+                   tu.randint(2, 1, 4, low=0, high=100).int(),
+                   tu.randint(2, 3, 4, low=0, high=100).long())
 
 
 # ==============================================================================

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -621,6 +621,32 @@ def TensorsConcatNegativeDimModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class TensorsConcatPromoteDTypeModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.bool, True),
+        ([-1, -1, -1], torch.int32, True),
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, x, y, z):
+        return torch.cat([x, y, z], dim=-2)
+
+
+@register_test_case(module_factory=lambda: TensorsConcatPromoteDTypeModule())
+def TensorsConcatPromoteDTypeModule_basic(module, tu: TestUtils):
+    module.forward(tu.randint(0, 2, (2, 2, 4)).bool(),
+                   tu.randint(0, 100, (2, 1, 4)).int(),
+                   tu.randint(0, 100, (2, 3, 4)).long())
+
+
+# ==============================================================================
+
+
 class GatherModule(torch.nn.Module):
 
     def __init__(self):

--- a/test/Dialect/Torch/refine-types-ops.mlir
+++ b/test/Dialect/Torch/refine-types-ops.mlir
@@ -164,6 +164,22 @@ func.func @torch.aten.cat(%t0: !torch.tensor<[?,1,4], f32>, %t1: !torch.tensor<[
 }
 
 // -----
+// CHECK-LABEL:   func.func @torch.aten.cat$promote_type(
+// CHECK-SAME:                                 %[[T1:.*]]: !torch.tensor<[2,1,4],i1>,
+// CHECK-SAME:                                 %[[T2:.*]]: !torch.tensor<[2,3,4],si64>) -> !torch.tensor {
+// CHECK:           %[[INT1:.*]] = torch.constant.int 1
+// CHECK:           %[[TENSORS:.*]] = torch.prim.ListConstruct %[[T1]], %[[T2]] : (!torch.tensor<[2,1,4],i1>, !torch.tensor<[2,3,4],si64>) -> !torch.list<tensor>
+// CHECK:           %[[RET:.*]] = torch.aten.cat %[[TENSORS]], %[[INT1]] : !torch.list<tensor>, !torch.int -> !torch.tensor<*,si64>
+// CHECK:           %[[CAST:.*]] = torch.tensor_static_info_cast %[[RET]] : !torch.tensor<*,si64> to !torch.tensor
+// CHECK:           return %[[CAST]] : !torch.tensor
+func.func @torch.aten.cat$promote_type(%t0: !torch.tensor<[2,1,4], i1>, %t1: !torch.tensor<[2,3,4], si64>) -> !torch.tensor {
+  %int1 = torch.constant.int 1
+  %tensorList = torch.prim.ListConstruct %t0, %t1: (!torch.tensor<[2,1,4], i1>, !torch.tensor<[2,3,4], si64>) -> !torch.list<tensor>
+  %ret = torch.aten.cat %tensorList, %int1 : !torch.list<tensor>, !torch.int -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
 // CHECK-LABEL:   func.func @torch.aten._shape_as_tensor(
 // CHECK-SAME:                                 %[[INPUT:.*]]: !torch.tensor<[?,1,4],f32>) -> !torch.tensor {
 // CHECK:           %[[RET:.*]] = torch.aten._shape_as_tensor %[[INPUT]] : !torch.tensor<[?,1,4],f32> -> !torch.tensor<*,si64>


### PR DESCRIPTION
Current type refinement implementation for cat is wrong when the operands have diffrent types