### PR TITLE
Constant pad nd to tosa

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -4287,16 +4287,6 @@ LogicalResult ConvertAtenOp<AtenConstantPadNdOp>::matchAndRewrite(
             op, "Pad value needs to be a scalar constant for conversion to "
                 "TOSA pad operation");
   
-  /*Value paddedResult = rewriter
-                          .create<mlir::tosa::PadOp>(
-                            loc,
-                            getTypeConverter()->convertType(op.getType()), self, 
-                            padsList1, padTensor)
-                          .getResult();
-
-  rewriter.replaceOpWithNewOp<tensor::CastOp>(
-      op, getTypeConverter()->convertType(op.getType()), paddedResult);*/
-
   rewriter.replaceOpWithNewOp<mlir::tosa::PadOp>(
         op, getTypeConverter()->convertType(op.getType()), self, padsList1, padTensor);
   return success();

--- a/test/Conversion/TorchToTosa/constant_pad_nd.mlir
+++ b/test/Conversion/TorchToTosa/constant_pad_nd.mlir
@@ -1,0 +1,17 @@
+// RUN: torch-mlir-opt <%s -convert-torch-to-tosa -split-input-file -verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL:   func.func @torch.aten.constant_pad_nd(
+// CHECK-SAME:                                %[[ARG:.*]]: !torch.vtensor<[1,512,13,13],f32>) -> !torch.vtensor<[1,512,14,14],f32> {
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"()
+// CHECK:           %[[VAL_3:.*]] = "tosa.const"() {value = dense<0xFF800000> : tensor<f32>} : () -> tensor<f32>
+// CHECK:           %[[VAL_4:.*]] = "tosa.pad"
+// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[VAL_4]] : tensor<1x512x14x14xf32> -> !torch.vtensor<[1,512,14,14],f32>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[1,512,14,14],f32>
+func.func @torch.aten.constant_pad_nd(%arg0: !torch.vtensor<[1,512,13,13],f32>) -> !torch.vtensor<[1,512,14,14],f32> {
+  %float-Inf = torch.constant.float 0xFFF0000000000000
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %1 = torch.prim.ListConstruct %int0, %int1, %int0, %int1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.aten.constant_pad_nd %arg0, %1, %float-Inf : !torch.vtensor<[1,512,13,13],f32>, !torch.list<int>, !torch.float -> !torch.vtensor<[1,512,14,14],f32>
+  return %2 : !torch.vtensor<[1,512,14,14],f32>
+}


### PR DESCRIPTION
Lowering torch.aten.constant_pad_nad to tosa has been implemented in this branch. Using this PR to check the implementation before up streaming to the torch-mlir.