### PR TITLE
CI: disable caching for release builds

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -2,6 +2,10 @@ name: "Setup build environment"
 description: "Setup the build environment. An action so that it can be shared between in-tree/out-of-tree jobs"
 
 inputs:
+  cache-enabled:
+    required: true
+    default: true
+
   cache-suffix:
     description: |
       Additional string that is used to compute the ccache hash.
@@ -48,6 +52,7 @@ runs:
     shell: bash
 
   - name: Configure ccache
+    if: ${{ inputs.cache-enabled == 'true' }}
     run: |
       rm -rf ${{ github.workspace }}/.ccache
       mkdir -p ${{ github.workspace }}/.ccache
@@ -58,6 +63,7 @@ runs:
     shell: bash
 
   - name: Enable ccache
+    if: ${{ inputs.cache-enabled == 'true' }}
     uses: actions/cache@v3
     with:
       path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -40,7 +40,7 @@ jobs:
 
     - uses: ./.github/actions/setup-build
       with:
-        cache-suffix: 'release'
+        cache-enabled: 'false'
     - name: Build Python wheels and smoke test.
       run: |
         cd $GITHUB_WORKSPACE
@@ -99,7 +99,7 @@ jobs:
         submodules: 'true'
     - uses: ./.github/actions/setup-build
       with:
-        cache-suffix: 'release'
+        cache-enabled: 'false'
     - name: Build Python wheels and smoke test.
       run: |
         cd $GITHUB_WORKSPACE
@@ -159,7 +159,7 @@ jobs:
         submodules: 'true'
     - uses: ./.github/actions/setup-build
       with:
-        cache-suffix: 'release'
+        cache-enabled: 'false'
     - name: Set up Visual Studio shell
       uses: egor-tensin/vs-shell@v2
       with:


### PR DESCRIPTION
This patch adds a (default-true) input called `cache-enabled` to the
setup-build action, so that when the input is false, ccache is not setup
on the host machine.  This patch also sets the input to be false for the
release builds.