### PR TITLE
[Tcp] Add passes to fuse TCP elementwise ops and isolate TCP groups

### DIFF
--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/CMakeLists.txt
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/CMakeLists.txt
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls)
+mlir_tablegen(Transforms.capi.h.inc -gen-pass-capi-header)
+mlir_tablegen(Transforms.capi.cpp.inc -gen-pass-capi-impl)
+add_public_tablegen_target(TorchMLIRTcpPassIncGen)

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/FuseTcpOpsPass.h
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/FuseTcpOpsPass.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir::tcp {
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+createTcpFuseElementwiseOpsPass();
+
+} // namespace mlir::tcp

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/IsolateGroupOpsPass.h
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/IsolateGroupOpsPass.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir::tcp {
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+createTcpIsolateGroupOpsPass();
+
+} // namespace mlir::tcp

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::tcp {
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+createTcpFuseElementwiseOpsPass();
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+createTcpIsolateGroupOpsPass();
+
+/// Registers all Tcp related passes.
+void registerTcpPasses();
+
+} // namespace mlir::tcp

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.td
@@ -1,0 +1,27 @@
+//===-- Passes.td - Pass definition file -------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_TCP_PASSES
+#define TORCHMLIR_TCP_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+// \brief This is a pass that performs fusion of TCP ops.
+def TcpFuseElementwiseOps : Pass<"tcp-fuse-elementwise-ops", "ModuleOp"> {
+  let summary = "Performs fusion of tcp elementwise ops";
+  let constructor = "mlir::tcp::createTcpFuseElementwiseOpsPass()";
+}
+
+// \brief This pass makes all TCP group ops isolated from above.
+def TcpIsolateGroupOps : Pass<"tcp-isolate-group-ops", "ModuleOp"> {
+  let summary = "Converts all tcp.group ops to tcp.isolated_group ops";
+  let constructor = "mlir::tcp::createTcpIsolateGroupOpsPass()";
+}
+
+#endif // TORCHMLIR_TCP_PASSES

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/CMakeLists.txt
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/CMakeLists.txt
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_library(TorchMLIRTcpPasses
+  FuseTcpOpsPass.cpp
+  IsolateGroupOpsPass.cpp
+  Passes.cpp
+
+  DEPENDS
+  TorchMLIRTcpPassIncGen
+
+  LINK_LIBS PUBLIC
+  TorchMLIRTcpDialect
+  MLIRIR
+  MLIRPass
+  MLIRFuncDialect
+  MLIRSupport
+  MLIRTransforms
+)

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/FuseTcpOpsPass.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/FuseTcpOpsPass.cpp
@@ -1,0 +1,112 @@
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/FuseTcpOpsPass.h"
+#include "./PassDetail.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "torch-mlir-dialects/Dialect/Tcp/IR/TcpDialect.h"
+#include "torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.h"
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h"
+
+using namespace mlir;
+
+namespace mlir::tcp {
+
+namespace {
+
+class GenericBottomUpFuser : public RewritePattern {
+public:
+  using CanFuseFuncType = std::function<bool(Operation *, Operation *)>;
+
+  GenericBottomUpFuser(MLIRContext *context, CanFuseFuncType cf)
+      : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/1, context),
+        canFuse(cf) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    Operation *use = op;
+    for (auto operand : op->getOperands()) {
+      if (operand.getDefiningOp()) {
+        Operation *def = operand.getDefiningOp();
+        if (canFuse(def, use)) {
+
+          // Currently we are only fusing ops at the top-level.
+          // This is to avoid recursing inside a group and ending up with
+          // nested groups that contain the same ops.
+          // Since we are iterating bottom up in a block, we only need to check
+          // if the def op has a func parent.
+          //
+          // TODO: Remove this restriction to allow fusing in nested regions.
+          if (!isa<func::FuncOp>(def->getParentOp())) {
+            continue;
+          }
+
+          // We only support fusing def ops that have exactly one use, for now.
+          if (!def->hasOneUse()) {
+            continue;
+          }
+
+          // Fuse the def and use ops into a group.
+
+          // * If both the ops have the same parent region, they must be part
+          //   of the top-level func. So, we need to create a new group.
+          // * The only other case is when the def op is part of the top-level
+          //   func and the use is already inside a group.
+          if (def->getParentRegion() == use->getParentRegion()) {
+            auto groupOp =
+                rewriter.create<GroupOp>(use->getLoc(), use->getResultTypes());
+            Block *groupBlock = new Block();
+            groupOp.getBody().push_back(groupBlock);
+            for (unsigned num = 0; num < use->getNumResults(); ++num) {
+              rewriter.replaceAllUsesWith(use->getResult(num),
+                                          groupOp->getResult(num));
+            }
+            {
+              OpBuilder::InsertionGuard guard(rewriter);
+              rewriter.setInsertionPointToStart(groupBlock);
+              auto yieldOp =
+                  rewriter.create<YieldOp>(use->getLoc(), use->getResults());
+              use->moveBefore(yieldOp);
+              operand.getDefiningOp()->moveBefore(use);
+            }
+          } else if (auto groupOp = dyn_cast<GroupOp>(use->getParentOp())) {
+            def->moveBefore(use);
+          } else {
+            llvm_unreachable("Unhandled case during fusion");
+          }
+        }
+      }
+    }
+    return success();
+  }
+
+private:
+  CanFuseFuncType canFuse;
+};
+
+class TcpFuseElementwiseOpsPass
+    : public TcpFuseElementwiseOpsBase<TcpFuseElementwiseOpsPass> {
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *context = op->getContext();
+    RewritePatternSet patterns(context);
+
+    auto canFuse = [](Operation *def, Operation *use) -> bool {
+      return def->hasTrait<OpTrait::Elementwise>() &&
+             use->hasTrait<OpTrait::Elementwise>();
+    };
+    patterns.add<GenericBottomUpFuser>(context, canFuse);
+    (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createTcpFuseElementwiseOpsPass() {
+  return std::make_unique<TcpFuseElementwiseOpsPass>();
+}
+
+} // namespace mlir::tcp

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/IsolateGroupOpsPass.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/IsolateGroupOpsPass.cpp
@@ -1,0 +1,87 @@
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/IsolateGroupOpsPass.h"
+#include "./PassDetail.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "torch-mlir-dialects/Dialect/Tcp/IR/TcpDialect.h"
+#include "torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.h"
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h"
+#include "llvm/ADT/DenseSet.h"
+
+#include <iostream>
+
+using namespace mlir;
+
+namespace mlir::tcp {
+
+namespace {
+
+class IsolateGroups : public OpRewritePattern<GroupOp> {
+public:
+  using OpRewritePattern<GroupOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(GroupOp groupOp,
+                                PatternRewriter &rewriter) const override {
+    // Collect the values used in the given GroupOp. Those will be the inputs
+    // to the IsolatedGroup op.
+    std::vector<Value> inputs;
+    llvm::SmallDenseSet<Value> defs;
+    for (auto &op : groupOp.getBody().front()) {
+      for (auto operand : op.getOperands()) {
+        if (defs.find(operand) == defs.end()) {
+          inputs.push_back(operand);
+        }
+      }
+      defs.insert(op.getResults().begin(), op.getResults().end());
+    }
+
+    auto isolatedGroupOp = rewriter.create<IsolatedGroupOp>(
+        groupOp.getLoc(), groupOp.getResultTypes(), inputs);
+    isolatedGroupOp->setAttrs(groupOp->getAttrs());
+
+    isolatedGroupOp.getBody().takeBody(groupOp.getBody());
+    auto &isolatedGroupBlock = isolatedGroupOp.getBody().front();
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&isolatedGroupBlock);
+      for (size_t n = 0; n < inputs.size(); ++n) {
+        isolatedGroupBlock.addArgument(inputs[n].getType(), groupOp.getLoc());
+        rewriter.replaceUsesWithIf(
+            inputs[n], isolatedGroupBlock.getArgument(n),
+            [&](OpOperand &opOperand) {
+              return (opOperand.getOwner()->getParentOp() == isolatedGroupOp);
+            });
+      }
+    }
+    for (unsigned n = 0; n < groupOp.getNumResults(); ++n) {
+      rewriter.replaceAllUsesWith(groupOp->getOpResult(n),
+                                  isolatedGroupOp->getOpResult(n));
+    }
+    rewriter.eraseOp(groupOp);
+    return success();
+  }
+};
+
+class TcpIsolateGroupOpsPass
+    : public TcpIsolateGroupOpsBase<TcpIsolateGroupOpsPass> {
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *context = op->getContext();
+    RewritePatternSet patterns(context);
+
+    patterns.add<IsolateGroups>(context);
+    (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createTcpIsolateGroupOpsPass() {
+  return std::make_unique<TcpIsolateGroupOpsPass>();
+}
+
+} // namespace mlir::tcp

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/PassDetail.h
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/PassDetail.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "mlir/Pass/Pass.h"
+
+#include "torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.h"
+
+namespace mlir::tcp {
+
+using namespace mlir;
+#define GEN_PASS_CLASSES
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h.inc"
+
+} // end namespace mlir::tcp

--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/Passes.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/Passes.cpp
@@ -1,0 +1,12 @@
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h"
+#include "mlir/Pass/Pass.h"
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/FuseTcpOpsPass.h"
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/IsolateGroupOpsPass.h"
+#include <memory>
+
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h.inc"
+} // end namespace
+
+void mlir::tcp::registerTcpPasses() { ::registerPasses(); }

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/tcp-fusion.mlir
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/tcp-fusion.mlir
@@ -1,0 +1,53 @@
+// RUN: torch-mlir-dialects-opt %s -split-input-file -tcp-fuse-elementwise-ops -verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL: func.func @test_basic_fusion(
+// CHECK-SAME:          %[[ARG0:.*]]: tensor<?x?xf32>,
+// CHECK-SAME:          %[[ARG1:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[GROUP:.*]] = tcp.group {
+// CHECK:           %[[TANH:.*]] = tcp.tanh %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:           %[[ADD:.*]] = tcp.add %[[TANH]], %[[ARG1]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:           tcp.yield %[[ADD]] : tensor<?x?xf32>
+// CHECK:         } : tensor<?x?xf32>
+// CHECK:         return %[[GROUP]] : tensor<?x?xf32>
+func.func @test_basic_fusion(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.tanh %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  %1 = tcp.add %0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_multiple_fusions(
+// CHECK-SAME:          %[[ARG0:.*]]: tensor<?x?xf32>, %[[ARG1:.*]]: tensor<?x?xf32>,
+// CHECK-SAME:          %[[ARG2:.*]]: tensor<1x?xf32>, %[[ARG3:.*]]: tensor<1x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[GROUP1:.*]] = tcp.group {
+// CHECK:           %[[TANH1:.*]] = tcp.tanh %[[ARG2]] : tensor<1x?xf32> -> tensor<1x?xf32>
+// CHECK:           %[[TANH2:.*]] = tcp.tanh %[[ARG3]] : tensor<1x?xf32> -> tensor<1x?xf32>
+// CHECK:           %[[MUL:.*]] = tcp.mul %[[TANH1]], %[[TANH2]] : tensor<1x?xf32>, tensor<1x?xf32> -> tensor<1x?xf32>
+// CHECK:           tcp.yield %[[MUL]] : tensor<1x?xf32>
+// CHECK:         } : tensor<1x?xf32>
+// CHECK:         %[[DIM:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?xf32>
+// CHECK:         %[[BCAST:.*]] = tcp.broadcast %[[GROUP1]], %[[DIM]] {axes = [0]} : tensor<1x?xf32>, index -> tensor<?x?xf32>
+// CHECK:         %[[GROUP2:.*]] = tcp.group {
+// CHECK:           %[[CLAMP:.*]] = tcp.clamp %[[BCAST]] {min_float = 0.000000e+00 : f32} : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:           %[[ADD:.*]] = tcp.add %[[ARG0]], %[[CLAMP]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:           %[[SUB:.*]] = tcp.sub %[[ARG1]], %[[ADD]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:           tcp.yield %[[SUB]] : tensor<?x?xf32>
+// CHECK:         } : tensor<?x?xf32>
+// CHECK:         return %[[GROUP2]] : tensor<?x?xf32>
+func.func @test_multiple_fusions(%arg0 : tensor<?x?xf32>,
+                                 %arg1 : tensor<?x?xf32>,
+                                 %arg2 : tensor<1x?xf32>,
+                                 %arg3 : tensor<1x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.tanh %arg2 : tensor<1x?xf32> -> tensor<1x?xf32>
+  %1 = tcp.tanh %arg3 : tensor<1x?xf32> -> tensor<1x?xf32>
+  %2 = tcp.mul %0, %1 : tensor<1x?xf32>, tensor<1x?xf32> -> tensor<1x?xf32>
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %3 = tcp.broadcast %2, %dim {axes = [0]} : tensor<1x?xf32>, index -> tensor<?x?xf32>
+  %4 = tcp.clamp %3 {min_float = 0.0 : f32} : tensor<?x?xf32> -> tensor<?x?xf32>
+  %5 = tcp.add %arg0, %4 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  %6 = tcp.sub %arg1, %5 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  return %6 : tensor<?x?xf32>
+}

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/tcp-isolate-groups.mlir
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/Dialect/Tcp/tcp-isolate-groups.mlir
@@ -1,0 +1,74 @@
+// RUN: torch-mlir-dialects-opt %s -split-input-file -tcp-isolate-group-ops -verify-diagnostics --mlir-print-ir-after-all | FileCheck %s
+
+// CHECK-LABEL: func.func @test_group(
+// CHECK-SAME:          %[[ARG0:.*]]: tensor<?x?xf32>,
+// CHECK-SAME:          %[[ARG1:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:          %[[GROUP:.*]] = tcp.isolated_group %[[ARG0]], %[[ARG1]] {
+// CHECK:            ^bb0(%[[ARG2:.*]]: tensor<?x?xf32>, %[[ARG3:.*]]: tensor<?x?xf32>):
+// CHECK:              %[[ADD:.*]] = tcp.add %[[ARG2]], %[[ARG3]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:              %[[TANH:.*]] = tcp.tanh %[[ADD]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:              tcp.yield %[[TANH]] : tensor<?x?xf32>
+// CHECK:          } : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:          return %[[GROUP]] : tensor<?x?xf32>
+// CHECK:        }
+func.func @test_group(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %10 = "tcp.group" () ({
+    ^bb0() :
+      %2 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+      tcp.yield %3 : tensor<?x?xf32>
+  }) : () -> tensor<?x?xf32>
+   return %10 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_bigger_group(
+// CHECK-SAME:          %[[ARG0:.*]]: tensor<?x?xf32>, %[[ARG1:.*]]: tensor<?x?xf32>,
+// CHECK-SAME:          %[[ARG2:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:          %[[GROUP:.*]] = tcp.isolated_group %[[ARG0]], %[[ARG1]], %[[ARG2]] {
+// CHECK:            ^bb0(%[[ARG3:.*]]: tensor<?x?xf32>, %[[ARG4:.*]]: tensor<?x?xf32>, %[[ARG5:.*]]: tensor<?x?xf32>):
+// CHECK:              %[[CLAMP:.*]] = tcp.clamp %[[ARG3]] {min_float = 0.000000e+00 : f32} : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:              %[[SUB:.*]] = tcp.sub %[[ARG4]], %[[CLAMP]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:              %[[TANH:.*]] = tcp.tanh %[[ARG5]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:              %[[ADD:.*]] = tcp.add %[[TANH]], %[[SUB]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:              tcp.yield %[[ADD]] : tensor<?x?xf32>
+// CHECK:          } : tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:          return %[[GROUP]] : tensor<?x?xf32>
+// CHECK:        }
+func.func @test_bigger_group(%arg0 : tensor<?x?xf32>,
+                             %arg1 : tensor<?x?xf32>,
+                             %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %10 = "tcp.group" () ({
+    ^bb0() :
+      %4 = tcp.clamp %arg0 {min_float = 0.0 : f32} : tensor<?x?xf32> -> tensor<?x?xf32>
+      %5 = tcp.sub %arg1, %4 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %6 = tcp.tanh %arg2 : tensor<?x?xf32> -> tensor<?x?xf32>
+      %7 = tcp.add %6, %5 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      tcp.yield %7 : tensor<?x?xf32>
+  }) : () -> tensor<?x?xf32>
+   return %10 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_propagate_attrs(
+// CHECK-SAME:          %[[ARG0:.*]]: tensor<?x?xf32>,
+// CHECK-SAME:          %[[ARG1:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:          %[[GROUP:.*]] = tcp.isolated_group %[[ARG0]], %[[ARG1]] attributes {test_attr} {
+// CHECK:            ^bb0(%[[ARG2:.*]]: tensor<?x?xf32>, %[[ARG3:.*]]: tensor<?x?xf32>):
+// CHECK:              %[[ADD:.*]] = tcp.add %[[ARG2]], %[[ARG3]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:              %[[TANH:.*]] = tcp.tanh %[[ADD]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:              tcp.yield %[[TANH]] : tensor<?x?xf32>
+// CHECK:          } : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:          return %[[GROUP]] : tensor<?x?xf32>
+// CHECK:        }
+func.func @test_propagate_attrs(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %10 = "tcp.group" () ({
+    ^bb0() :
+      %2 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+      %3 = tcp.tanh %2 : tensor<?x?xf32> -> tensor<?x?xf32>
+      tcp.yield %3 : tensor<?x?xf32>
+  }) { "test_attr" } : () -> tensor<?x?xf32>
+   return %10 : tensor<?x?xf32>
+}

--- a/externals/llvm-external-projects/torch-mlir-dialects/tools/torch-mlir-dialects-opt/CMakeLists.txt
+++ b/externals/llvm-external-projects/torch-mlir-dialects/tools/torch-mlir-dialects-opt/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBS
 
 if(TORCH_MLIR_DIALECTS_ENABLE_TCP)
   list(APPEND LIBS TorchMLIRTcpDialect)
+  list(APPEND LIBS TorchMLIRTcpPasses)
 endif()
 
 if(TORCH_MLIR_ENABLE_STABLEHLO)

--- a/externals/llvm-external-projects/torch-mlir-dialects/tools/torch-mlir-dialects-opt/torch-mlir-dialects-opt.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/tools/torch-mlir-dialects-opt/torch-mlir-dialects-opt.cpp
@@ -22,6 +22,7 @@
 #include "torch-mlir-dialects/Conversion/Passes.h"
 #ifdef TORCH_MLIR_DIALECTS_ENABLE_TCP
 #include "torch-mlir-dialects/Dialect/Tcp/IR/TcpDialect.h"
+#include "torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h"
 #endif // TORCH_MLIR_DIALECTS_ENABLE_TCP
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
 #include "stablehlo/dialect/StablehloOps.h"
@@ -57,6 +58,10 @@ int main(int argc, char **argv) {
       mlir::arith::ArithDialect, mlir::linalg::LinalgDialect,
       mlir::func::FuncDialect, mlir::memref::MemRefDialect,
       mlir::scf::SCFDialect, mlir::tensor::TensorDialect>();
+
+#ifdef TORCH_MLIR_DIALECTS_ENABLE_TCP
+  mlir::tcp::registerTcpPasses();
+#endif // TORCH_MLIR_DIALECTS_ENABLE_TCP
 
   mlir::torch_mlir_dialects::registerConversionPasses();
 

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -905,6 +905,55 @@ cc_library(
     ],
 )
 
+td_library(
+    name = "TorchMLIRTcpTransformsPassesTdFiles",
+    srcs = [
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.td",
+    ],
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "TorchMLIRTcpTransformsPassesIncGen",
+    strip_include_prefix = "externals/llvm-external-projects/torch-mlir-dialects/include",
+    tbl_outs = [
+        (
+            ["-gen-pass-decls"],
+            "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.td",
+    deps = [
+        ":TorchMLIRTcpTransformsPassesTdFiles",
+    ],
+)
+
+cc_library(
+    name = "TorchMLIRTcpPasses",
+    srcs = [
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/FuseTcpOpsPass.cpp",
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/IsolateGroupOpsPass.cpp",
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/PassDetail.h",
+        "externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/Passes.cpp",
+    ],
+    hdrs = [
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/FuseTcpOpsPass.h",
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/IsolateGroupOpsPass.h",
+        "externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h",
+    ],
+    strip_include_prefix = "externals/llvm-external-projects/torch-mlir-dialects/include",
+    deps = [
+        ":TorchMLIRTcpDialect",
+        ":TorchMLIRTcpTransformsPassesIncGen",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
 cc_library(
     name = "TorchMLIRTorchToTcp",
     srcs = glob([
@@ -1055,6 +1104,7 @@ cc_binary(
         ":TorchMLIRTMTensorDialect",
         ":TorchMLIRTMTensorPasses",
         ":TorchMLIRTcpDialect",
+        ":TorchMLIRTcpPasses",
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:Dialect",
         "@llvm-project//mlir:DialectUtils",


### PR DESCRIPTION
This PR adds 2 transformation passes in TCP:
1. A pass to fuse elementwise ops into `tcp.group` ops. This in turn uses a generic fuser that can be used to create groups to represent different kind of fusions.
2. A pass to convert `tcp.group` ops to `tcp.isolated_group` ops. This is useful when we want to lower from TCP to any backend that have a special way of handling the group.