### PR TITLE
[MLIR][TOSA] Fix aten.div conversion for integer inputs

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -230,6 +230,9 @@ TORCHDYNAMO_XFAIL_SET = {
     # ERROR: 'torch.aten.div.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.float'
     "ElementwiseDivScalarModule_basic",
 
+    # ERROR: 'torch.aten.div.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.int'
+    "ElementwiseAtenDivIntScalarModule_basic",
+
     # ERROR: 'torch.aten.mul.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.int'
     "ElementwiseMulScalarModule_int",
 
@@ -420,6 +423,7 @@ STABLEHLO_PASS_SET = {
     "ElementwiseAddScalar_NumToTensorFloat_Module_basic",
     "ElementwiseAddScalar_TensorLiteralInt32_Module_basic",
     "ElementwiseDivScalarModule_basic",
+    "ElementwiseAtenDivIntScalarModule_basic",
     "ElementwiseEqDiffWidthScalarModule_basic",
     "ElementwiseEqFloatScalarModule_basic",
     "ElementwiseEqIntScalarModule_basic",
@@ -878,6 +882,7 @@ TOSA_PASS_SET = {
     "ElementwiseMulScalarModule_float",
     "ElementwiseMulTensorIntModule_basic",
     "ElementwiseDivScalarModule_basic",
+    "ElementwiseAtenDivIntScalarModule_basic",
     "ElementwiseSubScalarFloatModule_basic",
     "ElementwiseAddScalarFloatModule_basic",
     "ElementwiseAddScalar_TensorLiteralInt32_Module_basic",

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -944,7 +944,7 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
       divScalar.emitError("unimplemented: non-floating point dtype");
       return nullptr;
     }
-    Value self = payloadArgs[0];
+    Value self = convertScalarToDtype(b, loc, payloadArgs[0], dtype);
     Value other = convertScalarToDtype(b, loc, operands[1], dtype);
     return b.create<arith::DivFOp>(loc, self, other);
   }

--- a/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -1615,6 +1615,28 @@ class ElementwiseDivScalarModule(torch.nn.Module):
 def ElementwiseDivScalarModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
 
+
+# ==============================================================================
+
+
+class ElementwiseAtenDivIntScalarModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.div(x, 128)
+
+
+@register_test_case(module_factory=lambda: ElementwiseAtenDivIntScalarModule())
+def ElementwiseAtenDivIntScalarModule_basic(module, tu: TestUtils):
+    module.forward(tu.randint(3, 4))
+
 # ==============================================================================
 
 

--- a/test/Conversion/TorchToTosa/torch-backend-to-tosa-backend-pipeline.mlir
+++ b/test/Conversion/TorchToTosa/torch-backend-to-tosa-backend-pipeline.mlir
@@ -91,8 +91,8 @@ func.func @torch.aten.bitwise_and.Tensor$mixed_type(%arg0: !torch.vtensor<[?,?],
 // CHECK-LABEL: torch.aten.div.Tensor$mixed_type_fp
 // CHECK-SAME: %[[VAL_0:.*]]: tensor<?x?xf32>,
 // CHECK-SAME: %[[VAL_1:.*]]: tensor<?x?xi32>
-// CHECK: %[[VAL_2:.*]] = "tosa.reciprocal"(%[[VAL_1]]) : (tensor<?x?xi32>) -> tensor<?x?xi32>
-// CHECK: %[[VAL_3:.*]] = "tosa.cast"(%[[VAL_2]]) : (tensor<?x?xi32>) -> tensor<?x?xf32>
+// CHECK: %[[VAL_2:.*]] = "tosa.cast"(%[[VAL_1]]) : (tensor<?x?xi32>) -> tensor<?x?xf32>
+// CHECK: %[[VAL_3:.*]] = "tosa.reciprocal"(%[[VAL_2]]) : (tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK: %[[VAL_4:.*]] = "tosa.mul"(%[[VAL_0]], %[[VAL_3]]) <{shift = 0 : i32}> : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
 func.func @torch.aten.div.Tensor$mixed_type_fp(%arg0: !torch.vtensor<[?, ?],f32>, %arg1: !torch.vtensor<[?, ?],si32>) -> !torch.vtensor<[?, ?],f32> {
   %0 = torch.aten.div.Tensor %arg0, %arg1 : !torch.vtensor<[?, ?],f32>, !torch.vtensor<[?, ?],si32> -> !torch.vtensor<[?, ?],f32>


### PR DESCRIPTION
When converting the following `torch.aten.div` operation:
```
 %int128 = torch.constant.int 128
 %0 = torch.aten.div.Scalar %arg0, %int128 : !torch.vtensor<[?,?],si64>, !torch.int -> !torch.vtensor<[?,?],f32>
```
The following TOSA IR would be generated:
```
  %0 = "torch_c.to_builtin_tensor"(%arg0) : (!torch.vtensor<[?,?],si64>) -> tensor<?x?xi64>
  %1 = "torch.constant.int"() {value = 128 : i64} : () -> !torch.int
  %2 = "tosa.const"() <{value = dense<128> : tensor<i64>}> : () -> tensor<i64>
  %3 = "tosa.cast"(%0) : (tensor<?x?xi64>) -> tensor<?x?xf32>
  %4 = "tosa.cast"(%2) : (tensor<i64>) -> tensor<f32>
  %5 = "tosa.div"(%3, %4) : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
```
Causing an error in the TOSA operation verifier:
```
'tosa.div' op operand #0 must be tensor of 32-bit signless integer values, but got 'tensor<?x?xf32>'
        return torch.ops.aten.div(x, 128)
```
The issue is the wrong TOSA operation was selected for the conversion. As a ReciprocalOp and MulOp are required to implement the floating point division rather than the TOSA integer division.

The fix is to check the output type of the division operation and select the appropriate TOSA conversion based on the output type. As in this case the two input integers are casted immediately to floating point. 

The same issue can be found in the TorchToLinalg pass as well. A simple up-cast on the self operand fixes the issue ensuring both inputs are floating point in this particular case. 