### PR TITLE
[TorchToLinalg] Drop constexpr from ifs in argmin/max.dim

### DIFF
--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -187,7 +187,7 @@ public:
           Value resultVal, predicate;
           if (inElementType.isa<mlir::FloatType>()) {
 	    arith::CmpFPredicate predType;
-            if constexpr (isMax) {
+            if (isMax) {
               predType = arith::CmpFPredicate::OGT;
               resultVal = rewriter.create<arith::MaximumFOp>(
                   nestedLoc, newValue, oldValue);
@@ -201,7 +201,7 @@ public:
 						       newValue, oldValue);
           } else {
             arith::CmpIPredicate predType;
-            if constexpr (isMax) {
+            if (isMax) {
               predType = arith::CmpIPredicate::sgt;
               resultVal = rewriter.create<arith::MaxSIOp>(nestedLoc, newValue,
                                                           oldValue);


### PR DESCRIPTION
MSVC-19 does not support constexprs of lambda captured constexpr values like this: https://godbolt.org/z/ej65rMzdr
Instead, this just drops the constexpr from the if statements.

See the discussion in https://discord.com/channels/689900678990135345/1062405112292712499/1182338050664185999