### PR TITLE
CI: Merge RollPyTorch PR upon successful completion

### DIFF
--- a/.github/workflows/merge-rollpytorch.yml
+++ b/.github/workflows/merge-rollpytorch.yml
@@ -15,10 +15,11 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
-    - run: |
+    - name: Merge RollPyTorch PR
+      run: |
         for pr_id in ${{ join(github.event.workflow_run.pull_requests.*.number, ' ') }}
         do
-          echo "[mock] Merging PR: $pr_id"
-          echo gh pr merge $pr_id --delete-branch --squash
+          echo "Merging PR: $pr_id"
+          gh pr merge $pr_id --delete-branch --squash
         done
       shell: bash


### PR DESCRIPTION
This patch removes the mock commands, so that once the Build And Test
workflow has successfully completed on the RollPyTorch action, the PR is
merged and the branch is deleted.