### PR TITLE
[MLIR] fold slice and copy int64_max support

### DIFF
--- a/python/torch_mlir_e2e_test/test_suite/slice_like.py
+++ b/python/torch_mlir_e2e_test/test_suite/slice_like.py
@@ -523,6 +523,28 @@ def SliceCopy_Module_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class SliceCopy2DStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 4], torch.int64, True),
+        ([1, 3], torch.int64, True),
+    ])
+    def forward(self, x, y):
+        xslice = torch.ops.aten.slice(x, 1, 1, 4, 1)
+        xslice.copy_(y)
+        return x
+
+
+@register_test_case(module_factory=lambda: SliceCopy2DStaticModule())
+def SliceCopy2DStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.randint(1, 4, high=4), tu.randint(1, 3, high=1))
+
+# ==============================================================================
+
 class SliceCopyNegative_Module(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
https://github.com/llvm/torch-mlir/issues/1953

SUCCESS [test_slicecopy.py](https://gist.github.com/AmosLewis/c6007c2154fedd51081faaee903a1b2c#file-test_slicecopy-py)

[test_slicecopyt_masked_fill.py](https://gist.github.com/AmosLewis/b53dfecbe4918618031cac01c8a88fb9#file-test_intmax-py)

[t5_small_torchscript_test2.mlir](https://gist.github.com/AmosLewis/d960c815d3de2f68949615c683cafca1)

```
➜  t5small git:(main) ✗ torch-mlir-opt -pass-pipeline='builtin.module(torchscript-module-to-torch-backend-pipeline{backend-legal-ops=torch.aten.flatten.using_ints,torch.aten.native_layer_norm,torch.aten.linear})' ./t5_small_torchscript_test2.mlir
module attributes {torch.debug_module_name = "_lambda"} {
  func.func @forward(%arg0: !torch.vtensor<[1,15],si64>, %arg1: !torch.vtensor<[1,4],si64>) -> !torch.vtensor<[1,4],si64> {
    %int1 = torch.constant.int 1
    %int0 = torch.constant.int 0
    %false = torch.constant.bool false
    %int4 = torch.constant.int 4
    %none = torch.constant.none
    %int-1 = torch.constant.int -1
    %int-100 = torch.constant.int -100
    %int9223372036854775807 = torch.constant.int 9223372036854775807
    %cpu = torch.constant.device "cpu"
    %0 = torch.prim.ListConstruct %int1, %int4 : (!torch.int, !torch.int) -> !torch.list<int>
    %1 = torch.aten.zeros %0, %int4, %int0, %cpu, %false : !torch.list<int>, !torch.int, !torch.int, !torch.Device, !torch.bool -> !torch.vtensor<[1,4],si64>
    %2 = torch.aten.slice.Tensor %arg1, %int1, %int0, %int-1, %int1 : !torch.vtensor<[1,4],si64>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,3],si64>
    %3 = torch.aten.clone %2, %none : !torch.vtensor<[1,3],si64>, !torch.none -> !torch.vtensor<[1,3],si64>
    %4 = torch.aten.slice.Tensor %1, %int1, %int1, %int9223372036854775807, %int1 : !torch.vtensor<[1,4],si64>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,3],si64>
    %5 = torch.aten.arange.start_step %int1, %int4, %int1, %none, %none, %none, %none : !torch.int, !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[3],si64>
    %6 = torch.prim.ListConstruct %none, %5 : (!torch.none, !torch.vtensor<[3],si64>) -> !torch.list<optional<vtensor>>
    %7 = torch.aten._index_put_impl %1, %6, %3, %false, %false : !torch.vtensor<[1,4],si64>, !torch.list<optional<vtensor>>, !torch.vtensor<[1,3],si64>, !torch.bool, !torch.bool -> !torch.vtensor<[1,4],si64>
    %8 = torch.aten.slice.Tensor %7, %int1, %int0, %int1, %int1 : !torch.vtensor<[1,4],si64>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,1],si64>
    %9 = torch.aten.squeeze.dim %8, %int1 : !torch.vtensor<[1,1],si64>, !torch.int -> !torch.vtensor<[1],si64>
    %10 = torch.aten.eq.Scalar %7, %int-100 : !torch.vtensor<[1,4],si64>, !torch.int -> !torch.vtensor<[1,4],i1>
    %11 = torch.prim.ListConstruct  : () -> !torch.list<int>
    %12 = torch.prim.NumToTensor.Scalar %int0 : !torch.int -> !torch.vtensor<[],si64>
    %13 = torch.aten.broadcast_to %12, %11 : !torch.vtensor<[],si64>, !torch.list<int> -> !torch.vtensor<[],si64>
    %14 = torch.aten.where.self %10, %13, %7 : !torch.vtensor<[1,4],i1>, !torch.vtensor<[],si64>, !torch.vtensor<[1,4],si64> -> !torch.vtensor<[1,4],si64>
    return %14 : !torch.vtensor<[1,4],si64>
  }
}

```