### PR TITLE
[Torch Dialect] revert canonicalizer for PrimListConstructOp

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -413,7 +413,6 @@ def Torch_PrimListConstructOp: Torch_Op<"prim.ListConstruct", [
   );
 
   let hasVerifier = 1;
-  let hasCanonicalizer = 1;
 
   let assemblyFormat = [{
     $elements attr-dict `:` functional-type(operands, results)

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -2100,32 +2100,6 @@ void PrimTupleUnpackOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 }
 
 //===----------------------------------------------------------------------===//
-// PrimListConstructOp
-//===----------------------------------------------------------------------===//
-
-void PrimListConstructOp::getCanonicalizationPatterns(
-    RewritePatternSet &patterns, MLIRContext *context) {
-  patterns.add(+[](PrimListConstructOp op, PatternRewriter &rewriter) {
-    if (isListPotentiallyMutated(op.getResult())) 
-      return failure();
-    SmallVector<Value> elements = llvm::to_vector<4>(op.getElements());
-    if (elements.size() == 0)
-      return failure();
-
-    auto listUnpackOp = elements[0].getDefiningOp<PrimListUnpackOp>();
-    if (!listUnpackOp)
-      return failure();
-    if (listUnpackOp.getResults() != elements)
-      return failure();
-    if (isListPotentiallyMutated(listUnpackOp.getOperand()))
-      return failure();
-
-    rewriter.replaceOp(op, listUnpackOp.getOperand());
-    return success();
-  });
-}
-
-//===----------------------------------------------------------------------===//
 // PrimListUnpackOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -965,15 +965,6 @@ func.func @torch.prim.If$fold_same_result$subset_of_results(%arg0: !torch.bool, 
   return %0, %1: !torch.int, !torch.int
 }
 
-// CHECK-LABEL: func.func @prim.ListConstruct$fold_list(
-// CHECK-SAME:      %[[ARG0:.*]]: !torch.list<tensor>) -> !torch.list<tensor> {
-// CHECK:         return %[[ARG0]] : !torch.list<tensor>
-func.func @prim.ListConstruct$fold_list(%arg0: !torch.list<tensor>) -> !torch.list<tensor> {
-  %0:2 = torch.prim.ListUnpack %arg0 : !torch.list<tensor> -> !torch.tensor, !torch.tensor
-  %1 = torch.prim.ListConstruct %0#0, %0#1 : (!torch.tensor, !torch.tensor) -> !torch.list<tensor>
-  return %1 : !torch.list<tensor>
-}
-
 // CHECK-LABEL:   func.func @torch.prim.TupleUnpack(
 // CHECK-SAME:                                         %[[ARG0:.*]]: !torch.tensor,
 // CHECK-SAME:                                         %[[ARG1:.*]]: !torch.tensor) -> !torch.tensor {


### PR DESCRIPTION
This a reverter for PR #2306 . PrimListConstructOp has so many complex usage scenarios. Canonializing it might not be a good idea. 
Here is an example. Suppose we have a IR like:
```mlir
%499 = torch.aten.chunk %498, %int4, %int0 : !torch.tensor, !torch.int, !torch.int -> !torch.list<tensor>
%500:4 = torch.prim.ListUnpack %499 : !torch.list<tensor> -> !torch.tensor, !torch.tensor, !torch.tensor, !torch.tensor
%501 = torch.prim.ListConstruct %500#0, %500#1, %500#2, %500#3 : (!torch.tensor, !torch.tensor, !torch.tensor, !torch.tensor) -> !torch.list<tensor>
%502 = torch.aten.cat %501, %int-1 : !torch.list<tensor>, !torch.int -> !torch.tensor
```
If we canonicalize the ListConstructOp, the `aten.cat` op will directly use the result from `aten.chunk`. It might fail some passes, since we often assume `aten.cat`'s operand comes from a ListConstructOp.