### PR TITLE
Set fetch-depth 0 for CI builds too

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -63,6 +63,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: 'true'
+        fetch-depth: 0
 
     - name: Fetch PyTorch commit hash
       if: ${{ matrix.os-arch != 'windows-x86_64' }}


### PR DESCRIPTION
The dreaded index.lock issue still exists (we tried enabled full checkouts for the Release builds before).