### PR TITLE
CI: prepare CI for ccache updates for MSVC/Windows

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -138,6 +138,6 @@ jobs:
       shell: bash
       run: ./build_tools/python_deploy/build_windows_ci.sh
 
-    - name: Print ccache configuration and statistics
+    - name: Print ccache statistics
       shell: bash
-      run: ccache --show-config --show-stats --print-stats
+      run: ccache --show-stats

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,21 +64,6 @@ torch_mlir_add_llvm_external_project(
 
 option(TORCH_MLIR_OUT_OF_TREE_BUILD "Specifies an out of tree build" OFF)
 
-# Adjustments to use ccache on Windows
-if (WIN32)
-  find_program(ccache_exe ccache)
-  if(ccache_exe)
-    file(COPY_FILE ${ccache_exe} ${CMAKE_BINARY_DIR}/cl.exe ONLY_IF_DIFFERENT)
-    set(CMAKE_VS_GLOBALS
-      "CLToolExe=cl.exe"
-      "CLToolPath=${CMAKE_BINARY_DIR}"
-      "TrackFileAccess=false"
-      "UseMultiToolTask=true"
-      "DebugInformationFormat=OldStyle"
-    )
-  endif()
-endif()
-
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR TORCH_MLIR_OUT_OF_TREE_BUILD)
   message(STATUS "Torch-MLIR out-of-tree build.")
   # Out-of-tree build

--- a/build_tools/python_deploy/build_windows_ci.sh
+++ b/build_tools/python_deploy/build_windows_ci.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 echo "Building torch-mlir"
 
@@ -16,6 +17,6 @@ cmake -GNinja -Bbuild \
   -DPython3_EXECUTABLE="$(which python)" \
   $GITHUB_WORKSPACE/externals/llvm-project/llvm
 
-cmake --build build
+cmake --build build --config Release
 
 echo "Build completed successfully"

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ class CMakeBuild(build_py):
                                   cmake_args, cwd=cmake_build_dir)
             subprocess.check_call(["cmake",
                                    "--build",  ".",
+                                   "--config", "Release",
                                    "--target", "TorchMLIRPythonModules"],
                                   cwd=cmake_build_dir)
 


### PR DESCRIPTION
This patch, by itself, doesn't fix caching on Windows, but once a new
release of ccache is available, caching for Windows builds should start
working again (validated by building ccache from source and using it
with LLVM builds).

Ccache rejects caching when either the `/Zi` or `/ZI` flags are used
during compilation on Windows, since these flags tell the compiler to
embed debug information in a PDB file (separate from the object file
produced by the compiler).  In particular, our CI builds add the `/Zi`
flag, making ccache mark these compiler invocations as uncacheable.

But what caused our CI to add debug flags, especially when we specified
`-DCMAKE_BUILD_TYPE=Release`?  On Windows, unless we specify the
`--config Release` flag during the CMake build step, CMake assumes a
debug build.  So all this while, we had been producing debug builds of
torch-mlir for every PR!  No doubt it took so long to build the Windows
binaries.

The reason for having to specify the configuration during the _build_
step (as opposed to the _configure_ step) of CMake on Windows is that
CMake's Visual Studio generators will produce _both_ Release and Debug
profiles during the CMake configure step (thus requiring a build-time
value that tells CMake whether to build in Release or Debug mode).
Luckily, on Linux and macOS, the `--config` flag seems to be simply
ignored, instead of causing build errors.

Strangely, based on cursory tests, it seems like on Windows we need to
specify the Relase configuration as both `-DCMAKE_BUILD_TYPE=Release` as
well as `--config Release`.  Dropping either made my build switch to a
Debug configuration.

Additionally, there is a bug in ccache v4.8 (although this is addressed
in trunk) that causes ccache to reject caching if the compiler
invocation includes any flag that starts with `/Z`, including /`Zc`,
which is added by LLVM's HandleLLVMOptions.cmake and which isn't related
to debug info or PDB files.  The next release of ccache should include
the fix, which is to reject caching only for `/Zi` and `/ZI` flags and
not all flags that start with `/Z`.

As a side note, debugging this problem was possible because of ccache's
log file, which is enabled by: `ccache --set-config="log_file=log.txt"`.

---

cc: @makslevental