### PR TITLE
CI: Use GitHub app token for creating PRs

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -132,4 +132,5 @@ jobs:
            - torchvision version: ${{ env.PTVISION_RELEASE }}
         committer: Roll PyTorch Action <torch-mlir@users.noreply.github.com>
         title: update PyTorch version to ${{ env.PT_RELEASE }}
+        token: ${{ secrets.ROLLPYTORCH_TOKEN0 }}
         reviewers: ashay, powderluv, vivekkhandelwal1


### PR DESCRIPTION
Since PRs created by the GitHub action bot cannot trigger workflows (and
thus build tests), this patch uses the token for a GitHub app that was
specifically created for the RollPyTorch action.