### PR TITLE
Per request, swap Sean Silva for Stella Laurenzo in code owners.

### DIFF
--- a/docs/code_owners.md
+++ b/docs/code_owners.md
@@ -12,14 +12,13 @@ and Clang's
 
 ### All parts not covered by anyone else
 
-- Sean Silva (@silvasean)
-- Stella Laurenzo (@stellaraccident) -- mostly emeritus
+- Stella Laurenzo (@stellaraccident)
 
 --------------------------------------------------------------------------------
 
 ### `torch` dialect and other core IR pieces, Python bindings/API, JIT IR importer
 
-- Sean Silva (@silvasean)
+- Stella Laurenzo (@stellaraccident)
 
 ### TorchToLinalg, Shape inference, Dtype refinement, MaximizeValueSemantics
 


### PR DESCRIPTION
Sean has decided to move on to other ventures and has requested that I help him disengage by resuming top level accountability for the project.