### PR TITLE
[MLIR][TORCH] add E2E support for aten.rand

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -17,7 +17,6 @@ LINALG_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS | {
     # Lowering Torch Backend IR -> Linalg-on-Tensors Backend IR failed
     # 'linalg.depthwise_conv_2d_nchw_chw' op inferred input/output operand #1 has shape's dimension #0 to be 4, but found 8
     "Conv2dWithPaddingDilationStrideStaticModule_depthwise_multiplier",
-    "RandModule_basic"
 }
 
 TORCHDYNAMO_XFAIL_SET = {
@@ -63,7 +62,6 @@ TORCHDYNAMO_XFAIL_SET = {
     # error: failed to legalize operation 'torch.aten.view' that was explicitly marked illegal
     "ElementwiseFlattenBroadcastModule_basic",
     "FlattenRank0Module_basic",
-    "RandModule_basic",
     "UniformModule_basic",
     "UniformStaticShapeModule_basic",
     # error: unsupported by backend contract: tensor with unknown rank

--- a/lib/Conversion/TorchToStablehlo/Basic.cpp
+++ b/lib/Conversion/TorchToStablehlo/Basic.cpp
@@ -1553,36 +1553,6 @@ LogicalResult ConvertAtenOp<AtenUniformOp>::matchAndRewrite(
   return success();
 }
 
-template <>
-LogicalResult ConvertAtenOp<AtenRandOp>::matchAndRewrite(
-    AtenRandOp op, OpAdaptor adaptor,
-    ConversionPatternRewriter &rewriter) const {
-  Location loc = op.getLoc();
-  SmallVector<int64_t> size;
-  if (!matchPattern(adaptor.getSize(), m_TorchListOfConstantInts(size))) {
-    return rewriter.notifyMatchFailure(op,
-                                       "only constant integer size supported");
-  }
-  auto shapeTensor = rewriter.create<stablehlo::ConstantOp>(
-      loc, rewriter.getI64TensorAttr(size));
-  auto outTy = getTypeConverter()->convertType(op.getType());
-  auto outElemTy = outTy.cast<RankedTensorType>().getElementType();
-
-  if (!outElemTy.isa<FloatType>()) {
-    return rewriter.notifyMatchFailure(op, "only float type supported");
-  }
-
-  Value from = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getFloatAttr(outElemTy, 0.0));
-  from = hlo::scalarToStablehloTensor(rewriter, op, from, outElemTy);
-  Value to = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getFloatAttr(outElemTy, 1.0));
-  to = hlo::scalarToStablehloTensor(rewriter, op, to, outElemTy);
-  rewriter.replaceOpWithNewOp<stablehlo::RngOp>(
-      op, outTy, from, to, shapeTensor, stablehlo::RngDistribution::UNIFORM);
-  return success();
-}
-
 // Converts `aten.empty.memory_format` to `tensor.empty` op.
 template <>
 LogicalResult ConvertAtenOp<AtenEmptyMemoryFormatOp>::matchAndRewrite(
@@ -1874,7 +1844,6 @@ void mlir::torch::torch_to_stablehlo::populateBasicOpPatternsAndLegality(
   INSERT_ATENOP_PATTERN(AtenWhereSelfOp);
   INSERT_ATENOP_PATTERN(AtenPowTensorTensorOp);
   INSERT_ATENOP_PATTERN(AtenUniformOp);
-  INSERT_ATENOP_PATTERN(AtenRandOp);
   INSERT_ATENOP_PATTERN(AtenEmptyMemoryFormatOp);
   INSERT_ATENOP_PATTERN(AtenFillScalarOp);
   INSERT_ATENOP_PATTERN(AtenFlipOp);

--- a/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
+++ b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
@@ -473,6 +473,7 @@ static void markDecomposedOpsAsIllegal(MLIRContext *context,
   target.addIllegalOp<PrimsConvertElementTypeOp>();
   target.addIllegalOp<PrimsVarOp>();
   target.addIllegalOp<PrimsSqrtOp>();
+  target.addIllegalOp<AtenRandOp>();
   target.addIllegalOp<AtenRandnOp>();
   target.addIllegalOp<AtenRandnGeneratorOp>();
   target.addIllegalOp<AtenRandnLikeOp>();


### PR DESCRIPTION
Implements a decomposition for aten.rand that fills an empty tensor with uniformly generated values between 0 and 1. This passes tests in all backends except for `tosa`, there is an existing implementation (merged yesterday) that is specific to `stablehlo` from @Vremold. Please let me know if the implementation is correct :)