### PR TITLE
CI: Spot fixes related to nightly and stable PyTorch builds

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -92,7 +92,7 @@ jobs:
         arch: x64
 
     - name: Try to Restore PyTorch Build Cache
-      if: matrix.os-arch != 'windows-x86_64'
+      if: ${{ matrix.torch-binary == 'OFF' }}
       id: cache-pytorch
       uses: actions/cache/restore@v3
       with:
@@ -150,7 +150,7 @@ jobs:
       run: ./build_tools/python_deploy/build_windows_ci.sh
 
     - name: Save PyTorch Build Cache
-      if: ${{ github.ref_name == 'main' && matrix.torch-binary == 'OFF' && matrix.os-arch != 'windows-x86_64' }}
+      if: ${{ github.ref_name == 'main' && matrix.torch-binary == 'OFF' }}
       uses: actions/cache/save@v3
       with:
         path: ${{ github.workspace }}/build_tools/python_deploy/wheelhouse

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -45,6 +45,9 @@ jobs:
             llvm-build: out-of-tree
           - os-arch: windows-x86_64
             torch-version: stable
+          # For PyTorch stable builds, we don't build PyTorch from source
+          - torch-version: stable
+            torch-binary: OFF
         include:
           # Specify OS versions
           - os-arch: ubuntu-x86_64


### PR DESCRIPTION
This PR contains two patches:

 - CI: Skip (redundant) libtorch build when using stable PyTorch version

> When we use PyTorch stable builds, there is no need to build libtorch
> from source, making the stable-pytorch-with-torch-binary-OFF
> configuration redundant with stable-pytorch-with-torch-binary-ON.  This
> patch drops the redundant configuration from CI.

 - CI: Simplify guard conditions for creating and using libtorch cache

> Whether libtorch is enabled or not is predicated on a host of conditions
> such as the platform, in-tree versus out-of-tree build, and stable
> versus nightly PyTorch builds.  Instead of repeating these conditions to
> guard whether to create or use the libtorch cache artifacts (and getting
> them almost incorrect), this patch predicates the relevant pipeline
> steps to whether libtorch is enabled, thus making the conditions far
> simpler.