### PR TITLE
[Torch Dialect] IntFloatOp fold: remove signedness

### DIFF
--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -1391,7 +1391,7 @@ OpFoldResult AtenIntFloatOp::fold(FoldAdaptor adaptor) {
   // Constant fold float -> int conversion.
   if (auto floatAttr = adaptor.getA().dyn_cast_or_null<FloatAttr>()) {
     return IntegerAttr::get(
-        mlir::IntegerType::get(getContext(), 64, IntegerType::Signed),
+        mlir::IntegerType::get(getContext(), 64),
         static_cast<int64_t>(floatAttr.getValue().convertToDouble()));
   }
   return nullptr;


### PR DESCRIPTION
Previously the resulting IR looks like
```
 %x = "torch.constant.int"() {value = xxx : si64} : () -> !torch.int
```
changed to
```
 %x = "torch.constant.int"() {value = xxx : i64} : () -> !torch.int
```

Signed integer is not being used elsewhere in `torch-mlir`, so remove its signedness semantics.