### PR TITLE
Revert "CI: drop deletion of workspace and limit submodule fetch concurrency"

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -14,15 +14,18 @@ jobs:
     if: github.repository == 'llvm/torch-mlir'
 
     steps:
+
+    - name: Prepare workspace
+      run: |
+        # Clear the workspace directory so that we don't run into errors about
+        # existing lock files.
+        sudo rm -rf $GITHUB_WORKSPACE/*
+
     - name: Get torch-mlir
       uses: actions/checkout@v3
       with:
+        submodules: 'true'
         token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
-
-    # We fetch the submodules sequentially to prevent multiple threads from
-    # trampling the index.lock file.
-    - name: Fetch submodules
-      run: git submodule update --init --force --depth=1 --jobs 1
 
     - name: Setup ccache
       uses: ./.github/actions/setup-build

--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -20,13 +20,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Prepare workspace
+      run: |
+        # Clear the workspace directory so that we don't run into errors about
+        # existing lock files.
+        sudo rm -rf $GITHUB_WORKSPACE/*
+
     - name: Checkout torch-mlir
       uses: actions/checkout@v3
-
-    # We fetch the submodules sequentially to prevent multiple threads from
-    # trampling the index.lock file.
-    - name: Fetch submodules
-      run: git submodule update --init --force --depth=1 --jobs 1
+      with:
+        submodules: 'true'
 
     # Continually update cache even if there's a "hit" during
     # restore to avoid the cache going stale over time

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -51,13 +51,18 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    
+    - name: Prepare workspace
+      if: ${{ matrix.os-arch == 'ubuntu-x86_64' }}
+      run: |
+        # Clear the workspace directory so that we don't run into errors about
+        # existing lock files.
+        sudo rm -rf $GITHUB_WORKSPACE/*
+    
     - name: Checkout torch-mlir
       uses: actions/checkout@v3
-
-    # We fetch the submodules sequentially to prevent multiple threads from
-    # trampling the index.lock file.
-    - name: Fetch submodules
-      run: git submodule update --init --force --depth=1 --jobs 1
+      with:
+        submodules: 'true'
 
     - name: Fetch PyTorch commit hash
       if: ${{ matrix.os-arch != 'windows-x86_64' }}

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -25,12 +25,17 @@ jobs:
             py_version: cp310-cp310
 
     steps:
+
+    - name: Prepare workspace
+      run: |
+        # Clear the workspace directory so that we don't run into errors about
+        # existing lock files.
+        sudo rm -rf $GITHUB_WORKSPACE/*
+
     - name: Get torch-mlir
       uses: actions/checkout@v3
-    # We fetch the submodules sequentially to prevent multiple threads from
-    # trampling the index.lock file.
-    - name: Fetch submodules
-      run: git submodule update --init --force --depth=1 --jobs 1
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/setup-build
       with:
         cache-suffix: 'release'
@@ -88,10 +93,8 @@ jobs:
     steps:
     - name: Get torch-mlir
       uses: actions/checkout@v3
-    # We fetch the submodules sequentially to prevent multiple threads from
-    # trampling the index.lock file.
-    - name: Fetch submodules
-      run: git submodule update --init --force --depth=1 --jobs 1
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/setup-build
       with:
         cache-suffix: 'release'
@@ -150,10 +153,8 @@ jobs:
     steps:
     - name: Get torch-mlir
       uses: actions/checkout@v3
-    # We fetch the submodules sequentially to prevent multiple threads from
-    # trampling the index.lock file.
-    - name: Fetch submodules
-      run: git submodule update --init --force --depth=1 --jobs 1
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/setup-build
       with:
         cache-suffix: 'release'

--- a/.github/workflows/gh-pages-releases.yml
+++ b/.github/workflows/gh-pages-releases.yml
@@ -13,6 +13,11 @@ jobs:
     if: github.repository == 'llvm/torch-mlir'
 
     steps:
+      - name: Prepare workspace
+        run: |
+          # Clear the workspace directory so that we don't run into errors about
+          # existing lock files.
+          sudo rm -rf $GITHUB_WORKSPACE/*
       - name: Checking out repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/oneshotSnapshotPackage.yml
+++ b/.github/workflows/oneshotSnapshotPackage.yml
@@ -10,6 +10,12 @@ jobs:
     # Don't run this in everyone's forks.
     if: github.repository == 'llvm/torch-mlir'
     steps:
+      - name: Prepare workspace
+        run: |
+          # Clear the workspace directory so that we don't run into errors about
+          # existing lock files.
+          sudo rm -rf $GITHUB_WORKSPACE/*
+
       - name: Checking out repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/releaseSnapshotPackage.yml
+++ b/.github/workflows/releaseSnapshotPackage.yml
@@ -14,6 +14,12 @@ jobs:
     if: github.repository == 'llvm/torch-mlir'
     steps:
 
+      - name: Prepare workspace
+        run: |
+          # Clear the workspace directory so that we don't run into errors about
+          # existing lock files.
+          sudo rm -rf $GITHUB_WORKSPACE/*
+
       - name: Checking out repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Reverts llvm/torch-mlir#1921 since we still need the sudo rm to clean up after nightly builds. 