### PR TITLE
[RFC, WIP] Collapse leading unit dims on input shapes

### DIFF
--- a/lib/Dialect/TorchConversion/IR/TorchConversionOps.cpp
+++ b/lib/Dialect/TorchConversion/IR/TorchConversionOps.cpp
@@ -25,8 +25,7 @@ static bool haveSameSizeAndElementType(TensorType lhs, TensorType rhs) {
   if (lhs.hasRank() != rhs.hasRank())
     return false;
   bool sameSize = lhs.hasRank() ? lhs.getShape().equals(rhs.getShape()) : true;
-  bool sameElementType = lhs.getElementType() == rhs.getElementType();
-  return sameElementType && sameSize;
+  return sameSize;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
additionally uses derived output shape as a hint in get input and output shapes.

Covers some cases like
before:
1,-1
-1,-1
after:
1,-1
1,-1