### PR TITLE
CI: drop deletion of workspace and limit submodule fetch concurrency

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -14,18 +14,15 @@ jobs:
     if: github.repository == 'llvm/torch-mlir'
 
     steps:
-
-    - name: Prepare workspace
-      run: |
-        # Clear the workspace directory so that we don't run into errors about
-        # existing lock files.
-        sudo rm -rf $GITHUB_WORKSPACE/*
-
     - name: Get torch-mlir
       uses: actions/checkout@v3
       with:
-        submodules: 'true'
         token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
+
+    # We fetch the submodules sequentially to prevent multiple threads from
+    # trampling the index.lock file.
+    - name: Fetch submodules
+      run: git submodule update --init --force --depth=1 --jobs 1
 
     - name: Setup ccache
       uses: ./.github/actions/setup-build

--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -20,16 +20,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Prepare workspace
-      run: |
-        # Clear the workspace directory so that we don't run into errors about
-        # existing lock files.
-        sudo rm -rf $GITHUB_WORKSPACE/*
-
     - name: Checkout torch-mlir
       uses: actions/checkout@v3
-      with:
-        submodules: 'true'
+
+    # We fetch the submodules sequentially to prevent multiple threads from
+    # trampling the index.lock file.
+    - name: Fetch submodules
+      run: git submodule update --init --force --depth=1 --jobs 1
 
     # Continually update cache even if there's a "hit" during
     # restore to avoid the cache going stale over time

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -51,18 +51,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    
-    - name: Prepare workspace
-      if: ${{ matrix.os-arch == 'ubuntu-x86_64' }}
-      run: |
-        # Clear the workspace directory so that we don't run into errors about
-        # existing lock files.
-        sudo rm -rf $GITHUB_WORKSPACE/*
-    
     - name: Checkout torch-mlir
       uses: actions/checkout@v3
-      with:
-        submodules: 'true'
+
+    # We fetch the submodules sequentially to prevent multiple threads from
+    # trampling the index.lock file.
+    - name: Fetch submodules
+      run: git submodule update --init --force --depth=1 --jobs 1
 
     - name: Fetch PyTorch commit hash
       if: ${{ matrix.os-arch != 'windows-x86_64' }}

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -25,17 +25,12 @@ jobs:
             py_version: cp310-cp310
 
     steps:
-
-    - name: Prepare workspace
-      run: |
-        # Clear the workspace directory so that we don't run into errors about
-        # existing lock files.
-        sudo rm -rf $GITHUB_WORKSPACE/*
-
     - name: Get torch-mlir
       uses: actions/checkout@v3
-      with:
-        submodules: 'true'
+    # We fetch the submodules sequentially to prevent multiple threads from
+    # trampling the index.lock file.
+    - name: Fetch submodules
+      run: git submodule update --init --force --depth=1 --jobs 1
     - uses: ./.github/actions/setup-build
       with:
         cache-suffix: 'release'
@@ -93,8 +88,10 @@ jobs:
     steps:
     - name: Get torch-mlir
       uses: actions/checkout@v3
-      with:
-        submodules: 'true'
+    # We fetch the submodules sequentially to prevent multiple threads from
+    # trampling the index.lock file.
+    - name: Fetch submodules
+      run: git submodule update --init --force --depth=1 --jobs 1
     - uses: ./.github/actions/setup-build
       with:
         cache-suffix: 'release'
@@ -153,8 +150,10 @@ jobs:
     steps:
     - name: Get torch-mlir
       uses: actions/checkout@v3
-      with:
-        submodules: 'true'
+    # We fetch the submodules sequentially to prevent multiple threads from
+    # trampling the index.lock file.
+    - name: Fetch submodules
+      run: git submodule update --init --force --depth=1 --jobs 1
     - uses: ./.github/actions/setup-build
       with:
         cache-suffix: 'release'

--- a/.github/workflows/gh-pages-releases.yml
+++ b/.github/workflows/gh-pages-releases.yml
@@ -13,11 +13,6 @@ jobs:
     if: github.repository == 'llvm/torch-mlir'
 
     steps:
-      - name: Prepare workspace
-        run: |
-          # Clear the workspace directory so that we don't run into errors about
-          # existing lock files.
-          sudo rm -rf $GITHUB_WORKSPACE/*
       - name: Checking out repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/oneshotSnapshotPackage.yml
+++ b/.github/workflows/oneshotSnapshotPackage.yml
@@ -10,12 +10,6 @@ jobs:
     # Don't run this in everyone's forks.
     if: github.repository == 'llvm/torch-mlir'
     steps:
-      - name: Prepare workspace
-        run: |
-          # Clear the workspace directory so that we don't run into errors about
-          # existing lock files.
-          sudo rm -rf $GITHUB_WORKSPACE/*
-
       - name: Checking out repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/releaseSnapshotPackage.yml
+++ b/.github/workflows/releaseSnapshotPackage.yml
@@ -14,12 +14,6 @@ jobs:
     if: github.repository == 'llvm/torch-mlir'
     steps:
 
-      - name: Prepare workspace
-        run: |
-          # Clear the workspace directory so that we don't run into errors about
-          # existing lock files.
-          sudo rm -rf $GITHUB_WORKSPACE/*
-
       - name: Checking out repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Despite using sudo to delete the workspace directory, we still
occasionally run into checkout errors.  This patch thus drops the
deletion of the workspace prior to checkout.  It also restricts the
number of parallel jobs in the submodule fetch step to just one, to try
and resolve the checkout issue ("index.lock: File exists.").