### PR TITLE
[Tcp] Enable Tcp by default in mlir-tcp branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(TORCH_MLIR_ENABLE_STABLEHLO)
   add_definitions(-DTORCH_MLIR_ENABLE_STABLEHLO)
 endif()
 
-option(TORCH_MLIR_ENABLE_TCP "Add TCP dialect" OFF)
+option(TORCH_MLIR_ENABLE_TCP "Add TCP dialect" ON)
 if (TORCH_MLIR_ENABLE_TCP)
   add_definitions(-DTORCH_MLIR_ENABLE_TCP)
 endif()

--- a/utils/bazel/torch-mlir-overlay/test/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/test/BUILD.bazel
@@ -24,7 +24,7 @@ expand_template(
         "@MLIR_ENABLE_BINDINGS_PYTHON@": "0",
         "@TORCH_MLIR_ENABLE_JIT_IR_IMPORTER@": "0",
         "@TORCH_MLIR_ENABLE_STABLEHLO@": "0",
-        "@TORCH_MLIR_ENABLE_TCP@": "0",
+        "@TORCH_MLIR_ENABLE_TCP@": "1",
     },
     template = "lit.site.cfg.py.in",
 )


### PR DESCRIPTION
This PR enables Tcp by default in the cmake as well as bazel builds in the `mlir-tcp` branch. 