### PR TITLE
Fix creation of empty tensor in decomposition for randn ops

### DIFF
--- a/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
+++ b/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
@@ -226,7 +226,8 @@ public:
         typeConverter->convertType(op.getType()).cast<RankedTensorType>();
     Type resultElementType;
     if (op.getDtype().getType().isa<Torch::NoneType>()) {
-      resultElementType = resultType.getElementType();
+      resultElementType = getDefaultDtypeForTorchScalar(
+          Torch::FloatType::get(op->getContext()));
     } else {
       int64_t dtypeInt;
       if (!matchPattern(op.getDtype(), m_TorchConstantInt(&dtypeInt)))

--- a/python/torch_mlir_e2e_test/test_suite/rng.py
+++ b/python/torch_mlir_e2e_test/test_suite/rng.py
@@ -459,6 +459,30 @@ def RandnGeneratorModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+
+class RandnGeneratorF64Module(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        a = torch.ops.aten.randn([4, 512, 1024], generator=None, dtype=torch.float64)
+        std = torch.std(a)
+        return std
+
+
+@register_test_case(module_factory=lambda: RandnGeneratorF64Module())
+def RandnGeneratorF64Module_basic(module, tu: TestUtils):
+    module.forward()
+
+
+# ==============================================================================
+
+
 class RandnLikeModule(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
The current decomposition for `aten.randn.generator` does not specify the `dtype` argument of the empty tensors created to store the random values. This leads to invalid IR when the output type of the `randn` op is not the default PyTorch dtype.