### PR TITLE
[onnx] Fix importer variable names to make `mlir` legal

### DIFF
--- a/python/torch_mlir/extras/onnx_importer.py
+++ b/python/torch_mlir/extras/onnx_importer.py
@@ -470,8 +470,6 @@ class ContextCache:
             name = "_" + name  
         return re.sub("[:/]", "_", name)  
 
-
-
     def tensor_proto_to_attr(self, tp: onnx.TensorProto) -> Attribute:
         tensor_type = self.tensor_proto_to_builtin_type(tp)
         if tp.HasField("raw_data"):

--- a/python/torch_mlir/extras/onnx_importer.py
+++ b/python/torch_mlir/extras/onnx_importer.py
@@ -38,6 +38,7 @@ from typing import Optional
 from dataclasses import dataclass
 
 import numpy as np
+import re
 
 from ..ir import (
     ArrayAttr,
@@ -465,12 +466,9 @@ class ContextCache:
             raise OnnxImportError(f"Unsupported ONNX TypeProto: {tp}")
 
     def _sanitize_name(self, name):
-        try:
-            name = f"__{int(name)}__"
-        except ValueError:
-            pass
-        name = name.replace(":", "_")
-        return name.replace("/", "_")
+        if not name.isidentifier():  
+            name = "_" + name  
+        return re.sub("[:/]", "_", name)  
 
 
 


### PR DESCRIPTION
Some names for `onnx` identifiers are not legal in `mlir-ir`. Sanitize
so that the generated `ir` is legal.