### PR TITLE
Onnx range

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -33,9 +33,6 @@ using namespace mlir::torch::onnx_c;
 namespace {
 template <typename T>
 Value getItemOp(OpBinder binder, ConversionPatternRewriter &rewriter,
-                Value &ofItem);
-template <typename T>
-Value getItemOp(OpBinder binder, ConversionPatternRewriter &rewriter,
                 Value &ofItem) {
   return rewriter.create<Torch::AtenItemOp>(binder.getLoc(),
                                             rewriter.getType<T>(), ofItem);
@@ -1370,13 +1367,13 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         // type of start, limit, delta can be one of: double, float, int16,
         // int32, int64 Assuming start, limit and delta to be same type (could
         // they be different?)
-        Torch::BaseTensorType startTesorType =
+        Torch::BaseTensorType startTensorType =
             start.getType().cast<Torch::BaseTensorType>();
-        bool isFloatDType = startTesorType.getDtype().isF64() ||
-                            startTesorType.getDtype().isF32();
-        bool isIntDType = startTesorType.getDtype().isInteger(16) ||
-                          startTesorType.getDtype().isInteger(32) ||
-                          startTesorType.getDtype().isInteger(64);
+        bool isFloatDType = startTensorType.getDtype().isF64() ||
+                            startTensorType.getDtype().isF32();
+        bool isIntDType = startTensorType.getDtype().isInteger(16) ||
+                          startTensorType.getDtype().isInteger(32) ||
+                          startTensorType.getDtype().isInteger(64);
         if (!isFloatDType && !isIntDType) {
           return rewriter.notifyMatchFailure(
               binder.op, "Expected the start, limit, delta to be one of "

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -1179,3 +1179,9 @@ func.func @test_reshape_zero_and_negative_dim(%arg0: !torch.vtensor<[2,3,4],f32>
   %0 = torch.operator "onnx.Reshape"(%arg0, %arg1) : (!torch.vtensor<[2,3,4],f32>, !torch.vtensor<[4],si64>) -> !torch.vtensor<[2,3,1,4],f32>
   return %0 : !torch.vtensor<[2,3,1,4],f32>
 }
+
+// CHECK-LABEL: func.func @test_range_float_type_positive_delta
+ func.func @test_range_float_type_positive_delta(%arg0: !torch.vtensor<[],f32>, %arg1: !torch.vtensor<[],f32>, %arg2: !torch.vtensor<[],f32>) -> !torch.vtensor<[2],f32> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+    %0 = torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],f32>, !torch.vtensor<[],f32>, !torch.vtensor<[],f32>) -> !torch.vtensor<[2],f32>
+    return %0 : !torch.vtensor<[2],f32>
+  }

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -1180,8 +1180,57 @@ func.func @test_reshape_zero_and_negative_dim(%arg0: !torch.vtensor<[2,3,4],f32>
   return %0 : !torch.vtensor<[2,3,1,4],f32>
 }
 
-// CHECK-LABEL: func.func @test_range_float_type_positive_delta
- func.func @test_range_float_type_positive_delta(%arg0: !torch.vtensor<[],f32>, %arg1: !torch.vtensor<[],f32>, %arg2: !torch.vtensor<[],f32>) -> !torch.vtensor<[2],f32> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-    %0 = torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],f32>, !torch.vtensor<[],f32>, !torch.vtensor<[],f32>) -> !torch.vtensor<[2],f32>
+// CHECK-LABEL: func.func @test_range_float64_type
+ func.func @test_range_float64_type(%arg0: !torch.vtensor<[],f64>, %arg1: !torch.vtensor<[],f64>, %arg2: !torch.vtensor<[],f64>) -> !torch.vtensor<[2],f64> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 13 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+    // CHECK: %[[NONE:.*]] torch.constant.none
+    // CHECK: torch.aten.item %arg0 : !torch.vtensor<[],f64> -> !torch.float
+    // CHECK: torch.aten.item %arg1 : !torch.vtensor<[],f64> -> !torch.float
+    // CHECK: torch.aten.item %arg2 : !torch.vtensor<[],f64> -> !torch.float
+    // CHECK: torch.aten.arange.start_step %0, %1, %2, %none, %none, %none, %none : !torch.float, !torch.float, !torch.float, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[2],f64>
+    // CHECK: torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],f64>, !torch.vtensor<[],f64>, !torch.vtensor<[],f64>) -> !torch.vtensor<[2],f64>
+    return %0 : !torch.vtensor<[2],f64>
+  }
+
+// CHECK-LABEL: func.func @test_range_float32_type
+ func.func @test_range_float32_type(%arg0: !torch.vtensor<[],f32>, %arg1: !torch.vtensor<[],f32>, %arg2: !torch.vtensor<[],f32>) -> !torch.vtensor<[2],f32> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 13 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+    // CHECK: %[[NONE:.*]] torch.constant.none
+    // CHECK: torch.aten.item %arg0 : !torch.vtensor<[],f32> -> !torch.float
+    // CHECK: torch.aten.item %arg1 : !torch.vtensor<[],f32> -> !torch.float
+    // CHECK: torch.aten.item %arg2 : !torch.vtensor<[],f32> -> !torch.float
+    // CHECK: torch.aten.arange.start_step %0, %1, %2, %none, %none, %none, %none : !torch.float, !torch.float, !torch.float, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[2],f32>
+    // CHECK: torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],f32>, !torch.vtensor<[],f32>, !torch.vtensor<[],f32>) -> !torch.vtensor<[2],f32>
     return %0 : !torch.vtensor<[2],f32>
   }
+
+// CHECK-LABEL: func.func @test_range_int64_type
+  func.func @test_range_int64_type(%arg0: !torch.vtensor<[],si64>, %arg1: !torch.vtensor<[],si64>, %arg2: !torch.vtensor<[],si64>) -> !torch.vtensor<[2],si64> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 13 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+    // CHECK: %[[NONE:.*]] torch.constant.none
+    // CHECK: torch.aten.item %arg0 : !torch.vtensor<[],si64> -> !torch.int
+    // CHECK: torch.aten.item %arg1 : !torch.vtensor<[],si64> -> !torch.int
+    // CHECK: torch.aten.item %arg2 : !torch.vtensor<[],si64> -> !torch.int
+    // CHECK: torch.aten.arange.start_step %0, %1, %2, %none, %none, %none, %none : !torch.int, !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[2],si64>
+    // CHECK: torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],si64>, !torch.vtensor<[],si64>, !torch.vtensor<[],si64>) -> !torch.vtensor<[2],si64>
+    return %0 : !torch.vtensor<[2],si64>
+  } 
+
+// CHECK-LABEL: func.func @test_range_int32_type
+  func.func @test_range_int32_type(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>) -> !torch.vtensor<[2],si32> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 13 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+    // CHECK: %[[NONE:.*]] torch.constant.none
+    // CHECK: torch.aten.item %arg0 : !torch.vtensor<[],si32> -> !torch.int
+    // CHECK: torch.aten.item %arg1 : !torch.vtensor<[],si32> -> !torch.int
+    // CHECK: torch.aten.item %arg2 : !torch.vtensor<[],si32> -> !torch.int
+    // CHECK: torch.aten.arange.start_step %0, %1, %2, %none, %none, %none, %none : !torch.int, !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[2],si32>
+    %0 = torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],si32>, !torch.vtensor<[],si32>, !torch.vtensor<[],si32>) -> !torch.vtensor<[2],si32>
+    return %0 : !torch.vtensor<[2],si32>
+  } 
+
+ // CHECK-LABEL: func.func @test_range_int16_type
+  func.func @test_range_int16_type(%arg0: !torch.vtensor<[],si16>, %arg1: !torch.vtensor<[],si16>, %arg2: !torch.vtensor<[],si16>) -> !torch.vtensor<[2],si16> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 13 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+    // CHECK: %[[NONE:.*]] torch.constant.none
+    // CHECK: torch.aten.item %arg0 : !torch.vtensor<[],si16> -> !torch.int
+    // CHECK: torch.aten.item %arg1 : !torch.vtensor<[],si16> -> !torch.int
+    // CHECK: torch.aten.item %arg2 : !torch.vtensor<[],si16> -> !torch.int
+    // CHECK: torch.aten.arange.start_step %0, %1, %2, %none, %none, %none, %none : !torch.int, !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[2],si16>
+    %0 = torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],si16>, !torch.vtensor<[],si16>, !torch.vtensor<[],si16>) -> !torch.vtensor<[2],si16>
+    return %0 : !torch.vtensor<[2],si16>
+  } 

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -1187,7 +1187,7 @@ func.func @test_reshape_zero_and_negative_dim(%arg0: !torch.vtensor<[2,3,4],f32>
     // CHECK: torch.aten.item %arg1 : !torch.vtensor<[],f64> -> !torch.float
     // CHECK: torch.aten.item %arg2 : !torch.vtensor<[],f64> -> !torch.float
     // CHECK: torch.aten.arange.start_step %0, %1, %2, %none, %none, %none, %none : !torch.float, !torch.float, !torch.float, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[2],f64>
-    // CHECK: torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],f64>, !torch.vtensor<[],f64>, !torch.vtensor<[],f64>) -> !torch.vtensor<[2],f64>
+    %0 = torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],f64>, !torch.vtensor<[],f64>, !torch.vtensor<[],f64>) -> !torch.vtensor<[2],f64>
     return %0 : !torch.vtensor<[2],f64>
   }
 
@@ -1198,7 +1198,7 @@ func.func @test_reshape_zero_and_negative_dim(%arg0: !torch.vtensor<[2,3,4],f32>
     // CHECK: torch.aten.item %arg1 : !torch.vtensor<[],f32> -> !torch.float
     // CHECK: torch.aten.item %arg2 : !torch.vtensor<[],f32> -> !torch.float
     // CHECK: torch.aten.arange.start_step %0, %1, %2, %none, %none, %none, %none : !torch.float, !torch.float, !torch.float, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[2],f32>
-    // CHECK: torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],f32>, !torch.vtensor<[],f32>, !torch.vtensor<[],f32>) -> !torch.vtensor<[2],f32>
+    %0 = torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],f32>, !torch.vtensor<[],f32>, !torch.vtensor<[],f32>) -> !torch.vtensor<[2],f32>
     return %0 : !torch.vtensor<[2],f32>
   }
 
@@ -1209,7 +1209,7 @@ func.func @test_reshape_zero_and_negative_dim(%arg0: !torch.vtensor<[2,3,4],f32>
     // CHECK: torch.aten.item %arg1 : !torch.vtensor<[],si64> -> !torch.int
     // CHECK: torch.aten.item %arg2 : !torch.vtensor<[],si64> -> !torch.int
     // CHECK: torch.aten.arange.start_step %0, %1, %2, %none, %none, %none, %none : !torch.int, !torch.int, !torch.int, !torch.none, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[2],si64>
-    // CHECK: torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],si64>, !torch.vtensor<[],si64>, !torch.vtensor<[],si64>) -> !torch.vtensor<[2],si64>
+    %0 = torch.operator "onnx.Range"(%arg0, %arg1, %arg2) : (!torch.vtensor<[],si64>, !torch.vtensor<[],si64>, !torch.vtensor<[],si64>) -> !torch.vtensor<[2],si64>
     return %0 : !torch.vtensor<[2],si64>
   } 
 


### PR DESCRIPTION
Implemented ONNX.Range. The spec says the data type for start, limit, delta are 0-D can be double, float, int16, int32, int64, All int types mapped to !torch.int and all float types mapped to !torch.float