### PR TITLE
fix cmake torch-mlir-capi linking and bazel build

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,10 +3,12 @@ add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(RefBackend)
 
+get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 set(LinkedLibs
   MLIRFuncDialect
   MLIRIR
   MLIRSupport
+  ${extension_libs}
 
   TorchMLIRTorchPasses
   TorchMLIRTorchConversionDialect

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -811,6 +811,7 @@ cc_library(
         ":TorchMLIRTorchConversionPasses",
         ":TorchMLIRTorchDialect",
         ":TorchMLIRTorchPasses",
+        "@llvm-project//mlir:AllExtensions",
         "@llvm-project//mlir:Dialect",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",


### PR DESCRIPTION
fix `torch-mlir-capi-torch-test` and `bazel` after merge.