### PR TITLE
[Tcp] Add Tcp passes bazel target to TorchMLIRInitAll

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -811,6 +811,7 @@ cc_library(
         ":TorchMLIRTMTensorDialect",
         ":TorchMLIRTMTensorPasses",
         ":TorchMLIRTcpDialect",
+        ":TorchMLIRTcpPasses",
         ":TorchMLIRTorchConversionDialect",
         ":TorchMLIRTorchConversionPasses",
         ":TorchMLIRTorchDialect",


### PR DESCRIPTION
Update the bazel rule `TorchMLIRInitAll` to include Tcp transformation passes.