### PR TITLE
Fix handling of non-int tensors in `getScalarValue`

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -89,6 +89,8 @@ TORCHDYNAMO_XFAIL_SET = {
     "ReduceMaxAlongDimUnsignedInt_basic",
     #ERROR: value (-56) is not equal to golden value (200)
     "AtenIntTensorByteDtypeModule_basic",
+    # ERROR: assert isinstance(e, FakeTensor)
+    "ElementwiseAddScalar_NumToTensorFloat_Module_basic",
 }
 
 STABLEHLO_PASS_SET = {
@@ -155,6 +157,8 @@ STABLEHLO_PASS_SET = {
     "ElementwiseAddScalarFloatModule_basic",
     "ElementwiseAddScalarInt64Module_basic",
     "ElementwiseAddScalarIntModule_basic",
+    "ElementwiseAddScalar_NumToTensorFloat_Module_basic",
+    "ElementwiseAddScalar_TensorLiteralInt32_Module_basic",
     "ElementwiseDivScalarModule_basic",
     "ElementwiseEqDiffWidthScalarModule_basic",
     "ElementwiseEqFloatScalarModule_basic",
@@ -537,6 +541,7 @@ TOSA_PASS_SET = {
     "ElementwiseDivScalarModule_basic",
     "ElementwiseSubScalarFloatModule_basic",
     "ElementwiseAddScalarFloatModule_basic",
+    "ElementwiseAddScalar_TensorLiteralInt32_Module_basic",
     "ElementwiseMulScalarModule_float",
     "ElementwiseCeilModule_basic",
     "ElementwiseReciprocalModule_basic",

--- a/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -1919,6 +1919,52 @@ def ElementwiseAddScalarFloatModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwiseAddScalar_NumToTensorFloat_Module(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        x = torch.ops.prim.NumToTensor(5.0)
+        return torch.add(x, 3)
+
+
+@register_test_case(
+    module_factory=lambda: ElementwiseAddScalar_NumToTensorFloat_Module())
+def ElementwiseAddScalar_NumToTensorFloat_Module_basic(module, tu: TestUtils):
+    module.forward()
+
+
+# ==============================================================================
+
+
+class ElementwiseAddScalar_TensorLiteralInt32_Module(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.x = torch.tensor(2, dtype=torch.int32)
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return torch.add(self.x, 3)
+
+
+@register_test_case(
+    module_factory=lambda: ElementwiseAddScalar_TensorLiteralInt32_Module())
+def ElementwiseAddScalar_TensorLiteralInt32_Module_basic(module, tu: TestUtils):
+    module.forward()
+
+
+# ==============================================================================
+
+
 class ElementwiseCloneModule(torch.nn.Module):
 
     def __init__(self):


### PR DESCRIPTION
The current implementation of `getScalarValue` does not check that the input to a `ValueTensorLiteralOp` is an i64 before extracting the value, and it does not check that the result type of the `PrimNumToTensorScalarOp` is also an i64. This leads to crashes or invalid IR generated when the `input` is something other than an i64 tensor or `!torch.int`.

This commit addresses those issues. In addition, the function `getScalarValue` is renamed to `getScalarIntValue` to make it clear that it *only* extracts scalar integers.