### PR TITLE
Add bazel targets for TorchOnnxToTorch conversion passes

### DIFF
--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -1,9 +1,8 @@
 name: Bazel Build and Test
 
 on:
-  # TODO: Fix bazel build after US holidays of 2023-Nov-23 and re-enable.
-  # push:
-  #   branches: [ main ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 # Ensure that only a single job or workflow using the same

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -282,6 +282,31 @@ gentbl_cc_library(
     ],
 )
 
+td_library(
+    name = "TorchMLIRConversionTorchOnnxToTorchPassTdFiles",
+    srcs = [
+        "include/torch-mlir/Conversion/TorchOnnxToTorch/Passes.td",
+    ],
+    includes = ["include"],
+)
+
+gentbl_cc_library(
+    name = "TorchMLIRConversionTorchOnnxToTorchPassIncGen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            ["-gen-pass-decls"],
+            "include/torch-mlir/Conversion/TorchOnnxToTorch/Passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "include/torch-mlir/Conversion/TorchOnnxToTorch/Passes.td",
+    deps = [
+        ":TorchMLIRConversionTorchOnnxToTorchPassTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
 # TorchConversion transforms
 td_library(
     name = "TorchMLIRTorchConversionPassesTdFiles",
@@ -455,6 +480,22 @@ cc_library(
 )
 
 cc_library(
+    name = "TorchMLIRTorchOnnxToTorch",
+    srcs = glob([
+        "lib/Conversion/TorchOnnxToTorch/*.h",
+        "lib/Conversion/TorchOnnxToTorch/*.cpp",
+    ]),
+    hdrs = glob(["include/torch-mlir/Conversion/TorchOnnxToTorch/*.h"]),
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRConversionTorchOnnxToTorchPassIncGen",
+        ":TorchMLIRTorchDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
     name = "TorchMLIRConversionPasses",
     srcs = [
         "lib/Conversion/Passes.cpp",
@@ -468,6 +509,7 @@ cc_library(
     strip_include_prefix = "include",
     deps = [
         ":TorchMLIRTorchConversionToMLProgram",
+        ":TorchMLIRTorchOnnxToTorch",
         ":TorchMLIRTorchToArith",
         ":TorchMLIRTorchToLinalg",
         ":TorchMLIRTorchToSCF",

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -490,8 +490,8 @@ cc_library(
     deps = [
         ":TorchMLIRConversionTorchOnnxToTorchPassIncGen",
         ":TorchMLIRTorchDialect",
-        "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
     ],
 )
 


### PR DESCRIPTION
Adapts to the TorchOnnxToTorch changes from https://github.com/llvm/torch-mlir/pull/2585. 
Also restores bazel builds in post-merge CI that was disabled in https://github.com/llvm/torch-mlir/commit/2148c4cd0d95d16ce11d44be7a545bdf2bda9889.

Bazel workflow: https://github.com/sjain-stanford/torch-mlir/actions/runs/7023912962
