### PR TITLE
[linalg] Add handling for leadin and trailing size-1 dims in ViewOp

### DIFF
--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -193,9 +193,6 @@ public:
                                              ArrayRef<int64_t> yDims,
                                              SmallVector<int64_t> &xIndices,
                                              SmallVector<int64_t> &yIndices) {
-    if (xDims.empty() || yDims.empty())
-      return failure();
-
     auto isValidReduction = [](int64_t expectedReductionProduct,
                                ArrayRef<int64_t> arrayToReduce) -> bool {
       if (llvm::count(arrayToReduce, kUnknownSize) > 0 ||
@@ -258,25 +255,6 @@ public:
     return success();
   }
 
-  // If one of the two dims arrays has size 0 and the other array only
-  // has dims of size 1, a mapping is created from no dimensions to
-  // all the dimensions of the other array.
-  static LogicalResult mapTrailingSizeOneDims(ArrayRef<int64_t> xDims,
-                                              ArrayRef<int64_t> yDims,
-                                              SmallVector<int64_t> &xIndices,
-                                              SmallVector<int64_t> &yIndices) {
-    SmallVector<int64_t> ignoredIndices;
-    if (xDims.empty()) {
-      return mapAllDimsToSingleDim(ArrayRef<int64_t>({1}), yDims,
-                                   ignoredIndices, yIndices);
-    } else if (yDims.empty()) {
-      return mapAllDimsToSingleDim(xDims, ArrayRef<int64_t>({1}), xIndices,
-                                   ignoredIndices);
-    } else {
-      return failure();
-    }
-  }
-
   // Calculates the size of a dynamic dimension if all other dimensions are
   // statically known, and rewrites that dynamic dimension with the static size.
   //
@@ -284,8 +262,6 @@ public:
   // all the dimensions in `outputShape`.
   static void calculateSingleDynamicSize(MutableArrayRef<int64_t> inputShape,
                                          MutableArrayRef<int64_t> outputShape) {
-    if (inputShape.empty() || outputShape.empty())
-      return;
     int64_t inputDynamicDimCount = llvm::count(inputShape, kUnknownSize);
     int64_t outputDynamicDimCount = llvm::count(outputShape, kUnknownSize);
     if (inputDynamicDimCount + outputDynamicDimCount != 1)
@@ -444,7 +420,7 @@ public:
     for (auto [nextUnchangedInput, nextUnchangedOutput] : unchangedDims) {
       // Used for ensuring that we don't have an ambiguous expansion
       bool assumedDynamicDimNotSplit = false;
-      while (inputDim < nextUnchangedInput || outputDim < nextUnchangedOutput) {
+      while (inputDim < nextUnchangedInput && outputDim < nextUnchangedOutput) {
         auto inputShapeSlice =
             MutableArrayRef<int64_t>(inputShape)
                 .slice(inputDim, nextUnchangedInput - inputDim);
@@ -465,15 +441,9 @@ public:
                   "(e.g. [-1, -1] -> [-1, -1, -1])");
         }
 
-        if (succeeded(mapTrailingSizeOneDims(inputShapeSlice, outputShapeSlice,
-                                             inputSliceIndices,
-                                             outputSliceIndices))) {
-        } else if (outputShapeSlice.empty()) {
-          inputSliceIndices.assign(
-              llvm::to_vector(llvm::seq<int64_t>(0, inputShapeSlice.size())));
-        } else if (succeeded(mapAllDimsToSingleDim(
-                       inputShapeSlice, outputShapeSlice, inputSliceIndices,
-                       outputSliceIndices))) {
+        if (succeeded(mapAllDimsToSingleDim(inputShapeSlice, outputShapeSlice,
+                                            inputSliceIndices,
+                                            outputSliceIndices))) {
           calculateSingleDynamicSize(inputShapeSlice, outputShapeSlice);
           // Update shape to pass the tensor.expand_shape and
           // tensor.collapse_shape verifiers. If one of the dimensions of the
@@ -492,8 +462,7 @@ public:
           /// `mapStaticallyKnownDims` maps the smallest number of
           /// input and output dimensions in the slice statically
           /// known to have the same number of elements.
-        } else if (inputShapeSlice.size() > 0 &&
-                   inputShapeSlice[0] == kUnknownSize) {
+        } else if (inputShapeSlice[0] == kUnknownSize) {
           // If the input is dynamic, assume it is not split
           checkDimEqualHelper(rewriter, loc, inputSize[inputDim],
                               outputSizeInt[outputDim]);
@@ -509,14 +478,8 @@ public:
                   "in `aten.view`");
         }
 
-        // If one of the slices is empty, this means we are handling
-        // the case of trailing dimensions, which does not require a
-        // new reassociation; the trailing dimensions get added to the
-        // last reassociation created.
-        if (inputShapeSlice.size() > 0 && outputShapeSlice.size() > 0) {
-          inputAssociations.emplace_back();
-          outputAssociations.emplace_back();
-        }
+        inputAssociations.emplace_back();
+        outputAssociations.emplace_back();
         for (int64_t inputSliceIndex : inputSliceIndices)
           inputAssociations.back().push_back(inputSliceIndex + inputDim);
         for (int64_t outputSliceIndex : outputSliceIndices)

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -193,6 +193,9 @@ public:
                                              ArrayRef<int64_t> yDims,
                                              SmallVector<int64_t> &xIndices,
                                              SmallVector<int64_t> &yIndices) {
+    if (xDims.empty() || yDims.empty())
+      return failure();
+
     auto isValidReduction = [](int64_t expectedReductionProduct,
                                ArrayRef<int64_t> arrayToReduce) -> bool {
       if (llvm::count(arrayToReduce, kUnknownSize) > 0 ||
@@ -262,6 +265,8 @@ public:
   // all the dimensions in `outputShape`.
   static void calculateSingleDynamicSize(MutableArrayRef<int64_t> inputShape,
                                          MutableArrayRef<int64_t> outputShape) {
+    if (inputShape.empty() || outputShape.empty())
+      return;
     int64_t inputDynamicDimCount = llvm::count(inputShape, kUnknownSize);
     int64_t outputDynamicDimCount = llvm::count(outputShape, kUnknownSize);
     if (inputDynamicDimCount + outputDynamicDimCount != 1)
@@ -488,12 +493,29 @@ public:
         outputDim = outputAssociations.back().back() + 1;
       }
 
-      // Append the associations for the dims matching `aten.size.int`
-      if (nextUnchangedInput != inputRank &&
-          nextUnchangedOutput != resultRank) {
+      // Handle any leading or trailing size-1 dimensions and append the
+      // associations for the dims matching `aten.size.int`.
+      if (nextUnchangedInput != inputRank) {
+        assert(nextUnchangedOutput != resultRank &&
+               "`nextUnchangedInput` and `nextUnchangedOutput` should equal "
+               "the respective input and output rank at the same time");
         inputAssociations.emplace_back();
         outputAssociations.emplace_back();
+      }
+      while (inputDim <= nextUnchangedInput && inputDim < inputRank) {
+        if (inputDim != nextUnchangedInput && inputShape[inputDim] != 1) {
+          return rewriter.notifyMatchFailure(
+              op, "unimplemented: only collapsing of static size-1 into "
+                  "unchanged dim supported");
+        }
         inputAssociations.back().push_back(inputDim++);
+      }
+      while (outputDim <= nextUnchangedOutput && outputDim < resultRank) {
+        if (outputDim != nextUnchangedOutput && outputShape[outputDim] != 1) {
+          return rewriter.notifyMatchFailure(
+              op, "unimplemented: only expanding of static size-1 out of "
+                  "unchanged dim supported");
+        }
         outputAssociations.back().push_back(outputDim++);
       }
     }

--- a/python/torch_mlir_e2e_test/test_suite/reshape_like.py
+++ b/python/torch_mlir_e2e_test/test_suite/reshape_like.py
@@ -672,6 +672,108 @@ class ViewNegativeStaticModule(torch.nn.Module):
 def ViewNegativeStaticModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1, 128))
 
+class ViewSizeDimFollowedByExpandedOnesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(a.size(0), 1, 1, 1)
+
+@register_test_case(module_factory=lambda: ViewSizeDimFollowedByExpandedOnesModule())
+def ViewSizeDimFollowedByExpandedOnesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(128))
+
+class ViewSizeDimFollowedByCollapsedOnesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, 1, 1, 1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(a.size(0))
+
+@register_test_case(module_factory=lambda: ViewSizeDimFollowedByCollapsedOnesModule())
+def ViewSizeDimFollowedByCollapsedOnesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(128, 1, 1, 1))
+
+class ViewSizeDimLedByExpandedOnesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(1, 1, 1, a.size(0))
+
+@register_test_case(module_factory=lambda: ViewSizeDimLedByExpandedOnesModule())
+def ViewSizeDimLedByExpandedOnesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(128))
+
+class ViewSizeDimLedByCollapsedOnesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 1, 1, -1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(a.size(3))
+
+@register_test_case(module_factory=lambda: ViewSizeDimLedByCollapsedOnesModule())
+def ViewSizeDimLedByCollapsedOnesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1, 1, 128))
+
+class ViewSizeDimLedAndFollowedByExpandedOnesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(1, 1, 1, a.size(0), 1, 1, 1)
+
+@register_test_case(module_factory=lambda: ViewSizeDimLedAndFollowedByExpandedOnesModule())
+def ViewSizeDimLedAndFollowedByExpandedOnesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(128))
+
+class ViewSizeDimLedAndFollowedByCollapsedOnesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 1, 1, -1, 1, 1, 1], torch.float32, True),
+    ])
+
+    def forward(self, a):
+        return a.view(a.size(3))
+
+@register_test_case(module_factory=lambda: ViewSizeDimLedAndFollowedByCollapsedOnesModule())
+def ViewSizeDimLedAndFollowedByCollapsedOnesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1, 1, 128, 1, 1, 1))
+
 # ==============================================================================
 
 class ReshapeAliasExpandModule(torch.nn.Module):

--- a/python/torch_mlir_e2e_test/test_suite/reshape_like.py
+++ b/python/torch_mlir_e2e_test/test_suite/reshape_like.py
@@ -672,40 +672,6 @@ class ViewNegativeStaticModule(torch.nn.Module):
 def ViewNegativeStaticModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1, 128))
 
-class ViewSizeDimFollowedByExpandedOnesModule(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([-1], torch.float32, True),
-    ])
-
-    def forward(self, a):
-        return a.view(a.size(0), 1, 1, 1)
-
-@register_test_case(module_factory=lambda: ViewSizeDimFollowedByExpandedOnesModule())
-def ViewSizeDimFollowedByExpandedOnesModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(128))
-
-class ViewSizeDimFollowedByCollapsedOnesModule(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([-1, 1, 1, 1], torch.float32, True),
-    ])
-
-    def forward(self, a):
-        return a.view(a.size(0))
-
-@register_test_case(module_factory=lambda: ViewSizeDimFollowedByCollapsedOnesModule())
-def ViewSizeDimFollowedByCollapsedOnesModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(128, 1, 1, 1))
-
 # ==============================================================================
 
 class ReshapeAliasExpandModule(torch.nn.Module):


### PR DESCRIPTION
After trying to generalize https://github.com/llvm/torch-mlir/pull/2474 to handle leading size-1 dims, it became clear that the approach used there was not the right one. Therefore, this PR:

- Reverts https://github.com/llvm/torch-mlir/pull/2474
- Adds to the lowering of `aten.view` handling for the following cases:
  - `(..., a.size(i))` -> `(..., a.size(i), 1, ..., 1)`
  - `(..., a.size(i), 1, ..., 1)` -> `(..., a.size(i))`
  - `(a.size(i), ...)` -> `(1, ..., 1, a.size(i), ...)`
  - `(1, ..., 1, a.size(i), ...)` -> `(a.size(i), ...)`

I recommend reviewing commits separately. 