### PR TITLE
Minor fixes for `ConvertTorchConversionToMLProgram`.

### DIFF
--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -125,7 +125,7 @@ def ConvertTorchToTMTensor : Pass<"convert-torch-to-tmtensor", "func::FuncOp"> {
   let constructor = "mlir::torch::createConvertTorchToTMTensorPass()";
 }
 
-def ConvertTorchConversionToMLProgram : Pass<"convert-torch-conversion-to-mlprogram", "func::FuncOp"> {
+def ConvertTorchConversionToMLProgram : Pass<"convert-torch-conversion-to-mlprogram", "ModuleOp"> {
   let summary = "Convert recognized TorchConversion ops to MLProgram ops";
   let description = [{
     Convert TorchConversion ops to mlprogram ops.

--- a/include/torch-mlir/Conversion/TorchConversionToMLProgram/TorchConversionToMLProgram.h
+++ b/include/torch-mlir/Conversion/TorchConversionToMLProgram/TorchConversionToMLProgram.h
@@ -10,12 +10,12 @@
 #ifndef TORCHMLIR_CONVERSION_TORCHCONVERSIONTOMLPROGRAM_TORCHCONVERSIONTOMLPROGRAM_H
 #define TORCHMLIR_CONVERSION_TORCHCONVERSIONTOMLPROGRAM_TORCHCONVERSIONTOMLPROGRAM_H
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
 namespace torch {
-std::unique_ptr<OperationPass<func::FuncOp>>
+std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTorchConversionToMLProgramPass();
 }
 } // namespace mlir

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -11,6 +11,7 @@
 #define TORCHMLIR_CONVERSION_PASSDETAIL_H
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -72,7 +72,7 @@ void TorchConversion::createTorchBackendToLinalgOnTensorsBackendPipeline(
   pm.addNestedPass<func::FuncOp>(createConvertTorchToLinalgPass());
   pm.addNestedPass<func::FuncOp>(createConvertTorchToSCFPass());
   pm.addNestedPass<func::FuncOp>(createConvertTorchToArithPass());
-  pm.addNestedPass<func::FuncOp>(createConvertTorchConversionToMLProgramPass());
+  pm.addPass(createConvertTorchConversionToMLProgramPass());
   pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
 
   // Clean up any non-canonical code introduced above..

--- a/test/Conversion/TorchConversionToMLProgram/multiple_functions.mlir
+++ b/test/Conversion/TorchConversionToMLProgram/multiple_functions.mlir
@@ -1,0 +1,15 @@
+// RUN: torch-mlir-opt %s -convert-torch-conversion-to-mlprogram -split-input-file | FileCheck %s
+
+module {
+  func.func private @f0() -> i64
+  func.func private @f1() -> i64
+  func.func private @f2() -> i64
+  func.func private @f3() -> i64
+  func.func private @f4() -> i64
+  func.func private @f5() -> i64
+  func.func private @f6() -> i64
+  func.func private @f7() -> i64
+}
+
+// CHECK:     ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>
+// CHECK-NOT: @global_seed


### PR DESCRIPTION
* Only create the global seed variable if it does not exist already.
* Make the pass a module pass. A func pass may not modify its parent op.