### PR TITLE
[Tcp] Remove Complex type

### DIFF
--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpBase.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpBase.td
@@ -68,13 +68,12 @@ def TCP_QuantizedInt	: AnyTypeOf<[ TCP_QuantizedType<"q8ua", [8], 0>,
                                      TCP_QuantizedType<"q8ss", [8, 0], 1>,
                                      TCP_QuantizedType<"q16ss", [16, 0], 1>]>;
 
-def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, AnyComplex, TCP_QuantizedInt]>;
+def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, TCP_QuantizedInt]>;
 def Tcp_Tensor : RankedTensorOf<[Tcp_Scalar]>;
 def Tcp_TensorOrScalar : AnyTypeOf<[Tcp_Tensor, Tcp_Scalar]>;
 
 def Tcp_FloatTensor : RankedTensorOf<[AnyFloat]>;
 def Tcp_FloatOrIntTensor : RankedTensorOf<[AnyFloat, AnySignlessInteger]>;
-def Tcp_FloatOrComplexTensor : RankedTensorOf<[AnyFloat, AnyComplex]>;
 
 //===----------------------------------------------------------------------===//
 // Tcp Ops Base.

--- a/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.td
+++ b/externals/llvm-external-projects/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/Tcp/IR/TcpOps.td
@@ -23,11 +23,11 @@ def Tcp_TanhOp : Tcp_UnaryElementwiseOp<"tanh", [SameOperandsAndResultElementTyp
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in
+    Tcp_FloatTensor:$in
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
@@ -73,11 +73,11 @@ def Tcp_SigmoidOp : Tcp_UnaryElementwiseOp<"sigmoid", [SameOperandsAndResultElem
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in
+    Tcp_FloatTensor:$in
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
@@ -359,11 +359,11 @@ def Tcp_CeilOp : Tcp_UnaryElementwiseOp<"ceil", [SameOperandsAndResultElementTyp
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in
+    Tcp_FloatTensor:$in
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
@@ -377,11 +377,11 @@ def Tcp_FloorOp : Tcp_UnaryElementwiseOp<"floor", [SameOperandsAndResultElementT
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in
+    Tcp_FloatTensor:$in
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
@@ -395,11 +395,11 @@ def Tcp_CosOp : Tcp_UnaryElementwiseOp<"cos", [SameOperandsAndResultElementType]
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in
+    Tcp_FloatTensor:$in
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
@@ -413,11 +413,11 @@ def Tcp_SinOp : Tcp_UnaryElementwiseOp<"sin", [SameOperandsAndResultElementType]
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in
+    Tcp_FloatTensor:$in
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
@@ -449,11 +449,11 @@ def Tcp_LogOp : Tcp_UnaryElementwiseOp<"log", [SameOperandsAndResultElementType]
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in
+    Tcp_FloatTensor:$in
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
@@ -467,11 +467,11 @@ def Tcp_NegOp : Tcp_UnaryElementwiseOp<"neg", [SameOperandsAndResultElementType]
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in
+    Tcp_FloatTensor:$in
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
@@ -485,11 +485,11 @@ def Tcp_AtanOp : Tcp_UnaryElementwiseOp<"atan", [SameOperandsAndResultElementTyp
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in
+    Tcp_FloatTensor:$in
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
@@ -504,12 +504,12 @@ def Tcp_Atan2Op : Tcp_BinaryElementwiseOp<"atan2", [SameOperandsAndResultElement
   }];
 
   let arguments = (ins
-    Tcp_FloatOrComplexTensor:$in1,
-    Tcp_FloatOrComplexTensor:$in2
+    Tcp_FloatTensor:$in1,
+    Tcp_FloatTensor:$in2
   );
 
   let results = (outs
-    Tcp_FloatOrComplexTensor:$out
+    Tcp_FloatTensor:$out
   );
 
   let assemblyFormat = "$in1 `,` $in2 attr-dict `:` type($in1) `,` type($in2) `->` type($out)";


### PR DESCRIPTION
This PR removes Complex type from TCP dialect. We do not support Complex type in any ops in TCP at this point. So, there is no reason to have it in the types at this time.