### PR TITLE
[Bazel] Add StableHLO registration dependency

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -450,6 +450,7 @@ cc_library(
         "@llvm-project//mlir:Dialect",
         "@mlir-hlo//:mlir_hlo",
         "@mlir-hlo//:transforms_passes",
+        "@mlir-hlo//stablehlo:register",
     ],
 )
 


### PR DESCRIPTION
Fixes a broken bazel build from https://github.com/llvm/torch-mlir/pull/1887 causing the following build error:

```
ERROR: /root/.cache/bazel/_bazel_root/b89349c08f7224396763d14fe35cba11/external/torch-mlir/BUILD.bazel:819:10: Compiling tools/torch-mlir-opt/torch-mlir-opt.cpp failed: (Exit 1): clang failed: error executing command /usr/lib/llvm-16/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer ... (remaining 366 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/torch-mlir/tools/torch-mlir-opt/torch-mlir-opt.cpp:16:10: fatal error: 'stablehlo/dialect/Register.h' file not found
#include "stablehlo/dialect/Register.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
Target @torch-mlir//:torch-mlir-opt failed to build
```

GHA workflow with the fix:
https://github.com/sjain-stanford/torch-mlir/actions/runs/4421486154

