### PR TITLE
Print name of the backend when tests fail to help debugging issues in CI

### DIFF
--- a/e2e_testing/main.py
+++ b/e2e_testing/main.py
@@ -141,7 +141,7 @@ def main():
     results = run_tests(tests, config, args.sequential, args.verbose)
 
     # Report the test results.
-    failed = report_results(results, xfail_set, args.verbose)
+    failed = report_results(results, xfail_set, args.verbose, args.config)
     if args.ignore_failures:
         sys.exit(0)
     sys.exit(1 if failed else 0)

--- a/python/test/torchscript_e2e_test/compilation_failure.py
+++ b/python/test/torchscript_e2e_test/compilation_failure.py
@@ -26,6 +26,7 @@ class MmModule(torch.nn.Module):
             return 3
 
 
+# CHECK: Unexpected outcome summary: (myconfig)
 # CHECK: FAIL - "MmModule_basic"
 # CHECK:     Compilation error:
 # Assume that the diagnostic from the TorchScript compiler will at least contain
@@ -39,7 +40,7 @@ def MmModule_basic(module, tu: TestUtils):
 def main():
     config = TorchScriptTestConfig()
     results = run_tests(GLOBAL_TEST_REGISTRY, config)
-    report_results(results, set(), verbose=True)
+    report_results(results, set(), verbose=True, config="myconfig")
 
 
 if __name__ == '__main__':

--- a/python/torch_mlir_e2e_test/reporting.py
+++ b/python/torch_mlir_e2e_test/reporting.py
@@ -263,7 +263,8 @@ class SingleTestReport:
 
 def report_results(results: List[TestResult],
                    expected_failures: Set[str],
-                   verbose: bool = False):
+                   verbose: bool = False,
+                   config: str = ""):
     """Print a basic error report summarizing various TestResult's.
 
     This report uses the PASS/FAIL/XPASS/XFAIL nomenclature of LLVM's
@@ -310,7 +311,7 @@ def report_results(results: List[TestResult],
         results_by_outcome['XPASS']) != 0
 
     if had_unexpected_results:
-        print('\nUnexpected outcome summary:')
+        print(f'\nUnexpected outcome summary: ({config})')
 
     # For FAIL and XPASS (unexpected outcomes), print a summary.
     for outcome, results in results_by_outcome.items():


### PR DESCRIPTION
When an end2end test fails or unexpectedly passes in CI, it sometimes takes me a bunch of scrolling to understand in which e2e config the test failed.
With this change, we show the name of the end2end config at the end of output.