### PR TITLE
[Torch Dialect] support uint8 dtype

### DIFF
--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -930,10 +930,14 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
   }
   if (auto atenToDtype = dyn_cast<AtenToDtypeOp>(op)) {
     Value input = payloadArgs[0];
+    Type srcOriginalDtype =
+        converter->convertType(atenToDtype.getSelf().getType())
+            .cast<RankedTensorType>()
+            .getElementType();
     Type dtype = converter->convertType(atenToDtype.getType())
                      .cast<RankedTensorType>()
                      .getElementType();
-    Value result = convertScalarToDtype(b, loc, input, dtype);
+    Value result = convertScalarToDtype(b, loc, input, dtype, srcOriginalDtype);
     return result;
   }
   if (auto divScalar = dyn_cast<AtenDivScalarOp>(op)) {

--- a/lib/Dialect/Torch/IR/TorchTypes.cpp
+++ b/lib/Dialect/Torch/IR/TorchTypes.cpp
@@ -402,8 +402,15 @@ static Type convertDtypeToBuiltinElementType(MLIRContext *context, Type dtype) {
   if (auto floatType = dtype.dyn_cast<mlir::FloatType>()) {
     return dtype;
   } else if (auto integerType = dtype.dyn_cast<IntegerType>()) {
-    return IntegerType::get(context, integerType.getWidth(),
-                            IntegerType::Signless);
+    // treat Signed and Signless as Signless, expect it's i1,
+    // treat Unsigned as Unsigned.
+    if (integerType.getWidth() == 1)
+      return IntegerType::get(context, integerType.getWidth(),
+                              IntegerType::Signless);
+    else
+      return IntegerType::get(context, integerType.getWidth(),
+                              integerType.isUnsigned() ? IntegerType::Unsigned
+                                                       : IntegerType::Signless);
   } else if (auto complexType = dtype.dyn_cast<mlir::ComplexType>()) {
     // torch-complex types add the precision of the real and imag values to
     // get the final precision i.e., if the real and imag value is of `float`

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -103,6 +103,7 @@ Torch::getTypeForScalarType(MLIRContext *context,
   case torch_upstream::ScalarType::Half:
     return mlir::FloatType::getF16(context);
   case torch_upstream::ScalarType::Byte:
+    return mlir::IntegerType::get(context, 8, mlir::IntegerType::Unsigned);
   case torch_upstream::ScalarType::Char:
     return mlir::IntegerType::get(context, 8, signedness);
   case torch_upstream::ScalarType::ComplexHalf:

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -3929,3 +3929,23 @@ class AtenComplexViewModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: AtenComplexViewModule())
 def AtenComplexViewModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(5,2))
+
+# ==============================================================================
+
+class ReshapeToDtypeUint8Module(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+    
+    @export
+    @annotate_args([
+        None,
+        ([3, 4], torch.uint8, True),
+    ])
+    def forward(self, x):
+        y = x.reshape(12)
+        return y.to(torch.float32)
+
+@register_test_case(module_factory=lambda: ReshapeToDtypeUint8Module())
+def ReshapeToDtypeUint8Module_basic(module, tu: TestUtils):
+    module.forward(tu.randint(3, 4, low=128, high=256, dtype=torch.uint8))

--- a/test/Conversion/TorchToLinalg/basic.mlir
+++ b/test/Conversion/TorchToLinalg/basic.mlir
@@ -97,11 +97,11 @@ func.func @torch.aten.Int.Tensor$non_zero_rank(%arg0: !torch.vtensor<[?,?],si64>
 
 // CHECK-LABEL:     func.func @torch.aten.Int.Tensor$zero_rank$byte_dtype
 // CHECK-SAME:          (%[[ARG:.*]]: !torch.vtensor<[],ui8>) -> !torch.int {
-// CHECK:               %[[I:.*]] = torch_c.to_builtin_tensor %[[ARG]] : !torch.vtensor<[],ui8> -> tensor<i8>
+// CHECK:               %[[I:.*]] = torch_c.to_builtin_tensor %[[ARG]] : !torch.vtensor<[],ui8> -> tensor<ui8>
 // CHECK:               %[[C1_I64:.*]] = arith.constant 1 : i64
 // CHECK:               %[[C0:.*]] = arith.constant 0 : index
-// CHECK:               %[[EXTRACT:.*]] = tensor.extract %[[I]][] : tensor<i8>
-// CHECK:               %[[RES:.*]] = arith.extui %[[EXTRACT]] : i8 to i64
+// CHECK:               %[[EXTRACT:.*]] = tensor.extract %[[I]][] : tensor<ui8>
+// CHECK:               %[[RES:.*]] = arith.extui %[[EXTRACT]] : ui8 to i64
 // CHECK:               %[[RET:.*]] = torch_c.from_i64 %[[RES]]
 // CHECK:               return %[[RET]] : !torch.int
 func.func @torch.aten.Int.Tensor$zero_rank$byte_dtype(%arg0: !torch.vtensor<[],ui8>) -> !torch.int {

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -888,7 +888,7 @@ func.func @torch.prim.NumToTensor.Scalar() -> !torch.vtensor<[],si64> {
 // -----
 // CHECK-LABEL:   func.func @torch.aten.copy(
 // CHECK-SAME:                                   %[[ARG_0:.*]]: !torch.vtensor<[1,1,5,5],ui8>) -> !torch.vtensor<[1,1,5,5],i1> {
-// CHECK:           %[[INP:.*]] = torch_c.to_builtin_tensor %[[ARG_0]] : !torch.vtensor<[1,1,5,5],ui8> -> tensor<1x1x5x5xi8>
+// CHECK:           %[[INP:.*]] = torch_c.to_builtin_tensor %[[ARG_0]] : !torch.vtensor<[1,1,5,5],ui8> -> tensor<1x1x5x5xui8>
 // CHECK:           %[[CST5:.*]] = torch.constant.int 5
 // CHECK:           %[[CST1:.*]] = torch.constant.int 1
 // CHECK:           %[[CST11:.*]] = torch.constant.int 11
@@ -899,8 +899,8 @@ func.func @torch.prim.NumToTensor.Scalar() -> !torch.vtensor<[],si64> {
 // CHECK:           %[[VAL_1:.*]] = "tosa.const"() <{value = dense<0> : tensor<i64>}> : () -> tensor<i64>
 // CHECK:           %[[VAL_2:.*]] = "tosa.equal"(%[[VAL_0]], %[[VAL_1]]) : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK:           %[[VAL_3:.*]] = "tosa.logical_not"(%[[VAL_2]]) : (tensor<i1>) -> tensor<i1>
-// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1x5x5xi8>}> : () -> tensor<1x1x5x5xi8>
-// CHECK:           %[[VAL_5:.*]] = "tosa.equal"(%[[INP]], %[[VAL_4]]) : (tensor<1x1x5x5xi8>, tensor<1x1x5x5xi8>) -> tensor<1x1x5x5xi1>
+// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{value = dense<0> : tensor<1x1x5x5xui8>}> : () -> tensor<1x1x5x5xui8>
+// CHECK:           %[[VAL_5:.*]] = "tosa.equal"(%[[INP]], %[[VAL_4]]) : (tensor<1x1x5x5xui8>, tensor<1x1x5x5xui8>) -> tensor<1x1x5x5xi1>
 // CHECK:           %[[VAL_6:.*]] = "tosa.logical_not"(%[[VAL_5]]) : (tensor<1x1x5x5xi1>) -> tensor<1x1x5x5xi1>
 // CHECK:           %[[VAL_7:.*]] = torch_c.from_builtin_tensor %[[VAL_6]] : tensor<1x1x5x5xi1> -> !torch.vtensor<[1,1,5,5],i1>
 // CHECK:           return %[[VAL_7]] : !torch.vtensor<[1,1,5,5],i1>


### PR DESCRIPTION
The original demand is to support following case which is common in preprocess stage of CV model.
```python
class ReshapeToDtypeUint8Module(torch.nn.Module):

    def __init__(self):
        super().__init__()
    
    @export
    @annotate_args([
        None,
        ([3, 4], torch.uint8, True),
    ])
    def forward(self, x):
        y = x.reshape(12)
        return y.to(torch.float32)

@register_test_case(module_factory=lambda: ReshapeToDtypeUint8Module())
def ReshapeToDtypeUint8Module_basic(module, tu: TestUtils):
    module.forward(tu.randint(3, 4, low=128, high=256, dtype=torch.uint8))
```

When I working on the case, I found some problems which can't be fixed easily.
I think it's necessary to open a discussion about how to lowering uint8.

@ramiro050 @vivekkhandelwal1 @silvasean 