### PR TITLE
Grouped conv2d: Use MLIR Op which matches memory layout of weight dimensions

### DIFF
--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -848,13 +848,15 @@ public:
                                                       indices);
       };
 
+      // expand F,C,H,W -> F/G,G,C,H,W
       auto expandWeight = [&](Value tensor) {
         auto inType = tensor.getType().cast<RankedTensorType>();
         auto inShape = makeShapeTorchCompatible(inType.getShape());
 
-        SmallVector<int64_t> outShape{
-            groupSize, (inShape[0] == kUnknownSize ? kUnknownSize
-                                                   : inShape[0] / groupSize)};
+        SmallVector<int64_t> outShape{(inShape[0] == kUnknownSize
+                                           ? kUnknownSize
+                                           : inShape[0] / groupSize),
+                                      groupSize};
         outShape.append(inShape.begin() + 1, inShape.end());
 
         SmallVector<ReassociationIndices> indices{{0, 1}};

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -23,14 +23,6 @@ LINALG_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS | {
     "IscloseStaticModuleTrue_basic"
 }
 
-if torch_version_for_comparison() >= version.parse("2.2.0.dev20231204"):
-    LINALG_XFAIL_SET |= {
-        "Conv2dWithPaddingDilationStrideStaticModule_grouped",
-        "Conv2dWithPaddingDilationStrideStaticModule_grouped_multiplier",
-        "ConvolutionModule2DGroups_basic",
-    }
-
-
 TORCHDYNAMO_XFAIL_SET = {
     #### General TorchDynamo/PyTorch errors
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -308,13 +308,6 @@ TORCHDYNAMO_XFAIL_SET = {
     "ArangeStartOutViewModule_basic",
 }
 
-if torch_version_for_comparison() >= version.parse("2.2.0.dev20231204"):
-    TORCHDYNAMO_XFAIL_SET |= {
-        "Conv2dWithPaddingDilationStrideStaticModule_grouped",
-        "Conv2dWithPaddingDilationStrideStaticModule_grouped_multiplier",
-        "ConvolutionModule2DGroups_basic",
-    }
-
 TORCHDYNAMO_CRASHING_SET = {
     # No upstream decompositions.
     # %6:4 = torch.operator "aten._embedding_bag_forward_only"(%1, %3, %5, %false, %int0, %false, %none, %false, %int-1) : (!torch.tensor<*,f32>, !torch.tensor<*,si64>, !torch.tensor<*,si64>, !torch.bool, !torch.int, !torch.bool, !torch.none, !torch.bool, !torch.int) -> (!torch.tensor, !torch.tensor, !torch.tensor, !torch.tensor)


### PR DESCRIPTION
The linalg Op `linalg.conv_2d_ngchw_fgchw` had a bug where

1. Weights were accessed as G,F,C,H,W instead of as F,G,C,H,W
2. Output was accessed as N,F,G,H,W instead of as N,G,F,H,W

Now this has been fixed in https://github.com/llvm/llvm-project/pull/73855 which broke the torch-mlir lowering to that Op. 

This patch switches lowering in torch-mlir to the newly introduced `linalg.conv_2d_ngchw_gfchw` op which accesses weights in an order that is compatible with PyTorch's memory layout.

Fix https://github.com/llvm/torch-mlir/issues/2622