### PR TITLE
[linalg] Added `aten.clamp` support with integers to `torch-to-linalg`

### DIFF
--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -1013,55 +1013,42 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
     Type dtype = converter->convertType(clamp.getType())
                      .cast<RankedTensorType>()
                      .getElementType();
-    if (dtype.isa<mlir::FloatType>()) {
-      auto result = payloadArgs[0];
-      if (!min.getType().isa<Torch::NoneType>()) {
-        auto minPromoted = convertScalarToDtype(b, loc, min, dtype);
-        auto pred = b.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ULT,
-                                            result, minPromoted);
-        result = b.create<arith::SelectOp>(loc, pred, minPromoted, result);
-      }
-      if (!max.getType().isa<Torch::NoneType>()) {
-        auto maxPromoted = convertScalarToDtype(b, loc, max, dtype);
-        auto pred = b.create<arith::CmpFOp>(loc, arith::CmpFPredicate::UGT,
-                                            result, maxPromoted);
-        result = b.create<arith::SelectOp>(loc, pred, maxPromoted, result);
-      }
-      return result;
+    if (!dtype.isa<mlir::FloatType, mlir::IntegerType>()) {
+      clamp.emitError("unimplement type for clamp");
+      return nullptr;
     }
 
-    if (auto intTy = dtype.dyn_cast<mlir::IntegerType>()) {
-      auto result = payloadArgs[0];
-
-      if (!min.getType().isa<Torch::NoneType>()) {
-        auto minPromoted =
-            convertScalarToDtype(b, loc, min, dtype,
-                                 /*srcOriginalDtype=*/std::nullopt,
-                                 /*dstOriginalDtype=*/b.getI64Type());
-        auto pred = b.create<arith::CmpIOp>(loc,
-                                            intTy.isUnsigned()
-                                                ? arith::CmpIPredicate::ult
-                                                : arith::CmpIPredicate::slt,
-                                            result, minPromoted);
-        result = b.create<arith::SelectOp>(loc, pred, minPromoted, result);
-      }
-      if (!max.getType().isa<Torch::NoneType>()) {
-        auto maxPromoted =
-            convertScalarToDtype(b, loc, max, dtype,
-                                 /*srcOriginalDtype=*/std::nullopt,
-                                 /*dstOriginalDtype=*/b.getI64Type());
-        auto pred = b.create<arith::CmpIOp>(loc,
-                                            intTy.isUnsigned()
-                                                ? arith::CmpIPredicate::ugt
-                                                : arith::CmpIPredicate::sgt,
-                                            result, maxPromoted);
-        result = b.create<arith::SelectOp>(loc, pred, maxPromoted, result);
-      }
-      return result;
+    Type dstOriginalDtype = clamp.getType().cast<BaseTensorType>().getDtype();
+    bool isUnsigned = isa<QUInt8Type>(dstOriginalDtype);
+    if (auto intTy = dstOriginalDtype.dyn_cast<IntegerType>()) {
+      isUnsigned = intTy.isUnsigned();
     }
+    auto cmpSelect = [&](Value input, Value clamp, bool getMax) -> Value {
+      clamp = convertScalarToDtype(b, loc, clamp, dtype,
+                                   /*srcOriginalDtype=*/std::nullopt,
+                                   /*dstOriginalDtype=*/dstOriginalDtype);
 
-    clamp.emitError("unimplemented: non-floating point dtype");
-    return nullptr;
+      Value pred;
+      if (dtype.isa<mlir::FloatType>()) {
+        auto cmp =
+            getMax ? arith::CmpFPredicate::UGT : arith::CmpFPredicate::ULT;
+        pred = b.create<arith::CmpFOp>(loc, cmp, input, clamp);
+      } else if (dtype.isa<mlir::IntegerType>()) {
+        auto cmp =
+            isUnsigned ? arith::CmpIPredicate::ult : arith::CmpIPredicate::slt;
+        if (getMax)
+          cmp = arith::invertPredicate(cmp);
+        pred = b.create<arith::CmpIOp>(loc, cmp, input, clamp);
+      }
+      return b.create<arith::SelectOp>(loc, pred, clamp, input);
+    };
+
+    auto result = payloadArgs[0];
+    if (!min.getType().isa<Torch::NoneType>())
+      result = cmpSelect(result, min, /*getMax=*/false);
+    if (!max.getType().isa<Torch::NoneType>())
+      result = cmpSelect(result, max, /*getMax=*/true);
+    return result;
   }
   if (auto clampTensor = dyn_cast<AtenClampTensorOp>(op)) {
     AtenClampTensorOp::Adaptor adaptor(operands);

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -988,6 +988,34 @@ def ElementwiseClampTensorIntModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwiseClampTensorInt8Module(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int8, True)
+    ])
+    def forward(self, x):
+        min = -5
+        max = 5
+        min_clamp = torch.clamp(x, min)
+        max_clamp = torch.clamp(x, max=max)
+        both_clamp = torch.clamp(x, min=min, max=max)
+        return min_clamp, max_clamp, both_clamp
+
+
+@register_test_case(module_factory=lambda: ElementwiseClampTensorInt8Module())
+def ElementwiseClampTensorInt8Module_basic(module, tu: TestUtils):
+    module.forward(tu.randint(3, 5, low=-10, high=10, dtype=torch.int8))
+
+
+# ==============================================================================
+
+
+
 class ElementwiseClampMinTensorFloatModule(torch.nn.Module):
 
     def __init__(self):

--- a/test/Conversion/TorchToLinalg/elementwise.mlir
+++ b/test/Conversion/TorchToLinalg/elementwise.mlir
@@ -102,3 +102,20 @@ func.func @elementwise_sinh(%arg0: !torch.vtensor<[3],f32>) -> !torch.vtensor<[3
   %0 = torch.aten.sinh %arg0 : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
   return %0 : !torch.vtensor<[3],f32>
 }
+
+// -----
+
+// CHECK-LABEL:    func.func @elementwise_clamp
+// CHECK:            linalg.generic
+// CHECK:            arith.trunci
+// CHECK:            arith.cmpi slt
+// CHECK:            arith.select
+// CHECK:            arith.trunci
+// CHECK:            arith.cmpi sgt
+// CHECK:            arith.select
+func.func @elementwise_clamp(%arg0: !torch.vtensor<[1,3,8,8],si8>) -> !torch.vtensor<[1,3,8,8],si8> {
+  %int-128 = torch.constant.int -128
+  %int127 = torch.constant.int 127
+  %0 = torch.aten.clamp %arg0, %int-128, %int127 : !torch.vtensor<[1,3,8,8],si8>, !torch.int, !torch.int -> !torch.vtensor<[1,3,8,8],si8>
+  return %0 : !torch.vtensor<[1,3,8,8],si8>
+}

--- a/test/Conversion/TorchToLinalg/elementwise.mlir
+++ b/test/Conversion/TorchToLinalg/elementwise.mlir
@@ -102,20 +102,3 @@ func.func @elementwise_sinh(%arg0: !torch.vtensor<[3],f32>) -> !torch.vtensor<[3
   %0 = torch.aten.sinh %arg0 : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
   return %0 : !torch.vtensor<[3],f32>
 }
-
-// -----
-
-// CHECK-LABEL:    func.func @elementwise_clamp
-// CHECK:            linalg.generic
-// CHECK:            arith.trunci
-// CHECK:            arith.cmpi slt
-// CHECK:            arith.select
-// CHECK:            arith.trunci
-// CHECK:            arith.cmpi sgt
-// CHECK:            arith.select
-func.func @elementwise_clamp(%arg0: !torch.vtensor<[1,3,8,8],si8>) -> !torch.vtensor<[1,3,8,8],si8> {
-  %int-128 = torch.constant.int -128
-  %int127 = torch.constant.int 127
-  %0 = torch.aten.clamp %arg0, %int-128, %int127 : !torch.vtensor<[1,3,8,8],si8>, !torch.int, !torch.int -> !torch.vtensor<[1,3,8,8],si8>
-  return %0 : !torch.vtensor<[1,3,8,8],si8>
-}


### PR DESCRIPTION
The lowering for `aten.clamp` did not support integer types. Added
support for integer types including a signed integer test.