### PR TITLE
Fix deprecation warnings for `isOneValue` and `getAllOnesValue`

### DIFF
--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -1065,7 +1065,7 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
     Value allOnesVal = b.create<arith::ConstantOp>(
         loc, b.getIntegerAttr(
                  elementType,
-                 APSInt::getAllOnesValue(elementType.getIntOrFloatBitWidth())));
+                 APSInt::getAllOnes(elementType.getIntOrFloatBitWidth())));
     return b.create<arith::XOrIOp>(loc, payloadArgs[0], allOnesVal);
   }
 

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -390,7 +390,7 @@ void PrimIfOp::getSuccessorRegions(std::optional<unsigned> index,
   // If the condition is constant, we can give a more precise answer.
   if (auto condAttr = operands.front().dyn_cast_or_null<IntegerAttr>()) {
     Region *executedRegion =
-        condAttr.getValue().isOneValue() ? &getThenRegion() : &getElseRegion();
+        condAttr.getValue().isOne() ? &getThenRegion() : &getElseRegion();
     regions.push_back(RegionSuccessor(executedRegion));
     return;
   }


### PR DESCRIPTION
The functions `isOneValue` and `getAllOnesValues` are deprecated. `isOne` and `getAllOnes` should be used instead.