### PR TITLE
Prevent failed stable CI job from cancelling nightly jobs

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -22,6 +22,7 @@ concurrency:
 # macos  - arm64  - llvm in-tree     - pytorch binary - build only    # cross compile, can't test arm64
 jobs:
   build-test:
+    continue-on-error: ${{ matrix.torch-version == 'stable' }}
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
The CI jobs that use stable PyTorch are currently not required to pass in order for a patch to get merged in `main`. This commit makes sure that if a CI job for stable PyTorch fails, it does not cancel the other required jobs.