### PR TITLE
Conform to Python custom exception api

### DIFF
--- a/python/torch_mlir/compiler_utils.py
+++ b/python/torch_mlir/compiler_utils.py
@@ -23,13 +23,7 @@ def get_module_name_for_debug_dump(module):
 
 
 class TorchMlirCompilerError(Exception):
-    def __init__(self, value: str):
-        super().__init__()
-        self.value = value
-
-    def __str__(self) -> str:
-        return self.value
-
+    pass
 
 def run_pipeline_with_repro_report(module,
                                    pipeline: str,


### PR DESCRIPTION
Some idiot ([me](https://github.com/llvm/torch-mlir/commit/d70bb68c9e8efd4fa940cddeb36cdfb48e87c909)) added `TorchMlirCompilerError` but didn't understand that in Python [user-defined exceptions](https://docs.python.org/3/tutorial/errors.html#user-defined-exceptions) don't take an argument. This causes the very inconvenient

```
TypeError: TorchMlirCompilerError.__init__() missing 1 required positional argument: 'value'
```

to confound actual compiler errors (for a long time now I guess). 

cc @123epsilon