### PR TITLE
[Tcp] Clone constants into the IsolatedGroup region

### DIFF
--- a/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/IsolateGroupOpsPass.cpp
+++ b/externals/llvm-external-projects/torch-mlir-dialects/lib/Dialect/Tcp/Transforms/IsolateGroupOpsPass.cpp
@@ -12,8 +12,6 @@
 #include "torch-mlir-dialects/Dialect/Tcp/Transforms/Passes.h"
 #include "llvm/ADT/DenseSet.h"
 
-#include <iostream>
-
 using namespace mlir;
 
 namespace mlir::tcp {
@@ -27,13 +25,22 @@ public:
   LogicalResult matchAndRewrite(GroupOp groupOp,
                                 PatternRewriter &rewriter) const override {
     // Collect the values used in the given GroupOp. Those will be the inputs
-    // to the IsolatedGroup op.
-    std::vector<Value> inputs;
+    // to the IsolatedGroup op. The constants used in the GroupOp are collected
+    // in a separate set and cloned into the body of the IsolatedGroupOp.
+    llvm::SmallVector<Value> inputs;
+    llvm::SmallDenseSet<Value> addedInputs;
+    llvm::SmallDenseSet<Value> consts;
     llvm::SmallDenseSet<Value> defs;
     for (auto &op : groupOp.getBody().front()) {
       for (auto operand : op.getOperands()) {
         if (defs.find(operand) == defs.end()) {
-          inputs.push_back(operand);
+          if (operand.getDefiningOp() &&
+              operand.getDefiningOp()->hasTrait<OpTrait::ConstantLike>()) {
+            consts.insert(operand);
+          } else if (!addedInputs.contains(operand)) {
+            inputs.push_back(operand);
+            addedInputs.insert(operand);
+          }
         }
       }
       defs.insert(op.getResults().begin(), op.getResults().end());
@@ -48,13 +55,22 @@ public:
     {
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(&isolatedGroupBlock);
+      auto belongsToIsolatedGroup = [&](OpOperand &opOperand) {
+        return (opOperand.getOwner()->getParentOp() == isolatedGroupOp);
+      };
+
+      // Clone the constants at the start of the isolated group block.
+      for (auto c : consts) {
+        auto newConst = rewriter.clone(*c.getDefiningOp());
+        rewriter.replaceUsesWithIf(c, newConst->getResult(0),
+                                   belongsToIsolatedGroup);
+      }
+
+      // Add inputs as arguments to the isolated group block.
       for (size_t n = 0; n < inputs.size(); ++n) {
         isolatedGroupBlock.addArgument(inputs[n].getType(), groupOp.getLoc());
-        rewriter.replaceUsesWithIf(
-            inputs[n], isolatedGroupBlock.getArgument(n),
-            [&](OpOperand &opOperand) {
-              return (opOperand.getOwner()->getParentOp() == isolatedGroupOp);
-            });
+        rewriter.replaceUsesWithIf(inputs[n], isolatedGroupBlock.getArgument(n),
+                                   belongsToIsolatedGroup);
       }
     }
     for (unsigned n = 0; n < groupOp.getNumResults(); ++n) {


### PR DESCRIPTION
This PR fixes the handling of constants in the IsolateGroupOps pass. Specifically, any constant that is used within the isolated group op will now be cloned into the start of the block.

This also fixes another issue with duplicate input arguments in the isolated blocks, when there are multiple uses of that value.