### PR TITLE
CI: Introduce workflow to auto-merge RollPyTorch updates

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -119,7 +119,7 @@ jobs:
       uses: peter-evans/create-pull-request@v5.0.1
       with:
         author: Roll PyTorch Action <torch-mlir@users.noreply.github.com>
-        branch: rollpytorch/${{ env.PT_RELEASE }}
+        branch: rollpytorch
         body: |
           torch version: ${{ env.PT_RELEASE }}
           torch commit hash: ${{ env.PT_HASH }}

--- a/.github/workflows/merge-rollpytorch.yml
+++ b/.github/workflows/merge-rollpytorch.yml
@@ -1,0 +1,21 @@
+name: RollPyTorch Merge
+
+on:
+  workflow_run:
+    workflows: [Build and Test]
+    types: [completed]
+    branches: [rollpytorch]
+
+jobs:
+  merge-pr:
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'llvm/torch-mlir' &&
+      github.event.workflow_run.actor.login == 'silvasean' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    env:
+      PR_IDS: ${{ toJson(github.event.workflow_run.pull_requests.*.number) }}
+
+    steps:
+      - run: echo "PRs to approve and merge: ${PR_IDS}"


### PR DESCRIPTION
This patch adds a new workflow that runs when an update to the
rollpytorch branch by silvasean (in whose name the RollPyTorch action
runs) causes the regular CI build to complete without errors.  Upon
execution, this workflow currently just prints the PR number(s) of the
PR created by the RollPyTorch action, but once this is working as
expected, we will add the step to merge the PR changes.