### PR TITLE
[RFC][Torch-Debug-Utility] Add a pass to return only a particular value

### DIFF
--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
@@ -54,6 +54,8 @@ createVerifyStablehloBackendContractPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createFuncBackendTypeConversionPass();
 
+std::unique_ptr<OperationPass<ModuleOp>> createSingleTensorReturnConversionPass(unsigned valueIndex);
+
 std::unique_ptr<OperationPass<func::FuncOp>>
 createFinalizingBackendTypeConversionPass();
 

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
@@ -21,6 +21,18 @@ def FuncBackendTypeConversion : Pass<"torch-func-backend-type-conversion", "Modu
   }];
 }
 
+def SingleTensorReturnConversion : Pass<"torch-single-tensor-return-conversion", "ModuleOp"> {
+  let summary = "Convert functions to return single tensor";
+  let constructor = "mlir::torch::TorchConversion::createSingleTensorReturnConversionPass(/*valueIndex=*/0)";
+  let options = [
+    Option<"valueIndex", "value-index", "unsigned", /*default=*/"0",
+           "Index of the value in original return op to return instead">
+  ];
+  let description = [{
+    Convert functions to return single tensor
+  }];
+}
+
 def FinalizingBackendTypeConversion
     : Pass<"torch-finalizing-backend-type-conversion", "func::FuncOp"> {
   let summary = "Finalizes a partial conversion to builtin tensors";

--- a/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ add_mlir_library(TorchMLIRTorchConversionPasses
   BackendTypeConversion.cpp
   BackendTypeConversionPasses.cpp  
   Passes.cpp
+  SingleTensorReturnConversionPass.cpp
   VerifyLinalgOnTensorsBackendContract.cpp
   VerifyTosaBackendContract.cpp
   VerifyStablehloBackendContract.cpp

--- a/lib/Dialect/TorchConversion/Transforms/SingleTensorReturnConversionPass.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/SingleTensorReturnConversionPass.cpp
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h"
+
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::TorchConversion;
+
+//===----------------------------------------------------------------------===//
+// SingleTensorReturnConversionPass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct SingleTensorReturnConversionPass
+    : public SingleTensorReturnConversionBase<SingleTensorReturnConversionPass> {
+  using SingleTensorReturnConversionBase<
+      SingleTensorReturnConversionPass>::SingleTensorReturnConversionBase;
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<TorchConversion::TorchConversionDialect>();
+  }
+  SingleTensorReturnConversionPass() = default;
+  SingleTensorReturnConversionPass(unsigned valueIndex) {
+    this->valueIndex = valueIndex;
+  }
+  void runOnOperation() override {
+    auto module = getOperation();
+    // We deal with ModuleOp containing ONLY one FuncOp.
+    module.walk([&](func::FuncOp funcOp) {
+      rewriteSignature(funcOp);
+      return WalkResult::interrupt();
+    });
+    return;
+  }
+  void rewriteSignature(func::FuncOp func) {
+    // Get the ReturnOp within function.
+    func::ReturnOp returnOp;
+    WalkResult walkResult = func.walk([&](func::ReturnOp op) {
+      returnOp = op;
+      return WalkResult::interrupt();
+    });
+
+    // Add an assertion to check whether the value index picked for
+    // returning is within the number of operands that the return op has.
+    assert(valueIndex<returnOp.getNumOperands() && "return value index incorrect");
+
+    // Update the ReturnOp to only have the value at `valueIndex` remain.
+    Value valueToReturn = returnOp.getOperand(valueIndex);
+    returnOp->setOperands({valueToReturn});
+
+    // Since we've changed the ReturnOp's return value set, we need to update
+    // the containing function's return type as well.
+    auto funcType = func.getFunctionType();
+    func.setType(FunctionType::get(funcType.getContext(), funcType.getInputs(),
+                                   ValueRange({valueToReturn}).getTypes()));
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::torch::TorchConversion::createSingleTensorReturnConversionPass(unsigned valueIndex) {
+  return std::make_unique<SingleTensorReturnConversionPass>(valueIndex);
+}
+


### PR DESCRIPTION
-- This commit adds a pass `torch-single-tensor-return-conversion` to
   return only a particular value from the return op using the pass option
   `value-index` which specifies the specific index of the value from the
   list of values being returned by the original ReturnOp.

Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>

**INPUT.mlir**:
```
#map = affine_map<(d0, d1) -> (d0, d1)>
#map1 = affine_map<(d0, d1) -> ()>
module attributes {torch.debug_module_name = "_lambda"} {
  ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>
  func.func @forward(%arg0: tensor<2x3xf32>) -> (tensor<f32>, tensor<f32>) {
    %cst = arith.constant 0.000000e+00 : f32
    %cst_0 = arith.constant 8.000000e+00 : f32
    %0 = tensor.empty() : tensor<2x3xf32>
    %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<2x3xf32>) outs(%0 : tensor<2x3xf32>) {
    ^bb0(%in: f32, %out: f32):
      %5 = arith.addf %in, %cst_0 : f32
      linalg.yield %5 : f32
    } -> tensor<2x3xf32>
    %2 = tensor.empty() : tensor<f32>
    %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<f32>) -> tensor<f32>
    %4 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["reduction", "reduction"]} ins(%1 : tensor<2x3xf32>) outs(%3 : tensor<f32>) {
    ^bb0(%in: f32, %out: f32):
      %5 = arith.addf %in, %out : f32
      linalg.yield %5 : f32
    } -> tensor<f32>
    return %4, %3 : tensor<f32>, tensor<f32>
  }
}
```
Run: `./build/bin/torch-mlir-opt  --torch-single-tensor-return-conversion="value-index=1" ~/input.mlir --cse`

**OUTPUT**:
```
#map = affine_map<(d0, d1) -> (d0, d1)>
module attributes {torch.debug_module_name = "_lambda"} {
  ml_program.global private mutable @global_seed(dense<0> : tensor<i64>) : tensor<i64>
  func.func @forward(%arg0: tensor<2x3xf32>) -> tensor<f32> {
    %cst = arith.constant 0.000000e+00 : f32
    %cst_0 = arith.constant 8.000000e+00 : f32
    %0 = tensor.empty() : tensor<2x3xf32>
    %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<2x3xf32>) outs(%0 : tensor<2x3xf32>) {
    ^bb0(%in: f32, %out: f32):
      %4 = arith.addf %in, %cst_0 : f32
      linalg.yield %4 : f32
    } -> tensor<2x3xf32>
    %2 = tensor.empty() : tensor<f32>
    %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<f32>) -> tensor<f32>
    return %3 : tensor<f32>
  }
}
```