### PR TITLE
[TCP] quant type support

### DIFF
--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpBase.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpBase.td
@@ -49,15 +49,17 @@ class TCP_QuantizedType<string n, list<int> params, bit signed>
 // Quantized Integer Types.
 //===----------------------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
-// Name    Symmetry   Grouping                Sign
+// Name    Symmetry           Sign
 //===----------------------------------------------------------------------===//
-// uint8 : asymmetric per tensor ,            unsigned
-// int8  : symmetric  per tensor/per channel, signed
-// int16 : symmetric  per tensor,             signed
+// q8ua  : asymmetric         unsigned
+// q8sa  : asymmetric         signed
+// q8ss  : symmetric          signed
+// q16ss : symmetric          signed
 //===----------------------------------------------------------------------===//
-def TCP_QuantizedInt	: AnyTypeOf<[ TCP_QuantizedType<"uint8", [8], 0>,
-                                     TCP_QuantizedType<"int8", [8, 0], 1>,
-                                     TCP_QuantizedType<"int16", [16, 0], 1>]>;
+def TCP_QuantizedInt	: AnyTypeOf<[ TCP_QuantizedType<"q8ua", [8], 0>,
+                                     TCP_QuantizedType<"q8sa", [8], 1>,
+                                     TCP_QuantizedType<"q8ss", [8, 0], 1>,
+                                     TCP_QuantizedType<"q16ss", [16, 0], 1>]>;
 
 def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, AnyComplex, TCP_QuantizedInt]>;
 def Tcp_Tensor : RankedTensorOf<[Tcp_Scalar]>;

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpBase.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpBase.td
@@ -31,7 +31,35 @@ def Tcp_Dialect : Dialect {
 // Tcp Type Definitions.
 //===----------------------------------------------------------------------===//
 
-def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, AnyComplex]>;
+// The base class of a quantized type.
+// Param tuple is: [bitwidth, zeropt, smantissa, sexp, low_end, high_end].
+// Where low and high ends are 0,255 when unsigned, -128,127 when signed, for
+// the 8-bit case.
+class TCP_QuantizedType<string n, list<int> params, bit signed>
+  : Type<And<[CPred<"$_self.isa<mlir::quant::QuantizedType>()">,
+              CPred<"$_self.cast<mlir::quant::QuantizedType>()" #
+                    ".getStorageTypeIntegralWidth() == " # !head(params)>]>,
+    "Q" # !if (signed, "int", "uint") # !head(params) # " type"> {
+  string name = n;
+  string asTraitArgsStr = !interleave(params, ", ") #
+                          !if(signed, ", true", ", false");
+}
+
+//===----------------------------------------------------------------------===//
+// Quantized Integer Types.
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+// Name    Symmetry   Grouping                Sign
+//===----------------------------------------------------------------------===//
+// uint8 : asymmetric per tensor ,            unsigned
+// int8  : symmetric  per tensor/per channel, signed
+// int16 : symmetric  per tensor,             signed
+//===----------------------------------------------------------------------===//
+def TCP_QuantizedInt	: AnyTypeOf<[ TCP_QuantizedType<"uint8", [8], 0>,
+                                     TCP_QuantizedType<"int8", [8, 0], 1>,
+                                     TCP_QuantizedType<"int16", [16, 0], 1>]>;
+
+def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, AnyComplex, TCP_QuantizedInt]>;
 def Tcp_Tensor : RankedTensorOf<[Tcp_Scalar]>;
 def Tcp_TensorOrScalar : AnyTypeOf<[Tcp_Tensor, Tcp_Scalar]>;
 

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.h
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.h
@@ -11,6 +11,7 @@
 #define TORCH_MLIR_DIALECTS_DIALECT_TCP_IR_TCPOPS_H_
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Quant/QuantTypes.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/misc.mlir
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/misc.mlir
@@ -252,3 +252,20 @@ func.func @test_concat(%arg0: tensor<1x5xf32>, %arg1: tensor<5x5xf32>) -> tensor
   %0 = tcp.concat %arg0, %arg1 attributes {axis = 0 : i64} : tensor<1x5xf32>, tensor<5x5xf32> -> tensor<4x5xf32>
   return %0 : tensor<4x5xf32>
 }
+
+// -----
+// CHECK-LABEL:   func.func @test_per_tensor_quant_type
+// CHECK: tensor<?x?x!quant.uniform<i8:f32, 7.843100e-02:-12>>, tensor<?x?x!quant.uniform<i8:f32, 7.843100e-02:-12>> -> tensor<?x?x!quant.uniform<i8:f32, 7.843100e-02:-12>>
+func.func @test_per_tensor_quant_type(%0 : tensor<?x?x!quant.uniform<i8:f32, 0.078431:-12>>) -> tensor<?x?x!quant.uniform<i8:f32, 0.078431:-12>> {
+  %1 = tcp.add %0, %0 : tensor<?x?x!quant.uniform<i8:f32, 0.078431:-12>>, tensor<?x?x!quant.uniform<i8:f32, 0.078431:-12>> -> tensor<?x?x!quant.uniform<i8:f32, 0.078431:-12>>
+  return %1 : tensor<?x?x!quant.uniform<i8:f32, 0.078431:-12>>
+}
+
+// -----
+// CHECK-LABEL:   func.func @test_per_axis_quant_type
+// CHECK: tensor<3x?x?x!quant.uniform<i8<-127:127>:f32:0, {1.000000e-01,1.000000e-01,1.000000e-01}>>, tensor<3x?x?x!quant.uniform<i8<-127:127>:f32:0, {1.000000e-01,1.000000e-01,1.000000e-01}>> 
+// CHECK: -> tensor<3x?x?x!quant.uniform<i8<-127:127>:f32:0, {1.000000e-01,1.000000e-01,1.000000e-01}>>
+func.func @test_per_axis_quant_type(%0 : tensor<3x?x?x!quant.uniform<i8<-127:127>:f32:0, {0.1,0.1,0.1}>>) -> tensor<3x?x?x!quant.uniform<i8<-127:127>:f32:0, {0.1,0.1,0.1}>> {
+  %1 = tcp.add %0, %0 : tensor<3x?x?x!quant.uniform<i8<-127:127>:f32:0, {0.1,0.1,0.1}>>, tensor<3x?x?x!quant.uniform<i8<-127:127>:f32:0, {0.1,0.1,0.1}>> -> tensor<3x?x?x!quant.uniform<i8<-127:127>:f32:0, {0.1,0.1,0.1}>>
+  return %1 : tensor<3x?x?x!quant.uniform<i8<-127:127>:f32:0, {0.1,0.1,0.1}>>
+}

--- a/externals/llvm-external-projects/torch-mlir-dialects/tools/torch-mlir-dialects-opt/torch-mlir-dialects-opt.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/tools/torch-mlir-dialects-opt/torch-mlir-dialects-opt.cpp
@@ -48,6 +48,7 @@ int main(int argc, char **argv) {
       mlir::torch::TMTensor::TMTensorDialect,
 #ifdef TORCH_MLIR_DIALECTS_ENABLE_TCP
       mlir::tcp::TcpDialect,
+      mlir::quant::QuantizationDialect,
 #endif // TORCH_MLIR_DIALECTS_ENABLE_TCP
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
       mlir::stablehlo::StablehloDialect,
@@ -55,8 +56,7 @@ int main(int argc, char **argv) {
       // Upstream dialects
       mlir::arith::ArithDialect, mlir::linalg::LinalgDialect,
       mlir::func::FuncDialect, mlir::memref::MemRefDialect,
-      mlir::scf::SCFDialect, mlir::tensor::TensorDialect,
-      mlir::quant::QuantizationDialect>();
+      mlir::scf::SCFDialect, mlir::tensor::TensorDialect>();
 
   mlir::torch_mlir_dialects::registerConversionPasses();
 

--- a/externals/llvm-external-projects/torch-mlir-dialects/tools/torch-mlir-dialects-opt/torch-mlir-dialects-opt.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/tools/torch-mlir-dialects-opt/torch-mlir-dialects-opt.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Quant/QuantOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -54,7 +55,8 @@ int main(int argc, char **argv) {
       // Upstream dialects
       mlir::arith::ArithDialect, mlir::linalg::LinalgDialect,
       mlir::func::FuncDialect, mlir::memref::MemRefDialect,
-      mlir::scf::SCFDialect, mlir::tensor::TensorDialect>();
+      mlir::scf::SCFDialect, mlir::tensor::TensorDialect,
+      mlir::quant::QuantizationDialect>();
 
   mlir::torch_mlir_dialects::registerConversionPasses();
 

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -833,6 +833,7 @@ cc_binary(
         ":TorchMLIRTorchPasses",
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:MlirOptLib",
+        "@llvm-project//mlir:QuantOps",
     ],
 )
 

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -900,6 +900,7 @@ cc_library(
         "@llvm-project//mlir:Dialect",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:QuantOps",
     ],
 )
 


### PR DESCRIPTION
Add quant datatype support in tcp dialect.

To test:

`./build/bin/llvm-lit externals/llvm-external-projects/torch-mlir-dialects/test/Conversion/TcpToLinalg/ -v`
`./build/bin/llvm-lit externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/ -v`
`./build/bin/llvm-lit test/Conversion/TorchToTcp/ -v`
`python -m e2e_testing.main --config=tcp -v -s`