### PR TITLE
CI: Checkout repo so that gh knows where to look for the PR

### DIFF
--- a/.github/workflows/merge-rollpytorch.yml
+++ b/.github/workflows/merge-rollpytorch.yml
@@ -15,6 +15,12 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
+    # Fetch the repo first so that the gh command knows where to look for the PR
+    - name: Fetch Repo
+      uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
+
     - name: Merge RollPyTorch PR
       run: |
         for pr_id in ${{ join(github.event.workflow_run.pull_requests.*.number, ' ') }}


### PR DESCRIPTION
Without this patch, the gh command (for merging the PR) doesn't know
which repo we're referring to.