### PR TITLE
RFC: Support pushing custom ops through backend-contract using `torch.operator`

### DIFF
--- a/examples/custom_op_demo.py
+++ b/examples/custom_op_demo.py
@@ -1,0 +1,95 @@
+import torch
+import torch.utils.cpp_extension
+import torch_mlir
+from torch_mlir import run_pipeline_with_repro_report
+from torch_mlir.ir import BoolAttr, Context, Module, InsertionPoint, Location
+from torch_mlir_e2e_test.annotations import export, annotate_args
+
+
+def identity(_5: torch.Tensor):
+    return _5
+
+
+goofy_lib = torch.library.Library("goofy", "DEF")
+goofy_lib.define("identity(Tensor t) -> Tensor")
+goofy_lib.impl("identity", identity)
+
+
+class CustomOpExampleModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, a):
+        b = 2 * a
+        return torch.ops.goofy.identity(b)
+
+
+mod = CustomOpExampleModule()
+mod.eval()
+
+module = torch_mlir.compile(mod, torch.ones(3, 4), output_type="raw")
+
+pipeline = (
+    "symbol-dce,"
+    "torch-prepare-for-globalize-object-graph,"
+    "torch-globalize-object-graph,"
+    "symbol-dce,"
+    "inline{default-pipeline= max-iterations=4 },"
+    "torch-adjust-calling-conventions"
+)
+
+run_pipeline_with_repro_report(
+    module, pipeline=f"builtin.module({pipeline})", description=""
+)
+print(module)
+
+forward = module.operation.regions[0].blocks[0].operations[1]
+goofy_op = forward.operation.regions[0].blocks[0].operations[4]
+goofy_op.attributes["has_value_semantics"] = BoolAttr.get(True, context=module.context)
+
+print(module)
+
+abstract_interp_src = """\
+func.func @__torch_mlir_shape_fn.operator.goofy.identity(%arg0: !torch.list<int>) -> !torch.list<int> {
+  return %arg0 : !torch.list<int>
+}
+func.func @__torch_mlir_dtype_fn.operator.goofy.identity(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
+  return %arg1 : !torch.int
+}
+"""
+
+with Location.unknown(module.context) as loc:
+    abstract_interp_module = Module.parse(abstract_interp_src)
+    with InsertionPoint.at_block_begin(module.body) as ip:
+        shape_fn = abstract_interp_module.body.operations[0]
+        dtype_fn = abstract_interp_module.body.operations[1]
+        InsertionPoint.insert(ip, shape_fn.detach_from_parent())
+        InsertionPoint.insert(ip, dtype_fn.detach_from_parent())
+
+print(module)
+
+run_pipeline_with_repro_report(
+    module,
+    pipeline="builtin.module(func.func(torch-reduce-op-variants,torch-maximize-value-semantics))",
+    description="",
+)
+
+print(module)
+
+run_pipeline_with_repro_report(
+    module,
+    pipeline="builtin.module(torch-lower-to-backend-contract{backend-legal-ops=torch.operator decompose=true max-iterations=10})",
+    description="",
+)
+
+shape_fn.detach_from_parent()
+dtype_fn.detach_from_parent()
+
+print(module)

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -829,7 +829,8 @@ def Torch_DerefineOp : Torch_Op<"derefine", [
 }
 
 def Torch_OperatorOp : Torch_Op<"operator", [
-    AllowsTypeRefinement
+    AllowsTypeRefinement,
+    HasValueSemantics
   ]> {
   let summary = "Opaque torch operator";
   let description = [{

--- a/lib/Dialect/Torch/Transforms/AdjustCallingConventions.cpp
+++ b/lib/Dialect/Torch/Transforms/AdjustCallingConventions.cpp
@@ -191,7 +191,10 @@ static bool isValidNonContainerResultType(Type resultType) {
          resultType.isa<Torch::FloatType>() ||
          resultType.isa<Torch::IntType>() ||
          resultType.isa<Torch::BoolType>() ||
-         resultType.isa<Torch::NoneType>();
+         resultType.isa<Torch::NoneType>() ||
+         (resultType.isa<Torch::ListType>() && cast<Torch::ListType>(resultType)
+                                                   .getContainedType()
+                                                   .isa<Torch::IntType>());
 }
 
 static LogicalResult validateReturns(func::FuncOp func) {

--- a/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
+++ b/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
@@ -52,6 +52,14 @@ static Type getContainerOrTensorTypeWithValueSemantics(Type type) {
   }
 }
 
+static bool operatorOpHasValueSemantics(OperatorOp opOp) {
+  if (!opOp->hasAttr("has_value_semantics"))
+    return false;
+  auto hasValueSemantics =
+      opOp->getAttr("has_value_semantics").cast<BoolAttr>().getValue();
+  return hasValueSemantics;
+}
+
 namespace {
 // Convert value semantic ops operating on mutable arrays to instead operate on
 // immutable tensors.
@@ -61,8 +69,13 @@ public:
       : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/1, context) {}
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    if (!op->hasTrait<Torch::OpTrait::HasValueSemantics>())
+    if (isa<OperatorOp>(op)) {
+      if (!operatorOpHasValueSemantics(cast<OperatorOp>(op))) {
+        return rewriter.notifyMatchFailure(op, "does not have value semantics");
+      }
+    } else if (!op->hasTrait<Torch::OpTrait::HasValueSemantics>()) {
       return rewriter.notifyMatchFailure(op, "does not have value semantics");
+    }
 
     rewriter.startRootUpdate(op);
     // Convert all operands.
@@ -254,7 +267,9 @@ class ReduceOpVariantsPass : public ReduceOpVariantsBase<ReduceOpVariantsPass> {
     target.addIllegalOp<NonValueTensorLiteralOp>();
     target.addIllegalOp<AtenBernoulli_FloatOp>();
     target.markUnknownOpDynamicallyLegal([](Operation *op) {
-      if (op->hasTrait<Torch::OpTrait::HasValueSemantics>()) {
+      if (op->hasTrait<Torch::OpTrait::HasValueSemantics>() ||
+          (isa<OperatorOp>(op) &&
+           operatorOpHasValueSemantics(cast<OperatorOp>(op)))) {
         auto hasValueSemantics = [](Type t) {
           // TODO: Make this an allowlist based on a closed torch dialect
           // type system.


### PR DESCRIPTION
# Pitch

I think lots of people want to be able to push opaque kernels through backend contract (https://github.com/llvm/torch-mlir/issues/1519, https://github.com/llvm/torch-mlir/pull/1947, https://github.com/llvm/torch-mlir/pull/1514). Indeed, there is also a similarly themed [proposal](https://github.com/llvm/torch-mlir/pull/1563) that goes through `backend-legal-ops` (and is specific to TOSA). I believe that there's also a need for supporting **custom ops**, i.e., ops that are effectively placeholders for some possible lowering/implementation on the otherside of backend contract (posterchild here is quantized ops).

# Approach

The approach here is an adaptation of the other approach - we go through `backend-legal-ops` using `torch.operator`. The catch is that because `OperandOp` doesn't possess the `HasValueSemantics` trait, `ReduceOpVariants` and `MaximizeValueSemantics` will stumble and ultimately backend contract won't be satisfied. Thus, we add `HasValueSemantics` to `torch.operator`. In addition, we extend `wrapWithCalculateOpIfLibraryFunctionAvailable` to support user-provided shape and dtype functions; in particular we provide these two (trivial) refinement functions:

```mlir
func.func @__torch_mlir_shape_fn.operator.goofy.identity(%arg0: !torch.list<int>) -> !torch.list<int> {
  return %arg0 : !torch.list<int>
}
func.func @__torch_mlir_dtype_fn.operator.goofy.identity(%arg0: !torch.int, %arg1: !torch.int) -> !torch.int {
  return %arg1 : !torch.int
}
```


 With the example/demo here I am able fully lower to

```
module attributes {torch.debug_module_name = "CustomOpExampleModule"} {
  func.func @forward(%arg0: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32> {
    %int2 = torch.constant.int 2
    %0 = torch.aten.mul.Scalar %arg0, %int2 : !torch.vtensor<[3,4],f32>, !torch.int -> !torch.vtensor<[3,4],f32>
    %1 = torch.operator "goofy.identity"(%0) {has_value_semantics = true} : (!torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32>
    return %1 : !torch.vtensor<[3,4],f32>
  }
}
```

Certainly there are other ways to do this, so I'm open to suggestions/advice.

cc @powderluv @qedawkins @AmosLewis