### PR TITLE
[torch-mlir] update e2e test class documentation

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/configs/stablehlo_backend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/configs/stablehlo_backend.py
@@ -18,10 +18,10 @@ from .utils import (
 
 
 class StablehloBackendTestConfig(TestConfig):
-    """Base class for TestConfig's that are implemented with linalg-on-tensors.
+    """Base class for TestConfig's that are implemented with StableHLO.
 
     This class handles all the common lowering that torch-mlir does before
-    reaching the linalg-on-tensors abstraction level.
+    reaching the StableHLO abstraction level.
     """
 
     def __init__(self, backend: StablehloBackend):

--- a/projects/pt1/python/torch_mlir_e2e_test/configs/tosa_backend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/configs/tosa_backend.py
@@ -18,10 +18,10 @@ from .utils import (
 
 
 class TosaBackendTestConfig(TestConfig):
-    """Base class for TestConfig's that are implemented with linalg-on-tensors.
+    """Base class for TestConfig's that are implemented with TOSA.
 
     This class handles all the common lowering that torch-mlir does before
-    reaching the linalg-on-tensors abstraction level.
+    reaching the TOSA abstraction level.
     """
     def __init__(self, backend: TosaBackend, use_make_fx: bool = False):
         super().__init__()


### PR DESCRIPTION
The doc seems copy-and-paste from the linalg-on-tensors class