### PR TITLE
add bool scalar type to int implicit cast

### DIFF
--- a/projects/pt1/python/torch_mlir/csrc/base_lazy_backend/utils/jit_utils.cpp
+++ b/projects/pt1/python/torch_mlir/csrc/base_lazy_backend/utils/jit_utils.cpp
@@ -20,7 +20,7 @@ void ConvertScalarImplicit(std::shared_ptr<Graph>& graph) {
 
     NodeKind node_type;
     TypePtr output_type;
-    if (c10::isIntegralType(*scalar_type, false)) {
+    if (c10::isIntegralType(*scalar_type, true)) {
       node_type = c10::aten::IntImplicit;
       output_type = IntType::get();
     } else if (c10::isFloatingType(*scalar_type)) {


### PR DESCRIPTION
This PR updates the JIT pass util for implicit scalar conversion (introduced [here](https://github.com/pytorch/pytorch/pull/92095) and merged [here](https://github.com/llvm/torch-mlir/pull/1798)) and  to include boolean scalar type for conversion from `aten::ScalarImplicit` to `aten::IntImplicit`.