### PR TITLE
[Torch Dialect] fix torch.uint8's dtype infer

### DIFF
--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -103,6 +103,7 @@ Torch::getTypeForScalarType(MLIRContext *context,
   case torch_upstream::ScalarType::Half:
     return mlir::FloatType::getF16(context);
   case torch_upstream::ScalarType::Byte:
+    return mlir::IntegerType::get(context, 8, mlir::IntegerType::Unsigned);
   case torch_upstream::ScalarType::Char:
     return mlir::IntegerType::get(context, 8, signedness);
   case torch_upstream::ScalarType::ComplexHalf:

--- a/test/Dialect/Torch/torch-function-to-torch-backend-pipeline.mlir
+++ b/test/Dialect/Torch/torch-function-to-torch-backend-pipeline.mlir
@@ -15,3 +15,13 @@ func.func @torch.aten.argmax(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor
   %0 = torch.aten.argmax %arg0, %int0, %true : !torch.vtensor<[?,?],f32>, !torch.int, !torch.bool -> !torch.vtensor<[1,?],si64>
   return %0 : !torch.vtensor<[1,?],si64>
 }
+
+// CHECK-LABEL: func.func @torch.uint8
+func.func @torch.uint8(%arg0: !torch.tensor {torch.type_bound = !torch.vtensor<[3,4],ui8>}) -> !torch.tensor {
+  %int12 = torch.constant.int 12
+  %0 = torch.prim.ListConstruct %int12 : (!torch.int) -> !torch.list<int>
+  // CHECK: torch.aten.view
+  // CHECK-SAME: !torch.vtensor<[12],ui8>
+  %1 = torch.aten.reshape %arg0, %0 : !torch.tensor, !torch.list<int> -> !torch.tensor
+  return %1 : !torch.tensor
+}


### PR DESCRIPTION
This is first PR for https://github.com/llvm/torch-mlir/pull/2184.
This PR fix `dtype inference` on torch.uint8.