### PR TITLE
[MLIR][TORCH] Fix TypeConverter automatically convert the ui8 to i8

### DIFF
--- a/lib/Dialect/Torch/IR/TorchTypes.cpp
+++ b/lib/Dialect/Torch/IR/TorchTypes.cpp
@@ -405,8 +405,7 @@ static Type convertDtypeToBuiltinElementType(MLIRContext *context, Type dtype) {
   if (auto floatType = dtype.dyn_cast<mlir::FloatType>()) {
     return dtype;
   } else if (auto integerType = dtype.dyn_cast<IntegerType>()) {
-    return IntegerType::get(context, integerType.getWidth(),
-                            IntegerType::Signless);
+    return dtype;
   } else if (dtype.isa<mlir::ComplexType>()){
     return dtype;
   }


### PR DESCRIPTION
  When converting vtenor to buildin tensor, the converter wrongly converts the ui8 to i8.
  This will lead to other typecast issues in later usage of i8. Here is an example:
  https://github.com/nod-ai/SHARK-Turbine/issues/110