### PR TITLE
Ignore constants in the legality error

### DIFF
--- a/test/Conversion/TorchToTosa/torch-backend-to-tosa-backend-pipeline.mlir
+++ b/test/Conversion/TorchToTosa/torch-backend-to-tosa-backend-pipeline.mlir
@@ -124,3 +124,11 @@ func.func @torch.aten.pow.Tensor$mixed_type(%arg0: !torch.vtensor<[?,?],f16>) ->
   return %0 : !torch.vtensor<[?,?],f32>
 }
 
+// -----
+func.func @torch.prim.TupleConstruct() {
+  %int128 = torch.constant.int 128
+  %0 = torch.prim.TupleConstruct %int128 : !torch.int -> !torch.tuple<int>
+  // expected-error @below {{failed to legalize operation 'torch.prim.Print' that was explicitly marked illegal}}
+  torch.prim.Print(%0) : !torch.tuple<int>
+  return
+}


### PR DESCRIPTION
This improves the error message when lowering to tosa fails by pointing at the actual op that is missing support.
The constants are never a problem because
- they are pure, so they will fold away if unused
- they don't return tensor types, so they cannot be used directly by the ReturnOp
Thus there is always some other op using them, and that op is the interesting one.