### PR TITLE
RefineTypes aten.sum: check dtype exists before accessing methods

### DIFF
--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -893,6 +893,13 @@ void TypeAnalysis::visitOperation(Operation *op,
 
   if (auto sum = dyn_cast<AtenSumOp>(op)) {
     Type defaultDtype = operands[0]->getValue().dtype;
+    if (!defaultDtype) {
+      incorporateKnowledge(
+          sum.getResult(),
+          ValueKnowledge::getTensorPessimisticValueState(op->getContext()));
+      return;
+    }
+
     // If the input dtype is bool, the result type should be i64.
     if (defaultDtype.isInteger(1))
       defaultDtype =


### PR DESCRIPTION
This commit adds a check that `defaultDtype` exists in the RefineTypes handling of `AtenSumOp` before accessing the method `isInteger`, which crashes the program is `defaultDtype` is null.

The handling of `defaultDtype` is the same as the one used for the `AtenSumDimIntListOp`.