### PR TITLE
[MLIR][TORCH] Add device "cpu" support for aten.to.dtype_layout op 

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -3380,10 +3380,15 @@ public:
             op, "unimplemented: pinMemory is expected to be false");
     }
 
-    // TODO: Add support for non-None device arg.
+    // TODO: Add support for device arg other than cpu.
     if (!op.getDevice().getType().isa<Torch::NoneType>()) {
-      return rewriter.notifyMatchFailure(
-          op, "unimplemented: device arg must be None");
+      std::string device;
+      if (!matchPattern(op.getDevice(), m_TorchConstantDevice(device)))
+        return rewriter.notifyMatchFailure(
+            op, "unimplemented: device must be a constant str");
+      else if (device != "cpu")
+        return rewriter.notifyMatchFailure(
+            op, "unimplemented: device is expected to be cpu");
     }
 
     // TODO: Add support for non-strided layout.

--- a/python/torch_mlir_e2e_test/test_suite/type_conversion.py
+++ b/python/torch_mlir_e2e_test/test_suite/type_conversion.py
@@ -169,6 +169,28 @@ class ToDtypeLayoutNoneModule(torch.nn.Module):
 def ToDtypeLayoutNoneModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 5))
 
+class ToDtypeLayoutCPUModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([None, ([-1, -1], torch.float32, True)])
+    def forward(self, x):
+        return torch.ops.aten.to(x,
+                                 dtype=torch.float64,
+                                 layout=None,
+                                 device="cpu",
+                                 pin_memory=None,
+                                 non_blocking=False,
+                                 copy=False,
+                                 memory_format=None)
+
+
+@register_test_case(module_factory=lambda: ToDtypeLayoutCPUModule())
+def ToDtypeLayoutCPUModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 5))
+
 
 class ToDtypeLayoutStridedModule(torch.nn.Module):
 


### PR DESCRIPTION
This PR adds device="cpu" support for `aten.to_dtypeLayout` op and corresponding e2e test suit.
(refer:  PR https://github.com/llvm/torch-mlir/pull/812/)

