### PR TITLE
[onnx] Add torch-mlir-import-onnx native port as an optional tool/library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ option(TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS "Enables PyTorch native extension fe
 cmake_dependent_option(TORCH_MLIR_ENABLE_JIT_IR_IMPORTER "Enables JIT IR Importer" ON TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS OFF)
 cmake_dependent_option(TORCH_MLIR_ENABLE_LTC "Enables LTC backend" OFF TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS OFF)
 
+option(TORCH_MLIR_ENABLE_ONNX_C_IMPORTER "Enables the ONNX C importer" OFF)
+
 #-------------------------------------------------------------------------------
 # Configure out-of-tree vs in-tree build
 #-------------------------------------------------------------------------------

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -1,5 +1,9 @@
 include(AddMLIRPython)
 
+if(TORCH_MLIR_ENABLE_ONNX_C_IMPORTER)
+  add_subdirectory(onnx_c_importer)
+endif()
+
 ################################################################################
 # PyTorch
 # Configure PyTorch if we have any features enabled which require it.

--- a/projects/onnx_c_importer/CMakeLists.txt
+++ b/projects/onnx_c_importer/CMakeLists.txt
@@ -1,0 +1,44 @@
+message(STATUS "Enabling onnx_c_importer...")
+
+include(FetchContent)
+
+find_package(Protobuf)
+if(NOT Protobuf_FOUND)
+    message(FATAL_ERROR 
+        "In order to build C ONNX support, the Protobuf package must be installed "
+        "on the system. Without this ONNX will attempt to build it in the project "
+        "and the dependent ABSEIL build system is incompatible. "
+        "On Ubuntu, install with: "
+        "apt install libprotobuf-dev protobuf-compiler\n\n"
+        "(or this entire component can be disabled with "
+        "-DTORCH_MLIR_ENABLE_ONNX_C_IMPORTER=OFF)")
+endif()
+
+option(ONNX_DISABLE_EXCEPTIONS "For compatibility with LLVM build" ON)
+
+FetchContent_Declare(
+    onnx
+    EXCLUDE_FROM_ALL
+    GIT_REPOSITORY https://github.com/onnx/onnx.git
+    GIT_TAG v1.15.0
+    GIT_SHALLOW ON
+    GIT_PROGRESS ON
+)
+FetchContent_MakeAvailable(onnx)
+
+add_llvm_executable(
+    torch-mlir-import-onnx
+    PARTIAL_SOURCES_INTENDED
+
+    import-onnx-main.cpp
+    OnnxImporter.h
+    OnnxImporter.cpp
+)
+
+target_link_libraries(
+    torch-mlir-import-onnx
+    LLVMSupport
+    MLIRCAPIIR
+    TorchMLIRCAPI
+    onnx
+)

--- a/projects/onnx_c_importer/OnnxImporter.cpp
+++ b/projects/onnx_c_importer/OnnxImporter.cpp
@@ -1,0 +1,1009 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxImporter.h"
+
+#include "mlir-c/BuiltinAttributes.h"
+#include "mlir-c/BuiltinTypes.h"
+
+#include <cstdio>
+#include <functional>
+
+using namespace torch_mlir_onnx;
+
+namespace {
+
+std::string SanitizeNameAsIdentifier(std::string_view in) {
+  std::string out;
+  if (!in.empty() && !std::isalnum(in.front())) {
+    out.append("_");
+  }
+  out.append(in);
+  for (char &c : out) {
+    if (c == ':' || c == '/')
+      c = '_';
+  }
+  return out;
+}
+
+template <typename T>
+void AppendDelimittedStrings(std::string &into, T &container) {
+  bool first = true;
+  for (auto &item : container) {
+    if (first) {
+      first = false;
+    } else {
+      into.append(", ");
+    }
+    into.append(item);
+  }
+}
+
+inline MlirStringRef toMlirStringRef(const std::string_view &s) {
+  return mlirStringRefCreate(s.data(), s.size());
+}
+
+inline MlirStringRef toMlirStringRef(const std::string &s) {
+  return mlirStringRefCreate(s.data(), s.size());
+}
+
+inline MlirStringRef toMlirStringRef(const char *s) {
+  return mlirStringRefCreate(s, std::strlen(s));
+}
+
+inline MlirNamedAttribute toMlirNamedAttribute(const char *s,
+                                               MlirAttribute attr) {
+  MlirContext context = mlirAttributeGetContext(attr);
+  MlirIdentifier ident = mlirIdentifierGet(context, toMlirStringRef(s));
+  return mlirNamedAttributeGet(ident, attr);
+}
+
+std::string getMlirAsm(MlirType t) {
+  std::string result;
+  mlirTypePrint(
+      t,
+      +[](MlirStringRef sr, void *userData) {
+        std::string *s = static_cast<std::string *>(userData);
+        s->append(sr.data, sr.length);
+      },
+      static_cast<void *>(&result));
+  return result;
+}
+
+// C++ helpers to create operations.
+void addToMlirOperationState(MlirOperationState &state,
+                             MlirNamedAttribute namedAttr) {
+  mlirOperationStateAddAttributes(&state, 1, &namedAttr);
+}
+
+void addToMlirOperationState(
+    MlirOperationState &state,
+    std::vector<std::pair<std::string, MlirAttribute>> &attrs) {
+  for (auto &p : attrs) {
+    addToMlirOperationState(state,
+                            toMlirNamedAttribute(p.first.c_str(), p.second));
+  }
+}
+
+void addToMlirOperationState(MlirOperationState &state, MlirRegion region) {
+  mlirOperationStateAddOwnedRegions(&state, 1, &region);
+}
+
+[[maybe_unused]] void addToMlirOperationState(MlirOperationState &state,
+                                              MlirValue value) {
+  mlirOperationStateAddOperands(&state, 1, &value);
+}
+
+void addToMlirOperationState(MlirOperationState &state,
+                             const std::vector<MlirValue> &values) {
+  mlirOperationStateAddOperands(&state, values.size(), values.data());
+}
+
+void addToMlirOperationState(MlirOperationState &state, MlirType resultType) {
+  mlirOperationStateAddResults(&state, 1, &resultType);
+}
+
+void addToMlirOperationState(MlirOperationState &state,
+                             const std::vector<MlirType> &resultTypes) {
+  mlirOperationStateAddResults(&state, resultTypes.size(), resultTypes.data());
+}
+
+[[maybe_unused]] void addToMlirOperationState(MlirOperationState &state) {}
+
+template <typename T, typename U, typename... Ts>
+void addToMlirOperationState(MlirOperationState &state, T &&t, U &&u,
+                             Ts &&...ts) {
+  addToMlirOperationState(state, std::forward<T>(t));
+  addToMlirOperationState(state, std::forward<U>(u), std::forward<Ts>(ts)...);
+}
+
+template <typename... Ts>
+MlirOperation createMlirOperation(std::string name, MlirLocation loc,
+                                  Ts &&...ts) {
+  MlirOperationState state = mlirOperationStateGet(toMlirStringRef(name), loc);
+  addToMlirOperationState(state, std::forward<Ts>(ts)...);
+  return mlirOperationCreate(&state);
+}
+
+template <typename... Ts>
+MlirOperation createMlirOperationAtEnd(MlirBlock block, std::string name,
+                                       MlirLocation loc, Ts &&...ts) {
+  MlirOperation operation =
+      createMlirOperation(name, loc, std::forward<Ts>(ts)...);
+  mlirBlockInsertOwnedOperationBefore(block, mlirBlockGetTerminator(block),
+                                      operation);
+  return operation;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------//
+// ModelInfo
+// ---------------------------------------------------------------------------//
+
+ModelInfo::ModelInfo() = default;
+
+void ModelInfo::DebugDumpProto() {
+  std::string debug_string = model_proto_.DebugString();
+  fprintf(stderr, "%s\n", debug_string.c_str());
+}
+
+Status ModelInfo::Initialize() {
+  if (!model_proto_.has_graph()) {
+    return SetError("ONNX ModelProto has no main graph");
+  }
+  main_graph_ = std::make_unique<GraphInfo>(*this, model_proto_.graph());
+  if (failed(main_graph_->Initialize())) {
+    return failure();
+  }
+
+  return success();
+}
+
+// ---------------------------------------------------------------------------//
+// GraphInfo
+// ---------------------------------------------------------------------------//
+
+Status GraphInfo::Initialize() {
+  // Initialize look up tables.
+  for (const onnx::TensorProto &t : graph_proto_.initializer()) {
+    initializer_map_.emplace(t.name(), t);
+  }
+  for (const onnx::ValueInfoProto &v : graph_proto_.value_info()) {
+    value_info_map_.emplace(v.name(), v);
+  }
+  for (const onnx::ValueInfoProto &v : graph_proto_.input()) {
+    declared_inputs_.emplace_back(&v);
+  }
+  for (const onnx::ValueInfoProto &v : graph_proto_.output()) {
+    outputs_.emplace_back(&v);
+  }
+
+  // Generate the effective input map, which for old models can be a subset of
+  // the input map.
+  if (model_info_.config().elide_initialized_inputs) {
+    // Default. Add declared inputs to the input map unless if they appear
+    // as an initializer.
+    for (const onnx::ValueInfoProto *it : declared_inputs_) {
+      std::string_view key = it->name();
+      if (initializer_map_.find(key) != initializer_map_.end()) {
+        // In initializers. Skip.
+        continue;
+      }
+      inputs_.emplace_back(it);
+    }
+  } else {
+    // Fallback for some legacy compatibility.
+    inputs_ = declared_inputs_;
+    std::vector<std::string_view> illegal_keys;
+    for (const onnx::ValueInfoProto *it : inputs_) {
+      std::string_view key = it->name();
+      if (initializer_map_.find(key) != initializer_map_.end()) {
+        illegal_keys.push_back(key);
+      }
+    }
+    if (!illegal_keys.empty()) {
+      std::string error = "When not in elide_initialized_inputs=true mode, we "
+                          "expect inputs to not have an initial value (got ";
+      AppendDelimittedStrings(error, illegal_keys);
+      error.append(")");
+      return model_info_.SetError(std::move(error));
+    }
+  }
+
+  // Index the inputs and outputs.
+  for (auto *input : inputs_) {
+    input_map_.emplace(input->name(), *input);
+  }
+  for (auto *output : outputs_) {
+    output_map_.emplace(output->name(), *output);
+  }
+  return success();
+}
+
+const onnx::TypeProto *GraphInfo::FindTypeProtoForName(std::string_view name) {
+  // Node outputs don't typically have type information, but shape inference
+  // will associate them in the value_info. If not there, it may be a
+  // graph output, which must have type information.
+  {
+    auto it = value_info_map_.find(name);
+    if (it != value_info_map_.end()) {
+      return &it->second.type();
+    }
+  }
+  {
+    auto it = output_map_.find(name);
+    if (it != output_map_.end()) {
+      return &it->second.type();
+    }
+  }
+
+  std::string msg = "No type information associated with '";
+  msg.append(name);
+  msg.append("'. Run shape inference?");
+  model_info_.SetError(std::move(msg));
+  return nullptr;
+}
+
+// ---------------------------------------------------------------------------//
+// ContextCache
+// ---------------------------------------------------------------------------//
+
+MlirType ContextCache::ConvertTypeProto(const onnx::TypeProto &tp) {
+  if (tp.has_tensor_type()) {
+    // Convert Tensor TypeProto.
+    const onnx::TypeProto_Tensor &tt = tp.tensor_type();
+    if (!tt.has_shape()) {
+      std::string msg =
+          "Unsupported Tensor type without shape (run shape inference?): ";
+      msg.append(tt.DebugString());
+      model_info_.SetError(std::move(msg));
+      return {nullptr};
+    }
+
+    MlirType element_type = ConvertTensorElementType(tt.elem_type());
+    if (mlirTypeIsNull(element_type)) {
+      return {nullptr};
+    }
+    shared_dims_.clear();
+    shared_dims_.reserve(6);
+    for (const onnx::TensorShapeProto::Dimension &dim : tt.shape().dim()) {
+      if (dim.has_dim_value()) {
+        // Static.
+        shared_dims_.push_back(dim.dim_value());
+      } else {
+        // Dynamic.
+        shared_dims_.push_back(-1);
+      }
+    }
+
+    return GetVtensorType(shared_dims_, element_type);
+  } else {
+    std::string msg = "Unsupported ONNX TypeProto: ";
+    msg.append(tp.DebugString());
+    model_info_.SetError(std::move(msg));
+    return {nullptr};
+  }
+}
+
+MlirType ContextCache::ConvertTensorElementType(int elem_type) {
+  auto it = elem_type_map_.find(elem_type);
+  if (it != elem_type_map_.end()) {
+    return it->second;
+  }
+
+  MlirType t = {nullptr};
+  switch (elem_type) {
+  case onnx::TensorProto::FLOAT:
+    t = mlirF32TypeGet(context_);
+    break;
+  case onnx::TensorProto::UINT8:
+    t = mlirIntegerTypeUnsignedGet(context_, 8);
+    break;
+  case onnx::TensorProto::INT8:
+    t = mlirIntegerTypeSignedGet(context_, 8);
+    break;
+  case onnx::TensorProto::UINT16:
+    t = mlirIntegerTypeUnsignedGet(context_, 16);
+    break;
+  case onnx::TensorProto::INT16:
+    t = mlirIntegerTypeSignedGet(context_, 16);
+    break;
+  case onnx::TensorProto::INT32:
+    t = mlirIntegerTypeSignedGet(context_, 32);
+    break;
+  case onnx::TensorProto::UINT32:
+    t = mlirIntegerTypeUnsignedGet(context_, 32);
+    break;
+  case onnx::TensorProto::INT64:
+    t = mlirIntegerTypeSignedGet(context_, 64);
+    break;
+  case onnx::TensorProto::UINT64:
+    t = mlirIntegerTypeUnsignedGet(context_, 64);
+    break;
+  case onnx::TensorProto::BOOL:
+    t = mlirIntegerTypeGet(context_, 1);
+    break;
+  case onnx::TensorProto::FLOAT16:
+    t = mlirF16TypeGet(context_);
+    break;
+  case onnx::TensorProto::DOUBLE:
+    t = mlirF64TypeGet(context_);
+    break;
+  case onnx::TensorProto::COMPLEX64:
+    t = mlirComplexTypeGet(mlirF32TypeGet(context_));
+    break;
+  case onnx::TensorProto::COMPLEX128:
+    t = mlirComplexTypeGet(mlirF64TypeGet(context_));
+    break;
+  case onnx::TensorProto::BFLOAT16:
+    t = mlirBF16TypeGet(context_);
+    break;
+  case onnx::TensorProto::FLOAT8E4M3FN:
+    t = mlirFloat8E4M3FNTypeGet(context_);
+    break;
+  case onnx::TensorProto::FLOAT8E4M3FNUZ:
+    t = mlirFloat8E4M3FNUZTypeGet(context_);
+    break;
+  case onnx::TensorProto::FLOAT8E5M2:
+    t = mlirFloat8E5M2TypeGet(context_);
+    break;
+  case onnx::TensorProto::FLOAT8E5M2FNUZ:
+    t = mlirFloat8E5M2FNUZTypeGet(context_);
+    break;
+  default: {
+    std::string msg = "Unknown ONNX tensor element type: ";
+    msg.append(std::to_string(elem_type));
+    model_info_.SetError(std::move(msg));
+    return {nullptr};
+  }
+  }
+
+  assert(t.ptr && "did not convert type");
+  elem_type_map_[elem_type] = t;
+  return t;
+}
+
+MlirAttribute
+ContextCache::ConvertTensorProtoToAttr(const onnx::TensorProto &tp) {
+  MlirType tensor_type = ConvertTensorProtoToBuiltinType(tp);
+  if (tp.has_raw_data()) {
+    std::string sanitized_name = SanitizeNameAsIdentifier(tp.name());
+    // Conveniently, DenseResourceElementsAttr shares the raw data
+    // format. We just give it maximum numeric alignment.
+    return mlirUnmanagedDenseResourceElementsAttrGet(
+        tensor_type, toMlirStringRef(sanitized_name),
+        const_cast<void *>(static_cast<const void *>(tp.raw_data().data())),
+        tp.raw_data().size(), /*dataAlignment=*/8, /*dataIsMutable=*/false,
+        /*deleter=*/nullptr, /*userData=*/nullptr);
+  } else {
+    switch (tp.data_type()) {
+    case onnx::TensorProto::DataType::TensorProto_DataType_FLOAT:
+      return mlirDenseElementsAttrFloatGet(tensor_type, tp.float_data_size(),
+                                           tp.float_data().data());
+    case onnx::TensorProto::DataType::TensorProto_DataType_INT32:
+      return mlirDenseElementsAttrInt32Get(tensor_type, tp.int32_data_size(),
+                                           tp.int32_data().data());
+    case onnx::TensorProto::DataType::TensorProto_DataType_INT64:
+      return mlirDenseElementsAttrInt64Get(tensor_type, tp.int64_data_size(),
+                                           tp.int64_data().data());
+    case onnx::TensorProto::DataType::TensorProto_DataType_DOUBLE:
+      return mlirDenseElementsAttrDoubleGet(tensor_type, tp.double_data_size(),
+                                            tp.double_data().data());
+    case onnx::TensorProto::DataType::TensorProto_DataType_UINT32: {
+      // Special case. See proto. Someone apparently got lazy.
+      std::vector<uint32_t> stupid_conversion;
+      stupid_conversion.reserve(tp.uint64_data_size());
+      for (uint64_t v : tp.uint64_data())
+        stupid_conversion.push_back(v);
+      return mlirDenseElementsAttrUInt32Get(
+          tensor_type, stupid_conversion.size(), stupid_conversion.data());
+    }
+    case onnx::TensorProto::DataType::TensorProto_DataType_UINT64:
+      return mlirDenseElementsAttrUInt64Get(tensor_type, tp.uint64_data_size(),
+                                            tp.uint64_data().data());
+    }
+  }
+
+  std::string message =
+      "Unable to convert ONNX TensorProto to MLIR attribute: ";
+  message.append(tp.DebugString());
+  model_info_.SetError(std::move(message));
+  return {nullptr};
+}
+
+MlirType
+ContextCache::ConvertTensorProtoToBuiltinType(const onnx::TensorProto &tp) {
+  MlirType element_type = ConvertTensorElementType(tp.data_type());
+  if (mlirTypeIsNull(element_type))
+    return {nullptr};
+
+  shared_dims_.clear();
+  for (auto dim : tp.dims()) {
+    shared_dims_.push_back(dim);
+  }
+  return mlirRankedTensorTypeGet(shared_dims_.size(), shared_dims_.data(),
+                                 element_type,
+                                 /*encoding=*/{nullptr});
+}
+
+MlirType
+ContextCache::ConvertTensorProtoToVtensorType(const onnx::TensorProto &tp) {
+  MlirType element_type = ConvertTensorElementType(tp.data_type());
+  if (mlirTypeIsNull(element_type))
+    return {nullptr};
+
+  shared_dims_.clear();
+  for (auto dim : tp.dims()) {
+    shared_dims_.push_back(dim);
+  }
+
+  return GetVtensorType(shared_dims_, element_type);
+}
+
+MlirType ContextCache::GetVtensorType(const std::vector<int64_t> &dims,
+                                      MlirType element_type) {
+  std::string type_asm = "!torch.vtensor<[";
+  // Add dimension list.
+  bool first_dim = true;
+  for (int dim : dims) {
+    if (first_dim)
+      first_dim = false;
+    else
+      type_asm.push_back(',');
+    if (dim < 0)
+      type_asm.push_back('?');
+    else
+      type_asm.append(std::to_string(dim));
+  }
+  type_asm.append("],");
+
+  // Add element type.
+  type_asm.append(getMlirAsm(element_type));
+  type_asm.push_back('>');
+
+  // Look in cache.
+  auto found_it = asm_type_map_.find(type_asm);
+  if (found_it != asm_type_map_.end()) {
+    return found_it->second;
+  }
+
+  // Parse.
+  MlirType t = mlirTypeParseGet(context_, toMlirStringRef(type_asm));
+  if (mlirTypeIsNull(t)) {
+    std::string message =
+        "internal error: could not parse !torch.vtensor type: ";
+    message.append(type_asm);
+    model_info_.SetError(std::move(message));
+    return t;
+  }
+
+  asm_type_map_[std::move(type_asm)] = t;
+  return t;
+}
+
+// ---------------------------------------------------------------------------//
+// NodeImporter
+// ---------------------------------------------------------------------------//
+
+NodeImporter::NodeImporter(GraphInfo &graph_info, ContextCache &cc,
+                           MlirOperation module_op)
+    : graph_info_(graph_info), cc_(cc),
+      context_(mlirOperationGetContext(module_op)), module_op_(module_op),
+      func_op_({nullptr}), body_block_({nullptr}) {
+  std::string locName = "graph:";
+  locName.append(graph_info.graph_proto().name());
+  default_loc_ = mlirLocationNameGet(context_, toMlirStringRef(locName),
+                                     /*childLoc=*/{nullptr});
+}
+
+Status NodeImporter::DefineFunction(std::optional<std::string> name) {
+  const onnx::GraphProto &p = graph_info_.graph_proto();
+  MlirRegion moduleBodyRegion = mlirOperationGetRegion(module_op_, 0);
+  MlirBlock moduleBody = mlirRegionGetFirstBlock(moduleBodyRegion);
+  MlirAttribute nameAttr;
+  if (name) {
+    // Explicitly named.
+    nameAttr = mlirStringAttrGet(context_, toMlirStringRef(*name));
+  } else {
+    // Name it according to the graph.
+    nameAttr = mlirStringAttrGet(context_, toMlirStringRef(p.name()));
+  }
+
+  // Derive the FunctionType.
+  std::vector<MlirType> input_types;
+  std::vector<MlirLocation> input_locs;
+  std::vector<MlirType> output_types;
+  for (auto *input : graph_info_.inputs()) {
+    MlirType t = cc_.ConvertTypeProto(input->type());
+    if (mlirTypeIsNull(t)) {
+      return failure();
+    }
+    input_types.push_back(t);
+    input_locs.push_back(default_loc_);
+  }
+  for (auto *output : graph_info_.outputs()) {
+    MlirType t = cc_.ConvertTypeProto(output->type());
+    if (mlirTypeIsNull(t)) {
+      return failure();
+    }
+    output_types.push_back(t);
+  }
+  MlirType ftype =
+      mlirFunctionTypeGet(context_, input_types.size(), input_types.data(),
+                          output_types.size(), output_types.data());
+
+  // Create func.func.
+  func_op_ = createMlirOperationAtEnd(
+      moduleBody, "func.func", default_loc_, mlirRegionCreate(),
+      toMlirNamedAttribute("function_type", mlirTypeAttrGet(ftype)),
+      toMlirNamedAttribute("sym_name", nameAttr));
+
+  // Add entry block.
+  body_block_ = mlirBlockCreate(input_types.size(), input_types.data(),
+                                input_locs.data());
+  MlirRegion bodyRegion = mlirOperationGetRegion(func_op_, 0);
+  mlirRegionAppendOwnedBlock(bodyRegion, body_block_);
+
+  // Map the block args to names and store for evaluation.
+  for (int i = 0, e = graph_info_.inputs().size(); i < e; ++i) {
+    std::string_view name = graph_info_.inputs()[i]->name();
+    MlirValue value = mlirBlockGetArgument(body_block_, i);
+    nv_map_[name] = value;
+  }
+
+  PopulateGraphAttrs(func_op_);
+  return success();
+}
+
+void NodeImporter::PopulateGraphAttrs(MlirOperation container_op) {
+  const onnx::ModelProto &m = graph_info_.model_info().model_proto();
+  MlirType i64_type = mlirIntegerTypeSignedGet(context_, 64);
+  int default_opset_version = 0;
+  std::unordered_map<std::string_view, MlirAttribute> opset_versions;
+  // Determine model level opset versions.
+  for (const onnx::OperatorSetIdProto &opset_import : m.opset_import()) {
+    if (opset_import.has_domain()) {
+      opset_versions[opset_import.domain()] =
+          mlirIntegerAttrGet(i64_type, opset_import.version());
+    } else {
+      default_opset_version = opset_import.version();
+    }
+  }
+
+  // Set the default domain version.
+  if (default_opset_version != 0) {
+    mlirOperationSetDiscardableAttributeByName(
+        container_op, toMlirStringRef("torch.onnx_meta.opset_version"),
+        mlirIntegerAttrGet(i64_type, default_opset_version));
+  }
+
+  // Set versions for other domains.
+  if (!opset_versions.empty()) {
+    std::vector<MlirNamedAttribute> version_attrs;
+    for (auto it : opset_versions) {
+      version_attrs.push_back(mlirNamedAttributeGet(
+          mlirIdentifierGet(context_, toMlirStringRef(it.first)), it.second));
+    }
+    MlirAttribute dict_attr = mlirDictionaryAttrGet(
+        context_, version_attrs.size(), version_attrs.data());
+    mlirOperationSetDiscardableAttributeByName(
+        container_op, toMlirStringRef("torch.onnx_meta.opset_versions"),
+        dict_attr);
+  }
+
+  // IR version and producer.
+  mlirOperationSetDiscardableAttributeByName(
+      container_op, toMlirStringRef("torch.onnx_meta.ir_version"),
+      mlirIntegerAttrGet(i64_type, m.ir_version()));
+  mlirOperationSetDiscardableAttributeByName(
+      container_op, toMlirStringRef("torch.onnx_meta.producer_name"),
+      mlirStringAttrGet(context_, toMlirStringRef(m.producer_name())));
+  mlirOperationSetDiscardableAttributeByName(
+      container_op, toMlirStringRef("torch.onnx_meta.producer_version"),
+      mlirStringAttrGet(context_, toMlirStringRef(m.producer_version())));
+}
+
+Status NodeImporter::ImportAll() {
+  // TODO: Consider pulling in initializers on demand since there can be so
+  // much unused crap.
+  for (auto it : graph_info_.initializer_map()) {
+    if (failed(ImportInitializer(it.second)))
+      return failure();
+  }
+  for (auto it : graph_info_.graph_proto().node()) {
+    if (failed(ImportNode(it)))
+      return failure();
+  }
+
+  // Lookup the outputs, which should all be in the nv_map if the graph was
+  // properly formed.
+  std::vector<MlirValue> output_values;
+  for (const auto *output : graph_info_.outputs()) {
+    std::string_view name = output->name();
+    auto found_it = nv_map_.find(name);
+    if (found_it == nv_map_.end()) {
+      std::string msg = "Non topologically produced ONNX graph output '";
+      msg.append(name);
+      msg.append("'");
+      return SetError(std::move(msg));
+    }
+    output_values.push_back(found_it->second);
+  }
+
+  createMlirOperationAtEnd(body_block_, "func.return", default_loc_,
+                           output_values);
+  return success();
+}
+
+Status NodeImporter::ImportInitializer(const onnx::TensorProto &initializer) {
+  std::string_view name = initializer.name();
+  MlirLocation loc = mlirLocationNameGet(context_, toMlirStringRef(name),
+                                         /*childLoc=*/{nullptr});
+
+  MlirAttribute value_attr = cc_.ConvertTensorProtoToAttr(initializer);
+  MlirType vtensor_type = cc_.ConvertTensorProtoToVtensorType(initializer);
+  if (mlirAttributeIsNull(value_attr) || mlirTypeIsNull(vtensor_type))
+    return failure();
+
+  MlirOperation op = createMlirOperationAtEnd(
+      body_block_, "torch.vtensor.literal", loc, vtensor_type,
+      toMlirNamedAttribute("value", value_attr));
+  MlirValue result = mlirOperationGetResult(op, 0);
+
+  auto inserted = nv_map_.insert(std::make_pair(name, result));
+  if (!inserted.second) {
+    std::string msg = "Multiple nodes produced a value for '";
+    msg.append(name);
+    msg.append("', most recent from ");
+    msg.append(initializer.DebugString());
+    return SetError(std::move(msg));
+  }
+
+  return success();
+}
+
+Status NodeImporter::ImportNode(const onnx::NodeProto &node) {
+  std::string_view op_type = node.op_type();
+  // Handle special-form op types that do not go down the generic path.
+  if (op_type == "ConstantOfShape") {
+    return ImportConstantOfShapeNode(node);
+  }
+
+  return ImportGeneralNode(node);
+}
+
+Status NodeImporter::ImportGeneralNode(const onnx::NodeProto &node) {
+  MlirLocation loc = mlirLocationNameGet(context_, toMlirStringRef(node.name()),
+                                         /*childLoc=*/{nullptr});
+
+  // Map inputs to values.
+  std::vector<MlirValue> input_values;
+  for (auto &input_name : node.input()) {
+    auto found_it = nv_map_.find(input_name);
+    if (found_it == nv_map_.end()) {
+      std::string msg = "Non topologically produced ONNX node input '";
+      msg.append(input_name);
+      msg.append("'");
+      return SetError(std::move(msg));
+    }
+    input_values.push_back(found_it->second);
+  }
+
+  // Map outputs to types.
+  std::vector<MlirType> output_types;
+  for (auto &output_name : node.output()) {
+    const onnx::TypeProto *type_proto =
+        graph_info_.FindTypeProtoForName(output_name);
+    if (!type_proto)
+      return failure();
+
+    MlirType t = cc_.ConvertTypeProto(*type_proto);
+    if (mlirTypeIsNull(t))
+      return failure();
+    output_types.push_back(t);
+  }
+
+  // Derive the op name.
+  std::string op_name = "onnx.";
+  op_name.append(node.op_type());
+  MlirAttribute op_name_attr =
+      mlirStringAttrGet(context_, toMlirStringRef(op_name));
+
+  // General attributes.
+  std::vector<std::pair<std::string, MlirAttribute>> general_attributes;
+  for (auto &onnx_attr : node.attribute()) {
+    MlirAttribute attr = ImportGeneralAttribute(onnx_attr);
+    if (mlirAttributeIsNull(attr))
+      return failure();
+    std::string full_name = "torch.onnx.";
+    full_name.append(onnx_attr.name());
+    general_attributes.push_back(std::make_pair(full_name, attr));
+  }
+
+  // Create op.
+  MlirOperation op = createMlirOperationAtEnd(
+      body_block_, "torch.operator", loc, output_types, input_values,
+      toMlirNamedAttribute("name", op_name_attr), general_attributes);
+
+  // Record the result values.
+  for (int i = 0, e = output_types.size(); i < e; ++i) {
+    MlirValue result = mlirOperationGetResult(op, i);
+    std::string_view name = node.output(i);
+    auto inserted = nv_map_.insert(std::make_pair(name, result));
+    if (!inserted.second) {
+      std::string msg = "Multiple nodes produced a value for '";
+      msg.append(name);
+      msg.append("', most recent from ");
+      msg.append(node.DebugString());
+      return SetError(std::move(msg));
+    }
+  }
+
+  return success();
+}
+
+MlirAttribute
+NodeImporter::ImportGeneralAttribute(const onnx::AttributeProto &onnx_attr) {
+  switch (onnx_attr.type()) {
+  case onnx::AttributeProto::UNDEFINED:
+    SetError("'UNDEFINED' attribute type not supported");
+    return {nullptr};
+  case onnx::AttributeProto::FLOAT:
+    return mlirFloatAttrDoubleGet(context_, mlirF32TypeGet(context_),
+                                  onnx_attr.f());
+  case onnx::AttributeProto::INT:
+    return mlirIntegerAttrGet(mlirIntegerTypeSignedGet(context_, 64),
+                              onnx_attr.i());
+  case onnx::AttributeProto::STRING:
+    return mlirStringAttrGet(context_, toMlirStringRef(onnx_attr.s()));
+  case onnx::AttributeProto::TENSOR:
+    return cc_.ConvertTensorProtoToAttr(onnx_attr.t());
+  case onnx::AttributeProto::GRAPH:
+    SetError("'GRAPH' attribute type not supported on this node");
+    return {nullptr};
+  case onnx::AttributeProto::SPARSE_TENSOR:
+    SetError("'SPARSE_TENSOR' attribute type not supported on this node");
+    return {nullptr};
+  case onnx::AttributeProto::TYPE_PROTO:
+    SetError("'TYPE_PROTO' attribute type not supported on this node");
+    return {nullptr};
+  case onnx::AttributeProto::FLOATS: {
+    std::vector<MlirAttribute> attrs;
+    for (auto f : onnx_attr.floats())
+      attrs.push_back(
+          mlirFloatAttrDoubleGet(context_, mlirF32TypeGet(context_), f));
+    return mlirArrayAttrGet(context_, attrs.size(), attrs.data());
+  }
+  case onnx::AttributeProto::INTS: {
+    std::vector<MlirAttribute> attrs;
+    for (auto i : onnx_attr.ints())
+      attrs.push_back(
+          mlirIntegerAttrGet(mlirIntegerTypeSignedGet(context_, 64), i));
+    return mlirArrayAttrGet(context_, attrs.size(), attrs.data());
+  }
+  case onnx::AttributeProto::STRINGS: {
+    std::vector<MlirAttribute> attrs;
+    for (auto s : onnx_attr.strings())
+      attrs.push_back(mlirStringAttrGet(context_, toMlirStringRef(s)));
+    return mlirArrayAttrGet(context_, attrs.size(), attrs.data());
+  }
+  case onnx::AttributeProto::TENSORS: {
+    std::vector<MlirAttribute> attrs;
+    for (auto &t : onnx_attr.tensors()) {
+      MlirAttribute attr = cc_.ConvertTensorProtoToAttr(t);
+      if (mlirAttributeIsNull(attr))
+        return {nullptr};
+      attrs.push_back(attr);
+    }
+    return mlirArrayAttrGet(context_, attrs.size(), attrs.data());
+  }
+  case onnx::AttributeProto::GRAPHS:
+    SetError("'GRAPHS' attribute type not supported on this node");
+    return {nullptr};
+  case onnx::AttributeProto::SPARSE_TENSORS:
+    SetError("'SPARSE_TENSORS' attribute type not supported on this node");
+    return {nullptr};
+  case onnx::AttributeProto::TYPE_PROTOS:
+    SetError("'TYPE_PROTOS' attribute type not supported on this node");
+    return {nullptr};
+  }
+
+  std::string msg = "Unhandled ONNX attribute type code ";
+  msg.append(std::to_string(onnx_attr.type()));
+  msg.append(": ");
+  msg.append(onnx_attr.DebugString());
+  SetError(std::move(msg));
+  return {nullptr};
+}
+
+Status NodeImporter::ImportConstantOfShapeNode(const onnx::NodeProto &node) {
+  std::string_view name = node.name();
+  MlirLocation loc = mlirLocationNameGet(context_, toMlirStringRef(name),
+                                         /*childLoc=*/{nullptr});
+
+  // This op is special: It has an input of the shape, and in full generality
+  // could involve eager production of constants of variable size. In
+  // practice, the DNN profile for ONNX makes this very difficult to do
+  // and we hard-assert that the input can be resolved to an immediate
+  // value.
+  if (node.input_size() != 1 || node.output_size() != 1) {
+    return SetError("ConstantOfShape node must have one input and output");
+  }
+
+  // Shape.
+  std::vector<int64_t> shape;
+  if (failed(GetImmediateShapeTensor(node.input(0), shape)))
+    return failure();
+
+  // Value.
+  const onnx::AttributeProto *value_proto = nullptr;
+  for (auto &attr : node.attribute()) {
+    if (attr.name() == "value") {
+      value_proto = &attr;
+      break;
+    }
+  }
+  if (!value_proto) {
+    return SetError("ConstantOfShape node must have a 'value' attribute");
+  }
+  if (value_proto->type() != onnx::AttributeProto_AttributeType_TENSOR) {
+    return SetError("ConstantOfShape node must have a tensor value attribute");
+  }
+
+  // Create the splat.
+  const onnx::TensorProto &tensor_proto = value_proto->t();
+  if (tensor_proto.dims_size() != 1 || tensor_proto.dims(0) != 1) {
+    return SetError("ConstantOfShape node expected a scalar tensor value");
+  }
+  auto tensorTypeFor = [&](MlirType element_type) {
+    return mlirRankedTensorTypeGet(shape.size(), shape.data(), element_type,
+                                   /*encoding*/ {nullptr});
+  };
+  MlirAttribute splat_attr = {nullptr};
+  switch (tensor_proto.data_type()) {
+  case onnx::TensorProto::DataType::TensorProto_DataType_FLOAT:
+    splat_attr = mlirDenseElementsAttrFloatSplatGet(
+        tensorTypeFor(mlirF32TypeGet(context_)), tensor_proto.float_data(0));
+    break;
+  case onnx::TensorProto::DataType::TensorProto_DataType_INT32:
+    splat_attr = mlirDenseElementsAttrFloatSplatGet(
+        tensorTypeFor(mlirIntegerTypeSignedGet(context_, 32)),
+        tensor_proto.int32_data(0));
+    break;
+  case onnx::TensorProto::DataType::TensorProto_DataType_INT64:
+    splat_attr = mlirDenseElementsAttrFloatSplatGet(
+        tensorTypeFor(mlirIntegerTypeSignedGet(context_, 64)),
+        tensor_proto.int64_data(0));
+    break;
+  case onnx::TensorProto::DataType::TensorProto_DataType_DOUBLE:
+    splat_attr = mlirDenseElementsAttrFloatSplatGet(
+        tensorTypeFor(mlirF64TypeGet(context_)), tensor_proto.double_data(0));
+    break;
+  case onnx::TensorProto::DataType::TensorProto_DataType_UINT64:
+    splat_attr = mlirDenseElementsAttrFloatSplatGet(
+        tensorTypeFor(mlirIntegerTypeUnsignedGet(context_, 64)),
+        tensor_proto.uint64_data(0));
+    break;
+  case onnx::TensorProto::DataType::TensorProto_DataType_UINT32:
+    // Special case: inline data is stored in uint64.
+    splat_attr = mlirDenseElementsAttrFloatSplatGet(
+        tensorTypeFor(mlirIntegerTypeUnsignedGet(context_, 32)),
+        tensor_proto.uint64_data(0));
+    break;
+  }
+
+  if (mlirAttributeIsNull(splat_attr)) {
+    std::string message =
+        "ConstantOfShape node has an unsupported splat data type: ";
+    message.append(tensor_proto.DebugString());
+    return SetError(std::move(message));
+  }
+
+  // Create the vtensor type for the result.
+  MlirType splat_type = mlirAttributeGetType(splat_attr);
+  MlirType element_type = mlirShapedTypeGetElementType(splat_type);
+  MlirType vtensor_type = cc_.GetVtensorType(shape, element_type);
+  if (mlirTypeIsNull(vtensor_type))
+    return failure();
+
+  MlirOperation op = createMlirOperationAtEnd(
+      body_block_, "torch.vtensor.literal", loc, vtensor_type,
+      toMlirNamedAttribute("value", splat_attr));
+  MlirValue result = mlirOperationGetResult(op, 0);
+
+  // Export to the nv_map.
+  auto inserted = nv_map_.insert(std::make_pair(name, result));
+  if (!inserted.second) {
+    std::string msg = "Multiple nodes produced a value for '";
+    msg.append(name);
+    msg.append("', most recent from ");
+    msg.append(node.DebugString());
+    return SetError(std::move(msg));
+  }
+
+  return success();
+}
+
+Status NodeImporter::GetImmediateShapeTensor(const std::string &name,
+                                             std::vector<int64_t> &shape) {
+  auto found_it = graph_info_.initializer_map().find(name);
+  if (found_it == graph_info_.initializer_map().end()) {
+    std::string message = "An immediate shape value for '";
+    message.append(name);
+    message.append("' was required but it is dynamically produced");
+    return SetError(std::move(message));
+  }
+
+  const onnx::TensorProto &tp = found_it->second;
+  shape.clear();
+
+  // Since this is being interpreted as a shape, we only support some limited
+  // types.
+  size_t raw_data_size;
+  switch (tp.data_type()) {
+  case onnx::TensorProto::DataType::TensorProto_DataType_INT32: {
+    auto *raw_data = graph_info_.GetOptionalRawData<int32_t>(tp, raw_data_size);
+    if (raw_data) {
+      std::copy(raw_data, raw_data + raw_data_size, std::back_inserter(shape));
+    } else {
+      for (auto v : tp.int32_data())
+        shape.push_back(v);
+    }
+    return success();
+  }
+  case onnx::TensorProto::DataType::TensorProto_DataType_INT64: {
+    auto *raw_data = graph_info_.GetOptionalRawData<int64_t>(tp, raw_data_size);
+    if (raw_data) {
+      std::copy(raw_data, raw_data + raw_data_size, std::back_inserter(shape));
+    } else {
+      for (auto v : tp.int64_data())
+        shape.push_back(v);
+    }
+    return success();
+  }
+  case onnx::TensorProto::DataType::TensorProto_DataType_UINT32: {
+    auto *raw_data =
+        graph_info_.GetOptionalRawData<uint32_t>(tp, raw_data_size);
+    if (raw_data) {
+      std::copy(raw_data, raw_data + raw_data_size, std::back_inserter(shape));
+    } else {
+      // Stupid special case: stored in uint64.
+      for (auto v : tp.uint64_data())
+        shape.push_back(v);
+    }
+    return success();
+  }
+  case onnx::TensorProto::DataType::TensorProto_DataType_UINT64: {
+    auto *raw_data =
+        graph_info_.GetOptionalRawData<uint64_t>(tp, raw_data_size);
+    if (raw_data) {
+      std::copy(raw_data, raw_data + raw_data_size, std::back_inserter(shape));
+    } else {
+      for (auto v : tp.uint64_data())
+        shape.push_back(v);
+    }
+    return success();
+  }
+  }
+
+  {
+    std::string message =
+        "An immediate shape value could not be converted from TensorProto: ";
+    message.append(tp.DebugString());
+    return SetError(std::move(message));
+  }
+}
+
+void NodeImporter::DebugDumpModule() {
+  auto callback = +[](MlirStringRef sr, void *) {
+    fwrite(sr.data, sizeof(char), sr.length, stderr);
+  };
+  mlirOperationPrint(module_op_, callback, nullptr);
+}

--- a/projects/onnx_c_importer/OnnxImporter.h
+++ b/projects/onnx_c_importer/OnnxImporter.h
@@ -1,0 +1,240 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+// Stand-alone ONNX -> MLIR importer.
+// This library only depends on ONNX (and transitively protobuf, of course)
+// and the MLIR C API. It does this to minimize its dependency surface area
+// and make it possible to integrate as source code into other systems while
+// retaining this implementation as the source of truth.
+//
+// It uses a hybrid of LLVM and Google C++ coding style, preferring the latter
+// for class members/accessors because canonical protobuf coding presumes
+// this kind of style.
+
+#include "mlir-c/IR.h"
+#include "onnx/onnx_pb.h"
+
+#include <optional>
+#include <string_view>
+#include <unordered_map>
+
+namespace torch_mlir_onnx {
+
+struct Config;
+class GraphInfo;
+class ModelInfo;
+
+struct Config {
+  // Ancient ONNX exporters would often add a model input for anything that
+  // might be mutable, providing an initializer for it as well. More modern
+  // tools tools realized this is a really bad idea for a lot of reasons.
+  // We choose to assume more recent norms, even if encountering older
+  // models. Setting this to False probably won't do what you want but
+  // should produce interesting errors to waste your time deciphering.
+  // We mainly use it as a way to document in the code that we are
+  // making an assumption.
+  bool elide_initialized_inputs = true;
+};
+
+/// A light-weight status. It only encapsulates success/failure.
+/// Full error information will be set on the ModelInfo.
+class Status {
+public:
+  static Status success(bool isSuccess = true) { return Status(isSuccess); }
+  static Status failure(bool isFailure = true) { return Status(!isFailure); }
+
+  bool is_success() { return is_success_; }
+
+private:
+  Status(bool is_success) : is_success_(is_success) {}
+  bool is_success_;
+};
+
+static inline Status success() { return Status::success(); }
+static inline Status failure() { return Status::failure(); }
+static inline bool succeeded(Status status) { return status.is_success(); }
+static inline bool failed(Status status) { return !status.is_success(); }
+
+// Accounting for a GraphProto.
+class GraphInfo {
+public:
+  GraphInfo(ModelInfo &model_info, const onnx::GraphProto &graph_proto)
+      : model_info_(model_info), graph_proto_(graph_proto) {}
+  ModelInfo &model_info() { return model_info_; }
+  const onnx::GraphProto &graph_proto() { return graph_proto_; }
+
+  /// Post-construction, failable initialization.
+  Status Initialize();
+
+  /// Finds a TypeProto for the given value name. If returning nullptr, then
+  /// an error will have been set.
+  const onnx::TypeProto *FindTypeProtoForName(std::string_view name);
+
+  /// Attempts to access the raw or external data of the TensorProto. If the
+  /// the data is located in those positions, returns a types pointer to it
+  /// and stores the number of elements to `out_size`. Otherwise, nullptr is
+  /// returned (and no error is set).
+  template <typename ElementType>
+  const ElementType *GetOptionalRawData(const onnx::TensorProto &tp,
+                                        size_t &out_size) {
+    if (tp.has_raw_data()) {
+      out_size = tp.raw_data().size() / sizeof(ElementType);
+      return reinterpret_cast<const ElementType *>(tp.raw_data().data());
+    }
+    return nullptr;
+  }
+
+  std::vector<const onnx::ValueInfoProto *> &inputs() { return inputs_; }
+  std::unordered_map<std::string_view, const onnx::ValueInfoProto &> &
+  input_map() {
+    return input_map_;
+  }
+  std::vector<const onnx::ValueInfoProto *> &outputs() { return outputs_; }
+  std::unordered_map<std::string_view, const onnx::ValueInfoProto &> &
+  output_map() {
+    return output_map_;
+  }
+
+  std::unordered_map<std::string_view, const onnx::TensorProto &> &
+  initializer_map() {
+    return initializer_map_;
+  }
+
+private:
+  ModelInfo &model_info_;
+  const onnx::GraphProto &graph_proto_;
+
+  std::unordered_map<std::string_view, const onnx::TensorProto &>
+      initializer_map_;
+  std::unordered_map<std::string_view, const onnx::ValueInfoProto &>
+      value_info_map_;
+
+  std::vector<const onnx::ValueInfoProto *> declared_inputs_;
+  std::vector<const onnx::ValueInfoProto *> inputs_;
+  std::vector<const onnx::ValueInfoProto *> outputs_;
+  std::unordered_map<std::string_view, const onnx::ValueInfoProto &> input_map_;
+  std::unordered_map<std::string_view, const onnx::ValueInfoProto &>
+      output_map_;
+};
+
+/// Top-level accounting and accessors for an ONNX model.
+class ModelInfo {
+public:
+  ModelInfo();
+  Config &config() { return config_; }
+  onnx::ModelProto &model_proto() { return model_proto_; }
+
+  /// Post-construction, failable initialization.
+  Status Initialize();
+
+  GraphInfo &main_graph() { return *main_graph_; }
+  const std::string &error_message() { return error_message_; }
+
+  Status SetError(std::string msg) {
+    error_message_ = std::move(msg);
+    return failure();
+  }
+
+  void DebugDumpProto();
+
+private:
+  Config config_;
+  onnx::ModelProto model_proto_;
+  std::unique_ptr<GraphInfo> main_graph_;
+
+  std::string error_message_;
+};
+
+class ContextCache {
+public:
+  ContextCache(ModelInfo &model_info, MlirContext context)
+      : model_info_(model_info), context_(context) {}
+
+  MlirContext context() { return context_; }
+
+  /// Converts the TypeProto to an MlirType, returning a null type and
+  /// setting an error if not possible.
+  MlirType ConvertTypeProto(const onnx::TypeProto &tp);
+
+  /// Converts the ONNX element type code to an MlirType, returning a null type
+  /// and setting an error if not possible.
+  MlirType ConvertTensorElementType(int element_type_code);
+
+  /// Converts an ONNX TensorProto to an MlirAttribute, returning a null
+  /// attribute and setting an error if not possible.
+  MlirAttribute ConvertTensorProtoToAttr(const onnx::TensorProto &tp);
+
+  /// Converts the ONNX TensorProto to an Mlir RankedTensor type.
+  MlirType ConvertTensorProtoToBuiltinType(const onnx::TensorProto &tp);
+
+  /// Converts the ONNX TensorProto to a !torch.vtensor type.
+  MlirType ConvertTensorProtoToVtensorType(const onnx::TensorProto &tp);
+
+  /// Gets a !torch.vtensor type for the given dims and element type.
+  /// Dynamic dims are represented as -1.
+  /// If it was not possible to create the type, sets an error and returns
+  /// the null type.
+  MlirType GetVtensorType(const std::vector<int64_t> &dims,
+                          MlirType element_type);
+
+private:
+  ModelInfo &model_info_;
+  MlirContext context_;
+
+  std::unordered_map<int, MlirType> elem_type_map_;
+  std::unordered_map<std::string, MlirType> asm_type_map_;
+  std::vector<int64_t> shared_dims_;
+};
+
+/// Imports graph nodes into a function.
+class NodeImporter {
+public:
+  NodeImporter(GraphInfo &graph_info, ContextCache &cc,
+               MlirOperation module_op);
+
+  /// Called after construction to define the function in the module. Must be
+  /// called prior to importing nodes.
+  Status DefineFunction(std::optional<std::string> name = {});
+
+  /// Imports all nodes topologically.
+  Status ImportAll();
+
+  void DebugDumpModule();
+
+private:
+  void PopulateGraphAttrs(MlirOperation container_op);
+  Status ImportInitializer(const onnx::TensorProto &initializer);
+  Status ImportNode(const onnx::NodeProto &node);
+  MlirAttribute ImportGeneralAttribute(const onnx::AttributeProto &onnx_attr);
+
+  // Special-form nodes.
+  Status ImportGeneralNode(const onnx::NodeProto &node);
+  Status ImportConstantOfShapeNode(const onnx::NodeProto &node);
+
+  /// Looks for an initializer for `name` and attempts to treat it as a 1D
+  /// shape, filling `shape` if successful. Returns failure and sets an error
+  /// if not.
+  Status GetImmediateShapeTensor(const std::string &name,
+                                 std::vector<int64_t> &shape);
+
+  Status SetError(std::string msg) {
+    return graph_info_.model_info().SetError(std::move(msg));
+  }
+
+  GraphInfo &graph_info_;
+  ContextCache &cc_;
+  MlirContext context_;
+  MlirOperation module_op_;
+  MlirOperation func_op_;
+  MlirBlock body_block_;
+  MlirLocation default_loc_;
+  std::unordered_map<std::string_view, MlirValue> nv_map_;
+};
+
+} // namespace torch_mlir_onnx

--- a/projects/onnx_c_importer/README.md
+++ b/projects/onnx_c_importer/README.md
@@ -1,0 +1,7 @@
+# ONNX C Importer
+
+This project provides a C implementation of the `onnx_importer.py`, which is
+the canonical source. It is provided as sample code for anyone who wishes to
+integrate it into their system. By design, it only depends on the ONNX API
+and the MLIR C API via the `mlir-c` headers. As such, it should be easy to
+build into any system that already has those things by adding the sources.

--- a/projects/onnx_c_importer/import-onnx-main.cpp
+++ b/projects/onnx_c_importer/import-onnx-main.cpp
@@ -1,0 +1,103 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+// This main driver uses LLVM tool-making facilities and the support lib.
+// The actual importer libraries, however, only depend on the C API so that
+// they can be included in foreign projects more easily.
+
+#include "torch-mlir-c/Registration.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "OnnxImporter.h"
+
+#include "onnx/onnx_pb.h"
+
+#include <fstream>
+#include <iostream>
+
+using namespace llvm;
+using namespace torch_mlir_onnx;
+
+struct MlirState {
+  MlirState() {
+    context = mlirContextCreateWithThreading(false);
+    torchMlirRegisterAllDialects(context);
+    module = mlirModuleCreateEmpty(mlirLocationUnknownGet(context));
+  }
+  ~MlirState() {
+    mlirModuleDestroy(module);
+    mlirContextDestroy(context);
+  }
+
+  MlirContext context;
+  MlirModule module;
+};
+
+int main(int argc, char **argv) {
+  static cl::opt<std::string> inputFilename(
+      cl::Positional, cl::desc("<input file>"), cl::init("-"));
+
+  static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
+                                             cl::value_desc("filename"),
+                                             cl::init("-"));
+
+  InitLLVM y(argc, argv);
+  cl::ParseCommandLineOptions(argc, argv, "torch-mlir-onnx-import-c");
+
+  // Open the input as an istream because that is what protobuf likes.
+  std::unique_ptr<std::ifstream> alloced_input_stream;
+  std::istream *input_stream = nullptr;
+  if (inputFilename == "-") {
+    errs() << "(parsing from stdin)\n";
+    input_stream = &std::cin;
+  } else {
+    alloced_input_stream = std::make_unique<std::ifstream>(
+        inputFilename, std::ios::in | std::ios::binary);
+    if (!*alloced_input_stream) {
+      errs() << "error: could not open input file " << inputFilename << "\n";
+      return 1;
+    }
+    input_stream = alloced_input_stream.get();
+  }
+
+  // Parse the model proto.
+  ModelInfo model_info;
+  if (!model_info.model_proto().ParseFromIstream(input_stream)) {
+    errs() << "Failed to parse ONNX ModelProto from " << inputFilename << "\n";
+    return 2;
+  }
+
+  if (failed(model_info.Initialize())) {
+    errs() << "error: Import failure: " << model_info.error_message() << "\n";
+    model_info.DebugDumpProto();
+    return 3;
+  }
+  model_info.DebugDumpProto();
+
+  // Import.
+  MlirState owned_state;
+  ContextCache cc(model_info, owned_state.context);
+  NodeImporter importer(model_info.main_graph(), cc,
+                        mlirModuleGetOperation(owned_state.module));
+  if (failed(importer.DefineFunction())) {
+    errs() << "error: Could not define MLIR function for graph: "
+           << model_info.error_message() << "\n";
+    return 4;
+  }
+  if (failed(importer.ImportAll())) {
+    errs() << "error: Could not import one or more graph nodes: "
+           << model_info.error_message() << "\n";
+    return 5;
+  }
+  importer.DebugDumpModule();
+
+  return 0;
+}


### PR DESCRIPTION
As noted in the plan when this work started, we need to produce an ORT EP plugin for a downstream project, and this will necessitate a C-based ONNX importer (as opposed to the existing Python one). Because this comes with dependencies that we do not want to impart on various projects, this is optional in torch-mlir. It is also factored so that it can be used as standalone sources in downstreams that need it. Since it only depends on public C APIs on the MLIR side, this will make build coupling a lot better (since a C++ dep is not needed on the compiler and it is trivial to dynamically load).

Our original plan was just to maintain this fork off to the side in our ORT plugin, but once work started, it seemed better to write it clean and contribute it upstream for anyone to use. We expect that for non-ORT use, the Python importer will have better ergonomics for most folks.

I will follow-up with a test suite refactor so that we can drive the Python or C importer.

This is a relatively mechanical port from Python to C, borrowing some scaffolding from the old JitIR importer. It does attempt to lay some groundwork for external data, which will need to be implemented on the Python side as well.