### PR TITLE
CI: Align Python version between RollPyTorch and Build Tests

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -98,7 +98,7 @@ jobs:
           ```
 
     - name: Update PyTorch Build Cache (if running on main branch)
-      if: github.ref_name == 'main'
+      if: github.ref_name == 'main' && env.PT_HASH_CHANGED != '0'
       id: cache-pytorch
       uses: actions/cache@v3
       with:
@@ -116,6 +116,7 @@ jobs:
         git pull origin main
 
     - name: Create pull request
+      if: env.PT_HASH_CHANGED != '0'
       uses: peter-evans/create-pull-request@v5.0.1
       with:
         author: Roll PyTorch Action <torch-mlir@users.noreply.github.com>

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -91,15 +91,15 @@ function run_on_host() {
       ;;
     out-of-tree)
       TM_CURRENT_DOCKER_IMAGE=${TM_CI_DOCKER_IMAGE}
-      # CI uses only Python3.10
-      TM_PYTHON_VERSIONS="cp310-cp310"
+      # CI uses only Python3.11
+      TM_PYTHON_VERSIONS="cp311-cp311"
       export USERID=$(id -u)
       export GROUPID=$(id -g)
       ;;
     in-tree)
       TM_CURRENT_DOCKER_IMAGE=${TM_CI_DOCKER_IMAGE}
-      # CI uses only Python3.10
-      TM_PYTHON_VERSIONS="cp310-cp310"
+      # CI uses only Python3.11
+      TM_PYTHON_VERSIONS="cp311-cp311"
       export USERID=$(id -u)
       export GROUPID=$(id -g)
       ;;


### PR DESCRIPTION
The RollPyTorch action uses Python v3.11 (so does the Release build),
but the workflow that runs the CI tests uses Python v3.10.  This can
cause subtle failures, so this patch makes all three of these workflows
use Python v3.11.

This patch also fixes a bug in the RollPyTorch action so that it skips
creating a PR if the pytorch commit hash has not changed.