### PR TITLE
Generalize install instructions to not exclude Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Meeting links can be found [here](https://discourse.llvm.org/t/new-community-mee
 
 ## Install torch-mlir snapshot
 
-At the time of writing, we release pre-built snapshot of torch-mlir for Python 3.11 on Linux and macOS.
+At the time of writing, we release pre-built snapshots of torch-mlir for Python 3.11.
 
 If you have Python 3.11, the following commands initialize a virtual environment.
 ```shell


### PR DESCRIPTION
Overly specific docs can get stale easily. It looks like https://llvm.github.io/torch-mlir/package-index/ has included Windows packages since around https://github.com/llvm/torch-mlir/pull/1521.

Here's an example release: https://github.com/llvm/torch-mlir/releases/tag/snapshot-20240118.1087

```
torch-2.3.0.dev20240109+cpu-cp311-cp311-linux_x86_64.whl
torch-2.3.0.dev20240109+cpu-cp311-cp311-win_amd64.whl
torch-2.3.0.dev20240109+cpu-cp38-cp38-linux_x86_64.whl
torch-2.3.0.dev20240109-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
torch-2.3.0.dev20240109-cp311-none-macosx_10_9_x86_64.whl
torch_mlir-20240118.1087-cp311-cp311-linux_aarch64.whl
torch_mlir-20240118.1087-cp311-cp311-linux_x86_64.whl
torch_mlir-20240118.1087-cp311-cp311-macosx_11_0_universal2.whl
torch_mlir-20240118.1087-cp311-cp311-win_amd64.whl
torch_mlir-20240118.1087-cp38-cp38-linux_x86_64.whl
```