### PR TITLE
[e2e_test] fix typo in pow_int e2e test

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -2868,7 +2868,7 @@ def ScalarImplicitIntModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
-class PowIntFloat(torch.nn.Module):
+class PowIntFloatModule(torch.nn.Module):
 
     def __init__(self):
         super().__init__()
@@ -2882,7 +2882,7 @@ class PowIntFloat(torch.nn.Module):
     def forward(self):
         return torch.ops.aten.pow(self.value, self.power_value)
 
-@register_test_case(module_factory=lambda: IntFloatModule())
+@register_test_case(module_factory=lambda: PowIntFloatModule())
 def PowIntFloatModule_basic(module, tu: TestUtils):
     module.forward()
 


### PR DESCRIPTION
There is a different behavior between torch and torch-mlir:
![img_v2_5ade5ba8-5b2c-4668-857c-b31555e9e0cg](https://user-images.githubusercontent.com/29956693/225598860-65e74bf1-8836-49cc-8110-419a79226aa2.jpg)
  
It's a bug or feature of pytorch?
