### PR TITLE
Update out of date docs

### DIFF
--- a/build_tools/write_env_file.sh
+++ b/build_tools/write_env_file.sh
@@ -13,7 +13,7 @@ portable_realpath() {
 
 td="$(portable_realpath "$(dirname "$0")"/..)"
 build_dir="$(portable_realpath "${TORCH_MLIR_BUILD_DIR:-$td/build}")"
-python_packages_dir="$build_dir/tools/torch-mlir/python_packages"
+python_packages_dir="$build_dir/python_packages"
 
 write_env_file() {
   echo "Updating $build_dir/.env file"

--- a/docs/adding_an_e2e_test.md
+++ b/docs/adding_an_e2e_test.md
@@ -5,7 +5,7 @@
 Adding support for a Torch operator in Torch-MLIR should always be accompanied
 by at least one end-to-end test to make sure the implementation of the op
 matches the behavior of PyTorch. The tests live in the
-`torch-mlir/python/torch_mlir_e2e_test/test_suite/` directory. When adding a new
+`torch-mlir/projects/pt1/python/torch_mlir_e2e_test/test_suite` directory. When adding a new
 test, choose a file that best matches the op you're testing, and if there is no
 file that best matches add a new file for your op.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,6 +20,7 @@ source mlir_venv/bin/activate
 python -m pip install --upgrade pip
 # Install latest PyTorch nightlies and build requirements.
 python -m pip install -r requirements.txt
+python -m pip install -r torchvision-requirements.txt
 ```
 
 ## CMake Build
@@ -108,25 +109,25 @@ cmake --build build
 ### Linux and macOS
 
 ```shell
-export PYTHONPATH=`pwd`/build/tools/torch-mlir/python_packages/torch_mlir:`pwd`/examples
+export PYTHONPATH=`pwd`/build/python_packages/torch_mlir:`pwd`/projects/pt1/examples
 ```
 
 ### Windows PowerShell
 
 ```shell
-$env:PYTHONPATH = "$PWD/build/tools/torch-mlir/python_packages/torch_mlir;$PWD/examples"
+$env:PYTHONPATH = "$PWD/build/python_packages/torch_mlir;$PWD/projects/pt1/examples"
 ```
 
 ## Testing MLIR output in various dialects
 
-To test the compiler's output to the different MLIR dialects, you can use the example `examples/torchscript_resnet18_all_output_types.py`.
+To test the compiler's output to the different MLIR dialects, you can use the example `projects/pt1/examples/torchscript_resnet18_all_output_types.py`.
 
 Make sure you have activated the virtualenv and set the `PYTHONPATH` above
 (if running on Windows, modify the environment variable as shown above):
 ```shell
 source mlir_venv/bin/activate
-export PYTHONPATH=`pwd`/build/tools/torch-mlir/python_packages/torch_mlir:`pwd`/examples
-python examples/torchscript_resnet18_all_output_types.py
+export PYTHONPATH=`pwd`/build/tpython_packages/torch_mlir:`pwd`/projects/pt1/examples
+python projects/pt1/examples/torchscript_resnet18_all_output_types.py
 ```
 
 This will display the Resnet18 network example in three dialects: TORCH, LINALG on TENSORS and TOSA.
@@ -331,8 +332,8 @@ Torch-MLIR has two types of tests:
 1. End-to-end execution tests. These compile and run a program and check the
    result against the expected output from execution on native Torch. These use
    a homegrown testing framework (see
-   `python/torch_mlir_e2e_test/torchscript/framework.py`) and the test suite
-   lives at `python/torch_mlir_e2e_test/test_suite/__init__.py`.
+   `projects/pt1/python/torch_mlir_e2e_test/framework.py`) and the test suite
+   lives at `projects/pt1/python/torch_mlir_e2e_test/test_suite/__init__.py`.
 
 2. Compiler and Python API unit tests. These use LLVM's `lit` testing framework.
    For example, these might involve using `torch-mlir-opt` to run a pass and


### PR DESCRIPTION
Some of docs referred to old file paths that no longer exists. This patch updates some of the instructions that I happened to notice were out of date. This is not a full update