### PR TITLE
Fixes Windows DLL crash

### DIFF
--- a/lib/InitAll.cpp
+++ b/lib/InitAll.cpp
@@ -9,6 +9,7 @@
 
 #include "torch-mlir/InitAll.h"
 
+#include <mlir/Dialect/Func/Extensions/InlinerExtension.h>
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Dialect.h"
 #include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"
@@ -29,6 +30,7 @@ void mlir::torch::registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<mlir::torch::Torch::TorchDialect>();
   registry.insert<mlir::torch::TorchConversion::TorchConversionDialect>();
   registry.insert<mlir::torch::TMTensor::TMTensorDialect>();
+  mlir::func::registerInlinerExtension(registry);
 }
 
 void mlir::torch::registerAllPasses() {

--- a/lib/InitAll.cpp
+++ b/lib/InitAll.cpp
@@ -9,7 +9,7 @@
 
 #include "torch-mlir/InitAll.h"
 
-#include <mlir/Dialect/Func/Extensions/InlinerExtension.h>
+#include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Dialect.h"
 #include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"


### PR DESCRIPTION
[LLVM bump](https://github.com/llvm/torch-mlir/commit/ebda6111000710470bad61ac9c467b57b2744d1a) brought in this [commit](https://reviews.llvm.org/D120368) that required inline extension for the func dialect to be declared explicitly.

This was causing the Windows dll to crash in SHARK in all snapshots after https://github.com/llvm/torch-mlir/releases/tag/snapshot-20230620.875