### PR TITLE
Increase ccache max_size

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -53,7 +53,7 @@ runs:
       mkdir -p ${{ github.workspace }}/.ccache
       ccache --set-config "cache_dir=${{ github.workspace }}/.ccache"
       ccache --set-config "compression=true"
-      ccache --set-config "max_size=300M"
+      ccache --set-config "max_size=6G"
       ccache --zero-stats
     shell: bash
 


### PR DESCRIPTION
Are we "cache" poor that we can't afford to increase this? I'm seeing recompiles after a sequence of test builds that make no change to llvm. [`6G`](https://github.com/iree-org/iree-llvm-sandbox/blob/main/.github/workflows/buildAndTestStructured.yml#L45-L47) seems to be a good number.