### PR TITLE
[FxImporter] make FxImporter to fit python<=3.9

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -5,10 +5,16 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
 
+from sys import version_info
+if version_info.major == 3 and version_info.minor >= 10:
+    from types import NoneType
+else:
+    NoneType = type(None)
+
 import logging
 import operator
 import re
-from types import NoneType, BuiltinMethodType, BuiltinFunctionType
+from types import BuiltinMethodType, BuiltinFunctionType
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 import weakref
 

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -5,10 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
 
-from sys import version_info
-if version_info.major == 3 and version_info.minor >= 10:
+try:
     from types import NoneType
-else:
+except ImportError:
+    # python less than 3.10 doesn't have NoneType
     NoneType = type(None)
 
 import logging


### PR DESCRIPTION
As that torch with py3.9 is also used widely.