### PR TITLE
[TCP] unary ops support for floor and ceil operations

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -467,6 +467,8 @@ TCP_PASS_SET = {
     "DropoutEvalIntModule_basic",
     "ElementwiseAddModule_basic",
     "ElementwiseSqrtModule_basic",
+    "ElementwiseCeilModule_basic",
+    "ElementwiseFloorModule_basic",
     "ElementwiseBinaryModule_basic",
     "ElementwiseClampModule_basic",
     "ElementwiseClampMaxModule_basic",

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.td
@@ -341,4 +341,40 @@ def Tcp_ConcatOp : Tcp_Op<"concat", [SameOperandsAndResultElementType]> {
   let hasVerifier = 1;
 }
 
+def Tcp_CeilOp : Tcp_UnaryElementwiseOp<"ceil"> {
+  let summary = "Computes ceil of input, elementwise";
+
+  let description = [{
+    Computes elementwise ceil of the input tensor.
+  }];
+
+  let arguments = (ins
+    Tcp_FloatOrComplexTensor:$in
+  );
+
+  let results = (outs
+    Tcp_FloatOrComplexTensor:$out
+  );
+
+  let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
+}
+
+def Tcp_FloorOp : Tcp_UnaryElementwiseOp<"floor"> {
+  let summary = "Computes floor of input, elementwise";
+
+  let description = [{
+    Computes elementwise floor of the input tensor.
+  }];
+
+  let arguments = (ins
+    Tcp_FloatOrComplexTensor:$in
+  );
+
+  let results = (outs
+    Tcp_FloatOrComplexTensor:$out
+  );
+
+  let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
+}
+
 #endif // TORCH_MLIR_DIALECT_TCP_OPS

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Conversion/TcpToLinalg/Elementwise.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Conversion/TcpToLinalg/Elementwise.cpp
@@ -110,6 +110,14 @@ createLinalgPayloadForElementwiseOp(Operation *op,
     return {b.create<math::SqrtOp>(loc, payloadArgs[0])};
   }
 
+  if (isa<CeilOp>(op)) {
+    return {b.create<math::CeilOp>(loc, payloadArgs[0])};
+  }
+
+  if (isa<FloorOp>(op)) {
+    return {b.create<math::FloorOp>(loc, payloadArgs[0])};
+  }
+
   if (isa<AddOp>(op)) {
     if (elemType.isa<mlir::FloatType>())
       return {b.create<arith::AddFOp>(loc, payloadArgs[0], payloadArgs[1])};
@@ -202,4 +210,6 @@ void mlir::TcpToLinalg::populateElementwisePatternsAndLegality(
   patterns.add<ConvertElementwiseOp<TanhOp>>(typeConverter, context);
   patterns.add<ConvertElementwiseOp<SigmoidOp>>(typeConverter, context);
   patterns.add<ConvertElementwiseOp<SqrtOp>>(typeConverter, context);
+  patterns.add<ConvertElementwiseOp<CeilOp>>(typeConverter, context);
+  patterns.add<ConvertElementwiseOp<FloorOp>>(typeConverter, context);
 }

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/Conversion/TcpToLinalg/unary.mlir
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/Conversion/TcpToLinalg/unary.mlir
@@ -112,3 +112,57 @@ func.func @sqrt(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = tcp.sqrt %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }
+
+// -----
+
+// CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @ceil(
+// CHECK-SAME:                %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
+// CHECK:         %[[CONST0:.*]] = arith.constant 0 : index
+// CHECK:         %[[DIM0:.*]] = tensor.dim %[[ARG]], %[[CONST0]] : tensor<?x?xf32>
+// CHECK:         %[[CONST1:.*]] = arith.constant 1 : index
+// CHECK:         %[[DIM1:.*]] = tensor.dim %[[ARG]], %[[CONST1]] : tensor<?x?xf32>
+// CHECK:         %[[EMPTY_TENSOR:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
+// CHECK:         %[[GENERIC:.*]] = linalg.generic {
+// CHECK-SAME:                        indexing_maps = [#[[MAP]], #[[MAP]]],
+// CHECK-SAME:                        iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME:                        ins(%[[ARG]] :  tensor<?x?xf32>)
+// CHECK-SAME:                        outs(%[[EMPTY_TENSOR]] : tensor<?x?xf32>) {
+// CHECK:         ^bb0(%[[BBARG0:.*]]: f32, %{{.*}}: f32):
+// CHECK:           %[[CEIL:.*]] = math.ceil %[[BBARG0]] : f32
+// CHECK:           linalg.yield %[[CEIL]] : f32
+// CHECK:         } -> tensor<?x?xf32>
+// CHECK:         return %[[GENERIC]] : tensor<?x?xf32>
+// CHECK:       }
+func.func @ceil(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.ceil %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @floor(
+// CHECK-SAME:                %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
+// CHECK:         %[[CONST0:.*]] = arith.constant 0 : index
+// CHECK:         %[[DIM0:.*]] = tensor.dim %[[ARG]], %[[CONST0]] : tensor<?x?xf32>
+// CHECK:         %[[CONST1:.*]] = arith.constant 1 : index
+// CHECK:         %[[DIM1:.*]] = tensor.dim %[[ARG]], %[[CONST1]] : tensor<?x?xf32>
+// CHECK:         %[[EMPTY_TENSOR:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
+// CHECK:         %[[GENERIC:.*]] = linalg.generic {
+// CHECK-SAME:                        indexing_maps = [#[[MAP]], #[[MAP]]],
+// CHECK-SAME:                        iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME:                        ins(%[[ARG]] :  tensor<?x?xf32>)
+// CHECK-SAME:                        outs(%[[EMPTY_TENSOR]] : tensor<?x?xf32>) {
+// CHECK:         ^bb0(%[[BBARG0:.*]]: f32, %{{.*}}: f32):
+// CHECK:           %[[CEIL:.*]] = math.floor %[[BBARG0]] : f32
+// CHECK:           linalg.yield %[[CEIL]] : f32
+// CHECK:         } -> tensor<?x?xf32>
+// CHECK:         return %[[GENERIC]] : tensor<?x?xf32>
+// CHECK:       }
+func.func @floor(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.floor %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/unary.mlir
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/unary.mlir
@@ -84,3 +84,25 @@ func.func @test_sqrt_f32(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = tcp.sqrt %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @test_ceil_f32(
+// CHECK-SAME:               %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[CEIL:.*]] = tcp.ceil %[[ARG]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:         return %[[CEIL]] : tensor<?x?xf32>
+func.func @test_ceil_f32(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.ceil %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_floor_f32(
+// CHECK-SAME:               %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[FLOOR:.*]] = tcp.floor %[[ARG]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:         return %[[FLOOR]] : tensor<?x?xf32>
+func.func @test_floor_f32(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.floor %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}

--- a/test/Conversion/TorchToTcp/elementwise.mlir
+++ b/test/Conversion/TorchToTcp/elementwise.mlir
@@ -172,6 +172,32 @@ func.func @torch.aten.sqrt(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[
 
 // -----
 
+// CHECK-LABEL:  func.func @torch.aten.ceil(
+// CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
+// CHECK:         %[[T1:.*]] = tcp.ceil %[[T0]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:         %[[T2:.*]] = torch_c.from_builtin_tensor %[[T1]] : tensor<?x?xf32> -> !torch.vtensor<[?,?],f32>
+// CHECK:         return %[[T2]] : !torch.vtensor<[?,?],f32>
+func.func @torch.aten.ceil(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.ceil %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.floor(
+// CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
+// CHECK:         %[[T1:.*]] = tcp.floor %[[T0]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:         %[[T2:.*]] = torch_c.from_builtin_tensor %[[T1]] : tensor<?x?xf32> -> !torch.vtensor<[?,?],f32>
+// CHECK:         return %[[T2]] : !torch.vtensor<[?,?],f32>
+func.func @torch.aten.floor(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.floor %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.batch_norm(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,4,?,?],f32>) -> !torch.vtensor<[?,4,?,?],f32> {
 // CHECK:              %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,4,?,?],f32> -> tensor<?x4x?x?xf32>


### PR DESCRIPTION
- Add the tcp op definitions for floor and ceil operations
- Add the torch->tcp and tcp->linarg conversion for floor and ceil operations.
- Updated test cases to include floor and ceil operations

To test:

`./build/bin/llvm-lit externals/llvm-external-projects/torch-mlir-dialects/test/Conversion/TcpToLinalg/ -v`
`./build/bin/llvm-lit externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/ -v`
`./build/bin/llvm-lit test/Conversion/TorchToTcp/ -v`
`python -m e2e_testing.main --config=tcp -v -s`