### PR TITLE
TorchToTosa: Support casts from and to bf16

### DIFF
--- a/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
@@ -222,21 +222,31 @@ std::optional<Value> getConstTensor<float>(PatternRewriter &rewriter,
 }
 
 static LogicalResult checkValidityOfCast(Type src, Type dest) {
-  if ((src == dest) || (src.isInteger(64) && dest.isInteger(32)) ||
+  if ((src == dest) ||
+      (src.isInteger(64) && dest.isInteger(32)) ||
       (src.isInteger(64) && dest.isInteger(8)) ||
       (src.isInteger(64) && dest.isInteger(1)) ||
       (src.isInteger(64) && dest.isF32()) ||
       (src.isInteger(32) && dest.isInteger(64)) ||
       (src.isInteger(32) && dest.isInteger(1)) ||
       (src.isInteger(32) && dest.isF32()) ||
+      (src.isInteger(32) && dest.isBF16()) ||
+      (src.isInteger(16) && dest.isBF16()) ||
       (src.isInteger(8) && dest.isInteger(1)) ||
+      (src.isInteger(8) && dest.isBF16()) ||
       (src.isInteger(1) && dest.isInteger(64)) ||
       (src.isInteger(1) && dest.isF32()) ||
       (src.isF32() && dest.isF64()) ||
+      (src.isF32() && dest.isBF16()) ||
       (src.isF64() && dest.isF32()) ||
+      (src.isF64() && dest.isBF16()) ||
       (src.isF32() && dest.isInteger(8)) ||
       (src.isF32() && dest.isInteger(64)) ||
-      (src.isF32() && dest.isInteger(1))) {
+      (src.isF32() && dest.isInteger(1)) ||
+      (src.isBF16() && dest.isInteger(8)) ||
+      (src.isBF16() && dest.isInteger(16)) ||
+      (src.isBF16() && dest.isInteger(32)) ||
+      (src.isBF16() && dest.isF32())) {
     return success();
   }
   return failure();


### PR DESCRIPTION
This PR adds all legal casts (according to TOSA spec) from/to bf16 into the TorchToTosa lowering pass,
and it also adds the cast from i64 to i32 (which was missing).

I did not add end2end tests as per the discussion on discord [0] and because the torch-mlir end2end testing
framework is not ready for bf16:
- It doesn't have the compiler-rt builtins for f32 to bf16 conversions
- Numpy doesn't support bf16, so it cannot tell them apart from f16.

[0] https://discordapp.com/channels/636084430946959380/742573221882364009/1104136103314849844