### PR TITLE
[PT1] Renaming lit testsuite for PyTorch1 project

### DIFF
--- a/projects/pt1/test/CMakeLists.txt
+++ b/projects/pt1/test/CMakeLists.txt
@@ -23,4 +23,4 @@ add_lit_testsuite(check-torch-mlir-pt1 "Running the torch-mlir PT1 regression te
         )
 set_target_properties(check-torch-mlir-pt1 PROPERTIES FOLDER "Tests")
 
-add_lit_testsuites(TORCH_MLIR ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TORCH_MLIR_TEST_DEPENDS})
+add_lit_testsuites(TORCH_MLIR_PT1 ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TORCH_MLIR_TEST_DEPENDS})

--- a/projects/pt1/test/lit.cfg.py
+++ b/projects/pt1/test/lit.cfg.py
@@ -19,7 +19,7 @@ from lit.llvm.subst import FindTool
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = 'TORCH_MLIR'
+config.name = 'TORCH_MLIR_PT1'
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 


### PR DESCRIPTION
Otherwise there is name clash with lit testsuit registered under `TORCH_MLIR` in main project.