### PR TITLE
[Torch Dialect] Add slice tensor canonicalize pattern

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -315,6 +315,7 @@ STABLEHLO_PASS_SET = {
     "SliceStaticModule_basic",
     "SliceModule_basic",
     "SliceNegIdxModule_basic",
+    "SliceListConcatModule_basic",
     "SliceOutOfLowerBoundStartIndexModule_basic",
     "SliceOutOfUpperBoundIndexModule_basic",
     "SliceStartEqEndModule_basic",

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -7588,6 +7588,7 @@ def Torch_AtenSliceTensorOp : Torch_Op<"aten.slice.Tensor", [
     }
   }];
   let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Torch_AtenLenTensorOp : Torch_Op<"aten.len.Tensor", [

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -161,8 +161,8 @@ static Value getScalarValue(Value input, Location loc,
 //===----------------------------------------------------------------------===//
 
 LogicalResult MethodOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  auto func = symbolTable.lookupNearestSymbolFrom<func::FuncOp>(
-      *this, getFunctionAttr());
+  auto func =
+      symbolTable.lookupNearestSymbolFrom<func::FuncOp>(*this, getFunctionAttr());
   if (!func)
     return emitError() << "'@" << getFunction()
                        << "' does not reference a valid function";
@@ -415,13 +415,11 @@ void PrimIfOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
   // If the condition is constant, delete the dead branch and inline the live
   // branch.
   patterns.add(+[](PrimIfOp op, PatternRewriter &rewriter) {
-    auto constantBool =
-        op.getCondition().getDefiningOp<Torch::ConstantBoolOp>();
+    auto constantBool = op.getCondition().getDefiningOp<Torch::ConstantBoolOp>();
     if (!constantBool)
       return rewriter.notifyMatchFailure(op, "non-constant condition");
-    replaceOpWithRegion(rewriter, op,
-                        constantBool.getValue() ? op.getThenRegion()
-                                                : op.getElseRegion());
+    replaceOpWithRegion(
+        rewriter, op, constantBool.getValue() ? op.getThenRegion() : op.getElseRegion());
     return success();
   });
   // If the thenRegion and elseRegion yield the same Value's, then use those
@@ -479,16 +477,14 @@ void PrimIfOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
         continue;
       newResultTypes.push_back(op->getResult(i).getType());
     }
-    auto newIf = rewriter.create<PrimIfOp>(op->getLoc(), newResultTypes,
-                                           op.getCondition());
+    auto newIf =
+        rewriter.create<PrimIfOp>(op->getLoc(), newResultTypes, op.getCondition());
     rewriter.inlineRegionBefore(op.getThenRegion(), newIf.getThenRegion(),
                                 newIf.getThenRegion().end());
     rewriter.inlineRegionBefore(op.getElseRegion(), newIf.getElseRegion(),
                                 newIf.getElseRegion().end());
-    newIf.getThenRegion().front().getTerminator()->eraseOperands(
-        resultsToErase);
-    newIf.getElseRegion().front().getTerminator()->eraseOperands(
-        resultsToErase);
+    newIf.getThenRegion().front().getTerminator()->eraseOperands(resultsToErase);
+    newIf.getElseRegion().front().getTerminator()->eraseOperands(resultsToErase);
     SmallVector<Value> replacementValues;
     for (int i = 0, e = op->getNumResults(), nextNewValue = 0; i < e; ++i) {
       if (resultsToErase[i])
@@ -1653,7 +1649,7 @@ void Torch::ConstantFloatOp::getAsmResultNames(
   // float string representation).
   SmallVector<char> buf;
   getValue().toString(buf, /*FormatPrecision=*/6, /*FormatMaxPadding=*/0,
-                      /*TruncateZero=*/false);
+                   /*TruncateZero=*/false);
   auto isValidMLIRIdentifierChar = [](char c) {
     return isalpha(c) || isdigit(c) || c == '_' || c == '$' || c == '.' ||
            c == '-';
@@ -1764,8 +1760,7 @@ void Aten__Getitem__TOp::getCanonicalizationPatterns(
     // compiler treat the size as having value semantics?
     // There's a small number of such ops, and they are marked as `inplace_view`
     // in PyTorch's `native_functions.yaml` file.
-    rewriter.replaceOpWithNewOp<AtenSizeIntOp>(op, sizeOp.getSelf(),
-                                               op.getIdx());
+    rewriter.replaceOpWithNewOp<AtenSizeIntOp>(op, sizeOp.getSelf(), op.getIdx());
     return success();
   });
 }
@@ -1777,13 +1772,11 @@ void Aten__Getitem__TOp::getCanonicalizationPatterns(
 void AtenAddTOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                              MLIRContext *context) {
   patterns.add(+[](AtenAddTOp op, PatternRewriter &rewriter) {
-    auto lhsListConstruct =
-        op.getA().getDefiningOp<Torch::PrimListConstructOp>();
+    auto lhsListConstruct = op.getA().getDefiningOp<Torch::PrimListConstructOp>();
     if (!lhsListConstruct || isListPotentiallyMutated(lhsListConstruct))
       return failure();
 
-    auto rhsListConstruct =
-        op.getB().getDefiningOp<Torch::PrimListConstructOp>();
+    auto rhsListConstruct = op.getB().getDefiningOp<Torch::PrimListConstructOp>();
     if (!rhsListConstruct || isListPotentiallyMutated(rhsListConstruct))
       return failure();
 
@@ -1901,8 +1894,7 @@ LogicalResult PrimTupleConstructOp::verify() {
 void PrimTupleIndexOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                                    MLIRContext *context) {
   patterns.add(+[](PrimTupleIndexOp op, PatternRewriter &rewriter) {
-    auto tupleConstruct =
-        op.getTup().getDefiningOp<Torch::PrimTupleConstructOp>();
+    auto tupleConstruct = op.getTup().getDefiningOp<Torch::PrimTupleConstructOp>();
     if (!tupleConstruct)
       return failure();
 
@@ -1952,8 +1944,7 @@ void PrimUninitializedOp::getCanonicalizationPatterns(
 void PrimTupleUnpackOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                                     MLIRContext *context) {
   patterns.add(+[](PrimTupleUnpackOp op, PatternRewriter &rewriter) {
-    auto tupleConstruct =
-        op.getTup().getDefiningOp<Torch::PrimTupleConstructOp>();
+    auto tupleConstruct = op.getTup().getDefiningOp<Torch::PrimTupleConstructOp>();
     if (!tupleConstruct)
       return failure();
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -507,7 +507,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::where.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)")
     emit("aten::where.ScalarOther : (Tensor, Tensor, Scalar) -> (Tensor)")
     emit("aten::where.ScalarSelf : (Tensor, Scalar, Tensor) -> (Tensor)")
-    emit("aten::slice.Tensor : (Tensor, int, int?, int?, int) -> (Tensor)", has_folder=True)
+    emit("aten::slice.Tensor : (Tensor, int, int?, int?, int) -> (Tensor)", has_folder=True, has_canonicalizer=True)
     emit("aten::len.Tensor : (Tensor) -> (int)")
     emit("aten::cpu : (Tensor) -> (Tensor)")
     emit("aten::gather : (Tensor, int, Tensor, bool) -> (Tensor)")

--- a/python/torch_mlir_e2e_test/test_suite/slice_like.py
+++ b/python/torch_mlir_e2e_test/test_suite/slice_like.py
@@ -233,6 +233,25 @@ def SliceWholeTensorModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class SliceListConcatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([3, 8], torch.float32, True)
+    ])
+    def forward(self, x):
+        slices = [torch.ops.aten.slice(input, 0, i, i+1, 1) for i in range(x.shape[0])]
+        return torch.cat(slices, 0)
+
+@register_test_case(module_factory=lambda: SliceListConcatModule())
+def SliceListConcatModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 8))
+
+# ==============================================================================
+
 class SelectIntModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -1838,3 +1838,26 @@ func.func @torch.aten.slice.tensor$fold_full_domain_slice(%arg0: !torch.vtensor<
   %0 = torch.aten.slice.Tensor %arg0, %int0, %int0, %int-1, %int1 : !torch.vtensor<[4], f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4], f32>
   return %0 : !torch.vtensor<[4],f32>
 }
+
+// CHECK-LABEL:    @torch.aten.slice.tensor$infer_dynamic_shape
+// CHECK-SAME:        %[[ARG0:.+]]: !torch.vtensor<[2,56,56,96],f16>
+// CHECK:             %[[NONE:.*]] = torch.constant.none
+// CHECK:             %[[INT0:.*]] = torch.constant.int 0
+// CHECK:             %[[INT1:.*]] = torch.constant.int 1
+// CHECK:             %[[INT3:.*]] = torch.constant.int 3
+// CHECK:             %[[PR0:.*]] = torch.aten.slice.Tensor %[[ARG0]], %[[INT1]], %[[INT3]], %[[NONE]], %[[INT1]] : !torch.vtensor<[2,56,56,96],f16>, !torch.int, !torch.int, !torch.none, !torch.int -> !torch.vtensor<[2,53,56,96],f16>
+// CHECK:             %[[PR1:.*]] = torch.aten.slice.Tensor %[[ARG0]], %[[INT1]], %[[INT0]], %[[INT3]], %[[INT1]] : !torch.vtensor<[2,56,56,96],f16>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[2,3,56,96],f16>
+// CHECK:             %[[PR2:.*]] = torch.prim.ListConstruct %[[PR0]], %[[PR1]] : (!torch.vtensor<[2,53,56,96],f16>, !torch.vtensor<[2,3,56,96],f16>) -> !torch.list<vtensor<[2,?,56,96],f16>>
+// CHECK:             %[[PR3:.*]] = torch.aten.cat %[[PR2]], %[[INT1]] : !torch.list<vtensor<[2,?,56,96],f16>>, !torch.int -> !torch.vtensor<[2,56,56,96],f16>
+// CHECK:             return %[[PR3]] : !torch.vtensor<[2,56,56,96],f16>
+func.func @torch.aten.slice.tensor$infer_dynamic_shape(%arg0: !torch.vtensor<[2,56,56,96],f16>) -> !torch.vtensor<[2,56,56,96],f16> {
+  %none = torch.constant.none
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %0 = torch.aten.slice.Tensor %arg0, %int1, %int3, %none, %int1 : !torch.vtensor<[2,56,56,96],f16>, !torch.int, !torch.int, !torch.none, !torch.int -> !torch.vtensor<[2,?,56,96],f16>
+  %1 = torch.aten.slice.Tensor %arg0, %int1, %int0, %int3, %int1 : !torch.vtensor<[2,56,56,96],f16>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[2,?,56,96],f16>
+  %2 = torch.prim.ListConstruct %0, %1 : (!torch.vtensor<[2,?,56,96],f16>, !torch.vtensor<[2,?,56,96],f16>) -> !torch.list<vtensor<[2,?,56,96],f16>>
+  %3 = torch.aten.cat %2, %int1 : !torch.list<vtensor<[2,?,56,96],f16>>, !torch.int -> !torch.vtensor<[2,56,56,96],f16>
+  return %3 : !torch.vtensor<[2,56,56,96],f16>
+}


### PR DESCRIPTION
- Rewrite `AtenSliceTensorOp` to infer result shape when all inputs(start, end, etc.) are known and result shape is unknown. 
- Update ValueTensorType's subtype rules to consider unknown shapes.