### PR TITLE
CI: let GitHub action create commit

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -114,9 +114,6 @@ jobs:
         git fetch --recurse-submodules=no
         git checkout main
         git pull origin main
-        git checkout -b rollpytorch/${{ env.PT_RELEASE }}
-        git add pytorch-hash.txt pytorch-requirements.txt torchvision-requirements.txt lib/Dialect/Torch/Transforms/AbstractInterpLibrary.cpp include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
-        git diff --cached --exit-code || git commit -m "update PyTorch version to ${{ env.PT_RELEASE }}"
 
     - name: Create pull request
       uses: peter-evans/create-pull-request@v5.0.1


### PR DESCRIPTION
The GitHub action for creating the PR expects that either the changes
are not committed (in which case it commits them with the specified
commit message) or that the commit exists but that it is also pushed to
remote.

Prior to this patch, we created the commit but did not push it to
remote, causing failures.  This patch leaves the changes uncommitted so
that they're committed and pushed to remote as part of the PR creation.