### PR TITLE
Mentioned helpful tooling to convert Onnx models to Torch MLIR

### DIFF
--- a/docs/importers/onnx_importer.md
+++ b/docs/importers/onnx_importer.md
@@ -28,6 +28,7 @@ are relatively straight-forward to map, following this general procedure:
     `tools/torch-mlir/test/python/onnx_importer/Output`. The `.mlir` files
     under there should provide good variants to drive lit test coverage of
     conversion.
+    * (Optionally) If there is an Onnx file that uses the op of interest, convert that file to Onnx MLIR form using the following Python command, `python -m torch_mlir.tools.import_onnx my_model.onnx`.
   * There are often many variants of tests for checking conformance of
     different historic ONNX encodings, but these are often not load bearing
     at the MLIR level.
@@ -35,6 +36,9 @@ are relatively straight-forward to map, following this general procedure:
     `test/Conversion/TorchOnnxToTorch/simple_ops_x_to_y.mlir` corresponding to an
     alphabetic breakdown. At this time, ignore tests that are not exercising
     useful differences in the pattern implementations.
+    * (Optionally) Use `torch-mlir-opt` to validate the outputs of the new op. 
+      First, build the project using `cmake --build build --target tools/torch-mlir/all`. 
+      This will generate the conversion binary, `torch-mlir-opt`. Then call `torch-mlir-opt` with the MLIR pass `convert-torch-onnx-to-torch` (i.e. `build/bin/torch-mlir-opt -convert-torch-onnx-to-torch -split-input-file test/Conversion/TorchOnnxToTorch/[DESIRED_ONNX_FILE].mlir`)
 * Generate failure test cases:
   * Some ops have forms that do not (easily) map to torch-mlir. If you leave
     an op under-implemented, add a failing test case to

--- a/docs/importers/onnx_importer.md
+++ b/docs/importers/onnx_importer.md
@@ -28,17 +28,25 @@ are relatively straight-forward to map, following this general procedure:
     `tools/torch-mlir/test/python/onnx_importer/Output`. The `.mlir` files
     under there should provide good variants to drive lit test coverage of
     conversion.
-    * (Optionally) If there is an Onnx file that uses the op of interest, convert that file to Onnx MLIR form using the following Python command, `python -m torch_mlir.tools.import_onnx my_model.onnx`.
+    * (Optionally) If there is an Onnx file that uses the op of interest,
+      convert that file to Onnx MLIR form using the following Python command,
+      `python -m torch_mlir.tools.import_onnx my_model.onnx`.
   * There are often many variants of tests for checking conformance of
     different historic ONNX encodings, but these are often not load bearing
     at the MLIR level.
   * Pick a handful of test cases and add them to 
-    `test/Conversion/TorchOnnxToTorch/simple_ops_x_to_y.mlir` corresponding to an
-    alphabetic breakdown. At this time, ignore tests that are not exercising
+    `test/Conversion/TorchOnnxToTorch/simple_ops_x_to_y.mlir` corresponding to
+    an alphabetic breakdown. At this time, ignore tests that are not exercising
     useful differences in the pattern implementations.
     * (Optionally) Use `torch-mlir-opt` to validate the outputs of the new op. 
-      First, build the project using `cmake --build build --target tools/torch-mlir/all`. 
-      This will generate the conversion binary, `torch-mlir-opt`. Then call `torch-mlir-opt` with the MLIR pass `convert-torch-onnx-to-torch` (i.e. `build/bin/torch-mlir-opt -convert-torch-onnx-to-torch -split-input-file test/Conversion/TorchOnnxToTorch/[DESIRED_ONNX_FILE].mlir`)
+      First, build the project using 
+      `cmake --build build --target tools/torch-mlir/all`. This will generate
+      the conversion binary, `torch-mlir-opt`. Then call `torch-mlir-opt` with
+      the MLIR pass `convert-torch-onnx-to-torch`:
+      ```
+      build/bin/torch-mlir-opt -convert-torch-onnx-to-torch \
+      -split-input-file [DESIRED_ONNX_FILE].mlir
+      ``` 
 * Generate failure test cases:
   * Some ops have forms that do not (easily) map to torch-mlir. If you leave
     an op under-implemented, add a failing test case to


### PR DESCRIPTION
- Going through the `#torch-mlir` channel on the `llvm` discord, I realize that there are some useful commands that would be extremely helpful in creating Onnx lowers to Torch MLIR. Seems a lot of people are contributing to this. So, I thought it would be good to add this information to the docs.

These tools helped streamlined the development of this PR: https://github.com/llvm/torch-mlir/pull/2682