### PR TITLE
CI: Update script to (mock) merge of RollPyTorch PRs

### DIFF
--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -133,4 +133,3 @@ jobs:
         committer: Roll PyTorch Action <torch-mlir@users.noreply.github.com>
         title: update PyTorch version to ${{ env.PT_RELEASE }}
         token: ${{ secrets.ROLLPYTORCH_TOKEN0 }}
-        reviewers: ashay, powderluv, vivekkhandelwal1

--- a/.github/workflows/merge-rollpytorch.yml
+++ b/.github/workflows/merge-rollpytorch.yml
@@ -14,8 +14,11 @@ jobs:
       github.event.workflow_run.actor.login == 'silvasean' &&
       github.event.workflow_run.conclusion == 'success'
 
-    env:
-      PR_IDS: ${{ toJson(github.event.workflow_run.pull_requests.*.number) }}
-
     steps:
-    - run: echo "PRs to approve and merge -- $PR_IDS"
+    - run: |
+        for pr_id in ${{ join(github.event.workflow_run.pull_requests.*.number, ' ') }}
+        do
+          echo "[mock] Merging PR: $pr_id"
+          echo gh pr merge $pr_id --delete-branch --squash
+        done
+      shell: bash


### PR DESCRIPTION
Before enabling the actual merge, this patch dumps to the console the
bash commands that it plans to execute.