### PR TITLE
LTC->MLIR Debug Info support

### DIFF
--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -211,7 +211,8 @@ void TorchMlirLoweringContext::AssignOutputOp(
 
   std::vector<std::string> source_files, functions;
   std::vector<int64_t> line_numbers;
-  const auto& frames = torch_mlir_node->metadata().frame_info;
+  const auto& metadata = torch_mlir_node->metadata();
+  const auto& frames = metadata.frame_info;
   if (!frames.empty()) {
     static std::vector<std::string> g_roots =
       string_split(sys_util::GetEnvString("LTC_IR_DEBUG_ROOT_PATH", ""), ":");
@@ -241,6 +242,10 @@ void TorchMlirLoweringContext::AssignOutputOp(
           c10::Symbol::attr("line_numbers"), line_numbers);
     }
   }
+  auto scope = ::c10::Symbol::scope(metadata.scope);
+  op->node()->setScope(
+    c10::make_intrusive<torch::jit::Scope>()->push(scope));
+
   emitted_outputs_[output] = std::move(op);
 }
 

--- a/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
+++ b/python/torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.cpp
@@ -15,6 +15,7 @@
 #include <torch/csrc/jit/api/compilation_unit.h>
 #include <torch/csrc/jit/passes/refine_tuple_types.h>
 #include <torch/csrc/lazy/core/lazy_graph_executor.h>
+#include <torch/csrc/lazy/core/config.h>
 #include "torch-mlir-c/Registration.h"
 #include "torch-mlir-c/Transforms.h"
 #include "mlir-c/IR.h"
@@ -205,13 +206,41 @@ void TorchMlirLoweringContext::AssignOutputOp(
     const Output& output, torch::jit::Value* op) {
   PRINT_FUNCTION();
 
-  // TODO (antoniojkim): Do we need this?
-  // auto torch_mlir_node =
-  //     NodeCast<TorchMlirNode>(output.node, output.node->op());
-  // if (!torch_mlir_node->getPythonStacktrace().empty()) {
-  //   op->node()->s_(
-  //       c10::Symbol::attr("source"), torch_mlir_node->getPythonStacktrace());
-  // }
+  auto torch_mlir_node =
+      NodeCast<TorchMlirNode>(output.node, output.node->op());
+
+  std::vector<std::string> source_files, functions;
+  std::vector<int64_t> line_numbers;
+  const auto& frames = torch_mlir_node->metadata().frame_info;
+  if (!frames.empty()) {
+    static std::vector<std::string> g_roots =
+      string_split(sys_util::GetEnvString("LTC_IR_DEBUG_ROOT_PATH", ""), ":");
+
+    std::for_each(frames.rbegin(), frames.rend(),
+      [&](const torch::lazy::SourceLocation& location) {
+        functions.push_back(location.function);
+        line_numbers.push_back(location.line);
+
+        std::string file_name = location.file;
+        for (const std::string& root : g_roots) {
+          if (startswith(file_name, root)) {
+            // location.file starts with root, strip it off
+            file_name = file_name.substr(root.size());
+            break;
+          }
+        }
+        source_files.push_back(file_name);
+    });
+
+    if (!source_files.empty()) {
+      op->node()->ss_(
+          c10::Symbol::attr("source_files"), source_files);
+      op->node()->ss_(
+          c10::Symbol::attr("functions"), functions);
+      op->node()->is_(
+          c10::Symbol::attr("line_numbers"), line_numbers);
+    }
+  }
   emitted_outputs_[output] = std::move(op);
 }
 
@@ -424,7 +453,11 @@ const std::string TorchMlirComputation::to_string() const {
     *ss_ptr << std::string(part.data, part.length);
   };
   std::stringstream ss;
-  mlirOperationPrint(mlirModuleGetOperation(module_op_), print_callback, &ss);
+
+  // Setup flags for MLIR serialization.
+  MlirOpPrintingFlags flags = mlirOpPrintingFlagsCreate();
+  mlirOpPrintingFlagsEnableDebugInfo(flags, FLAGS_torch_lazy_ir_debug, false);
+  mlirOperationPrintWithFlags(mlirModuleGetOperation(module_op_), flags, print_callback, &ss);
   return ss.str();
 }
 

--- a/python/torch_mlir/csrc/base_lazy_backend/utils/string_utils.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/utils/string_utils.h
@@ -22,6 +22,24 @@ std::string string_join(const std::vector<T>& v, const std::string& delimiter) {
     return joined.str();
 }
 
+inline std::vector<std::string> string_split(
+    const std::string& str,
+    const std::string& sep
+) {
+    std::vector<std::string> tokens;
+    std::size_t pos1 = str.find_first_not_of(sep);
+    while (pos1 != std::string::npos) {
+        std::size_t pos2 = str.find_first_of(sep, pos1);
+        if (pos2 == std::string::npos) {
+            tokens.push_back(str.substr(pos1));
+            pos1 = pos2;
+        } else {
+            tokens.push_back(str.substr(pos1, pos2 - pos1));
+            pos1 = str.find_first_not_of(sep, pos2 + 1);
+        }
+    }
+    return tokens;
+}
 
 /*
  * Returns true if str starts with prefix

--- a/python/torch_mlir/csrc/base_lazy_backend/utils/sys_utils.h
+++ b/python/torch_mlir/csrc/base_lazy_backend/utils/sys_utils.h
@@ -14,6 +14,14 @@ static T GetEnv(const std::string& name, const T& default_value = T(0)) {
   return T(std::atoi(env));
 }
 
+static std::string GetEnvString(const std::string& name, const std::string& default_value) {
+  const char* env = std::getenv(name.c_str());
+  if (!env) {
+    return default_value;
+  }
+  return std::string(env);
+}
+
 static bool GetEnvBool(const char* name, bool defval) {
   const char* env = std::getenv(name);
   if (env == nullptr) {

--- a/python/torch_mlir/csrc/reference_lazy_backend/reference_lazy_backend_pybind.cpp
+++ b/python/torch_mlir/csrc/reference_lazy_backend/reference_lazy_backend_pybind.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "torch/csrc/jit/python/pybind.h"
+#include "torch/csrc/lazy/core/config.h"
 #include "torch/csrc/lazy/backend/backend_interface.h"
 
 #include <torch_mlir/csrc/base_lazy_backend/mlir_lowering_context.h>
@@ -25,6 +26,7 @@ namespace py = pybind11;
 
 namespace {
 bool verbose = sys_util::GetEnv("VERBOSE", false);
+bool ir_debug = sys_util::GetEnv("LTC_IR_DEBUG", false);
 
 struct NoGilSection {
   NoGilSection() : state(PyEval_SaveThread()) {}
@@ -51,6 +53,11 @@ void Initialize() {
 
   if (verbose) {
     std::cout << "MLIR LTC PyTorch Plugin Initialized." << std::endl;
+  }
+
+  if (ir_debug) {
+      FLAGS_torch_lazy_ir_debug = true;
+      std::cout << "Enabled lazy tensor IR debugging." << std::endl;
   }
 }
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.cpp
@@ -438,12 +438,21 @@ MlirLocation torch_mlir::getMlirLocationFromNode(MlirContext context,
     loc = mlirLocationFileLineColGet(context, toMlirStringRef(file), line, col);
   }
 
+  std::string locationName;
   auto scopeName = node->scopeName();
   if (!scopeName.empty()) {
-    loc = mlirLocationNameGet(context, toMlirStringRef(scopeName), loc);
-  } else if (const c10::FunctionSchema *schema = node->maybeSchema()) {
-    loc = mlirLocationNameGet(
-        context, toMlirStringRef(schema->operator_name().name), loc);
+    locationName = scopeName;
+  }
+
+  if (const c10::FunctionSchema *schema = node->maybeSchema()) {
+    if (!locationName.empty()) {
+      locationName += "/";
+    }
+    locationName += schema->operator_name().name;
+  }
+
+  if (!locationName.empty()) {
+    loc = mlirLocationNameGet(context, toMlirStringRef(locationName), loc);
   }
 
   return loc;

--- a/test/python/importer/jit_ir/node_import/debug-info.py
+++ b/test/python/importer/jit_ir/node_import/debug-info.py
@@ -19,9 +19,14 @@ mb = ModuleBuilder()
 def add3(t0, t1, t2):
   # TODO: Checks for debug info are quite hard with the new trailing debug
   # attribute print. See if this can be improved.
-  # CHECK: loc({{.*}}debug-info.py":[[# @LINE + 1]]
+  # CHECK: torch.aten.add.Tensor {{.*}} loc(#[[LOC1:loc.*]])
+  # CHECK: torch.aten.add.Tensor {{.*}} loc(#[[LOC2:loc.*]])
+  # CHECK-DAG: #[[OP_NAME:loc.*]] = loc("aten::add")
+  # CHECK-DAG: #[[LOC1]] = loc(fused[#[[FLC_1:loc.*]], #[[OP_NAME]]])
+  # CHECK-DAG: #[[LOC2]] = loc(fused[#[[FLC_2:loc.*]], #[[OP_NAME]]])
+  # CHECK-DAG: #[[FLC_1]] = loc({{.*}}debug-info.py":[[# @LINE + 1]]
   intermediate = t0 + t1
-  # CHECK: loc({{.*}}debug-info.py":[[# @LINE + 1]]
+  # CHECK-DAG: #[[FLC_2]] = loc({{.*}}debug-info.py":[[# @LINE + 1]]
   final = intermediate + t2
   return final
 

--- a/test/python/importer/jit_ir/node_import/debug-info.py
+++ b/test/python/importer/jit_ir/node_import/debug-info.py
@@ -17,19 +17,11 @@ mb = ModuleBuilder()
 @mb.import_function
 @torch.jit.script
 def add3(t0, t1, t2):
-  # TODO: Checks for debug info are quite hard with the new trailing debug
-  # attribute print. See if this can be improved.
-  # CHECK: torch.aten.add.Tensor {{.*}} loc(#[[LOC1:loc.*]])
-  # CHECK: torch.aten.add.Tensor {{.*}} loc(#[[LOC2:loc.*]])
-  # CHECK-DAG: #[[OP_NAME:loc.*]] = loc("aten::add")
-  # CHECK-DAG: #[[LOC1]] = loc(fused[#[[FLC_1:loc.*]], #[[OP_NAME]]])
-  # CHECK-DAG: #[[LOC2]] = loc(fused[#[[FLC_2:loc.*]], #[[OP_NAME]]])
-  # CHECK-DAG: #[[FLC_1]] = loc({{.*}}debug-info.py":[[# @LINE + 1]]
+  # CHECK-DAG: torch.aten.add.Tensor {{.*}} loc("aten::add"({{.*}}debug-info.py":[[# @LINE + 1]]
   intermediate = t0 + t1
-  # CHECK-DAG: #[[FLC_2]] = loc({{.*}}debug-info.py":[[# @LINE + 1]]
-  final = intermediate + t2
-  return final
+  # CHECK-DAG: torch.aten.mul.Tensor {{.*}} loc("aten::mul"({{.*}}debug-info.py":[[# @LINE + 1]]
+  return intermediate * t2
 
 # Verify again with debug info present. Just checking that it makes it in there.
-mb.module.operation.print(enable_debug_info=True)
+mb.module.operation.print(enable_debug_info=True, use_local_scope=True)
 print()


### PR DESCRIPTION
### Description
Added support for LTC stack trace propagation up to torch MLIR locations. This option is turned off by default. To enable debug info you need to specify these options:
* `LTC_IR_DEBUG=1` - enables debug info.
* `LTC_IR_DEBUG_ROOT_PATH="/home/gleb/torch-mlir/:/home/gleb/pytorch/"` - list of paths which are used to trim absolute paths for readability _(optional)._

### Example
To check how it works you can run LTC MNIST test with reference backend:
```
LTC_IR_DEBUG=1 python ./torch-mlir/examples/ltc_backend_mnist.py -d MLIR_EXAMPLE
```

This is an example of `addmm` operation locations which consist of `function_name/file_name/line_number` per `callsite`:
```
%4 = torch.aten.addmm %arg4, %arg0, %1, %2, %3 : !torch.vtensor<[10],f32>, !torch.vtensor<[1,5],f32>, !torch.vtensor<[5,10],f32>, !torch.int, !torch.int -> !torch.vtensor<[1,10],f32> loc(callsite("forward"("pytorch/torch/nn/modules/linear.py":114:0) at callsite("_call_impl"("pytorch/torch/nn/modules/module.py":1488:0) at callsite("forward"("./torch-mlir/examples/ltc_backend_mnist.py":38:0) at callsite("_call_impl"("pytorch/torch/nn/modules/module.py":1488:0) at callsite("main"("./torch-mlir/examples/ltc_backend_mnist.py":56:0) at "<module>"("./torch-mlir/examples/ltc_backend_mnist.py":105:0)))))))
```
