### PR TITLE
[Tosa backend] Support MatmulStaticBroadcast_basic for tosa

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -1496,10 +1496,11 @@ public:
         }
 
         // Step: Construct the output transpose/reshape information
+        int32_t transposedOpDim = 0;
         // First the common_dims
         for (uint32_t i = 0; i < commonElems.size(); i++) {
           reshapedOpShape.push_back(commonElems[i].shape);
-          transposedOpDims.push_back(commonElems[i].dim);
+          transposedOpDims[commonElems[i].dim] = transposedOpDim++;
         }
 
         // Then the LHS squeezed dims
@@ -1508,14 +1509,14 @@ public:
           // other input.
           if (lhsSqueezedElems[i].shape != 1) {
             reshapedOpShape.push_back(lhsSqueezedElems[i].shape);
-            transposedOpDims.push_back(lhsSqueezedElems[i].dim);
+            transposedOpDims[lhsSqueezedElems[i].dim] = transposedOpDim++;
           }
         }
         // The last squeezed dim is lhs[-2] which needs to be
         // checked separately for broadcasting
         if (lhsRank > 1) {
           reshapedOpShape.push_back(lhsBroadcastedShape[maxInputRank - 2]);
-          transposedOpDims.push_back(maxInputRank - 2);
+          transposedOpDims[maxInputRank - 2] = transposedOpDim++;
         }
 
         // then the RHS squeezed dims except rhs[-1] which is handled like
@@ -1523,13 +1524,13 @@ public:
         for (uint32_t i = 0; i < rhsSqueezedElems.size() - 1; i++) {
           if (rhsSqueezedElems[i].shape != 1) {
             reshapedOpShape.push_back(rhsSqueezedElems[i].shape);
-            transposedOpDims.push_back(rhsSqueezedElems[i].dim);
+            transposedOpDims[rhsSqueezedElems[i].dim] = transposedOpDim++;
           }
         }
         // rhs[-1]
         if (rhsRank > 1) {
           reshapedOpShape.push_back(rhsBroadcastedShape[maxInputRank - 1]);
-          transposedOpDims.push_back(maxInputRank - 1);
+          transposedOpDims[maxInputRank - 1] = transposedOpDim++;
         }
 
         // Final transposed output shape construction
@@ -1555,7 +1556,7 @@ public:
       };
 
       SmallVector<int64_t> reshapedOpShape, transposedOpShape;
-      SmallVector<int32_t> transposedOpDims;
+      SmallVector<int32_t> transposedOpDims(maxInputRank);
 
       computeOpShape(reshapedOpShape, transposedOpDims, transposedOpShape);
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1022,6 +1022,7 @@ TOSA_PASS_SET = {
     "BmmFloatModule_basic",
     "MmDagModule_basic",
     "Matmul4dStatic_basic",
+    "MatmulStaticBroadcast_basic",
     "Matmul_dot",
     "Matmul_3d",
     "RsubFloatModule_basic",


### PR DESCRIPTION
This PR is to solve this issue: #2581 
# Test case
```
class Matmul(nn.Module):
    def __init__(self):
        super(Matmul, self).__init__()
 
    def forward(self, x, weight):
        r = torch.matmul(x, weight)
        return r

def gen_mt_mlir():
    model = Matmul()
    weight = torch.randn(80,300,250,150,dtype=torch.float32)
    input = torch.ones(300,100,250)
    res = model(input,weight)
    print(res.shape)
    module = torch_mlir.compile(model, [input,weight], output_type="TOSA")

if __name__=='__main__':
    gen_mt_mlir()
```
# Before bug fix
```
func.func @forward(%arg0: !torch.vtensor<[300,100,250],f32>, %arg1: !torch.vtensor<[80,300,250,150],f32>) -> !torch.vtensor<[80,300,100,150],f32> {
  %0 = builtin.unrealized_conversion_cast %arg1 : !torch.vtensor<[80,300,250,150],f32> to tensor<80x300x250x150xf32>
  %1 = builtin.unrealized_conversion_cast %arg0 : !torch.vtensor<[300,100,250],f32> to tensor<300x100x250xf32>
  %2 = tosa.reshape %1 {new_shape = array<i64: 1, 300, 100, 250>} : (tensor<300x100x250xf32>) -> tensor<1x300x100x250xf32>
  %3 = "tosa.const"() <{value = dense<[1, 0, 2, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
  %4 = tosa.transpose %2, %3 : (tensor<1x300x100x250xf32>, tensor<4xi32>) -> tensor<300x1x100x250xf32>
  %5 = tosa.reshape %4 {new_shape = array<i64: 300, 100, 250>} : (tensor<300x1x100x250xf32>) -> tensor<300x100x250xf32>
  %6 = "tosa.const"() <{value = dense<[1, 2, 0, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
  %7 = tosa.transpose %0, %6 : (tensor<80x300x250x150xf32>, tensor<4xi32>) -> tensor<300x250x80x150xf32>
  %8 = tosa.reshape %7 {new_shape = array<i64: 300, 250, 12000>} : (tensor<300x250x80x150xf32>) -> tensor<300x250x12000xf32>
  %9 = tosa.matmul %5, %8 : (tensor<300x100x250xf32>, tensor<300x250x12000xf32>) -> tensor<300x100x12000xf32>
  %10 = tosa.reshape %9 {new_shape = array<i64: 300, 100, 80, 150>} : (tensor<300x100x12000xf32>) -> tensor<300x100x80x150xf32>
  %11 = "tosa.const"() <{value = dense<[1, 2, 0, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
  %12 = tosa.transpose %10, %11 : (tensor<300x100x80x150xf32>, tensor<4xi32>) -> tensor<80x300x100x150xf32>
  %13 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[300,100,250],f32>, !torch.vtensor<[80,300,250,150],f32> -> !torch.vtensor<[80,300,100,150],f32>
  return %13 : !torch.vtensor<[80,300,100,150],f32>
}
```
# Bug fix
```
func.func @forward(%arg0: !torch.vtensor<[300,100,250],f32>, %arg1: !torch.vtensor<[80,300,250,150],f32>) -> !torch.vtensor<[80,300,100,150],f32> {
  %0 = builtin.unrealized_conversion_cast %arg1 : !torch.vtensor<[80,300,250,150],f32> to tensor<80x300x250x150xf32>
  %1 = builtin.unrealized_conversion_cast %arg0 : !torch.vtensor<[300,100,250],f32> to tensor<300x100x250xf32>
  %2 = tosa.reshape %1 {new_shape = array<i64: 1, 300, 100, 250>} : (tensor<300x100x250xf32>) -> tensor<1x300x100x250xf32>
  %3 = "tosa.const"() <{value = dense<[1, 0, 2, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
  %4 = tosa.transpose %2, %3 : (tensor<1x300x100x250xf32>, tensor<4xi32>) -> tensor<300x1x100x250xf32>
  %5 = tosa.reshape %4 {new_shape = array<i64: 300, 100, 250>} : (tensor<300x1x100x250xf32>) -> tensor<300x100x250xf32>
  %6 = "tosa.const"() <{value = dense<[1, 2, 0, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
  %7 = tosa.transpose %0, %6 : (tensor<80x300x250x150xf32>, tensor<4xi32>) -> tensor<300x250x80x150xf32>
  %8 = tosa.reshape %7 {new_shape = array<i64: 300, 250, 12000>} : (tensor<300x250x80x150xf32>) -> tensor<300x250x12000xf32>
  %9 = tosa.matmul %5, %8 : (tensor<300x100x250xf32>, tensor<300x250x12000xf32>) -> tensor<300x100x12000xf32>
  %10 = tosa.reshape %9 {new_shape = array<i64: 300, 100, 80, 150>} : (tensor<300x100x12000xf32>) -> tensor<300x100x80x150xf32>
  %11 = "tosa.const"() <{value = dense<[2, 0, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
  %12 = tosa.transpose %10, %11 : (tensor<300x100x80x150xf32>, tensor<4xi32>) -> tensor<80x300x100x150xf32>
  %13 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[300,100,250],f32>, !torch.vtensor<[80,300,250,150],f32> -> !torch.vtensor<[80,300,100,150],f32>
  return %13 : !torch.vtensor<[80,300,100,150],f32>
}
```
# Result analysis
there are some mistake on %11:
```
%11 = "tosa.const"() <{value = dense<[1, 2, 0, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
```
It was transformed into this:
```
%11 = "tosa.const"() <{value = dense<[2, 0, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
```