### PR TITLE
Add alias analysis for cast-like ops to maximize-value-semantics

### DIFF
--- a/test/Dialect/Torch/maximize-value-semantics.mlir
+++ b/test/Dialect/Torch/maximize-value-semantics.mlir
@@ -261,3 +261,19 @@ func.func @viewlike$two_inputs_two_copies(%arg0: !torch.vtensor, %arg1: !torch.v
   %3 = torch.copy.to_vtensor %2 : !torch.vtensor
   return %3 : !torch.vtensor
 }
+
+// CHECK-LABEL:   func.func @castlike(
+// CHECK-SAME:                       %[[ARG0:.*]]: !torch.vtensor<[5,4],f32>) -> !torch.tensor {
+// CHECK:           %[[CAST1:.*]] = torch.tensor_static_info_cast %[[ARG0]] : !torch.vtensor<[5,4],f32> to !torch.vtensor
+// CHECK:           %[[CAST2:.*]] = torch.tensor_static_info_cast %[[CAST1]] : !torch.vtensor to !torch.vtensor<[5,4],f32>
+// CHECK:           %[[CAST3:.*]] = torch.tensor_static_info_cast %[[CAST2]] : !torch.vtensor<[5,4],f32> to !torch.vtensor
+// CHECK:           %[[COPY:.*]] = torch.copy.to_tensor %[[CAST3]] : !torch.tensor
+// CHECK:           return %[[COPY]] : !torch.tensor
+func.func @castlike(%arg0: !torch.vtensor<[5,4],f32>) -> !torch.tensor {
+  %0 = torch.tensor_static_info_cast %arg0 : !torch.vtensor<[5,4],f32> to !torch.vtensor
+  %1 = torch.copy.to_tensor %0 : !torch.tensor
+  %2 = torch.tensor_static_info_cast %1 : !torch.tensor to !torch.tensor<[5,4],f32>
+  %3 = torch.copy.to_vtensor %2 : !torch.vtensor<[5,4],f32>
+  torch.overwrite.tensor.contents %3 overwrites %2 : !torch.vtensor<[5,4],f32>, !torch.tensor<[5,4],f32>
+  return %1 : !torch.tensor
+}


### PR DESCRIPTION
When `use_tracing=True` is used to import a model into Torch-MLIR, several casts get inserted in the IR to bridge the untyped inputs and outputs with the typed body of the computation. These casts create extra aliases of tensors that cause the current analysis in `maximize-value-semantics` to fail.

In particular, the `maximize-value-semantics` analysis assumes that the only valid alias right after an overwrite is the overwritten alias. So, if there is a use of a casted version of the overwritten alias after the overwrite, the analysis fails.

This commit improves the analysis by identifying all cast-like aliases of the overwritten alias and allowing such aliases to be used after an overwrite.

Because this issue only arises when using tracing, it cannot be currently tested e2e, so only lit test is added.