### PR TITLE
setup-python only on x64 machines

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -15,6 +15,7 @@ runs:
 
   steps:
   - name: Set up Python
+    if: ${{ runner.arch == 'X64' }}
     uses: actions/setup-python@v4
     with:
       python-version: '3.11'


### PR DESCRIPTION
there are no arm64 Python binaries. Should also work on x86//64 macOS runners.