### PR TITLE
[TorchToLinalg] Fix integer type handling for aten.mm

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -226,3 +226,39 @@ class Mv(torch.nn.Module):
 @register_test_case(module_factory=lambda: Mv())
 def Mv_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 2), tu.rand(2))
+
+# ==============================================================================
+
+class AtenMmFloatTypes(torch.nn.Module):
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, a, b):
+        return torch.ops.aten.mm(a, b)
+
+
+@register_test_case(module_factory=lambda: AtenMmFloatTypes())
+def AtenMmFloatTypes_basic(module, tu: TestUtils):
+    module.forward(tu.rand(8, 8), tu.rand(8, 8))
+
+# ==============================================================================
+
+class AtenMmIntTypes(torch.nn.Module):
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+        ([-1, -1], torch.int64, True),
+    ])
+    def forward(self, a, b):
+        return torch.ops.aten.mm(a, b)
+
+
+@register_test_case(module_factory=lambda: AtenMmIntTypes())
+def AtenMmIntTypes_basic(module, tu: TestUtils):
+    module.forward(tu.randint(16, 4, high=100), tu.randint(4, 16, high=100))

--- a/test/Conversion/TorchToLinalg/basic.mlir
+++ b/test/Conversion/TorchToLinalg/basic.mlir
@@ -40,6 +40,17 @@ func.func @torch.aten.mm$basic_strict(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !
 
 // -----
 
+// CHECK-LABEL: func.func @torch.aten.mm$basic_unsigned(
+// CHECK: linalg.matmul_unsigned
+func.func @torch.aten.mm$basic_unsigned(%arg0: !torch.vtensor<[?,?],ui32>, %arg1: !torch.vtensor<[?,?],ui32>) -> !torch.vtensor<[?,2],ui32> 
+  attributes {torch.assume_strict_symbolic_shapes}
+{
+  %0 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[?,?],ui32>, !torch.vtensor<[?,?],ui32> -> !torch.vtensor<[?,2],ui32>
+  return %0 : !torch.vtensor<[?,2],ui32>
+}
+
+// -----
+
 // If the operands are missing dtype, we cannot lower it.
 func.func @torch.aten.mm$no_convert$missing_dtype(%arg0: !torch.vtensor, %arg1: !torch.vtensor) -> !torch.vtensor {
   // expected-error@+1 {{failed to legalize}}


### PR DESCRIPTION
Despite aten.mm requiring the input and output types match, we still opt to maintain signedness semantics in case later passes try to do any sort of integer type narrowing.