### PR TITLE
[torch-mlir][sparse] preserve sparsity during lowering torch to linalg

### DIFF
--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -110,29 +110,22 @@ LogicalResult prepareArgumentsForSlicingOp(OpTy op, OpAdaptor adaptor,
 // Example:
 // input =  tensor([[[0., 1., 2., 3.],
 //                   [4., 5., 6., 7.]]])
-// torch.ops.aten.reflection_pad1d(input, (3,1)) ; padding_left = 3,
-// padding_right = 1 tensor([[[3., 2., 1., 0., 1., 2., 3., 2.],
+// torch.ops.aten.reflection_pad1d(input, (3,1)) ; padding_left = 3, padding_right = 1
+// tensor([[[3., 2., 1., 0., 1., 2., 3., 2.],
 //          [7., 6., 5., 4., 5., 6., 7., 6.]]])
-// Checks: 1) Each of padding_left and padding_right must be non-negative less
-// than size of last dimension Implementation: a) Construct a result tensor of
-// shape of input tensor except for the last dimension.
-//                    The last dimension of the result tensor should be last
-//                    dimension of input tensor + left padding size + right
-//                    padding size. INitialize result tensor to all zeros
-//                 b) Setup affine map to take slice from input tensor of size
-//                 left padding starting from
-//                    second column onwards as first column is reflection
-//                    boundary
+// Checks: 1) Each of padding_left and padding_right must be non-negative less than size of last dimension 
+// Implementation: a) Construct a result tensor of shape of input tensor except for the last dimension.
+//                    The last dimension of the result tensor should be last dimension of input tensor +
+//                    left padding size + right padding size. INitialize result tensor to all zeros
+//                 b) Setup affine map to take slice from input tensor of size left padding starting from
+//                    second column onwards as first column is reflection boundary
 //                 c) Reflect the affine map to have resultant slice reflected
 //                 d) Take the slice and write from begining in result tensor
 //                 e) write the original tensor next into result tensor
-//                 f) Setup affine map to take slice from input tensor of right
-//                 padding size ending
-//                    at second last column as last column is reflection
-//                    boundary for right padding
+//                 f) Setup affine map to take slice from input tensor of right padding size ending 
+//                    at second last column as last column is reflection boundary for right padding
 //                 g) Reflect the affine map to have resultant slice reflected
-//                 h) Take the slice and write from left padding size + orignal
-//                 tensor last dim size
+//                 h) Take the slice and write from left padding size + orignal tensor last dim size 
 //                    into result tensor
 // Uses the ideas/code used for AtenReflectionPad2dOp
 namespace {
@@ -145,7 +138,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
       return failure();
-
+    
     SmallVector<int64_t> padInts;
     if (!matchPattern(op.getPadding(), m_TorchListOfConstantInts(padInts)))
       return rewriter.notifyMatchFailure(
@@ -180,7 +173,7 @@ public:
     Value lastDimSize = inputShape[lastDim]; // input [1,2,4], then lastDim = 2, inputShape[2] will give 4
 
     Value tileWidth[3], extractOffset[3], insertOffset[3];
-
+   
     tileWidth[PAD_LEFT] = getConstant(rewriter, loc, padInts[PAD_LEFT], indexType);
     tileWidth[PAD_RIGHT] = getConstant(rewriter, loc, padInts[PAD_RIGHT], indexType);
     tileWidth[PAD_CENTER] = lastDimSize;
@@ -188,13 +181,13 @@ public:
     extractOffset[PAD_LEFT] = one;
     // for (1,2,4) input, padding (3,1) lastDimSize=4, 4 - 1 - 1 = 2   [3,5, 6,7], so start offset to 6, which is right
     // lasDimSize - (tileWidth[PAD_RIGHT] + one)
-    extractOffset[PAD_RIGHT] =
-        createISub(lastDimSize, createIAdd(tileWidth[PAD_RIGHT], one));
+    extractOffset[PAD_RIGHT] = createISub(lastDimSize, createIAdd(tileWidth[PAD_RIGHT], one)); 
     extractOffset[PAD_CENTER] = zero;
 
     insertOffset[PAD_LEFT] = zero;
     insertOffset[PAD_RIGHT] = createIAdd(lastDimSize, tileWidth[PAD_LEFT]);
     insertOffset[PAD_CENTER] = tileWidth[PAD_LEFT];
+    
 
     SmallVector<Value> resultShape{inputShape};
     // Result's last dimension will have shape lastDimSize + left padding size + right padding size
@@ -221,7 +214,7 @@ public:
       Value tile = rewriter.create<tensor::ExtractSliceOp>(
           loc, input, extractOffsets, extractShape, allOneStrides);
 
-
+      
       auto inputMap = AffineMap::getMultiDimIdentityMap(numDims, context);
       // Setup the affine map function to resverse the tile along the horizontal for left and right slices
       if(padPosition < PAD_CENTER) {
@@ -238,7 +231,7 @@ public:
       insertOffsets[lastDim] = insertOffset[padPosition];
       resultTensor = rewriter.create<tensor::InsertSliceOp>(loc, tile, resultTensor, insertOffsets, extractShape, allOneStrides);
     };
-
+   
     if(padInts[PAD_LEFT] > 0)
        addTileToResult(PAD_LEFT);
     if(padInts[PAD_RIGHT] > 0)
@@ -1013,7 +1006,7 @@ public:
         intermediateShape.push_back(sum);
       }
 
-      // TODO: audit possibility of sparsity on this tensor
+      // TODO: audit possibility of sparsity on these tensor
       Type intermediateResultType =
           RankedTensorType::get(makeShapeLLVMCompatible(intermediateShape),
                                 resultType.getElementType());
@@ -1666,7 +1659,7 @@ public:
     auto srcType = src.getType().cast<RankedTensorType>();
     int64_t srcRank = srcType.getRank();
     SmallVector<int64_t> srcAbstractSizes(srcRank, kUnknownSize);
-    // TODO: audit possibility of sparsity on this tensor
+    // TODO: audit possibility of sparsity on these tensor
     auto abstractSrcType = RankedTensorType::get(
         makeShapeLLVMCompatible(srcAbstractSizes), srcType.getElementType());
     Value abstractSrc =

--- a/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
@@ -206,8 +206,8 @@ namespace {
 //
 // TODO: Find an optimal lowering.
 //       current lowering is not optimal for bags of large embeddings.
-//       Since it traverses the output tensor multiple times. 
-//      
+//       Since it traverses the output tensor multiple times.
+//
 //
 
 class ConvertAtenEmbeddingBagPaddingIdxOp

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -377,8 +377,8 @@ public:
       // TODO: Improve usage of static shape information.
       SmallVector<int64_t> lhsTargetShape(lhsBroadcastToShape.size(),
                                           ShapedType::kDynamic);
-      auto lhsBroadcastType =
-          RankedTensorType::get(lhsTargetShape, lhsType.getElementType());
+      auto lhsBroadcastType = RankedTensorType::get(
+          lhsTargetShape, lhsType.getElementType(), lhsType.getEncoding());
       if (failed(torch_to_linalg::broadcastToGivenShape(
               op, rewriter, lhs, lhsBroadcastToShape, lhsBroadcastType,
               broadcastedLhs))) {
@@ -387,8 +387,8 @@ public:
       }
       SmallVector<int64_t> rhsTargetShape(rhsBroadcastToShape.size(),
                                           ShapedType::kDynamic);
-      auto rhsBroadcastType =
-          RankedTensorType::get(rhsTargetShape, rhsType.getElementType());
+      auto rhsBroadcastType = RankedTensorType::get(
+          rhsTargetShape, rhsType.getElementType(), rhsType.getEncoding());
       if (failed(torch_to_linalg::broadcastToGivenShape(
               op, rewriter, rhs, rhsBroadcastToShape, rhsBroadcastType,
               broadcastedRhs))) {
@@ -880,7 +880,7 @@ public:
       if(numSpacialDims != 2)
         return rewriter.notifyMatchFailure(
             op, "unimplemented: only 2D grouped convolution supported");
-      
+
       // Special depthwise case
       auto inShape = makeShapeTorchCompatible(
           input.getType().cast<RankedTensorType>().getShape());
@@ -894,6 +894,7 @@ public:
             (weightShape[0] == kUnknownSize ? kUnknownSize
                                             : weightShape[0] * weightShape[1]),
             weightShape[2], weightShape[3]};
+        // TODO: audit possibility of sparsity on this tensor
         Type collapsedType = RankedTensorType::get(
             makeShapeLLVMCompatible(collapsedShape), elementType);
         Value collapsedWeight = rewriter.create<tensor::CollapseShapeOp>(

--- a/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
+++ b/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
@@ -86,205 +86,220 @@ namespace {
   // Lower aten.replication_pad2d operator into a sequence of
   // tensor.extract_slice and tensor.concat operations.
 
-  class ConvertAtenReplicationPad2dOp 
-      : public OpConversionPattern<AtenReplicationPad2dOp> {
-  public:
-    using OpConversionPattern::OpConversionPattern;
-    LogicalResult
-    matchAndRewrite(AtenReplicationPad2dOp op, OpAdaptor adaptor,
-                    ConversionPatternRewriter &rewriter) const override {
-      if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
-        return failure();
+class ConvertAtenReplicationPad2dOp
+    : public OpConversionPattern<AtenReplicationPad2dOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenReplicationPad2dOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+      return failure();
 
-      Location loc = op->getLoc();
-      Value input = adaptor.getSelf();
-      auto inputType = llvm::cast<RankedTensorType>(input.getType());
-      int64_t inputRank = inputType.getRank();
-      unsigned numDims = inputType.getRank();
-        assert(numDims >= 2 && "Not enough input dimensions");
+    Location loc = op->getLoc();
+    Value input = adaptor.getSelf();
+    auto inputType = llvm::cast<RankedTensorType>(input.getType());
+    int64_t inputRank = inputType.getRank();
+    unsigned numDims = inputType.getRank();
+    assert(numDims >= 2 && "Not enough input dimensions");
 
-      SmallVector<int64_t> padInts;
-      if (!matchPattern(op.getPadding(), m_TorchListOfConstantInts(padInts)))
-        return rewriter.notifyMatchFailure(
+    SmallVector<int64_t> padInts;
+    if (!matchPattern(op.getPadding(), m_TorchListOfConstantInts(padInts)))
+      return rewriter.notifyMatchFailure(
           op, "only support constant int pad ranges");
-      uint64_t padRank = padInts.size() / 2;
-      if (padRank * 2 != padInts.size())
-        return rewriter.notifyMatchFailure(op, "pad range size is not even");
-      if (inputRank < 0 || padRank > (uint64_t)inputRank)
-        return rewriter.notifyMatchFailure(op, "padding exceeds tensor rank");
+    uint64_t padRank = padInts.size() / 2;
+    if (padRank * 2 != padInts.size())
+      return rewriter.notifyMatchFailure(op, "pad range size is not even");
+    if (inputRank < 0 || padRank > (uint64_t)inputRank)
+      return rewriter.notifyMatchFailure(op, "padding exceeds tensor rank");
 
-      SmallVector<Value> inputShape = getTensorSizes(rewriter, loc, input);
-      int64_t hDim = numDims - 1;
-      int64_t vDim = numDims - 2;
-      Value hDimSize = inputShape[hDim];
-      Value vDimSize = inputShape[vDim];
+    SmallVector<Value> inputShape = getTensorSizes(rewriter, loc, input);
+    int64_t hDim = numDims - 1;
+    int64_t vDim = numDims - 2;
+    Value hDimSize = inputShape[hDim];
+    Value vDimSize = inputShape[vDim];
 
-      enum tileHLoc { LEFT = 0, HCENTER = 1, RIGHT = 2 };
-      enum tileVLoc { TOP = 0, VCENTER = 2, BOTTOM = 1, };
-      // vTile denotes the vertical size of the tile
-      // hTile denotes the horizontal size of the tile
-      // The padding results are composed of following tiles:
-      // vTile[TOP]hTile[LEFT], vTile[TOP]hTile[HCENTER], vTile[TOP]hTile[RIGHT]
-      // vTile[VCENTER]hTile[LEFT], vTile[VCENTER]hTile[HCENTER], vTile[VCENTER]hTile[RIGHT]
-      // vTile[BOTTOM]hTile[LEFT], vTile[BOTTOM]hTile[HCENTER], vTile[BOTTOM]hTile[RIGHT]
-      // vTile[VCENTER]hTile[HCENTER] is the original input tensor
-      Type indexType = rewriter.getIndexType();
-      Value vTile[3];
-      Value hTile[3];
-      vTile[VCENTER] = vDimSize;
-      hTile[HCENTER] = hDimSize;
-      vTile[TOP] = getConstant(rewriter, loc, padInts[2], indexType);
-      vTile[BOTTOM] = getConstant(rewriter, loc, padInts[3], indexType);
-      hTile[LEFT] = getConstant(rewriter, loc, padInts[0], indexType);
-      hTile[RIGHT] = getConstant(rewriter, loc, padInts[1], indexType);
+    enum tileHLoc { LEFT = 0, HCENTER = 1, RIGHT = 2 };
+    enum tileVLoc {
+      TOP = 0,
+      VCENTER = 2,
+      BOTTOM = 1,
+    };
+    // vTile denotes the vertical size of the tile
+    // hTile denotes the horizontal size of the tile
+    // The padding results are composed of following tiles:
+    // vTile[TOP]hTile[LEFT], vTile[TOP]hTile[HCENTER], vTile[TOP]hTile[RIGHT]
+    // vTile[VCENTER]hTile[LEFT], vTile[VCENTER]hTile[HCENTER],
+    // vTile[VCENTER]hTile[RIGHT] vTile[BOTTOM]hTile[LEFT],
+    // vTile[BOTTOM]hTile[HCENTER], vTile[BOTTOM]hTile[RIGHT]
+    // vTile[VCENTER]hTile[HCENTER] is the original input tensor
+    Type indexType = rewriter.getIndexType();
+    Value vTile[3];
+    Value hTile[3];
+    vTile[VCENTER] = vDimSize;
+    hTile[HCENTER] = hDimSize;
+    vTile[TOP] = getConstant(rewriter, loc, padInts[2], indexType);
+    vTile[BOTTOM] = getConstant(rewriter, loc, padInts[3], indexType);
+    hTile[LEFT] = getConstant(rewriter, loc, padInts[0], indexType);
+    hTile[RIGHT] = getConstant(rewriter, loc, padInts[1], indexType);
 
-      bool hasLeftPadding = false;
-      bool hasRightPadding = false;
-      bool hasTopPadding = false;
-      bool hasBottomPadding = false;
+    bool hasLeftPadding = false;
+    bool hasRightPadding = false;
+    bool hasTopPadding = false;
+    bool hasBottomPadding = false;
 
-      for (auto i: {TOP, VCENTER, BOTTOM}){
-        for (auto j: {LEFT, HCENTER, RIGHT}) {
-          auto constVtile{
-          mlir::dyn_cast<mlir::arith::ConstantOp>(vTile[i].getDefiningOp())
-              .getValue()
-              .dyn_cast_or_null<mlir::IntegerAttr>()};
+    for (auto i : {TOP, VCENTER, BOTTOM}) {
+      for (auto j : {LEFT, HCENTER, RIGHT}) {
+        auto constVtile{
+            mlir::dyn_cast<mlir::arith::ConstantOp>(vTile[i].getDefiningOp())
+                .getValue()
+                .dyn_cast_or_null<mlir::IntegerAttr>()};
 
-          auto constHtile{
-          mlir::dyn_cast<mlir::arith::ConstantOp>(hTile[j].getDefiningOp())
-              .getValue()
-              .dyn_cast_or_null<mlir::IntegerAttr>()};
-          auto vSize = constVtile.getInt();
-          auto hSize = constHtile.getInt();
+        auto constHtile{
+            mlir::dyn_cast<mlir::arith::ConstantOp>(hTile[j].getDefiningOp())
+                .getValue()
+                .dyn_cast_or_null<mlir::IntegerAttr>()};
+        auto vSize = constVtile.getInt();
+        auto hSize = constHtile.getInt();
 
-          if ((i == TOP) && (vSize > 0))
-            hasTopPadding = true;
-          if ((i == BOTTOM) && (vSize > 0))
-            hasBottomPadding = true;
-          if ((j == LEFT) && (hSize > 0))
-            hasLeftPadding = true;
-          if ((j == RIGHT) && (hSize > 0))
-            hasRightPadding = true;
-        }
+        if ((i == TOP) && (vSize > 0))
+          hasTopPadding = true;
+        if ((i == BOTTOM) && (vSize > 0))
+          hasBottomPadding = true;
+        if ((j == LEFT) && (hSize > 0))
+          hasLeftPadding = true;
+        if ((j == RIGHT) && (hSize > 0))
+          hasRightPadding = true;
       }
-
-      auto createSub = [&](Value x, Value y) {
-        return rewriter.create<arith::SubIOp>(loc, x, y);
-      };
-
-      // Extract left and right pad tiles.
-      Value zero = getConstant(rewriter, loc, 0, indexType);
-      Value one = getConstant(rewriter, loc, 1, indexType);
-      Value hDimSizeMinusOne = createSub(hDimSize, one);
-      Value vDimSizeMinusOne = createSub(vDimSize, one);
-      SmallVector<Value> allOneStrides(numDims, one);
-
-      SmallVector<Value> extractOffsetsLT(numDims, zero);
-      extractOffsetsLT[hDim] = zero;
-      extractOffsetsLT[vDim] = zero;
-      SmallVector<Value> extractShapeLR(numDims, one);
-      extractShapeLR[hDim] = one;
-      extractShapeLR[vDim] = vDimSize;
-
-      SmallVector<Value> extractOffsetsRight(numDims, zero);
-      extractOffsetsRight[hDim] = hDimSizeMinusOne;
-      extractOffsetsRight[vDim] = zero;
-
-      SmallVector<Value> extractOffsetsBottom(numDims, zero);
-      extractOffsetsBottom[hDim] = zero;
-      extractOffsetsBottom[vDim] = vDimSizeMinusOne;
-
-      SmallVector<Value> extractShapeTB(numDims, one);
-      extractShapeTB[hDim] = hDimSize;
-      extractShapeTB[vDim] = one;
-
-      SmallVector<Value> tensorsLeft;
-      SmallVector<Value> tensorsRight;
-      SmallVector<Value> tensorsCenter;
-      Value centerTile;
-      SmallVector<Value> tensorsRes;
-
-      if (hasLeftPadding) {
-        Value vCenterLeftSlice = rewriter.create<tensor::ExtractSliceOp>(
-            loc, input, extractOffsetsLT, extractShapeLR, allOneStrides);
-        Value vLeftSlice = vCenterLeftSlice;
-        if (hasTopPadding) {
-          Value topLeftValue = rewriter.create<tensor::ExtractOp>(
-              loc, input, ValueRange{zero, zero, zero, zero});
-          //pad vCenterLeftSlice on the top
-          SmallVector<int64_t> lowPadding(4, 0);
-          SmallVector<int64_t> highPadding(4, 0);
-          lowPadding[2] = padInts[2];
-          vLeftSlice = torch_to_linalg::getPaddedTensor(op, rewriter, vLeftSlice, lowPadding, highPadding, topLeftValue);
-        }
-        if (hasBottomPadding) {
-          Value bottomLeftValue = rewriter.create<tensor::ExtractOp> (loc, input, ValueRange{zero, zero, vDimSizeMinusOne, zero});
-
-          //pad vLeftSlice at the bottom
-          SmallVector<int64_t> lowPadding(4, 0);
-          SmallVector<int64_t> highPadding(4, 0);
-          highPadding[2] = padInts[3];
-          vLeftSlice = torch_to_linalg::getPaddedTensor(op, rewriter, vLeftSlice, lowPadding, highPadding, bottomLeftValue);
-        }
-        for (auto i=0; i<padInts[0]; ++i) {
-          tensorsLeft.push_back(vLeftSlice);
-        }
-        Value leftPadTile =
-            rewriter.create<tensor::ConcatOp>(loc, 3, tensorsLeft);
-        tensorsRes.push_back(leftPadTile);
-      }
-      if (hasTopPadding) {
-        Value topHcenterSlice = rewriter.create<tensor::ExtractSliceOp>(
-            loc, input, extractOffsetsLT, extractShapeTB, allOneStrides);
-        for (auto i = 0; i < padInts[2]; ++i) {
-          tensorsCenter.push_back(topHcenterSlice);
-        }
-      }
-      tensorsCenter.push_back(input);
-      if (hasBottomPadding) {
-        Value bottomHcenterSlice = rewriter.create<tensor::ExtractSliceOp>(
-            loc, input, extractOffsetsBottom, extractShapeTB, allOneStrides);
-        for (auto i = 0; i < padInts[3]; ++i) {
-          tensorsCenter.push_back(bottomHcenterSlice);
-        }
-      }
-      centerTile = rewriter.create<tensor::ConcatOp>(loc, 2, tensorsCenter);
-      tensorsRes.push_back(centerTile);
-
-      if (hasRightPadding) {
-        Value vCenterRightSlice = rewriter.create<tensor::ExtractSliceOp>(
-            loc, input, extractOffsetsRight, extractShapeLR, allOneStrides);
-        Value vRightSlice = vCenterRightSlice;
-        if (hasTopPadding) {
-          Value topRightValue = rewriter.create<tensor::ExtractOp> (loc, input, ValueRange{zero, zero, zero, hDimSizeMinusOne});
-
-          //pad vCenterRightSlice on the top
-          SmallVector<int64_t> lowPadding(4, 0);
-          SmallVector<int64_t> highPadding(4, 0);
-          lowPadding[2] = padInts[2];
-          vRightSlice = torch_to_linalg::getPaddedTensor(op, rewriter, vRightSlice, lowPadding, highPadding, topRightValue);
-        }
-        if (hasBottomPadding) {
-          Value bottomRightValue = rewriter.create<tensor::ExtractOp> (loc, input, ValueRange{zero, zero, vDimSizeMinusOne, hDimSizeMinusOne});
-
-          // Pad vCenterRightSlice or vRightTopPaddedSlice at the bottom.
-          SmallVector<int64_t> lowPadding(4, 0);
-          SmallVector<int64_t> highPadding(4, 0);
-          highPadding[2] = padInts[3];
-          vRightSlice = torch_to_linalg::getPaddedTensor(op, rewriter, vRightSlice, lowPadding, highPadding, bottomRightValue);
-        }
-        for (auto i=0; i<padInts[1]; ++i) {
-          tensorsRight.push_back(vRightSlice);
-        }
-        Value rightPadTile = rewriter.create<tensor::ConcatOp>(loc, 3, tensorsRight);
-        tensorsRes.push_back(rightPadTile);
-      }     
-      Value resTensor = rewriter.create<tensor::ConcatOp>(loc, 3, tensorsRes);
-      Type newResultType = getTypeConverter()->convertType(op.getType());
-      rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, resTensor);
-      return success();
     }
-  };
+
+    auto createSub = [&](Value x, Value y) {
+      return rewriter.create<arith::SubIOp>(loc, x, y);
+    };
+
+    // Extract left and right pad tiles.
+    Value zero = getConstant(rewriter, loc, 0, indexType);
+    Value one = getConstant(rewriter, loc, 1, indexType);
+    Value hDimSizeMinusOne = createSub(hDimSize, one);
+    Value vDimSizeMinusOne = createSub(vDimSize, one);
+    SmallVector<Value> allOneStrides(numDims, one);
+
+    SmallVector<Value> extractOffsetsLT(numDims, zero);
+    extractOffsetsLT[hDim] = zero;
+    extractOffsetsLT[vDim] = zero;
+    SmallVector<Value> extractShapeLR(numDims, one);
+    extractShapeLR[hDim] = one;
+    extractShapeLR[vDim] = vDimSize;
+
+    SmallVector<Value> extractOffsetsRight(numDims, zero);
+    extractOffsetsRight[hDim] = hDimSizeMinusOne;
+    extractOffsetsRight[vDim] = zero;
+
+    SmallVector<Value> extractOffsetsBottom(numDims, zero);
+    extractOffsetsBottom[hDim] = zero;
+    extractOffsetsBottom[vDim] = vDimSizeMinusOne;
+
+    SmallVector<Value> extractShapeTB(numDims, one);
+    extractShapeTB[hDim] = hDimSize;
+    extractShapeTB[vDim] = one;
+
+    SmallVector<Value> tensorsLeft;
+    SmallVector<Value> tensorsRight;
+    SmallVector<Value> tensorsCenter;
+    Value centerTile;
+    SmallVector<Value> tensorsRes;
+
+    if (hasLeftPadding) {
+      Value vCenterLeftSlice = rewriter.create<tensor::ExtractSliceOp>(
+          loc, input, extractOffsetsLT, extractShapeLR, allOneStrides);
+      Value vLeftSlice = vCenterLeftSlice;
+      if (hasTopPadding) {
+        Value topLeftValue = rewriter.create<tensor::ExtractOp>(
+            loc, input, ValueRange{zero, zero, zero, zero});
+        // pad vCenterLeftSlice on the top
+        SmallVector<int64_t> lowPadding(4, 0);
+        SmallVector<int64_t> highPadding(4, 0);
+        lowPadding[2] = padInts[2];
+        vLeftSlice = torch_to_linalg::getPaddedTensor(
+            op, rewriter, vLeftSlice, lowPadding, highPadding, topLeftValue);
+      }
+      if (hasBottomPadding) {
+        Value bottomLeftValue = rewriter.create<tensor::ExtractOp>(
+            loc, input, ValueRange{zero, zero, vDimSizeMinusOne, zero});
+
+        // pad vLeftSlice at the bottom
+        SmallVector<int64_t> lowPadding(4, 0);
+        SmallVector<int64_t> highPadding(4, 0);
+        highPadding[2] = padInts[3];
+        vLeftSlice = torch_to_linalg::getPaddedTensor(
+            op, rewriter, vLeftSlice, lowPadding, highPadding, bottomLeftValue);
+      }
+      for (auto i = 0; i < padInts[0]; ++i) {
+        tensorsLeft.push_back(vLeftSlice);
+      }
+      Value leftPadTile =
+          rewriter.create<tensor::ConcatOp>(loc, 3, tensorsLeft);
+      tensorsRes.push_back(leftPadTile);
+    }
+    if (hasTopPadding) {
+      Value topHcenterSlice = rewriter.create<tensor::ExtractSliceOp>(
+          loc, input, extractOffsetsLT, extractShapeTB, allOneStrides);
+      for (auto i = 0; i < padInts[2]; ++i) {
+        tensorsCenter.push_back(topHcenterSlice);
+      }
+    }
+    tensorsCenter.push_back(input);
+    if (hasBottomPadding) {
+      Value bottomHcenterSlice = rewriter.create<tensor::ExtractSliceOp>(
+          loc, input, extractOffsetsBottom, extractShapeTB, allOneStrides);
+      for (auto i = 0; i < padInts[3]; ++i) {
+        tensorsCenter.push_back(bottomHcenterSlice);
+      }
+    }
+    centerTile = rewriter.create<tensor::ConcatOp>(loc, 2, tensorsCenter);
+    tensorsRes.push_back(centerTile);
+
+    if (hasRightPadding) {
+      Value vCenterRightSlice = rewriter.create<tensor::ExtractSliceOp>(
+          loc, input, extractOffsetsRight, extractShapeLR, allOneStrides);
+      Value vRightSlice = vCenterRightSlice;
+      if (hasTopPadding) {
+        Value topRightValue = rewriter.create<tensor::ExtractOp>(
+            loc, input, ValueRange{zero, zero, zero, hDimSizeMinusOne});
+
+        // pad vCenterRightSlice on the top
+        SmallVector<int64_t> lowPadding(4, 0);
+        SmallVector<int64_t> highPadding(4, 0);
+        lowPadding[2] = padInts[2];
+        vRightSlice = torch_to_linalg::getPaddedTensor(
+            op, rewriter, vRightSlice, lowPadding, highPadding, topRightValue);
+      }
+      if (hasBottomPadding) {
+        Value bottomRightValue = rewriter.create<tensor::ExtractOp>(
+            loc, input,
+            ValueRange{zero, zero, vDimSizeMinusOne, hDimSizeMinusOne});
+
+        // Pad vCenterRightSlice or vRightTopPaddedSlice at the bottom.
+        SmallVector<int64_t> lowPadding(4, 0);
+        SmallVector<int64_t> highPadding(4, 0);
+        highPadding[2] = padInts[3];
+        vRightSlice = torch_to_linalg::getPaddedTensor(
+            op, rewriter, vRightSlice, lowPadding, highPadding,
+            bottomRightValue);
+      }
+      for (auto i = 0; i < padInts[1]; ++i) {
+        tensorsRight.push_back(vRightSlice);
+      }
+      Value rightPadTile =
+          rewriter.create<tensor::ConcatOp>(loc, 3, tensorsRight);
+      tensorsRes.push_back(rightPadTile);
+    }
+    Value resTensor = rewriter.create<tensor::ConcatOp>(loc, 3, tensorsRes);
+    Type newResultType = getTypeConverter()->convertType(op.getType());
+    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, resTensor);
+    return success();
+  }
+};
 }
 
 namespace {

--- a/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
+++ b/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
@@ -86,220 +86,205 @@ namespace {
   // Lower aten.replication_pad2d operator into a sequence of
   // tensor.extract_slice and tensor.concat operations.
 
-class ConvertAtenReplicationPad2dOp
-    : public OpConversionPattern<AtenReplicationPad2dOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-  LogicalResult
-  matchAndRewrite(AtenReplicationPad2dOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
-      return failure();
+  class ConvertAtenReplicationPad2dOp 
+      : public OpConversionPattern<AtenReplicationPad2dOp> {
+  public:
+    using OpConversionPattern::OpConversionPattern;
+    LogicalResult
+    matchAndRewrite(AtenReplicationPad2dOp op, OpAdaptor adaptor,
+                    ConversionPatternRewriter &rewriter) const override {
+      if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+        return failure();
 
-    Location loc = op->getLoc();
-    Value input = adaptor.getSelf();
-    auto inputType = llvm::cast<RankedTensorType>(input.getType());
-    int64_t inputRank = inputType.getRank();
-    unsigned numDims = inputType.getRank();
-    assert(numDims >= 2 && "Not enough input dimensions");
+      Location loc = op->getLoc();
+      Value input = adaptor.getSelf();
+      auto inputType = llvm::cast<RankedTensorType>(input.getType());
+      int64_t inputRank = inputType.getRank();
+      unsigned numDims = inputType.getRank();
+        assert(numDims >= 2 && "Not enough input dimensions");
 
-    SmallVector<int64_t> padInts;
-    if (!matchPattern(op.getPadding(), m_TorchListOfConstantInts(padInts)))
-      return rewriter.notifyMatchFailure(
+      SmallVector<int64_t> padInts;
+      if (!matchPattern(op.getPadding(), m_TorchListOfConstantInts(padInts)))
+        return rewriter.notifyMatchFailure(
           op, "only support constant int pad ranges");
-    uint64_t padRank = padInts.size() / 2;
-    if (padRank * 2 != padInts.size())
-      return rewriter.notifyMatchFailure(op, "pad range size is not even");
-    if (inputRank < 0 || padRank > (uint64_t)inputRank)
-      return rewriter.notifyMatchFailure(op, "padding exceeds tensor rank");
+      uint64_t padRank = padInts.size() / 2;
+      if (padRank * 2 != padInts.size())
+        return rewriter.notifyMatchFailure(op, "pad range size is not even");
+      if (inputRank < 0 || padRank > (uint64_t)inputRank)
+        return rewriter.notifyMatchFailure(op, "padding exceeds tensor rank");
 
-    SmallVector<Value> inputShape = getTensorSizes(rewriter, loc, input);
-    int64_t hDim = numDims - 1;
-    int64_t vDim = numDims - 2;
-    Value hDimSize = inputShape[hDim];
-    Value vDimSize = inputShape[vDim];
+      SmallVector<Value> inputShape = getTensorSizes(rewriter, loc, input);
+      int64_t hDim = numDims - 1;
+      int64_t vDim = numDims - 2;
+      Value hDimSize = inputShape[hDim];
+      Value vDimSize = inputShape[vDim];
 
-    enum tileHLoc { LEFT = 0, HCENTER = 1, RIGHT = 2 };
-    enum tileVLoc {
-      TOP = 0,
-      VCENTER = 2,
-      BOTTOM = 1,
-    };
-    // vTile denotes the vertical size of the tile
-    // hTile denotes the horizontal size of the tile
-    // The padding results are composed of following tiles:
-    // vTile[TOP]hTile[LEFT], vTile[TOP]hTile[HCENTER], vTile[TOP]hTile[RIGHT]
-    // vTile[VCENTER]hTile[LEFT], vTile[VCENTER]hTile[HCENTER],
-    // vTile[VCENTER]hTile[RIGHT] vTile[BOTTOM]hTile[LEFT],
-    // vTile[BOTTOM]hTile[HCENTER], vTile[BOTTOM]hTile[RIGHT]
-    // vTile[VCENTER]hTile[HCENTER] is the original input tensor
-    Type indexType = rewriter.getIndexType();
-    Value vTile[3];
-    Value hTile[3];
-    vTile[VCENTER] = vDimSize;
-    hTile[HCENTER] = hDimSize;
-    vTile[TOP] = getConstant(rewriter, loc, padInts[2], indexType);
-    vTile[BOTTOM] = getConstant(rewriter, loc, padInts[3], indexType);
-    hTile[LEFT] = getConstant(rewriter, loc, padInts[0], indexType);
-    hTile[RIGHT] = getConstant(rewriter, loc, padInts[1], indexType);
+      enum tileHLoc { LEFT = 0, HCENTER = 1, RIGHT = 2 };
+      enum tileVLoc { TOP = 0, VCENTER = 2, BOTTOM = 1, };
+      // vTile denotes the vertical size of the tile
+      // hTile denotes the horizontal size of the tile
+      // The padding results are composed of following tiles:
+      // vTile[TOP]hTile[LEFT], vTile[TOP]hTile[HCENTER], vTile[TOP]hTile[RIGHT]
+      // vTile[VCENTER]hTile[LEFT], vTile[VCENTER]hTile[HCENTER], vTile[VCENTER]hTile[RIGHT]
+      // vTile[BOTTOM]hTile[LEFT], vTile[BOTTOM]hTile[HCENTER], vTile[BOTTOM]hTile[RIGHT]
+      // vTile[VCENTER]hTile[HCENTER] is the original input tensor
+      Type indexType = rewriter.getIndexType();
+      Value vTile[3];
+      Value hTile[3];
+      vTile[VCENTER] = vDimSize;
+      hTile[HCENTER] = hDimSize;
+      vTile[TOP] = getConstant(rewriter, loc, padInts[2], indexType);
+      vTile[BOTTOM] = getConstant(rewriter, loc, padInts[3], indexType);
+      hTile[LEFT] = getConstant(rewriter, loc, padInts[0], indexType);
+      hTile[RIGHT] = getConstant(rewriter, loc, padInts[1], indexType);
 
-    bool hasLeftPadding = false;
-    bool hasRightPadding = false;
-    bool hasTopPadding = false;
-    bool hasBottomPadding = false;
+      bool hasLeftPadding = false;
+      bool hasRightPadding = false;
+      bool hasTopPadding = false;
+      bool hasBottomPadding = false;
 
-    for (auto i : {TOP, VCENTER, BOTTOM}) {
-      for (auto j : {LEFT, HCENTER, RIGHT}) {
-        auto constVtile{
-            mlir::dyn_cast<mlir::arith::ConstantOp>(vTile[i].getDefiningOp())
-                .getValue()
-                .dyn_cast_or_null<mlir::IntegerAttr>()};
+      for (auto i: {TOP, VCENTER, BOTTOM}){
+        for (auto j: {LEFT, HCENTER, RIGHT}) {
+          auto constVtile{
+          mlir::dyn_cast<mlir::arith::ConstantOp>(vTile[i].getDefiningOp())
+              .getValue()
+              .dyn_cast_or_null<mlir::IntegerAttr>()};
 
-        auto constHtile{
-            mlir::dyn_cast<mlir::arith::ConstantOp>(hTile[j].getDefiningOp())
-                .getValue()
-                .dyn_cast_or_null<mlir::IntegerAttr>()};
-        auto vSize = constVtile.getInt();
-        auto hSize = constHtile.getInt();
+          auto constHtile{
+          mlir::dyn_cast<mlir::arith::ConstantOp>(hTile[j].getDefiningOp())
+              .getValue()
+              .dyn_cast_or_null<mlir::IntegerAttr>()};
+          auto vSize = constVtile.getInt();
+          auto hSize = constHtile.getInt();
 
-        if ((i == TOP) && (vSize > 0))
-          hasTopPadding = true;
-        if ((i == BOTTOM) && (vSize > 0))
-          hasBottomPadding = true;
-        if ((j == LEFT) && (hSize > 0))
-          hasLeftPadding = true;
-        if ((j == RIGHT) && (hSize > 0))
-          hasRightPadding = true;
+          if ((i == TOP) && (vSize > 0))
+            hasTopPadding = true;
+          if ((i == BOTTOM) && (vSize > 0))
+            hasBottomPadding = true;
+          if ((j == LEFT) && (hSize > 0))
+            hasLeftPadding = true;
+          if ((j == RIGHT) && (hSize > 0))
+            hasRightPadding = true;
+        }
       }
-    }
 
-    auto createSub = [&](Value x, Value y) {
-      return rewriter.create<arith::SubIOp>(loc, x, y);
-    };
+      auto createSub = [&](Value x, Value y) {
+        return rewriter.create<arith::SubIOp>(loc, x, y);
+      };
 
-    // Extract left and right pad tiles.
-    Value zero = getConstant(rewriter, loc, 0, indexType);
-    Value one = getConstant(rewriter, loc, 1, indexType);
-    Value hDimSizeMinusOne = createSub(hDimSize, one);
-    Value vDimSizeMinusOne = createSub(vDimSize, one);
-    SmallVector<Value> allOneStrides(numDims, one);
+      // Extract left and right pad tiles.
+      Value zero = getConstant(rewriter, loc, 0, indexType);
+      Value one = getConstant(rewriter, loc, 1, indexType);
+      Value hDimSizeMinusOne = createSub(hDimSize, one);
+      Value vDimSizeMinusOne = createSub(vDimSize, one);
+      SmallVector<Value> allOneStrides(numDims, one);
 
-    SmallVector<Value> extractOffsetsLT(numDims, zero);
-    extractOffsetsLT[hDim] = zero;
-    extractOffsetsLT[vDim] = zero;
-    SmallVector<Value> extractShapeLR(numDims, one);
-    extractShapeLR[hDim] = one;
-    extractShapeLR[vDim] = vDimSize;
+      SmallVector<Value> extractOffsetsLT(numDims, zero);
+      extractOffsetsLT[hDim] = zero;
+      extractOffsetsLT[vDim] = zero;
+      SmallVector<Value> extractShapeLR(numDims, one);
+      extractShapeLR[hDim] = one;
+      extractShapeLR[vDim] = vDimSize;
 
-    SmallVector<Value> extractOffsetsRight(numDims, zero);
-    extractOffsetsRight[hDim] = hDimSizeMinusOne;
-    extractOffsetsRight[vDim] = zero;
+      SmallVector<Value> extractOffsetsRight(numDims, zero);
+      extractOffsetsRight[hDim] = hDimSizeMinusOne;
+      extractOffsetsRight[vDim] = zero;
 
-    SmallVector<Value> extractOffsetsBottom(numDims, zero);
-    extractOffsetsBottom[hDim] = zero;
-    extractOffsetsBottom[vDim] = vDimSizeMinusOne;
+      SmallVector<Value> extractOffsetsBottom(numDims, zero);
+      extractOffsetsBottom[hDim] = zero;
+      extractOffsetsBottom[vDim] = vDimSizeMinusOne;
 
-    SmallVector<Value> extractShapeTB(numDims, one);
-    extractShapeTB[hDim] = hDimSize;
-    extractShapeTB[vDim] = one;
+      SmallVector<Value> extractShapeTB(numDims, one);
+      extractShapeTB[hDim] = hDimSize;
+      extractShapeTB[vDim] = one;
 
-    SmallVector<Value> tensorsLeft;
-    SmallVector<Value> tensorsRight;
-    SmallVector<Value> tensorsCenter;
-    Value centerTile;
-    SmallVector<Value> tensorsRes;
+      SmallVector<Value> tensorsLeft;
+      SmallVector<Value> tensorsRight;
+      SmallVector<Value> tensorsCenter;
+      Value centerTile;
+      SmallVector<Value> tensorsRes;
 
-    if (hasLeftPadding) {
-      Value vCenterLeftSlice = rewriter.create<tensor::ExtractSliceOp>(
-          loc, input, extractOffsetsLT, extractShapeLR, allOneStrides);
-      Value vLeftSlice = vCenterLeftSlice;
+      if (hasLeftPadding) {
+        Value vCenterLeftSlice = rewriter.create<tensor::ExtractSliceOp>(
+            loc, input, extractOffsetsLT, extractShapeLR, allOneStrides);
+        Value vLeftSlice = vCenterLeftSlice;
+        if (hasTopPadding) {
+          Value topLeftValue = rewriter.create<tensor::ExtractOp>(
+              loc, input, ValueRange{zero, zero, zero, zero});
+          //pad vCenterLeftSlice on the top
+          SmallVector<int64_t> lowPadding(4, 0);
+          SmallVector<int64_t> highPadding(4, 0);
+          lowPadding[2] = padInts[2];
+          vLeftSlice = torch_to_linalg::getPaddedTensor(op, rewriter, vLeftSlice, lowPadding, highPadding, topLeftValue);
+        }
+        if (hasBottomPadding) {
+          Value bottomLeftValue = rewriter.create<tensor::ExtractOp> (loc, input, ValueRange{zero, zero, vDimSizeMinusOne, zero});
+
+          //pad vLeftSlice at the bottom
+          SmallVector<int64_t> lowPadding(4, 0);
+          SmallVector<int64_t> highPadding(4, 0);
+          highPadding[2] = padInts[3];
+          vLeftSlice = torch_to_linalg::getPaddedTensor(op, rewriter, vLeftSlice, lowPadding, highPadding, bottomLeftValue);
+        }
+        for (auto i=0; i<padInts[0]; ++i) {
+          tensorsLeft.push_back(vLeftSlice);
+        }
+        Value leftPadTile =
+            rewriter.create<tensor::ConcatOp>(loc, 3, tensorsLeft);
+        tensorsRes.push_back(leftPadTile);
+      }
       if (hasTopPadding) {
-        Value topLeftValue = rewriter.create<tensor::ExtractOp>(
-            loc, input, ValueRange{zero, zero, zero, zero});
-        // pad vCenterLeftSlice on the top
-        SmallVector<int64_t> lowPadding(4, 0);
-        SmallVector<int64_t> highPadding(4, 0);
-        lowPadding[2] = padInts[2];
-        vLeftSlice = torch_to_linalg::getPaddedTensor(
-            op, rewriter, vLeftSlice, lowPadding, highPadding, topLeftValue);
+        Value topHcenterSlice = rewriter.create<tensor::ExtractSliceOp>(
+            loc, input, extractOffsetsLT, extractShapeTB, allOneStrides);
+        for (auto i = 0; i < padInts[2]; ++i) {
+          tensorsCenter.push_back(topHcenterSlice);
+        }
       }
+      tensorsCenter.push_back(input);
       if (hasBottomPadding) {
-        Value bottomLeftValue = rewriter.create<tensor::ExtractOp>(
-            loc, input, ValueRange{zero, zero, vDimSizeMinusOne, zero});
+        Value bottomHcenterSlice = rewriter.create<tensor::ExtractSliceOp>(
+            loc, input, extractOffsetsBottom, extractShapeTB, allOneStrides);
+        for (auto i = 0; i < padInts[3]; ++i) {
+          tensorsCenter.push_back(bottomHcenterSlice);
+        }
+      }
+      centerTile = rewriter.create<tensor::ConcatOp>(loc, 2, tensorsCenter);
+      tensorsRes.push_back(centerTile);
 
-        // pad vLeftSlice at the bottom
-        SmallVector<int64_t> lowPadding(4, 0);
-        SmallVector<int64_t> highPadding(4, 0);
-        highPadding[2] = padInts[3];
-        vLeftSlice = torch_to_linalg::getPaddedTensor(
-            op, rewriter, vLeftSlice, lowPadding, highPadding, bottomLeftValue);
-      }
-      for (auto i = 0; i < padInts[0]; ++i) {
-        tensorsLeft.push_back(vLeftSlice);
-      }
-      Value leftPadTile =
-          rewriter.create<tensor::ConcatOp>(loc, 3, tensorsLeft);
-      tensorsRes.push_back(leftPadTile);
-    }
-    if (hasTopPadding) {
-      Value topHcenterSlice = rewriter.create<tensor::ExtractSliceOp>(
-          loc, input, extractOffsetsLT, extractShapeTB, allOneStrides);
-      for (auto i = 0; i < padInts[2]; ++i) {
-        tensorsCenter.push_back(topHcenterSlice);
-      }
-    }
-    tensorsCenter.push_back(input);
-    if (hasBottomPadding) {
-      Value bottomHcenterSlice = rewriter.create<tensor::ExtractSliceOp>(
-          loc, input, extractOffsetsBottom, extractShapeTB, allOneStrides);
-      for (auto i = 0; i < padInts[3]; ++i) {
-        tensorsCenter.push_back(bottomHcenterSlice);
-      }
-    }
-    centerTile = rewriter.create<tensor::ConcatOp>(loc, 2, tensorsCenter);
-    tensorsRes.push_back(centerTile);
+      if (hasRightPadding) {
+        Value vCenterRightSlice = rewriter.create<tensor::ExtractSliceOp>(
+            loc, input, extractOffsetsRight, extractShapeLR, allOneStrides);
+        Value vRightSlice = vCenterRightSlice;
+        if (hasTopPadding) {
+          Value topRightValue = rewriter.create<tensor::ExtractOp> (loc, input, ValueRange{zero, zero, zero, hDimSizeMinusOne});
 
-    if (hasRightPadding) {
-      Value vCenterRightSlice = rewriter.create<tensor::ExtractSliceOp>(
-          loc, input, extractOffsetsRight, extractShapeLR, allOneStrides);
-      Value vRightSlice = vCenterRightSlice;
-      if (hasTopPadding) {
-        Value topRightValue = rewriter.create<tensor::ExtractOp>(
-            loc, input, ValueRange{zero, zero, zero, hDimSizeMinusOne});
+          //pad vCenterRightSlice on the top
+          SmallVector<int64_t> lowPadding(4, 0);
+          SmallVector<int64_t> highPadding(4, 0);
+          lowPadding[2] = padInts[2];
+          vRightSlice = torch_to_linalg::getPaddedTensor(op, rewriter, vRightSlice, lowPadding, highPadding, topRightValue);
+        }
+        if (hasBottomPadding) {
+          Value bottomRightValue = rewriter.create<tensor::ExtractOp> (loc, input, ValueRange{zero, zero, vDimSizeMinusOne, hDimSizeMinusOne});
 
-        // pad vCenterRightSlice on the top
-        SmallVector<int64_t> lowPadding(4, 0);
-        SmallVector<int64_t> highPadding(4, 0);
-        lowPadding[2] = padInts[2];
-        vRightSlice = torch_to_linalg::getPaddedTensor(
-            op, rewriter, vRightSlice, lowPadding, highPadding, topRightValue);
-      }
-      if (hasBottomPadding) {
-        Value bottomRightValue = rewriter.create<tensor::ExtractOp>(
-            loc, input,
-            ValueRange{zero, zero, vDimSizeMinusOne, hDimSizeMinusOne});
-
-        // Pad vCenterRightSlice or vRightTopPaddedSlice at the bottom.
-        SmallVector<int64_t> lowPadding(4, 0);
-        SmallVector<int64_t> highPadding(4, 0);
-        highPadding[2] = padInts[3];
-        vRightSlice = torch_to_linalg::getPaddedTensor(
-            op, rewriter, vRightSlice, lowPadding, highPadding,
-            bottomRightValue);
-      }
-      for (auto i = 0; i < padInts[1]; ++i) {
-        tensorsRight.push_back(vRightSlice);
-      }
-      Value rightPadTile =
-          rewriter.create<tensor::ConcatOp>(loc, 3, tensorsRight);
-      tensorsRes.push_back(rightPadTile);
+          // Pad vCenterRightSlice or vRightTopPaddedSlice at the bottom.
+          SmallVector<int64_t> lowPadding(4, 0);
+          SmallVector<int64_t> highPadding(4, 0);
+          highPadding[2] = padInts[3];
+          vRightSlice = torch_to_linalg::getPaddedTensor(op, rewriter, vRightSlice, lowPadding, highPadding, bottomRightValue);
+        }
+        for (auto i=0; i<padInts[1]; ++i) {
+          tensorsRight.push_back(vRightSlice);
+        }
+        Value rightPadTile = rewriter.create<tensor::ConcatOp>(loc, 3, tensorsRight);
+        tensorsRes.push_back(rightPadTile);
+      }     
+      Value resTensor = rewriter.create<tensor::ConcatOp>(loc, 3, tensorsRes);
+      Type newResultType = getTypeConverter()->convertType(op.getType());
+      rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, resTensor);
+      return success();
     }
-    Value resTensor = rewriter.create<tensor::ConcatOp>(loc, 3, tensorsRes);
-    Type newResultType = getTypeConverter()->convertType(op.getType());
-    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, resTensor);
-    return success();
-  }
-};
+  };
 }
 
 namespace {

--- a/lib/Conversion/TorchToLinalg/Utils.cpp
+++ b/lib/Conversion/TorchToLinalg/Utils.cpp
@@ -87,6 +87,7 @@ Value torch_to_linalg::getDynamicZeroPaddedTensor(
     *pad = castIntToIndex(b, loc, *pad);
 
   Type elementType = input.getType().cast<RankedTensorType>().getElementType();
+  // TODO: audit possibility of sparsity on this tensor
   Type inputType =
       RankedTensorType::get(makeShapeLLVMCompatible(llvm::ArrayRef<int64_t>(
                                 SmallVector<int64_t>(inRank, kUnknownSize))),

--- a/lib/Dialect/Torch/IR/TorchTypes.cpp
+++ b/lib/Dialect/Torch/IR/TorchTypes.cpp
@@ -467,7 +467,8 @@ TensorType ValueTensorType::toBuiltinTensor() const {
   Type elementType = convertDtypeToBuiltinElementType(getContext(), getDtype());
   if (!elementType)
     return nullptr;
-  return RankedTensorType::get(makeShapeLLVMCompatible(getSizes()), elementType);
+  return RankedTensorType::get(makeShapeLLVMCompatible(getSizes()), elementType,
+                               getOptionalSparsity());
 }
 
 LogicalResult

--- a/test/Conversion/TorchToLinalg/sparse.mlir
+++ b/test/Conversion/TorchToLinalg/sparse.mlir
@@ -1,0 +1,36 @@
+// RUN: torch-mlir-opt <%s -convert-torch-to-linalg -split-input-file -verify-diagnostics | FileCheck %s
+
+// -----
+
+#CSR = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed) }>
+
+// CHECK: #[[$CSR:.*]] = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed) }>
+// CHECK-LABEL: func.func @sum(
+// CHECK-SAME:  %[[A:.*]]: !torch.vtensor<[64,64],f32,#[[$CSR]]>) -> !torch.vtensor<[],f32>
+// CHECK:       %[[S:.*]] = torch_c.to_builtin_tensor %[[A]] : !torch.vtensor<[64,64],f32,#[[$CSR]]> -> tensor<64x64xf32, #[[$CSR]]>
+// CHECK:       linalg.generic {{{.*}}} ins(%[[S]] : tensor<64x64xf32, #[[$CSR]]>)
+func.func @sum(%arg0: !torch.vtensor<[64,64],f32,#CSR>) -> !torch.vtensor<[],f32> {
+  %none = torch.constant.none
+  %0 = torch.aten.sum %arg0, %none
+     : !torch.vtensor<[64,64],f32,#CSR>, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+#CSR = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed) }>
+
+// CHECK: #[[$CSR:.*]] = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed) }>
+// CHECK-LABEL: func.func @SpMM(
+// CHECK-SAME:  %[[A:.*]]: !torch.vtensor<[8,16],f32,#[[$CSR]]>,
+// CHECK-SAME:  %[[B:.*]]: !torch.vtensor<[16,8],f32>) -> !torch.vtensor<[8,8],f32>
+// CHECK:       %[[S:.*]] = torch_c.to_builtin_tensor %[[A]] : !torch.vtensor<[8,16],f32,#[[$CSR]]> -> tensor<8x16xf32, #[[$CSR]]>
+// CHECK:       %[[T:.*]] = torch_c.to_builtin_tensor %[[B]] : !torch.vtensor<[16,8],f32> -> tensor<16x8xf32>
+// CHECK:       linalg.matmul ins(%[[S]], %[[T]] : tensor<8x16xf32, #[[$CSR]]>, tensor<16x8xf32>)
+func.func @SpMM(%arg0: !torch.vtensor<[8,16],f32,#CSR>,
+                %arg1: !torch.vtensor<[16,8],f32>) -> !torch.vtensor<[8,8],f32> {
+  %0 = torch.aten.matmul %arg0, %arg1
+     : !torch.vtensor<[8,16],f32,#CSR>,
+       !torch.vtensor<[16,8],f32> -> !torch.vtensor<[8,8],f32>
+  return %0 : !torch.vtensor<[8,8],f32>
+}


### PR DESCRIPTION
This preserves sparsity at the most obvious places of lowering TORCH tensors to MLIR RankedTensorType tensors. Other places are marked for audit. With some initial lowering tests.