### PR TITLE
Decompose aten.index_put_impl to aten.index_put.hacked_twin

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -904,6 +904,9 @@ STABLEHLO_CRASHING_SET = {
     "ViewCollapseDynamicWithAtenSizeIntModule_basic",
     "UnsafeViewCollapseDynamicWithAtenSizeIntModule_basic",
 
+    # LLVM ERROR: SmallVector unable to grow. Requested capacity (9223372036854775808) is larger than maximum value for size type (4294967295)
+    "SliceCopyNonZeroDim_Module_basic",
+
     "Aten_EmbeddingBagExample_basic",
     "AtenEmbeddingBagSumExample_basic"
 }

--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -17,6 +17,8 @@ LINALG_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS | {
     # Lowering Torch Backend IR -> Linalg-on-Tensors Backend IR failed
     # 'linalg.depthwise_conv_2d_nchw_chw' op inferred input/output operand #1 has shape's dimension #0 to be 4, but found 8
     "Conv2dWithPaddingDilationStrideStaticModule_depthwise_multiplier",
+    "IndexPutImplIndexWithNoneModule_basic",
+    "SliceCopyNonZeroDim_Module_basic",
 }
 
 TORCHDYNAMO_XFAIL_SET = {
@@ -274,6 +276,9 @@ TORCHDYNAMO_XFAIL_SET = {
     "ScatterValueFloatModule_basic",
     # ERROR: torch._dynamo.exc.Unsupported: call_function BuiltinVariable(int) [TensorVariable()] {}
     "ScatterValueIntModule_basic",
+
+    # After decompose, the IndexputHackedTwin lowered to linalg fail
+    "IndexPutImplIndexWithNoneModule_basic",
 
     # AssertionError: Unregistered operation: torch.aten._unsafe_index_put
     "UnsafeIndexPutHackedTwin1DFloatNonAccumulateModule_basic",
@@ -904,9 +909,6 @@ STABLEHLO_CRASHING_SET = {
     "ViewCollapseDynamicWithAtenSizeIntModule_basic",
     "UnsafeViewCollapseDynamicWithAtenSizeIntModule_basic",
 
-    # LLVM ERROR: SmallVector unable to grow. Requested capacity (9223372036854775808) is larger than maximum value for size type (4294967295)
-    "SliceCopyNonZeroDim_Module_basic",
-
     "Aten_EmbeddingBagExample_basic",
     "AtenEmbeddingBagSumExample_basic"
 }
@@ -917,6 +919,7 @@ TOSA_PASS_SET = {
     "TileBigDimsSizeModule_basic",
     "TileSmallDimsSizeModule_basic",
     "IndexPutImpl2DNoneIndexStaticModule_basic",
+    "SliceCopy_Module_basic",
     "AliasModule_basic",
     "MaxPool2dEmptyStrideStaticModule_basic",
     "ConstantBoolParameterModule_basic",

--- a/include/torch-mlir/Conversion/Utils/Utils.h
+++ b/include/torch-mlir/Conversion/Utils/Utils.h
@@ -100,6 +100,27 @@ void computeBroadcastShape(ConversionPatternRewriter &rewriter, Location loc,
                            SmallVector<int64_t> &resultShape,
                            SmallVector<Value> &resultShapeValue);
 
+// Input a/b are 2 different shapes of index tensor. We will broadcast them to
+// same shape. The return is the final same broadcast shape. This is a helper
+// function for expandSizes which can broadcast more than 2 input index tensor.
+// Example: a = 1x1,  b = 1x3 -> return = 1x3.
+SmallVector<int64_t> inferSizesFromTwoTensor(PatternRewriter &rewriter,
+                                             Location loc,
+                                             SmallVector<int64_t> a,
+                                             SmallVector<int64_t> b);
+
+// Expand index tentors shape into same size.
+// toExpand: A list of index tensor, will will be broadcast to same shape.
+// The return is a list of same shape size.
+// Example:
+// toExpand:[[0]], [[1,2,3]] -> [[0,0,0]], [[1,2,3]].
+// toExpand shapes: 1x1, 1x3.
+// broadcast shape: 1x3.
+// return shape: (1x3,1x3).
+SmallVector<SmallVector<int64_t>> expandSizes(PatternRewriter &rewriter,
+                                              Location loc,
+                                              SmallVector<Value> &toExpand);
+
 } // namespace Torch
 } // namespace torch
 } // namespace mlir

--- a/lib/Conversion/TorchToStablehlo/GatherScatter.cpp
+++ b/lib/Conversion/TorchToStablehlo/GatherScatter.cpp
@@ -689,6 +689,299 @@ LogicalResult ConvertAtenOp<AtenScatterSrcOp>::matchAndRewrite(
   return success();
 }
 
+// Aten_IndexPutImplOp
+template <>
+LogicalResult ConvertAtenOp<Aten_IndexPutImplOp>::matchAndRewrite(
+    Aten_IndexPutImplOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  Location loc = op->getLoc();
+  // For understanding of the algorithm, I comment the code with this example.
+  // a = torch.tensor([[0, 1, 2, 3]])
+  // a[..., 1:] = torch.tensor([4, 5, 6])
+  // = a[..., 1:4] = torch.tensor([4, 5, 6])
+  // = a[[0, 0, 0], [1, 2, 3]] = torch.tensor([4, 5, 6]) # tensor([[0, 4, 5,
+  // 6]]) = torch.ops.aten.index_put(torch.tensor([[0, 1, 2, 3]]), # input
+  //                            (torch.tensor([0, 0, 0]), torch.tensor([1, 2,
+  //                            3])), # indicies torch.tensor([4, 5, 6])) #
+  //                            value
+  // = torch.ops.aten.index_put(torch.tensor([[0, 1, 2, 3]]), # input
+  //                            (None, torch.tensor([1, 2, 3]),),# indicies
+  //                            torch.tensor([4, 5, 6])) # value
+
+  // Not a tensor type.
+  auto input = adaptor.getSelf();
+  auto inputType = adaptor.getSelf().getType().dyn_cast<TensorType>();
+  if (!inputType)
+    return rewriter.notifyMatchFailure(
+        op, "Only tensor types input are currently supported");
+
+  auto fillValues = adaptor.getValues();
+  auto fillValuesType = adaptor.getValues().getType().dyn_cast<TensorType>();
+  if (!fillValuesType)
+    return rewriter.notifyMatchFailure(
+        op, "Only tensor types input are currently supported");
+
+  bool accumulate;
+  if (!matchPattern(op.getAccumulate(), m_TorchConstantBool(&accumulate)))
+    return rewriter.notifyMatchFailure(
+        op, "only constant sparse is currently supported");
+  if (accumulate)
+    return rewriter.notifyMatchFailure(
+        op, "Only support false accumulate right now.");
+
+ bool unsafe;
+  if (!matchPattern(op.getUnsafe(), m_TorchConstantBool(&unsafe)))
+    return rewriter.notifyMatchFailure(
+        op, "only constant sparse is currently supported");
+  if (unsafe)
+    return rewriter.notifyMatchFailure(
+        op, "Only support false unsafe right now.");
+  
+  // Deal with torch.prim.ListConstruct of non const value to get the index
+  auto tensorList = op.getIndices();
+  SmallVector<Value> tensorsTorchType;
+  if (!getListConstructElements(tensorList, tensorsTorchType))
+    return op.emitError(
+        "unimplemented: the tensor list is not from list construct");
+  auto indexTensors = getTypeConvertedValues(
+      rewriter, op->getLoc(), getTypeConverter(), tensorsTorchType);
+
+  // convert list of indices with none into indices tensor  without none
+  // indexTensors (none,[1,2,3]) -> ([0,0,0],[1,2,3])
+  // ([[0],[0],[0]],[[1],[2],[3]])-> [[0,1],[0,2], [0,3]]
+  if (indexTensors.size() <= 1) {
+    return rewriter.notifyMatchFailure(
+        op, "Only support indexput with multiple index.");
+  }
+  SmallVector<Value> indicesConcatTensors;
+  SmallVector<int64_t> indexesRank;
+  SmallVector<SmallVector<int64_t>> indexesShape;
+
+  // concat index tensor into to indices tensor for concat
+  for (size_t i = 0; i < indexTensors.size(); i++) {
+    auto index = indexTensors[i];
+    auto indexTorch = tensorsTorchType[i];
+    // TODO add support for none index other than i==0, like (index0, None)
+    // (None, index1)
+    if (i == 0 && indexTorch.getType().isa<Torch::NoneType>()) {
+      // convert None to [0,0,0]
+      auto indexNext = indexTensors[i + 1];
+      auto indexNextTorch = tensorsTorchType[i + 1];
+      if (indexNextTorch.getType().isa<Torch::NoneType>()) {
+        return rewriter.notifyMatchFailure(
+            op, "Multiple None index is not support for now.");
+      }
+      auto indexNextType = indexNext.getType().dyn_cast<RankedTensorType>();
+      auto indexNextShape = indexNextType.getShape();
+
+      int64_t size = 1;
+      for (auto s : indexNextShape)
+        size *= s;
+      SmallVector<int64_t> values(size, i);
+      index = hlo::getConstTensor<int64_t>(rewriter, op, values, indexNextShape)
+                  .value();
+    }
+
+    auto indexType = index.getType().dyn_cast<RankedTensorType>();
+    // Reshape the zero rank index to rank 1
+    if (indexType.getRank() == 0) {
+      // [] -> [0]
+      SmallVector<int64_t, 1> oneShape({1}); // {1}
+      RankedTensorType reshapeType =
+          RankedTensorType::get(oneShape, indexType.getElementType());
+      auto indexOneReshapeOp =
+          rewriter.create<stablehlo::ReshapeOp>(loc, reshapeType, fillValues);
+      index = indexOneReshapeOp.getResult();
+      indexType = index.getType().dyn_cast<RankedTensorType>();
+    }
+    auto indexShape = indexType.getShape();
+    indexesShape.push_back(makeShapeTorchCompatible(indexShape));
+    indexesRank.push_back(indexType.getRank());
+
+    // Expand last dim of index to indices [3] -> [3,1]
+    // convert [0,0,0]  to [[0],[0],[0]]
+    SmallVector<int64_t> indiceShapeOneDim(indexShape.begin(), indexShape.end());
+    indiceShapeOneDim.push_back(1);
+    auto indexElemTy = indexType.getElementType();
+    RankedTensorType reshapeType =
+        RankedTensorType::get(indiceShapeOneDim, indexElemTy);
+    auto indicesOneDim =
+        rewriter.create<stablehlo::ReshapeOp>(loc, reshapeType, index);
+
+    // create concat tensor for indices
+    // ([[0],[0],[0]], [[1],[2],[3]])
+    indicesConcatTensors.push_back(indicesOneDim.getResult());
+  }
+
+  // Right now only support multiple indexes with same shape
+  // TODO for different shape multiple indexes, add broadcast_to for small
+  // shape
+  for (auto indexShapeOneDim : indexesShape) {
+    if (!llvm::equal(indexesShape[0], indexShapeOneDim)) {
+      return rewriter.notifyMatchFailure(
+          op, "unimplemented: Only support multi indexes with same shape");
+    }
+  }
+
+  // concat each indices into indices: shape ([3,1],[3,1]) -> [3,2]
+  // ([0,0,0],[1,2,3]) -> [[0,1],[0,2], [0,3]]
+  auto indicesShapeConcat = indexesShape[0];
+  uint64_t lastDim = indexesRank[0];
+  indicesShapeConcat.push_back(indicesConcatTensors.size());
+  auto indices = rewriter.create<stablehlo::ConcatenateOp>(
+      loc,
+      GetTypeFromTensorShape(indicesShapeConcat, rewriter.getIntegerType(64)),
+      ValueRange(indicesConcatTensors), lastDim);
+
+  if (!indices) {
+    return rewriter.notifyMatchFailure(op,
+                                       "Convert TorchIndex To Indices fail.");
+  }
+
+  // Reshape the fillValues to the requirement shape in %updates of scatter op
+  auto indicesType = indices.getResult().getType().dyn_cast<RankedTensorType>();
+  auto indicesElemTy = indicesType.getElementType();
+  int inputRank = inputType.getShape().size();     // 2
+  int indicesRank = indicesType.getShape().size(); // 2
+
+  int N = 1, W = 1, fillK = 1, C = 1, ND = 1;
+  //  ND: indices.shape[-1]
+  ND = indicesType.getShape()[indicesRank - 1]; // 2 depth of input
+
+  // Calculate N, K, W, C.  (N is always 1)
+  // number of indices/selected value in each batch product(indices.shape[0:-1])
+  // (all but the last dimension) W = 1*3 = 3
+  for (int i = 0; i < (indicesRank - 1); i++) {
+    W *= indicesType.getShape()[i];
+  }
+
+  // C: number of channels for each index : numbers of values inside each
+  // input(chould be scatter) C = product(params.shape[ND:] ND = 2, paramsRank,
+  // C = 1
+  for (int i = ND; i < inputRank; i++) {
+    C *= inputType.getShape()[i];
+  }
+
+  // Preprocess fill value.
+  // There are 2 cases of fillValues,
+  // Let's replace the example [4,5,6] with [0,0,0] here for easy understanding
+  // and comparation of the 2 cases.
+  // 1. !torch.vtensor<[1,3],si64>
+  //  [[0,0,0]] -> [[[0], [0], [0]]]
+  // 2. !torch.vtensor<[],si64>
+  //    reshape(1) tile(3)  reshape(1,3)   reshape(1,3,1)
+  //  [] -> [0] -> [0,0,0] -> [[0,0,0]] -> [[[0], [0], [0]]]
+  //    reshape to [1] and then tile to same number of indicesValue.shape[0],
+  //    [1,1,1]
+  if (fillValuesType.getRank() == 0) {
+    // Reshape the zero rank value into rank 1
+    // [] -> [0]
+    SmallVector<int64_t, 1> oneShape({1}); // {1}
+    RankedTensorType reshapeType =
+        RankedTensorType::get(oneShape, indicesElemTy);
+    auto fillValuesOneReshapeOp =
+        rewriter.create<stablehlo::ReshapeOp>(loc, reshapeType, fillValues);
+
+    // [0] -> [0,0,0]
+    SmallVector<int64_t, 1> bcastShape({W}); // {3}
+    RankedTensorType bcastIndicesType =
+        RankedTensorType::get(bcastShape, indicesElemTy);
+    Value bcastVal = hlo::promoteAndBroadcast(
+        rewriter, fillValuesOneReshapeOp.getResult(), bcastIndicesType);
+
+    // [0,0,0] -> [[0,0,0]]
+    SmallVector<int64_t, 2> newFillValuesShape({N, W}); // {1,3}
+    reshapeType = RankedTensorType::get(newFillValuesShape, indicesElemTy);
+    auto newFillValuesReshapeOp =
+        rewriter.create<stablehlo::ReshapeOp>(loc, reshapeType, bcastVal);
+    fillValues = newFillValuesReshapeOp.getResult();
+    fillValuesType = fillValues.getType().dyn_cast<RankedTensorType>();
+  }
+
+  // fillK: range of each index, total number of fillInput(could be scatter)
+  // after flattened k = 1*1*3 = 3
+  for (int i = 0; i < ND; i++) {
+    if(i < (int)fillValuesType.getShape().size()){
+      fillK *= fillValuesType.getShape()[i];
+    }
+  }
+  SmallVector<int64_t, 2> scatterUpdatesShape({fillK, C}); // {3,1}
+
+  RankedTensorType reshapeType =
+      RankedTensorType::get(scatterUpdatesShape, indicesElemTy);
+  auto scatterUpdatesReshapeOp =
+      rewriter.create<stablehlo::ReshapeOp>(loc, reshapeType, fillValues);
+
+  // Generate ScatterDimensionNumbers for stablehlo::Scatter op.
+  // index_vector_dim = 1 means the values in scatter_indices like [0,2] is
+  // started from dim=1 of scatter_indices. In python, we will use : to slice
+  // all the value at index_vector_dim once all the other dims are given, like
+  // scatter_indices[1,:]. In current setting, the last dim is where is where
+  // indices value exist.
+  int64_t indexVecDim = indicesRank - 1; // 1
+
+  //  scatter_dims_to_operand_dims exists because the value in scatter_indices
+  //  might represent different dim in input operand. Let's say the value
+  //  [0,2] in scatter_indices, since scatter_dims_to_operand_dims=[0,1], so the
+  //  indices 2 represent the indice that need to be selected on the input's
+  //  dim 1.
+  //	If we change the scatter_dims_to_operand_dims=[1,0], so the indices 2
+  // represent the indice that need to be selected on the input's dim 0. The
+  // result full_start_index = [2,0]. The scatter_dims_to_operand_dims=[0,1] is
+  // more intuitive in most cases.
+  SmallVector<int64_t> scatterDimOperandDimMap;
+  for (int64_t i = 0; i < inputType.getRank(); ++i) {
+    scatterDimOperandDimMap.push_back(i);
+  }
+
+  // The update_window_dims means in the %update/fillValues, only the dim in
+  // update_window_dims has the actual value that will be used. The other dims
+  // will only be used to index it. In this examples, we always set the last
+  // dim.
+  SmallVector<int64_t> updateWindowDims;
+  updateWindowDims.push_back(reshapeType.getRank() - 1); // [1]
+
+  // Since scatter spec (C2) rank(inputs[0]) = size(update_window_dims) +
+  // size(inserted_window_dims). We can derive the insertedWindowDims from
+  // updateWindowDims size. The dim start from 0.
+  SmallVector<int64_t> insertedWindowDims; // [0]
+  int64_t offset = inputType.getRank() - updateWindowDims.size();
+  for (int64_t i = 0; i < offset; i++) {
+    insertedWindowDims.push_back(i);
+  }
+
+  auto scatterDimensionNumbers = stablehlo::ScatterDimensionNumbersAttr::get(
+      rewriter.getContext(),
+      /*updateWindowDims=*/updateWindowDims,
+      /*insertedWindowDims=*/insertedWindowDims,
+      /*scatterDimsToOperandDim=*/scatterDimOperandDimMap,
+      /*indexVectorDim=*/indexVecDim);
+
+  auto stablehloScatterOp = rewriter.create<stablehlo::ScatterOp>(
+      loc, input, indices.getResult(), scatterUpdatesReshapeOp.getResult(),
+      scatterDimensionNumbers, false, false);
+
+  // config update computation function: just return the element from src.
+  Block &block = stablehloScatterOp.getUpdateComputation().emplaceBlock();
+  // add block arguments
+  auto blockArgumentType =
+      RankedTensorType::get({}, inputType.getElementType());
+  block.addArgument(blockArgumentType, loc);
+  block.addArgument(blockArgumentType, loc);
+
+  auto *lhsArg = block.args_begin();
+  auto *rhsArg = std::next(lhsArg);
+
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(&block);
+    rewriter.create<stablehlo::ReturnOp>(loc, *rhsArg);
+  }
+
+  rewriter.replaceOp(op, stablehloScatterOp.getResults());
+  return success();
+}
+
 // AtenIndexTensorOp
 // Convert AtenIndexTensorOp to StableHlo::GatherOp
 // Step 1: broadcast indices to the same shape
@@ -852,6 +1145,7 @@ void mlir::torch::torch_to_stablehlo::
   INSERT_ATENOP_PATTERN(AtenGatherOp);
   INSERT_ATENOP_PATTERN(AtenSliceScatterOp);
   INSERT_ATENOP_PATTERN(AtenIndexTensorHackedTwinOp);
+  INSERT_ATENOP_PATTERN(Aten_IndexPutImplOp);
   INSERT_ATENOP_PATTERN(AtenScatterSrcOp);
 #undef INSERT_ATENOP_PATTERN
 }

--- a/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
@@ -577,7 +577,9 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
   // fillK: range of each index, total number of fillInput(could be scatter)
   // after flattened k = 1*1*3 = 3
   for (int i = 0; i < ND; i++) {
-    fillK *= fillValuesType.getShape()[i];
+    if (i < (int)fillValuesType.getShape().size()) {
+      fillK *= fillValuesType.getShape()[i];
+    }
   }
   SmallVector<int64_t, 3> tosaFillValuesShape({N, fillK, C}); // {1,3,1}
 

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -3277,24 +3277,6 @@ class DecomposeAtenNewEmptyOp : public OpRewritePattern<AtenNewEmptyOp> {
 } // namespace
 
 namespace {
-// Decompose `aten.indexPut.hackedTwin` op into `valsem.aten.indexPutImpl`
-// op.
-class DecomposeAtenIndexPutHackedTwinOp
-    : public OpRewritePattern<AtenIndexPutHackedTwinOp> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(AtenIndexPutHackedTwinOp op,
-                                PatternRewriter &rewriter) const override {
-    Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(op.getLoc(), false);
-    rewriter.replaceOpWithNewOp<Aten_IndexPutImplOp>(
-        op, op.getType(), op.getSelf(), op.getIndices(), op.getValues(), op.getAccumulate(),
-        /*unsafe=*/cstFalse);
-    return success();
-  }
-};
-} // namespace
-
-namespace {
 // Decompose `aten._unsafe_indexPut.hackedTwin` op into `aten._index_put_impl`
 // op.
 class DecomposeAten_UnsafeIndexPutHackedTwinOp
@@ -4910,7 +4892,7 @@ public:
 
     SmallVector<bool> indexUsed =
         llvm::to_vector(llvm::map_range(indices, isTensor));
-    for (size_t i = indices.size(); i < inputRank; ++i) 
+    for (int64_t i = indices.size(); i < inputRank; ++i)
       indexUsed.emplace_back(false);
     bool indexIsConsecutive = true;
     int64_t firstUsedIndex = -1;
@@ -5017,6 +4999,229 @@ public:
         loc, Torch::ListType::get(listElemType), listElements);
     rewriter.replaceOpWithNewOp<Torch::AtenIndexTensorHackedTwinOp>(
         op, op.getType(), newInput, newIndexList);
+    return success();
+  }
+};
+} // namespace
+
+// Aten_IndexPutImplOp
+namespace {
+// The goal of this pattern is to eliminate none index in aten.Index.Tensor's
+// `indices` param for the ease of various backend. The detailed steps are:
+//    1. reorder input tensor so that the non-none index appears at adjacent
+//    positions.
+//    2. manually generate index tensor with some ops like iota, to replace the
+//    none index in `indices`
+//    3. replace the old aten._index_put_impl with a new
+//    aten._index_put_impl.hacked_twin.
+class DecomposeAten_IndexPutImplOp
+    : public OpRewritePattern<Aten_IndexPutImplOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  // TODO: It might be better to use aten.view op instead of mulitple
+  // aten.unsqueeze. But currently, torch-to-linalg pass has limited support for
+  // view on dynamic shapes, such as [?] -> [?,1,1,1]. Using aten.view op will
+  // cause relevant e2e tests fail.
+  static FailureOr<Value>
+  unsqueezeTensorAtTrailingDim(Operation *op, PatternRewriter &rewriter,
+                               Value input, int count) {
+    Location loc = op->getLoc();
+    Value constMinusOne = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(-1));
+    Value result = input;
+    while (count--) {
+      auto unsqzTensorInfo =
+          unsqueezeTensor(rewriter, op, result, /*dim=*/constMinusOne);
+      if (failed(unsqzTensorInfo)) {
+        return failure();
+      }
+
+      result = *unsqzTensorInfo;
+    }
+    return result;
+  }
+
+  static Value createIndexToReplaceNone(Operation *op,
+                                        PatternRewriter &rewriter, Value input,
+                                        int dimInt, int64_t dimSize) {
+    Location loc = op->getLoc();
+    MLIRContext *context = op->getContext();
+    Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
+    auto int64Dtype = getDtypeIntValueForType(
+        rewriter, loc,
+        rewriter.getIntegerType(/*width=*/64, /*isSigned=*/true));
+
+    auto resultType = ValueTensorType::get(
+        context, {dimSize},
+        rewriter.getIntegerType(/*width=*/64, /*isSigned=*/true));
+    auto dim = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(dimInt));
+    auto end = rewriter.create<Torch::AtenSizeIntOp>(loc, input, dim);
+    auto v = rewriter.create<Torch::AtenArangeOp>(
+        loc, resultType, /*end=*/end, /*dtype=*/int64Dtype, /*layout=*/none,
+        /*device=*/none, /*pin_memory=*/none);
+    return v;
+  }
+
+  LogicalResult matchAndRewrite(Aten_IndexPutImplOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    MLIRContext *context = op.getContext();
+    SmallVector<Value> indices;
+    if (!getListConstructElements(op.getIndices(), indices))
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to get elements of `indices`");
+
+    auto input = op.getSelf();
+    auto inputType = input.getType().cast<BaseTensorType>();
+    if (!inputType.hasSizes()) {
+      return rewriter.notifyMatchFailure(
+          op, "only input with shape information is supported");
+    }
+    auto inputSizes = inputType.getSizes();
+    int64_t inputRank = inputSizes.size();
+    auto outputType = op.getType().cast<BaseTensorType>();
+    if (!outputType.hasSizes()) {
+      return rewriter.notifyMatchFailure(
+          op, "only output with shape information is supported");
+    }
+    auto outputRank = outputType.getSizes().size();
+
+    auto isTensor = [](Value v) {
+      return v.getType().isa<Torch::BaseTensorType>();
+    };
+
+    // directly replace aten._index_put_impl with
+    // aten._index_put_impl.hacked_twin
+    if (llvm::all_of(indices, isTensor)) {
+      if (indices.size() == 0) {
+        return rewriter.notifyMatchFailure(
+            op, "the indices is empty, it should be folded as a nop");
+      }
+      // By default, we regard the first index type as the list element type.
+      auto indexElemType = indices[0]
+                               .getType()
+                               .template cast<BaseTensorType>()
+                               .getWithSizesAndDtype(std::nullopt, nullptr);
+      auto newIndex = rewriter.create<PrimListConstructOp>(
+          loc, Torch::ListType::get(indexElemType), indices);
+      rewriter.replaceOpWithNewOp<AtenIndexPutHackedTwinOp>(
+          op, op.getType(), input, newIndex, op.getValues(),
+          op.getAccumulate());
+      return success();
+    }
+
+    SmallVector<bool> indexUsed =
+        llvm::to_vector(llvm::map_range(indices, isTensor));
+    for (int64_t i = indices.size(); i < inputRank; ++i)
+      indexUsed.emplace_back(false);
+    bool indexIsConsecutive = true;
+    int64_t firstUsedIndex = -1;
+    for (size_t i = 0; i < indices.size(); ++i) {
+      if (indexUsed[i] && firstUsedIndex == -1) {
+        firstUsedIndex = i;
+      } else if (indexUsed[i] && !indexUsed[i - 1]) {
+        indexIsConsecutive = false;
+        break;
+      }
+    }
+
+    // use aten.permute to reorder the input
+    Value newInput;
+    // `dims` stores the mapping from new index to the old index of input
+    // tensor.
+    SmallVector<int64_t> dims;
+    if (!indexIsConsecutive) {
+      SmallVector<Value> dimValues;
+      SmallVector<int64_t> permutedSizes;
+      for (int i = 0; i < inputRank; i++) {
+        if (indexUsed[i]) {
+          dims.emplace_back(i);
+          dimValues.emplace_back(rewriter.create<Torch::ConstantIntOp>(
+              loc, rewriter.getI64IntegerAttr(i)));
+          permutedSizes.emplace_back(inputSizes[i]);
+        }
+      }
+      for (int i = 0; i < inputRank; i++) {
+        if (!indexUsed[i]) {
+          dims.emplace_back(i);
+          dimValues.emplace_back(rewriter.create<Torch::ConstantIntOp>(
+              loc, rewriter.getI64IntegerAttr(i)));
+          permutedSizes.emplace_back(inputSizes[i]);
+        }
+      }
+      auto dimValueList = rewriter.create<Torch::PrimListConstructOp>(
+          loc, Torch::ListType::get(Torch::IntType::get(context)), dimValues);
+      newInput = rewriter.create<Torch::AtenPermuteOp>(
+          loc,
+          inputType.getWithSizesAndDtype(permutedSizes,
+                                         inputType.getOptionalDtype()),
+          input, dimValueList);
+    } else {
+      newInput = input;
+      for (int i = 0; i < inputRank; i++) {
+        dims.emplace_back(i);
+      }
+    }
+
+    // manually generate new indices.
+    SmallVector<Value> listElements(inputRank);
+
+    int64_t trailingDimCnt = 0;
+    int64_t i;
+    // handle trailing none index.
+    for (i = inputRank - 1; i >= 0; --i) {
+      int64_t oldI = dims[i];
+      if (indexUsed[oldI])
+        break;
+      Value v =
+          createIndexToReplaceNone(op, rewriter, newInput, i, inputSizes[oldI]);
+      auto vInfo =
+          unsqueezeTensorAtTrailingDim(op, rewriter, v, trailingDimCnt);
+      if (failed(vInfo)) {
+        return rewriter.notifyMatchFailure(op, "failed to unsqueeze tensor");
+      }
+      listElements[i] = *vInfo;
+      trailingDimCnt++;
+    }
+    // handle non-none index in between.
+    for (; i >= 0; --i) {
+      int64_t oldI = dims[i];
+      if (!indexUsed[oldI])
+        break;
+      auto vInfo = unsqueezeTensorAtTrailingDim(op, rewriter, indices[oldI],
+                                                trailingDimCnt);
+      if (failed(vInfo)) {
+        return rewriter.notifyMatchFailure(op, "failed to unsqueeze tensor");
+      }
+      listElements[i] = *vInfo;
+    }
+
+    // handle possible leading none dimensions.
+    for (; i >= 0; --i) {
+      int64_t oldI = dims[i];
+      if (indexUsed[oldI]) {
+        return rewriter.notifyMatchFailure(
+            op, "the indices are still unconsecutive after reordering input "
+                "tensor");
+      }
+      Value v =
+          createIndexToReplaceNone(op, rewriter, newInput, i, inputSizes[oldI]);
+      auto vInfo =
+          unsqueezeTensorAtTrailingDim(op, rewriter, v, outputRank - 1 - i);
+      if (failed(vInfo)) {
+        return rewriter.notifyMatchFailure(op, "failed to unsqueeze tensor");
+      }
+      listElements[i] = *vInfo;
+    }
+
+    auto listElemType = ValueTensorType::get(context, std::nullopt, nullptr);
+    auto newIndexList = rewriter.create<Torch::PrimListConstructOp>(
+        loc, Torch::ListType::get(listElemType), listElements);
+    rewriter.replaceOpWithNewOp<Torch::AtenIndexPutHackedTwinOp>(
+        op, op.getType(), newInput, newIndexList, op.getValues(),
+        op.getAccumulate());
     return success();
   }
 };
@@ -5184,7 +5389,6 @@ public:
     addPatternIfTargetOpIsIllegal<DecomposeAtenDropoutOp>(patterns);
     addPatternIfTargetOpIsIllegal<DeomposeAtenNativeDropoutOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenNewEmptyOp>(patterns);
-    addPatternIfTargetOpIsIllegal<DecomposeAtenIndexPutHackedTwinOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAten_UnsafeIndexPutHackedTwinOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenPadOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenToDtypeLayoutOp>(patterns);
@@ -5236,6 +5440,7 @@ public:
     addPatternIfTargetOpIsIllegal<DecomposeAtenTypeAsOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenTileOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenIndexTensorOp>(patterns);
+    addPatternIfTargetOpIsIllegal<DecomposeAten_IndexPutImplOp>(patterns);
 
     GreedyRewriteConfig config;
     config.useTopDownTraversal = true;

--- a/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
+++ b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
@@ -443,7 +443,7 @@ static void markDecomposedOpsAsIllegal(MLIRContext *context,
   target.addIllegalOp<AtenDropoutOp>();
   target.addIllegalOp<AtenNativeDropoutOp>();
   target.addIllegalOp<AtenNewEmptyOp>();
-  target.addIllegalOp<AtenIndexPutHackedTwinOp>();
+  target.addIllegalOp<Aten_IndexPutImplOp>();
   target.addIllegalOp<Aten_UnsafeIndexPutHackedTwinOp>();
   target.addIllegalOp<AtenPadOp>();
   target.addIllegalOp<AtenToDtypeLayoutOp>();

--- a/test/Conversion/TorchToStablehlo/scatter.mlir
+++ b/test/Conversion/TorchToStablehlo/scatter.mlir
@@ -36,68 +36,34 @@ func.func @forward(%arg0: !torch.vtensor<[?,?],si64>, %arg1: !torch.vtensor<[?,?
 
 // -----
 
-// CHECK-LABEL:   func.func @torch.aten._index_put_impl(
-// CHECK-SAME:                                          %[[VAL_0:.*]]: !torch.vtensor<[1,4],si64>,
-// CHECK-SAME:                                          %[[VAL_1:.*]]: !torch.vtensor<[3],si64>,
-// CHECK-SAME:                                          %[[VAL_2:.*]]: !torch.vtensor<[1,3],si64>) -> !torch.vtensor<[1,4],si64> {
-// CHECK:           %[[VAL_3:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[1,4],si64> -> tensor<1x4xi64>
-// CHECK:           %[[VAL_4:.*]] = torch_c.to_builtin_tensor %[[VAL_2]] : !torch.vtensor<[1,3],si64> -> tensor<1x3xi64>
-// CHECK:           %[[VAL_5:.*]] = torch.constant.bool false
-// CHECK:           %[[VAL_6:.*]] = torch.constant.none
-// CHECK:           %[[VAL_7:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_1]] : (!torch.none, !torch.vtensor<[3],si64>) -> !torch.list<optional<vtensor>>
-// CHECK:           %[[VAL_8:.*]] = torch_c.to_builtin_tensor %[[VAL_1]] : !torch.vtensor<[3],si64> -> tensor<3xi64>
-// CHECK:           %[[VAL_9:.*]] = stablehlo.constant dense<0> : tensor<3xi64>
-// CHECK:           %[[VAL_10:.*]] = stablehlo.reshape %[[VAL_9]] : (tensor<3xi64>) -> tensor<3x1xi64>
-// CHECK:           %[[VAL_11:.*]] = stablehlo.reshape %[[VAL_8]] : (tensor<3xi64>) -> tensor<3x1xi64>
-// CHECK:           %[[VAL_12:.*]] = stablehlo.concatenate %[[VAL_10]], %[[VAL_11]], dim = 1 : (tensor<3x1xi64>, tensor<3x1xi64>) -> tensor<3x2xi64>
-// CHECK:           %[[VAL_13:.*]] = stablehlo.reshape %[[VAL_4]] : (tensor<1x3xi64>) -> tensor<3x1xi64>
-// CHECK:           %[[VAL_14:.*]] = "stablehlo.scatter"(%[[VAL_3]], %[[VAL_12]], %[[VAL_13]]) ({
-// CHECK:           ^bb0(%[[VAL_15:.*]]: tensor<i64>, %[[VAL_16:.*]]: tensor<i64>):
-// CHECK:             stablehlo.return %[[VAL_16]] : tensor<i64>
+// CHECK-LABEL:   func.func @torch.aten.index_put.hacked_twin(
+// CHECK-SAME:                                                %[[VAL_0:.*]]: !torch.vtensor<[1,4],si64>,
+// CHECK-SAME:                                                %[[VAL_1:.*]]: !torch.vtensor<[1,1],si64>,
+// CHECK-SAME:                                                %[[VAL_2:.*]]: !torch.vtensor<[3],si64>,
+// CHECK-SAME:                                                %[[VAL_3:.*]]: !torch.vtensor<[1,3],si64>) -> !torch.vtensor<[1,4],si64> {
+// CHECK:           %[[VAL_4:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[1,4],si64> -> tensor<1x4xi64>
+// CHECK:           %[[VAL_5:.*]] = torch_c.to_builtin_tensor %[[VAL_3]] : !torch.vtensor<[1,3],si64> -> tensor<1x3xi64>
+// CHECK:           %[[VAL_6:.*]] = torch.constant.bool false
+// CHECK:           %[[VAL_7:.*]] = torch.prim.ListConstruct %[[VAL_1]], %[[VAL_2]] : (!torch.vtensor<[1,1],si64>, !torch.vtensor<[3],si64>) -> !torch.list<vtensor>
+// CHECK:           %[[VAL_8:.*]] = torch_c.to_builtin_tensor %[[VAL_1]] : !torch.vtensor<[1,1],si64> -> tensor<1x1xi64>
+// CHECK:           %[[VAL_9:.*]] = torch_c.to_builtin_tensor %[[VAL_2]] : !torch.vtensor<[3],si64> -> tensor<3xi64>
+// CHECK:           %[[VAL_10:.*]] = stablehlo.reshape %[[VAL_8]] : (tensor<1x1xi64>) -> tensor<1x1x1xi64>
+// CHECK:           %[[VAL_11:.*]] = stablehlo.broadcast_in_dim %[[VAL_10]], dims = [0, 1, 2] : (tensor<1x1x1xi64>) -> tensor<1x3x1xi64>
+// CHECK:           %[[VAL_12:.*]] = stablehlo.reshape %[[VAL_9]] : (tensor<3xi64>) -> tensor<3x1xi64>
+// CHECK:           %[[VAL_13:.*]] = stablehlo.broadcast_in_dim %[[VAL_12]], dims = [1, 2] : (tensor<3x1xi64>) -> tensor<1x3x1xi64>
+// CHECK:           %[[VAL_14:.*]] = stablehlo.concatenate %[[VAL_11]], %[[VAL_13]], dim = 2 : (tensor<1x3x1xi64>, tensor<1x3x1xi64>) -> tensor<1x3x2xi64>
+// CHECK:           %[[VAL_15:.*]] = stablehlo.reshape %[[VAL_5]] : (tensor<1x3xi64>) -> tensor<3x1xi64>
+// CHECK:           %[[VAL_16:.*]] = stablehlo.reshape %[[VAL_14]] : (tensor<1x3x2xi64>) -> tensor<3x2xi64>
+// CHECK:           %[[VAL_17:.*]] = "stablehlo.scatter"(%[[VAL_4]], %[[VAL_16]], %[[VAL_15]]) ({
+// CHECK:           ^bb0(%[[VAL_18:.*]]: tensor<i64>, %[[VAL_19:.*]]: tensor<i64>):
+// CHECK:             stablehlo.return %[[VAL_19]] : tensor<i64>
 // CHECK:           }) {indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = false} : (tensor<1x4xi64>, tensor<3x2xi64>, tensor<3x1xi64>) -> tensor<1x4xi64>
-// CHECK:           %[[VAL_17:.*]] = torch_c.from_builtin_tensor %[[VAL_14]] : tensor<1x4xi64> -> !torch.vtensor<[1,4],si64>
-// CHECK:           return %[[VAL_17]] : !torch.vtensor<[1,4],si64>
+// CHECK:           %[[VAL_20:.*]] = torch_c.from_builtin_tensor %[[VAL_17]] : tensor<1x4xi64> -> !torch.vtensor<[1,4],si64>
+// CHECK:           return %[[VAL_20]] : !torch.vtensor<[1,4],si64>
 // CHECK:         }
-func.func @torch.aten._index_put_impl(%input: !torch.vtensor<[1,4],si64>, %index: !torch.vtensor<[3],si64>, %fillValues: !torch.vtensor<[1,3],si64>) -> !torch.vtensor<[1,4],si64>{
+func.func @torch.aten.index_put.hacked_twin(%input: !torch.vtensor<[1,4],si64>, %index1: !torch.vtensor<[1,1],si64>, %index2: !torch.vtensor<[3],si64>, %fillValues: !torch.vtensor<[1,3],si64>) -> !torch.vtensor<[1,4],si64>{
   %false = torch.constant.bool false
-  %none = torch.constant.none
-  %indices = torch.prim.ListConstruct %none, %index : (!torch.none, !torch.vtensor<[3],si64>) -> !torch.list<optional<vtensor>>
-  %out = torch.aten._index_put_impl %input, %indices, %fillValues, %false, %false : !torch.vtensor<[1,4],si64>, !torch.list<optional<vtensor>>, !torch.vtensor<[1,3],si64>, !torch.bool, !torch.bool -> !torch.vtensor<[1,4],si64>
-  return %out : !torch.vtensor<[1,4],si64>
-}
-
-// -----
-
-// CHECK-LABEL:   func.func @torch.aten._index_put_impl.zerorank(
-// CHECK-SAME:                                                   %[[VAL_0:.*]]: !torch.vtensor<[1,4],si64>,
-// CHECK-SAME:                                                   %[[VAL_1:.*]]: !torch.vtensor<[],si64>,
-// CHECK-SAME:                                                   %[[VAL_2:.*]]: !torch.vtensor<[],si64>) -> !torch.vtensor<[1,4],si64> {
-// CHECK:           %[[VAL_3:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[1,4],si64> -> tensor<1x4xi64>
-// CHECK:           %[[VAL_4:.*]] = torch_c.to_builtin_tensor %[[VAL_2]] : !torch.vtensor<[],si64> -> tensor<i64>
-// CHECK:           %[[VAL_5:.*]] = torch.constant.bool false
-// CHECK:           %[[VAL_6:.*]] = torch.constant.none
-// CHECK:           %[[VAL_7:.*]] = torch.prim.ListConstruct %[[VAL_6]], %[[VAL_1]] : (!torch.none, !torch.vtensor<[],si64>) -> !torch.list<optional<vtensor>>
-// CHECK:           %[[VAL_8:.*]] = torch_c.to_builtin_tensor %[[VAL_1]] : !torch.vtensor<[],si64> -> tensor<i64>
-// CHECK:           %[[VAL_9:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[VAL_10:.*]] = stablehlo.reshape %[[VAL_4]] : (tensor<i64>) -> tensor<1xi64>
-// CHECK:           %[[VAL_11:.*]] = stablehlo.reshape %[[VAL_10]] : (tensor<1xi64>) -> tensor<1x1xi64>
-// CHECK:           %[[VAL_12:.*]] = stablehlo.reshape %[[VAL_4]] : (tensor<i64>) -> tensor<1xi64>
-// CHECK:           %[[VAL_13:.*]] = stablehlo.reshape %[[VAL_12]] : (tensor<1xi64>) -> tensor<1x1xi64>
-// CHECK:           %[[VAL_14:.*]] = stablehlo.concatenate %[[VAL_11]], %[[VAL_13]], dim = 1 : (tensor<1x1xi64>, tensor<1x1xi64>) -> tensor<1x2xi64>
-// CHECK:           %[[VAL_15:.*]] = stablehlo.reshape %[[VAL_4]] : (tensor<i64>) -> tensor<1xi64>
-// CHECK:           %[[VAL_16:.*]] = stablehlo.reshape %[[VAL_15]] : (tensor<1xi64>) -> tensor<1x1xi64>
-// CHECK:           %[[VAL_17:.*]] = stablehlo.reshape %[[VAL_16]] : (tensor<1x1xi64>) -> tensor<1x1xi64>
-// CHECK:           %[[VAL_18:.*]] = "stablehlo.scatter"(%[[VAL_3]], %[[VAL_14]], %[[VAL_17]]) ({
-// CHECK:           ^bb0(%[[VAL_19:.*]]: tensor<i64>, %[[VAL_20:.*]]: tensor<i64>):
-// CHECK:             stablehlo.return %[[VAL_20]] : tensor<i64>
-// CHECK:           }) {indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = false} : (tensor<1x4xi64>, tensor<1x2xi64>, tensor<1x1xi64>) -> tensor<1x4xi64>
-// CHECK:           %[[VAL_21:.*]] = torch_c.from_builtin_tensor %[[VAL_18]] : tensor<1x4xi64> -> !torch.vtensor<[1,4],si64>
-// CHECK:           return %[[VAL_21]] : !torch.vtensor<[1,4],si64>
-// CHECK:         }
-func.func @torch.aten._index_put_impl.zerorank(%input: !torch.vtensor<[1,4],si64>, %index: !torch.vtensor<[],si64>, %fillValues: !torch.vtensor<[],si64>) -> !torch.vtensor<[1,4],si64>{
-  %false = torch.constant.bool false
-  %none = torch.constant.none
-  %indices = torch.prim.ListConstruct %none, %index : (!torch.none, !torch.vtensor<[],si64>) -> !torch.list<optional<vtensor>>
-  %out = torch.aten._index_put_impl %input, %indices, %fillValues, %false, %false : !torch.vtensor<[1,4],si64>, !torch.list<optional<vtensor>>, !torch.vtensor<[],si64>, !torch.bool, !torch.bool -> !torch.vtensor<[1,4],si64>
+  %indices = torch.prim.ListConstruct %index1, %index2 : (!torch.vtensor<[1,1],si64>, !torch.vtensor<[3],si64>) -> !torch.list<vtensor>
+  %out = torch.aten.index_put.hacked_twin %input, %indices, %fillValues, %false: !torch.vtensor<[1,4],si64>, !torch.list<vtensor>, !torch.vtensor<[1,3],si64>, !torch.bool -> !torch.vtensor<[1,4],si64>
   return %out : !torch.vtensor<[1,4],si64>
 }


### PR DESCRIPTION
This patch is to remove the none-index in aten.index_put, then lower it to stablehlo and tosa.
This patch will use and change the commit in [[Stablehlo] Add converter for aten._index_put_impl op](https://github.com/llvm/torch-mlir/pull/2343#top) #2343. Then add a decompose pass, which will lead to rewritting of tosa index_put and some torchdynamo/linalg bug. The decompose pass is mostly inspired from https://github.com/llvm/torch-mlir/pull/2344. And rewrite some tosa indexput code for the new decompose pass.

Demand from https://github.com/nod-ai/SHARK/issues/1336
New generated T5 model: https://storage.googleapis.com/shark_tank/chi-nod/t5_small/stablehlo/t5small_stablehlo_0829_transformers4.26.0_elide.mlir


6 different index broadcast cases need to be supported:
```
# First 3 cases the index2 is torch.Size([3])
# Case 1
input = torch.tensor([[0, 1, 2, 3]])
index1 = torch.tensor([[0]])
index2 = torch.tensor([1,2,3])
update =  torch.tensor([4, 5, 6])
output = torch.ops.aten.index_put.hacked_twin(input, (index1, index2), update)
print("index1.shape: ", index1.shape) # torch.Size([1, 1])
print("index2.shape: ", index2.shape) # torch.Size([3])
print(output) # tensor([[0, 4, 5, 6]])
# Case 2
input = torch.tensor([[0, 1, 2, 3]])
index1 = torch.tensor([[0,0,0]])
index2 = torch.tensor([1,2,3])
update =  torch.tensor([4, 5, 6])
output = torch.ops.aten.index_put.hacked_twin(input, (index1, index2), update)
print("index1.shape: ", index1.shape) # torch.Size([1, 3])
print("index2.shape: ", index2.shape) # torch.Size([3])
print(output) # tensor([[0, 4, 5, 6]])
# Case 3
input = torch.tensor([[0, 1, 2, 3]])
index1 = torch.tensor([0,0,0])
index2 = torch.tensor([1,2,3])
update =  torch.tensor([4, 5, 6])
output = torch.ops.aten.index_put.hacked_twin(input, (index1, index2), update)
print("index1.shape: ", index1.shape) # torch.Size([1, 3])
print("index2.shape: ", index2.shape) # torch.Size([3])
print(output) # tensor([[0, 4, 5, 6]])

# Next 3 cases Change the index2 into torch.Size([1, 3])
# Case 4
input = torch.tensor([[0, 1, 2, 3]])
index1 = torch.tensor([[0]]) # torch.Size([1,1])
index2 = torch.tensor([[1,2,3]]) # torch.Size([1, 3])
update =  torch.tensor([4, 5, 6])
output = torch.ops.aten.index_put.hacked_twin(input, (index1, index2), update)
print("index1.shape: ", index1.shape) # torch.Size([1, 1])
print("index2.shape: ", index2.shape) # torch.Size([1, 3])
print(output) # tensor([[0, 4, 5, 6]])
# Case 5
input = torch.tensor([[0, 1, 2, 3]])
index1 = torch.tensor([[0,0,0]]) # torch.Size([1, 3])
index2 = torch.tensor([[1,2,3]]) # torch.Size([1, 3])
update =  torch.tensor([4, 5, 6])
output = torch.ops.aten.index_put.hacked_twin(input, (index1, index2), update)
print("index1.shape: ", index1.shape) # torch.Size([1, 3])
print("index2.shape: ", index2.shape) # torch.Size([1, 3])
print(output) # tensor([[0, 4, 5, 6]])
#Case 6
input = torch.tensor([[0, 1, 2, 3]])
index1 = torch.tensor([0,0,0]) # torch.Size([3])
index2 = torch.tensor([[1,2,3]]) # torch.Size([1, 3])
update =  torch.tensor([4, 5, 6])
output = torch.ops.aten.index_put.hacked_twin(input, (index1, index2), update)
print("index1.shape: ", index1.shape) # torch.Size([3])
print("index2.shape: ", index2.shape) # torch.Size([1, 3])
print(output) # tensor([[0, 4, 5, 6]])
```

For anyone( @Vremold @RamirezLucas @mgehre-amd @vivekkhandelwal1 @eric-k256  ) who might review/test, you can cherry-pick and use this test code directly [test_indexput_hacketwin_35.py](https://gist.github.com/AmosLewis/979d1aca948b3cd821d6edadc160f610#file-test_indexput_hacketwin_35-py):
```
import torch
import torch_mlir
class Net(torch.nn.Module):
    def __init__(self) -> None:
        super().__init__()
    def forward(self, input, index1, index2, src):
        return torch.index_put(input, indices=(index1, index2), values=src, accumulate=False)
m = Net()
src = torch.arange(1, 6)
index1 = torch.tensor([0, 0, 0, 0, 0])
index2 = torch.tensor([1, 2, 3, 4, 0])
input = torch.arange(10, 25, step=1, dtype=src.dtype).view(3, 5)
m = torch_mlir.compile(m, [input, index1, index2, src], output_type="stablehlo")
print(m.operation.get_asm())
m = torch_mlir.compile(m, [input, index1, index2, src], output_type="tosa")
print(m.operation.get_asm())
```
