### PR TITLE
Tweak development.md for more speed

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -5,8 +5,11 @@
 ```shell
 git clone https://github.com/llvm/torch-mlir
 cd torch-mlir
-git submodule update --init
+git submodule update --init --progress
 ```
+
+Optionally, use `--depth=1` to make a shallow clone of the submodules.
+While this is running, you can already setup the Python venv and dependencies in the next step.
 
 ## Setup your Python VirtualEnvironment and Dependencies
 


### PR DESCRIPTION
Adding the `--progress` flag shows the same output as what `git clone` would show. This is very nice for slow connections. Without it, the command may run for many minutes without providing any indication that it is still doing something.

For `--depth=1`, I think it should be safe as most people have new enough git versions nowadays, but let's be safe and make it an optional suggestion. I ran all the tests fine with `--depth=1`, but I don't know whether things will keep working when the submodules get updated for systems with old git versions.