### PR TITLE
Don't crash when the input to aten.copy is unranked

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -3162,6 +3162,11 @@ public:
       return rewriter.notifyMatchFailure(
           op, "expected result type to have a dtype");
     }
+    auto srcTy = op.getSrc().getType().cast<BaseTensorType>();
+    if (!srcTy.hasSizes() || !srcTy.hasDtype()) {
+      return rewriter.notifyMatchFailure(
+          op, "expected src type to have a known rank and dtype");
+    }
     Type resultDtype = resultType.getDtype();
     Value srcToDtype =
         convertTensorToDtype(rewriter, op.getLoc(), op.getSrc(), resultDtype);


### PR DESCRIPTION
This can happen when the input comes from an unsupported operator.
`convertTensorToDtype` below relies on that information.