### PR TITLE
Remove spurious pip in Release builds

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -44,7 +44,6 @@ jobs:
     - name: Build Python wheels and smoke test.
       run: |
         cd $GITHUB_WORKSPACE
-        python -m pip install wheel
         TM_PACKAGE_VERSION=${{ github.event.inputs.python_package_version }}
         printf "TORCH_MLIR_PYTHON_PACKAGE_VERSION=%s\n" $TM_PACKAGE_VERSION > ./torch_mlir_package_version
         TM_PYTHON_VERSIONS=${{ matrix.py_version }} TM_PACKAGES=${{ matrix.package }} ./build_tools/python_deploy/build_linux_packages.sh


### PR DESCRIPTION
(left over from a previous commit that was approved and landed in a branch on accident)