### PR TITLE
[TCP] Implements folder for tcp.const op (+ unit test)

### DIFF
--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.td
@@ -175,8 +175,7 @@ def Tcp_ConstOp : Tcp_Op<"const", [ConstantLike, Pure]> {
 
   let assemblyFormat = "attr-dict `:` type($out)";
 
-  // TODO: Enable this after adding `ConstOp::fold` and unit tests
-  // let hasFolder = 1;
+  let hasFolder = 1;
 }
 
 def Tcp_BroadcastOp : Tcp_Op<"broadcast", [

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/IR/TcpOps.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/IR/TcpOps.cpp
@@ -109,4 +109,9 @@ LogicalResult IsolatedGroupOp::verify() {
   return success();
 }
 
+OpFoldResult ConstOp::fold(ArrayRef<Attribute> operands) {
+  assert(operands.empty() && "constant can have no operands");
+  return getValueAttr();
+}
+
 } // namespace mlir::tcp

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/canonicalize.mlir
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/canonicalize.mlir
@@ -1,0 +1,12 @@
+// RUN: torch-mlir-dialects-opt %s -canonicalize | FileCheck %s
+
+// CHECK-LABEL: func.func @test_constant_folding() -> tensor<f32>
+// CHECK:         %[[CONST0:.*]] = tcp.const {value = dense<2.500000e+00> : tensor<f32>} : tensor<f32>
+// CHECK:         %[[MUL:.*]] = tcp.mul %[[CONST0]], %[[CONST0]] : tensor<f32>, tensor<f32> -> tensor<f32>
+// CHECK:         return %[[MUL]] : tensor<f32>
+func.func @test_constant_folding() -> tensor<f32> {
+  %0 = tcp.const {value = dense<2.5> : tensor<f32>} : tensor<f32>
+  %1 = tcp.const {value = dense<2.5> : tensor<f32>} : tensor<f32>
+  %2 = tcp.mul %0, %1 : tensor<f32>, tensor<f32> -> tensor<f32>
+  return %2 : tensor<f32>
+}


### PR DESCRIPTION
As titled. This is needed to unblock CI on `mlir-tcp` (results in failing assertion on `ConstantLike` ops without a folder).

Will need to refactor to use the new `FoldAdaptor` convention after `mlir-tcp` rebases to `main`.