### PR TITLE
Set fetch-depth 0

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -36,6 +36,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: 'true'
+        fetch-depth: 0
+
     - uses: ./.github/actions/setup-build
       with:
         cache-suffix: 'release'


### PR DESCRIPTION
This is to potentially workaround the index.lock issue in git when we checkout new depth 1 submodules of recently updated mhlo.