### PR TITLE
[NFC] Clean-up `ConvertAtenViewOp` in linalg backend

### DIFF
--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -459,6 +459,9 @@ public:
         } else if (succeeded(mapStaticallyKnownDims(
                        inputShapeSlice, outputShapeSlice, inputSliceIndices,
                        outputSliceIndices))) {
+          /// `mapStaticallyKnownDims` maps the smallest number of
+          /// input and output dimensions in the slice statically
+          /// known to have the same number of elements.
         } else if (inputShapeSlice[0] == kUnknownSize) {
           // If the input is dynamic, assume it is not split
           checkDimEqualHelper(rewriter, loc, inputSize[inputDim],

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -353,12 +353,6 @@ public:
           op, "desired size list length mismatches with the result type rank");
     }
 
-    // Currently, we only handle the cases where each dimension is either
-    // being expanded or collapsed. We do not handle cases where it's neither
-    // collapsing nor expanding like view of [2,3] for 3x2 tensor.
-    // TODO: For neither collapsing nor expanding, we could find a intermediate
-    // shape to collapse and then expanded to the target shape. Like [2,3] =>
-    // [6] => [3, 2].
     auto [inputShape, outputShape] =
         getInputAndOutputShape(op.getSelf(), outputSizeTorchInt);
 
@@ -460,7 +454,9 @@ public:
           outputSliceIndices.push_back(0);
           assumedDynamicDimNotSplit = true;
         } else {
-          return rewriter.notifyMatchFailure(op, "TODO(ramiro050)");
+          return rewriter.notifyMatchFailure(
+              op, "unimplemented: found unhandled case of expansion/collapse "
+                  "in `aten.view`");
         }
 
         inputAssociations.emplace_back();

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -398,12 +398,12 @@ public:
       // ambiguous case below
       bool hasDynamic = false;
       while (inputDim < nextUnchangedInput && outputDim < nextUnchangedOutput) {
-        MutableArrayRef<int64_t> inputShapeSlice(inputShape);
-        inputShapeSlice =
-            inputShapeSlice.slice(inputDim, nextUnchangedInput - inputDim);
-        MutableArrayRef<int64_t> outputShapeSlice(outputShape);
-        outputShapeSlice =
-            outputShapeSlice.slice(outputDim, nextUnchangedOutput - outputDim);
+        auto inputShapeSlice =
+            MutableArrayRef<int64_t>(inputShape)
+                .slice(inputDim, nextUnchangedInput - inputDim);
+        auto outputShapeSlice =
+            MutableArrayRef<int64_t>(outputShape)
+                .slice(outputDim, nextUnchangedOutput - outputDim);
         SmallVector<int64_t> inputSliceIndices;
         SmallVector<int64_t> outputSliceIndices;
 

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -205,12 +205,12 @@ public:
       if (!isValidReduction(xDims[0], yDims))
         return failure();
       xIndices.assign({0});
-      yIndices.assign(llvm::to_vector(llvm::seq(0l, (int64_t)yDims.size())));
+      yIndices.assign(llvm::to_vector(llvm::seq<int64_t>(0, yDims.size())));
     } else if (yDims.size() == 1) {
       if (!isValidReduction(yDims[0], xDims))
         return failure();
       yIndices.assign({0});
-      xIndices.assign(llvm::to_vector(llvm::seq(0l, (int64_t)xDims.size())));
+      xIndices.assign(llvm::to_vector(llvm::seq<int64_t>(0, xDims.size())));
     } else {
       return failure();
     }

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -253,9 +253,13 @@ public:
     return success();
   }
 
-  // TODO(ramiro050): improve naming + docstring
-  static void solveSingleDynamicSize(MutableArrayRef<int64_t> inputShape,
-                                     MutableArrayRef<int64_t> outputShape) {
+  // Calculates the size of a dynamic dimension if all other dimensions are
+  // statically known, and rewrites that dynamic dimension with the static size.
+  //
+  // Note: this function assumes that all the dimensions in `inputShape` map to
+  // all the dimensions in `outputShape`.
+  static void calculateSingleDynamicSize(MutableArrayRef<int64_t> inputShape,
+                                         MutableArrayRef<int64_t> outputShape) {
     int64_t inputDynamicDimCount = llvm::count(inputShape, kUnknownSize);
     int64_t outputDynamicDimCount = llvm::count(outputShape, kUnknownSize);
     if (inputDynamicDimCount + outputDynamicDimCount != 1)
@@ -298,7 +302,7 @@ public:
       }
     }
 
-    solveSingleDynamicSize(inputShape, outputShape);
+    calculateSingleDynamicSize(inputShape, outputShape);
     return std::make_pair(inputShape, outputShape);
   }
 
@@ -430,7 +434,7 @@ public:
         if (succeeded(mapAllDimsToSingleDim(inputShapeSlice, outputShapeSlice,
                                             inputSliceIndices,
                                             outputSliceIndices))) {
-          solveSingleDynamicSize(inputShapeSlice, outputShapeSlice);
+          calculateSingleDynamicSize(inputShapeSlice, outputShapeSlice);
           // Update shape to pass the tensor.expand_shape and
           // tensor.collapse_shape verifiers. If one of the dimensions of the
           // tensor being flattened is dynamic, the size of the flattened tensor

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -217,23 +217,6 @@ public:
     }
   }
 
-  static LogicalResult allDynamicCase(ArrayRef<int64_t> xs,
-                                      ArrayRef<int64_t> ys,
-                                      SmallVector<int64_t> &xIndices,
-                                      SmallVector<int64_t> &yIndices) {
-    // TODO(ramiro050): should this come with a warning? Maybe
-    // `checkDimEqualHelper` takes care of it?
-    auto isStatic = [](int64_t value) { return value != kUnknownSize; };
-    if (llvm::any_of(xs, isStatic) && llvm::any_of(ys, isStatic))
-      return failure();
-
-    xIndices.append(llvm::to_vector(
-        llvm::iota_range<int64_t>(0, xs.size(), /*inclusive=*/false)));
-    yIndices.append(llvm::to_vector(
-        llvm::iota_range<int64_t>(0, ys.size(), /*inclusive=*/false)));
-    return success();
-  }
-
   // TODO(ramiro050): add better description
   // Returns error when total number of elements does not match expansion total
   // TODO(ramiro050): don't mutate results until you know there's success
@@ -504,10 +487,6 @@ public:
           inputIndices.push_back(0);
           outputIndices.push_back(0);
           hasDynamic = true;
-        } else if (succeeded(allDynamicCase(inputShapeSlice, outputShapeSlice,
-                                            inputIndices, outputIndices))) {
-          assert(false);
-          hasDynamic = false;
         } else if (succeeded(minimallyCollapseDimHelper2(
                        inputShapeSlice, outputShapeSlice, inputIndices,
                        outputIndices))) {


### PR DESCRIPTION
While trying to fix a bug in the `ConvertAtenViewOp` pattern in the linalg backend, I realized that the pattern had become quite complex and had accumulated some dead code, making it hard to reason about.

This commit simplifies the pattern quite a bit. The main changes are:
1. All the static helper functions in the `ConvertAtenViewOp` class have been simplified, both in their signature and their body. Each one now performs simple calculations on arrays, and take the least number of arguments necessary.
2. The body of [the `while` loop](https://github.com/ramiro050/torch-mlir/blob/9fce566b0cb64ff2b198693d1f6ee9580b8fa01f/lib/Conversion/TorchToLinalg/DataMovement.cpp#L407) inside the main pattern has been changed to work on `MutableArrayRef` slices, to avoid having to keep track of `start` and `end` indices for the input and output shape arrays.
3. All the heuristics used to determine the mapping between the input and output dimensions are now in [this relatively short `if-else` section](https://github.com/ramiro050/torch-mlir/blob/9fce566b0cb64ff2b198693d1f6ee9580b8fa01f/lib/Conversion/TorchToLinalg/DataMovement.cpp#L428-L460), making it easy to see what is going on.
4. Dead code was eliminated + updates to some of the documentation comments

This commit does not add any new functionality to the `ConvertAtenViewOp` pattern.