### PR TITLE
[torch] Support `torch.convolution` quantized lowering to `linalg`

### DIFF
--- a/include/torch-mlir/Conversion/TorchToLinalg/Utils.h
+++ b/include/torch-mlir/Conversion/TorchToLinalg/Utils.h
@@ -36,7 +36,7 @@ Value getZeroPaddedTensor(Operation *op, OpBuilder &b, Value &input,
 // padding value is zero.
 Value getDynamicZeroPaddedTensor(Operation *op, OpBuilder &b, Value &input,
                                  SmallVectorImpl<Value> &padding,
-                                 int unpaddedDims = 0);
+                                 int unpaddedDims = 0, Value pad = {});
 
 // Helper function to caculate the output tensor dims for convolution-like ops.
 // Along each dim:

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -975,6 +975,7 @@ public:
       Type newResultType = getTypeConverter()->convertType(op.getType());
       rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, conv);
       return success();
+    }
 
     if (groupSize == 1 && inputZp && weightZp) {
       // The quantized version uses a different channel ordering so we need to

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -36,6 +36,27 @@ static void getZeroPoint(Value value, Value &zeropoint) {
   }
 }
 
+static Value transposeValue(Location loc, Value value, ArrayRef<int64_t> perms,
+                            PatternRewriter &rewriter) {
+  auto valueTy = value.getType().cast<RankedTensorType>();
+  auto inShape = valueTy.getShape();
+  llvm::SmallVector<int64_t> outShape;
+  llvm::SmallVector<Value> dynDims;
+  for (size_t i = 0; i < perms.size(); ++i) {
+    outShape.push_back(inShape[perms[i]]);
+    if (ShapedType::isDynamic(inShape[perms[i]])) {
+      dynDims.push_back(rewriter.create<tensor::DimOp>(loc, value, perms[i]));
+    }
+  }
+
+  auto outTy = RankedTensorType::get(outShape, valueTy.getElementType());
+  Value empty = rewriter.create<tensor::EmptyOp>(loc, outTy, dynDims);
+  Value transpose =
+      rewriter.create<linalg::TransposeOp>(loc, value, empty, perms)
+          ->getResult(0);
+  return transpose;
+}
+
 class ConvertAtenMmOp : public OpConversionPattern<AtenMmOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
@@ -600,19 +621,64 @@ public:
     MLIRContext *context = op->getContext();
     Value input = adaptor.getInput();   /* in form of N*C*H*W */
     Value weight = adaptor.getWeight(); /* in form of F*C*H*W */
+    Value bias = adaptor.getBias();
+    auto resultTy = op.getType().cast<ValueTensorType>();
+
+    Value inputZp, weightZp, biasZp;
+    if (auto make = op.getInput()
+                        .getDefiningOp<Aten_MakePerTensorQuantizedTensorOp>()) {
+      input = make.getSelf();
+      inputZp = make.getZeroPoint();
+      input = typeConverter->materializeTargetConversion(
+          rewriter, loc, getTypeConverter()->convertType(input.getType()),
+          input);
+      inputZp = typeConverter->materializeTargetConversion(
+          rewriter, loc, getTypeConverter()->convertType(inputZp.getType()),
+          inputZp);
+    }
+
+    if (auto make = op.getWeight()
+                        .getDefiningOp<Aten_MakePerTensorQuantizedTensorOp>()) {
+      weight = make.getSelf();
+      weightZp = make.getZeroPoint();
+
+      weight = typeConverter->materializeTargetConversion(
+          rewriter, loc, getTypeConverter()->convertType(weight.getType()),
+          weight);
+      weightZp = typeConverter->materializeTargetConversion(
+          rewriter, loc, getTypeConverter()->convertType(weightZp.getType()),
+          weightZp);
+    }
+
+    if (static_cast<bool>(inputZp) != static_cast<bool>(weightZp)) {
+      return rewriter.notifyMatchFailure(
+          op, "lhs and rhs of convolution must either be both int or fp");
+    }
+
+    if (inputZp && weightZp) {
+      auto biasDTy = bias.getType().cast<RankedTensorType>().getElementType();
+      if (!biasDTy.isInteger(32)) {
+        return rewriter.notifyMatchFailure(
+            op, "quantized result ty should be i32 accumulator");
+      }
+    }
 
     bool transposed = true;
     if (!matchPattern(op.getTransposed(), m_TorchConstantBool(&transposed)))
       return rewriter.notifyMatchFailure(
           op, "unimplemented: only constant transposed supported");
 
-    Type elementType =
-        input.getType().cast<RankedTensorType>().getElementType();
-    if (!elementType.isa<mlir::FloatType>())
-      return op.emitError("unimplemented: non-floating point type");
+    auto inputDTy = input.getType().cast<RankedTensorType>().getElementType();
+    auto weightDTy = weight.getType().cast<RankedTensorType>().getElementType();
+    auto resultDTy = resultTy.getDtype();
+
+    if (!inputDTy.isa<mlir::FloatType, mlir::IntegerType>() ||
+        !weightDTy.isa<mlir::FloatType, mlir::IntegerType>() ||
+        !resultDTy.isa<mlir::FloatType, mlir::IntegerType>())
+      return op.emitError("unimplemented: non-fp not-int type");
     size_t inRank = input.getType().cast<RankedTensorType>().getRank();
-    size_t numSpacialDims = inRank - 2;
-    if (numSpacialDims < 1 || numSpacialDims > 3)
+    size_t numSpatialDims = inRank - 2;
+    if (numSpatialDims < 1 || numSpatialDims > 3)
       return rewriter.notifyMatchFailure(
           op, "unimplemented: only 1d-3d convolution currently supported");
 
@@ -684,6 +750,12 @@ public:
     SmallVector<Value> outDims{inBatch, weightBatch};
     Value paddedInput;
     if (transposed) {
+      if (!inputDTy.isa<mlir::FloatType>() ||
+          !weightDTy.isa<mlir::FloatType>() ||
+          !resultDTy.isa<mlir::FloatType>())
+        return rewriter.notifyMatchFailure(
+            op, "transpose does not support non-fp type yet");
+
       Value c0 =
           rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
       Value c1 =
@@ -696,7 +768,7 @@ public:
       std::iter_swap(weightInitDims.begin(), weightInitDims.begin() + 1);
       outDims[1] = weightInitDims[0];
       Value weightInitTensor =
-          createZeroInitTensor(rewriter, loc, weightInitDims, elementType);
+          createZeroInitTensor(rewriter, loc, weightInitDims, inputDTy);
       SmallVector<utils::IteratorType> iteratorTypes(
           inRank, utils::IteratorType::parallel);
       SmallVector<AffineMap> indexingMaps{
@@ -729,7 +801,7 @@ public:
       SmallVector<Value> outerSizes{inBatch, inChannels};
       SmallVector<Value> innerSizes{inBatch, inChannels};
       SmallVector<Value> offsets{c0, c0};
-      for (size_t i = 0; i < numSpacialDims; i++) {
+      for (size_t i = 0; i < numSpatialDims; i++) {
         Value innerSize = rewriter.create<arith::SubIOp>(loc, inDims[i], c1);
         innerSize = rewriter.create<arith::MulIOp>(
             loc, innerSize, castIntToIndex(rewriter, loc, strideIntValues[i]));
@@ -753,7 +825,7 @@ public:
 
       // Allocate padded input tensor
       Value initTensor =
-          createZeroInitTensor(rewriter, loc, outerSizes, elementType);
+          createZeroInitTensor(rewriter, loc, outerSizes, resultDTy);
 
       // Insert input into allocated tensor
       SmallVector<Value> strideIndexValues{c1, c1};
@@ -766,7 +838,7 @@ public:
           initTensor, offsets, insertSizes, strideIndexValues);
 
       // Calculate output dims
-      for (size_t i = 0; i < numSpacialDims; i++)
+      for (size_t i = 0; i < numSpatialDims; i++)
         outDims.push_back(torch_to_linalg::getOutputDimForConvTransposeOps(
             rewriter, loc, inDims[i], paddingIntValues[i], dilationIntValues[i],
             castIndexToInt(weightDims[i]), strideIntValues[i],
@@ -774,7 +846,7 @@ public:
 
       // Set stride to 1
       strideInts.clear();
-      strideInts.append(numSpacialDims, 1);
+      strideInts.append(numSpatialDims, 1);
 
     } else {
       // Pad input
@@ -782,28 +854,32 @@ public:
           op, rewriter, input, paddingIntValues, /*unpaddedDims=*/2);
 
       // Calculate output dims
-      for (size_t i = 0; i < numSpacialDims; i++)
+      for (size_t i = 0; i < numSpatialDims; i++)
         outDims.push_back(torch_to_linalg::getOutputDimForConvOps(
             rewriter, loc, inDims[i], paddingIntValues[i], dilationIntValues[i],
             castIndexToInt(weightDims[i]), strideIntValues[i]));
     }
 
     Value initTensor = rewriter.create<tensor::EmptyOp>(
-        loc, getAsOpFoldResult(outDims), elementType);
+        loc, getAsOpFoldResult(outDims), resultDTy);
 
-    Value bias = adaptor.getBias();
     Value outputTensor;
     if (bias.getType().isa<Torch::NoneType>()) {
-      Value c0float = rewriter.create<arith::ConstantOp>(
-          loc, FloatAttr::get(elementType, 0.0));
-      outputTensor = rewriter.create<linalg::FillOp>(loc, c0float, initTensor)
-                         .getResult(0);
+      if (resultDTy.isa<mlir::FloatType>()) {
+        Value c0float = rewriter.create<arith::ConstantOp>(
+            loc, FloatAttr::get(resultDTy, 0.0));
+        outputTensor = rewriter.create<linalg::FillOp>(loc, c0float, initTensor)
+                           .getResult(0);
+      } else if (resultDTy.isa<mlir::IntegerType>()) {
+        Value c0int = rewriter.create<arith::ConstantOp>(
+            loc, IntegerAttr::get(resultDTy, 0));
+        outputTensor = rewriter.create<linalg::FillOp>(loc, c0int, initTensor)
+                           .getResult(0);
+      }
     } else {
       auto biasType = bias.getType().cast<RankedTensorType>();
       if (biasType.getRank() != 1)
         return rewriter.notifyMatchFailure(op, "expect bias to be rank 1");
-      if (elementType != biasType.getElementType())
-        return rewriter.notifyMatchFailure(op, "unimplemented: type promotion");
 
       auto resultRank = initTensor.getType().cast<RankedTensorType>().getRank();
       SmallVector<AffineMap> indexingMaps = {
@@ -843,16 +919,16 @@ public:
     weightSliceSizes.append(weightDims);
 
     Value conv;
-    // the code so far is able to respect all numSpacialDims
-    // the code below this point is numSpacialDims specific and groupSize
+    // the code so far is able to respect all numSpatialDims
+    // the code below this point is numSpatialDims specific and groupSize
     // specific
     // TODO: factor out the above code into a helper function, and then separate
     // convolution into:
     // - grouped 1d-3d
+    // - grouped 1d-3d (quantized)
     // - ungrouped 1d-3d
-    if (groupSize == 1) {
-      // TODO: 3D case
-      switch (numSpacialDims) {
+    if (groupSize == 1 && !inputZp && !weightZp) {
+      switch (numSpatialDims) {
       case 1:
         conv = rewriter
                    .create<linalg::Conv1DNcwFcwOp>(
@@ -884,113 +960,192 @@ public:
       Type newResultType = getTypeConverter()->convertType(op.getType());
       rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, conv);
       return success();
-    } else {
-      if (numSpacialDims != 2)
-        return rewriter.notifyMatchFailure(
-            op, "unimplemented: only 2D grouped convolution supported");
 
-      // Special depthwise case
-      auto inShape = makeShapeTorchCompatible(
-          input.getType().cast<RankedTensorType>().getShape());
-      auto weightShape = makeShapeTorchCompatible(
-          weight.getType().cast<RankedTensorType>().getShape());
-      if (weightShape[0] != kUnknownSize && inShape[1] == groupSize &&
-          weightShape[0] % inShape[1] == 0 && weightShape[1] == 1) {
-        // Collapse weight shape
-        SmallVector<ReassociationIndices, 4> collapsedDims = {{0, 1}, {2}, {3}};
-        SmallVector<int64_t> collapsedShape{
-            (weightShape[0] == kUnknownSize ? kUnknownSize
-                                            : weightShape[0] * weightShape[1]),
-            weightShape[2], weightShape[3]};
-        // TODO: audit possibility of sparsity on this tensor
-        Type collapsedType = RankedTensorType::get(
-            makeShapeLLVMCompatible(collapsedShape), elementType);
-        Value collapsedWeight = rewriter.create<tensor::CollapseShapeOp>(
-            loc, collapsedType, weight, collapsedDims);
+    if(numSpatialDims != 2)
+      return rewriter.notifyMatchFailure(
+          op, "unimplemented: only 2D grouped convolution supported");
 
-        conv = rewriter
-                   .create<linalg::DepthwiseConv2DNchwChwOp>(
-                       loc, outputTensor.getType(),
-                       ValueRange{paddedInput, collapsedWeight}, outputTensor,
-                       stridesAttr, dilationAttr)
-                   .getResult(0);
+    // Special depthwise case
+    auto inShape = makeShapeTorchCompatible(
+        input.getType().cast<RankedTensorType>().getShape());
+    auto weightShape = makeShapeTorchCompatible(
+        weight.getType().cast<RankedTensorType>().getShape());
+    if (weightShape[0] != kUnknownSize && inShape[1] == groupSize &&
+        weightShape[0] % inShape[1] == 0 && weightShape[1] == 1) {
+      // Collapse weight shape
+      SmallVector<ReassociationIndices, 4> collapsedDims = {{0, 1}, {2}, {3}};
+      SmallVector<int64_t> collapsedShape{
+          (weightShape[0] == kUnknownSize ? kUnknownSize
+                                          : weightShape[0] * weightShape[1]),
+          weightShape[2], weightShape[3]};
+      // TODO: audit possibility of sparsity on this tensor
+      Type collapsedType = RankedTensorType::get(
+          makeShapeLLVMCompatible(collapsedShape), weightDTy);
+      Value collapsedWeight = rewriter.create<tensor::CollapseShapeOp>(
+          loc, collapsedType, weight, collapsedDims);
 
-        Type newResultType = getTypeConverter()->convertType(op.getType());
-        rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, conv);
-        return success();
+    if (groupSize == 1 && inputZp && weightZp) {
+      // The quantized version uses a different channel ordering so we need to
+      // permute the tensors in order to use the existing path. We should
+      // eventually directly support this channel ordering.
+      llvm::SmallVector<int64_t> inPerms, weightPerms;
+      inPerms.push_back(0); // N stays at the front for input.
+      // Then we expect the spatial dimensions
+      for (size_t i = 0; i < numSpatialDims; ++i) {
+        inPerms.push_back(i + 2);
+        weightPerms.push_back(i + 2);
       }
+      inPerms.push_back(1);
+      weightPerms.append({1, 0});
 
-      // Grouped case, use the grouped conv linalg op
-      auto expandGroups = [&](Value tensor, size_t dim) {
-        auto inType = tensor.getType().cast<RankedTensorType>();
-        auto inShape = makeShapeTorchCompatible(inType.getShape());
+      paddedInput = transposeValue(op.getLoc(), paddedInput, inPerms, rewriter);
+      weight = transposeValue(op.getLoc(), weight, weightPerms, rewriter);
+      outputTensor =
+          transposeValue(op.getLoc(), outputTensor, inPerms, rewriter);
 
-        SmallVector<int64_t> outShape;
-        for (auto i = 0; i < (long)inShape.size(); i++) {
-          if (i == 1) {
-            outShape.push_back(groupSize);
-          }
-          if (i == (long)dim) {
-            outShape.push_back(inShape[i] == kUnknownSize
-                                   ? kUnknownSize
-                                   : inShape[i] / groupSize);
-          } else {
-            outShape.push_back(inShape[i]);
-          }
-        }
-
-        SmallVector<ReassociationIndices> indices;
-        for (auto i = 0; i <= (long)inShape.size(); i++) {
-          if (i == (long)dim) {
-            indices.push_back({i, ++i});
-            continue;
-          }
-          indices.push_back({i});
-        }
-
-        auto retType = inType.clone(makeShapeLLVMCompatible(outShape));
-        return rewriter.create<tensor::ExpandShapeOp>(loc, retType, tensor,
-                                                      indices);
+      switch (numSpatialDims) {
+      case 2:
+        conv = rewriter
+                   .create<linalg::Conv2DNhwcHwcfQOp>(
+                       loc, outputTensor.getType(),
+                       ValueRange{paddedInput, weight, inputZp, weightZp},
+                       outputTensor, stridesAttr, dilationAttr)
+                   .getResult(0);
+        break;
+      case 3:
+        conv = rewriter
+                   .create<linalg::Conv3DNdhwcDhwcfQOp>(
+                       loc, outputTensor.getType(),
+                       ValueRange{paddedInput, weight, inputZp, weightZp},
+                       outputTensor, stridesAttr, dilationAttr)
+                   .getResult(0);
+        break;
+      default:
+        return rewriter.notifyMatchFailure(
+            op, "unimplemented: only 1D, 2D, and 3D convolution supported");
       };
 
-      // expand F,C,H,W -> G,F/G,C,H,W
-      auto expandWeight = [&](Value tensor) {
-        auto inType = tensor.getType().cast<RankedTensorType>();
-        auto inShape = makeShapeTorchCompatible(inType.getShape());
+      llvm::SmallVector<int64_t> outPerms;
+      outPerms.push_back(0);
+      outPerms.push_back(inPerms.size() - 1);
+      for (size_t i = 0; i < numSpatialDims; ++i) {
+        outPerms.push_back(i + 1);
+      }
+      conv = transposeValue(op.getLoc(), conv, outPerms, rewriter);
 
-        SmallVector<int64_t> outShape{
-            groupSize, (inShape[0] == kUnknownSize ? kUnknownSize
-                                                   : inShape[0] / groupSize)};
-        outShape.append(inShape.begin() + 1, inShape.end());
-
-        SmallVector<ReassociationIndices> indices{{0, 1}};
-        for (auto i = 2; i <= (long)inShape.size(); i++)
-          indices.push_back({i});
-
-        auto retType = inType.clone(makeShapeLLVMCompatible(outShape));
-        return rewriter.create<tensor::ExpandShapeOp>(loc, retType, tensor,
-                                                      indices);
-      };
-
-      Value paddedInputExpanded = expandGroups(paddedInput, 1);
-      Value weightExpanded = expandWeight(weight);
-      auto expandOutputTensor = expandGroups(outputTensor, 1);
-
-      // TODO: add 1D and 3D case
-      conv = rewriter
-                 .create<linalg::Conv2DNgchwGfchwOp>(
-                     loc, expandOutputTensor.getResultType(),
-                     ValueRange{paddedInputExpanded, weightExpanded},
-                     expandOutputTensor.getResult(), stridesAttr, dilationAttr)
-                 .getResult(0);
-
-      conv = rewriter.create<tensor::CollapseShapeOp>(
-          loc, outputTensor.getType(), conv,
-          expandOutputTensor.getReassociationIndices());
       Type newResultType = getTypeConverter()->convertType(op.getType());
       rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, conv);
       return success();
     }
+
+    if (inputZp || weightZp)
+      return rewriter.notifyMatchFailure(
+          op, "unimplemented: quantized grouped convolutions");
+
+    if (numSpatialDims != 2)
+      return rewriter.notifyMatchFailure(
+          op, "unimplemented: only 2D grouped convolution supported");
+
+    // Special depthwise case
+    auto inShape = makeShapeTorchCompatible(
+        input.getType().cast<RankedTensorType>().getShape());
+    auto weightShape = makeShapeTorchCompatible(
+        weight.getType().cast<RankedTensorType>().getShape());
+    if (weightShape[0] != kUnknownSize && inShape[1] == groupSize &&
+        weightShape[0] % inShape[1] == 0 && weightShape[1] == 1) {
+      // Collapse weight shape
+      SmallVector<ReassociationIndices, 4> collapsedDims = {{0, 1}, {2}, {3}};
+      SmallVector<int64_t> collapsedShape{
+          (weightShape[0] == kUnknownSize ? kUnknownSize
+                                          : weightShape[0] * weightShape[1]),
+          weightShape[2], weightShape[3]};
+      Type collapsedType = RankedTensorType::get(
+          makeShapeLLVMCompatible(collapsedShape), weightDTy);
+      Value collapsedWeight = rewriter.create<tensor::CollapseShapeOp>(
+          loc, collapsedType, weight, collapsedDims);
+
+      conv = rewriter
+                 .create<linalg::DepthwiseConv2DNchwChwOp>(
+                     loc, outputTensor.getType(),
+                     ValueRange{paddedInput, collapsedWeight}, outputTensor,
+                     stridesAttr, dilationAttr)
+                 .getResult(0);
+
+      Type newResultType = getTypeConverter()->convertType(op.getType());
+      rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, conv);
+      return success();
+    }
+
+    // Grouped case, use the grouped conv linalg op
+    auto expandGroups = [&](Value tensor, size_t dim) {
+      auto inType = tensor.getType().cast<RankedTensorType>();
+      auto inShape = makeShapeTorchCompatible(inType.getShape());
+
+      SmallVector<int64_t> outShape;
+      for (auto i = 0; i < (long)inShape.size(); i++) {
+        if (i == 1) {
+          outShape.push_back(groupSize);
+        }
+        if (i == (long)dim) {
+          outShape.push_back(inShape[i] == kUnknownSize
+                                 ? kUnknownSize
+                                 : inShape[i] / groupSize);
+        } else {
+          outShape.push_back(inShape[i]);
+        }
+      }
+
+      SmallVector<ReassociationIndices> indices;
+      for (auto i = 0; i <= (long)inShape.size(); i++) {
+        if (i == (long)dim) {
+          indices.push_back({i, ++i});
+          continue;
+        }
+        indices.push_back({i});
+      }
+
+      auto retType = inType.clone(makeShapeLLVMCompatible(outShape));
+      return rewriter.create<tensor::ExpandShapeOp>(loc, retType, tensor,
+                                                    indices);
+    };
+
+    // expand F,C,H,W -> G,F/G,C,H,W
+    auto expandWeight = [&](Value tensor) {
+      auto inType = tensor.getType().cast<RankedTensorType>();
+      auto inShape = makeShapeTorchCompatible(inType.getShape());
+
+      SmallVector<int64_t> outShape{
+          groupSize,
+          (inShape[0] == kUnknownSize ? kUnknownSize : inShape[0] / groupSize)};
+      outShape.append(inShape.begin() + 1, inShape.end());
+
+      SmallVector<ReassociationIndices> indices{{0, 1}};
+      for (auto i = 2; i <= (long)inShape.size(); i++)
+        indices.push_back({i});
+
+      auto retType = inType.clone(makeShapeLLVMCompatible(outShape));
+      return rewriter.create<tensor::ExpandShapeOp>(loc, retType, tensor,
+                                                    indices);
+    };
+
+    Value paddedInputExpanded = expandGroups(paddedInput, 1);
+    Value weightExpanded = expandWeight(weight);
+    auto expandOutputTensor = expandGroups(outputTensor, 1);
+
+    // TODO: add 1D and 3D case
+    conv = rewriter
+               .create<linalg::Conv2DNgchwGfchwOp>(
+                   loc, expandOutputTensor.getResultType(),
+                   ValueRange{paddedInputExpanded, weightExpanded},
+                   expandOutputTensor.getResult(), stridesAttr, dilationAttr)
+               .getResult(0);
+
+    conv = rewriter.create<tensor::CollapseShapeOp>(
+        loc, outputTensor.getType(), conv,
+        expandOutputTensor.getReassociationIndices());
+    Type newResultType = getTypeConverter()->convertType(op.getType());
+    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, conv);
+    return success();
   }
 };
 } // namespace

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -624,7 +624,7 @@ public:
     Value bias = adaptor.getBias();
     auto resultTy = op.getType().cast<ValueTensorType>();
 
-    Value inputZp, weightZp, biasZp;
+    Value inputZp, weightZp;
     if (auto make = op.getInput()
                         .getDefiningOp<Aten_MakePerTensorQuantizedTensorOp>()) {
       input = make.getSelf();

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -845,10 +845,9 @@ public:
       // Set stride to 1
       strideInts.clear();
       strideInts.append(numSpatialDims, 1);
-
     } else {
       Value pad = inputZp;
-      if (!inputZp) {
+      if (!pad) {
         if (isa<mlir::FloatType>(inputDTy))
           pad = rewriter.create<arith::ConstantOp>(
               op.getLoc(), rewriter.getFloatAttr(inputDTy, 0.0));
@@ -857,14 +856,12 @@ public:
               op.getLoc(), rewriter.getIntegerAttr(inputDTy, 0));
       }
 
-      if (inputZp.getType() != inputDTy) {
+      if (pad.getType() != inputDTy) {
         if (isa<mlir::FloatType>(inputDTy))
-          pad =
-              rewriter.create<arith::TruncFOp>(op.getLoc(), inputDTy, inputZp);
+          pad = rewriter.create<arith::TruncFOp>(op.getLoc(), inputDTy, pad);
 
         if (isa<mlir::IntegerType>(inputDTy))
-          pad =
-              rewriter.create<arith::TruncIOp>(op.getLoc(), inputDTy, inputZp);
+          pad = rewriter.create<arith::TruncIOp>(op.getLoc(), inputDTy, pad);
       }
 
       // Pad input

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -2238,7 +2238,6 @@ public:
     auto qoperand = op.getOperand();
     auto make = qoperand.getDefiningOp<Aten_MakePerChannelQuantizedTensorOp>();
     if (!make) {
-      llvm::errs() << "Did not find make per channel\n";
       return rewriter.notifyMatchFailure(op, "did not find per channel qint");
     }
 

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -1356,8 +1356,6 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
     }
 
     if (!zp || !scale) {
-      op->emitWarning(
-          "unimplemented: dequantizing tensor of unknown scale / zero-point");
       return nullptr;
     }
 

--- a/lib/Conversion/TorchToLinalg/Utils.cpp
+++ b/lib/Conversion/TorchToLinalg/Utils.cpp
@@ -70,7 +70,7 @@ Value torch_to_linalg::getZeroPaddedTensor(
 // padding value is zero.
 Value torch_to_linalg::getDynamicZeroPaddedTensor(
     Operation *op, OpBuilder &b, Value &input, SmallVectorImpl<Value> &padding,
-    int unpaddedDims) {
+    int unpaddedDims, Value pad) {
   assert(input.getType().isa<RankedTensorType>() &&
          "input must be RankedTensorType");
   unsigned int inRank = input.getType().cast<RankedTensorType>().getRank();
@@ -93,12 +93,10 @@ Value torch_to_linalg::getDynamicZeroPaddedTensor(
                                 SmallVector<int64_t>(inRank, kUnknownSize))),
                             elementType);
 
-  Value cf0 =
-      b.create<arith::ConstantOp>(loc, b.getFloatAttr(elementType, 0.0));
   SmallVector<OpFoldResult> paddingValues =
       getAsOpFoldResult(paddingIncludingUnchanged);
   return b.create<tensor::PadOp>(loc, inputType, input, /*low=*/paddingValues,
-                                 /*high=*/paddingValues, cf0);
+                                 /*high=*/paddingValues, pad);
 }
 
 Value torch_to_linalg::getOutputDimForConvOps(OpBuilder &b, Location loc,

--- a/lib/Dialect/Torch/Transforms/FuseQuantizedOps.cpp
+++ b/lib/Dialect/Torch/Transforms/FuseQuantizedOps.cpp
@@ -102,14 +102,16 @@ public:
         op.getLoc(), newBiasTy, bias, biasScale, zero, dtype);
     bias = rewriter.create<AtenIntReprOp>(
         op.getLoc(),
-        rewriter.getType<ValueTensorType>(biasTy.getOptionalSizes(),
-                                          rewriter.getI32Type()),
+        rewriter.getType<ValueTensorType>(
+            biasTy.getOptionalSizes(),
+            rewriter.getIntegerType(32, IntegerType::isSigned)),
         bias);
 
     operands[2] = bias;
 
-    auto convTy = rewriter.getType<ValueTensorType>(resultTy.getOptionalSizes(),
-                                                    rewriter.getI32Type());
+    auto convTy = rewriter.getType<ValueTensorType>(
+        resultTy.getOptionalSizes(),
+        rewriter.getIntegerType(32, IntegerType::isSigned));
     auto conv = rewriter.create<SrcOp>(op.getLoc(), convTy, operands);
 
     auto convQTy =

--- a/lib/Dialect/Torch/Transforms/FuseQuantizedOps.cpp
+++ b/lib/Dialect/Torch/Transforms/FuseQuantizedOps.cpp
@@ -104,14 +104,14 @@ public:
         op.getLoc(),
         rewriter.getType<ValueTensorType>(
             biasTy.getOptionalSizes(),
-            rewriter.getIntegerType(32, IntegerType::isSigned)),
+            rewriter.getIntegerType(32, IntegerType::Signed)),
         bias);
 
     operands[2] = bias;
 
     auto convTy = rewriter.getType<ValueTensorType>(
         resultTy.getOptionalSizes(),
-        rewriter.getIntegerType(32, IntegerType::isSigned));
+        rewriter.getIntegerType(32, IntegerType::Signed));
     auto conv = rewriter.create<SrcOp>(op.getLoc(), convTy, operands);
 
     auto convQTy =

--- a/lib/Dialect/Torch/Transforms/FuseQuantizedOps.cpp
+++ b/lib/Dialect/Torch/Transforms/FuseQuantizedOps.cpp
@@ -30,7 +30,7 @@ public:
     llvm::SmallVector<Value> operands(op->getOperands());
 
     bool dequanted = false;
-    for (auto &operand : operands) {
+    auto f = [&dequanted](Value operand) {
       if (auto dequant = operand.getDefiningOp<AtenDequantizeTensorOp>()) {
         operand = dequant.getOperand();
         dequanted = true;
@@ -39,7 +39,11 @@ public:
         operand = dequant.getOperand();
         dequanted = true;
       }
-    }
+      return operand;
+    };
+
+    operands[0] = f(operands[0]);
+    operands[1] = f(operands[1]);
 
     if (!dequanted) {
       return rewriter.notifyMatchFailure(op, "no dequantizations found");
@@ -77,6 +81,7 @@ public:
     if (!rhsScale || !lhsScale)
       return failure();
 
+    auto resultTy = cast<ValueTensorType>(op.getType());
     auto biasTy = bias.getType().cast<ValueTensorType>();
     auto biasETy = biasTy.getOptionalDtype();
     if (!biasETy || !isa<mlir::FloatType>(biasETy))
@@ -95,9 +100,25 @@ public:
     Value dtype = getDtypeIntValueForType(rewriter, op.getLoc(), qi32Ty);
     bias = rewriter.create<AtenQuantizePerTensorOp>(
         op.getLoc(), newBiasTy, bias, biasScale, zero, dtype);
+    bias = rewriter.create<AtenIntReprOp>(
+        op.getLoc(),
+        rewriter.getType<ValueTensorType>(biasTy.getOptionalSizes(),
+                                          rewriter.getI32Type()),
+        bias);
 
     operands[2] = bias;
-    rewriter.replaceOpWithNewOp<SrcOp>(op, op.getType(), operands);
+
+    auto convTy = rewriter.getType<ValueTensorType>(resultTy.getOptionalSizes(),
+                                                    rewriter.getI32Type());
+    auto conv = rewriter.create<SrcOp>(op.getLoc(), convTy, operands);
+
+    auto convQTy =
+        rewriter.getType<ValueTensorType>(resultTy.getOptionalSizes(), qi32Ty);
+    auto makeOut = rewriter.create<Aten_MakePerTensorQuantizedTensorOp>(
+        op.getLoc(), convQTy, conv, biasScale, zero);
+    rewriter.replaceOpWithNewOp<AtenDequantizeTensorOp>(op, op.getType(),
+                                                        makeOut);
+
     return success();
   }
 };
@@ -151,7 +172,7 @@ public:
         rewriter.getType<ValueTensorType>(resultTy.getOptionalSizes(), qi32Ty);
     auto conv = rewriter.create<SrcOp>(op.getLoc(), newResultTy, operands);
 
-    // Attach the quantize information to the resulting quint32:
+    // Attach the quantize information to the resulting qint32:
     auto intReprTy = rewriter.getType<ValueTensorType>(
         resultTy.getOptionalSizes(),
         rewriter.getIntegerType(32, IntegerType::Signed));
@@ -194,7 +215,6 @@ public:
                 RemoveUnused<AtenDequantizeTensorOp>,
                 RemoveUnused<AtenQuantizePerTensorOp>,
                 QuantizeOperands<AtenConvolutionOp>, QuantizeOperands<AtenMmOp>,
-                QuantizeAccumulator<AtenConvolutionOp>,
                 QuantizeAccumulator<AtenMmOp>, QuantizeBias<AtenConvolutionOp>>(
             context);
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -317,6 +317,7 @@ TORCHDYNAMO_XFAIL_SET = {
     "ElementwiseDequantizePerTensorModule_basic",
     "ElementwiseQuantizePerTensorModule_basic",
     "AtenMmQuint8_basic",
+    "Conv2dQInt8Module_basic",
 
     # Dynamo not supporting conv_tbc
     "ConvTbcModule_basic",

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1541,4 +1541,5 @@ LTC_XFAIL_SET = {
     "ElementwiseBitwiseAndScalarInt64Module_basic",
     "ElementwiseBitwiseAndScalarInt32Module_basic",
     "ElementwiseBitwiseAndScalarInt8Module_basic",
+    "Conv2dQInt8Module_basic",
 }

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
@@ -858,37 +858,37 @@ class ConvTbcModule(torch.nn.Module):
 def ConvTbcModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(9, 4, 5), tu.rand(3, 5, 6), tu.rand(6))
 
-# class Conv2dQInt8Module(torch.nn.Module):
-#     def __init__(self):
-#         super().__init__()
-# 
-#     @export
-#     @annotate_args([
-#         None,
-#         ([-1, -1, -1, -1], torch.int8, True),
-#         ([-1, -1, -1, -1], torch.int8, True),
-#         ([-1], torch.float, True),
-#     ])
-#     def forward(self, inputVec, weight, bias):
-#         inputVec = torch._make_per_tensor_quantized_tensor(inputVec, 0.01, 7)
-#         inputVec = torch.dequantize(inputVec)
-# 
-#         weight = torch._make_per_tensor_quantized_tensor(weight, 0.01, 3)
-#         weight = torch.dequantize(weight)
-# 
-#         bias = torch.quantize_per_tensor(bias, 0.0001, 0, torch.qint32)
-#         bias = torch.dequantize(bias)
-# 
-#         return torch.ops.aten.conv2d(inputVec,
-#                                      weight,
-#                                      bias=bias,
-#                                      stride=[1, 1],
-#                                      padding=[0, 0],
-#                                      dilation=[1, 1],
-#                                      groups=1)
-# @register_test_case(module_factory=lambda: Conv2dQInt8Module())
-# def Conv2dQInt8Module_basic(module, tu: TestUtils):
-#     inputVec = tu.randint(2, 4, 7, 8, low=-128, high=127).to(torch.int8)
-#     weight = tu.randint(3, 4, 3, 2, low=-128, high=127).to(torch.int8)
-#     bias = torch.rand(3)
-#     module.forward(inputVec, weight, bias)
+class Conv2dQInt8Module(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.int8, True),
+        ([-1, -1, -1, -1], torch.int8, True),
+        ([-1], torch.float, True),
+    ])
+    def forward(self, inputVec, weight, bias):
+        inputVec = torch._make_per_tensor_quantized_tensor(inputVec, 0.01, 7)
+        inputVec = torch.dequantize(inputVec)
+
+        weight = torch._make_per_tensor_quantized_tensor(weight, 0.01, 3)
+        weight = torch.dequantize(weight)
+
+        bias = torch.quantize_per_tensor(bias, 0.0001, 0, torch.qint32)
+        bias = torch.dequantize(bias)
+
+        return torch.ops.aten.conv2d(inputVec,
+                                     weight,
+                                     bias=bias,
+                                     stride=[1, 1],
+                                     padding=[0, 0],
+                                     dilation=[1, 1],
+                                     groups=1)
+@register_test_case(module_factory=lambda: Conv2dQInt8Module())
+def Conv2dQInt8Module_basic(module, tu: TestUtils):
+    inputVec = tu.randint(2, 4, 7, 8, low=-128, high=127).to(torch.int8)
+    weight = tu.randint(3, 4, 3, 2, low=-128, high=127).to(torch.int8)
+    bias = torch.rand(3)
+    module.forward(inputVec, weight, bias)

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
@@ -858,37 +858,37 @@ class ConvTbcModule(torch.nn.Module):
 def ConvTbcModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(9, 4, 5), tu.rand(3, 5, 6), tu.rand(6))
 
-class Conv2dQInt8Module(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    @export
-    @annotate_args([
-        None,
-        ([-1, -1, -1, -1], torch.int8, True),
-        ([-1, -1, -1, -1], torch.int8, True),
-        ([-1], torch.float, True),
-    ])
-    def forward(self, inputVec, weight, bias):
-        inputVec = torch._make_per_tensor_quantized_tensor(inputVec, 0.01, 7)
-        inputVec = torch.dequantize(inputVec)
-
-        weight = torch._make_per_tensor_quantized_tensor(weight, 0.01, 3)
-        weight = torch.dequantize(weight)
-
-        bias = torch.quantize_per_tensor(bias, 0.0001, 0, torch.qint32)
-        bias = torch.dequantize(bias)
-
-        return torch.ops.aten.conv2d(inputVec,
-                                     weight,
-                                     bias=bias,
-                                     stride=[1, 1],
-                                     padding=[0, 0],
-                                     dilation=[1, 1],
-                                     groups=1)
-@register_test_case(module_factory=lambda: Conv2dQInt8Module())
-def Conv2dQInt8Module_basic(module, tu: TestUtils):
-    inputVec = tu.randint(2, 4, 7, 8, low=-128, high=127).to(torch.int8)
-    weight = tu.randint(3, 4, 3, 2, low=-128, high=127).to(torch.int8)
-    bias = torch.rand(3)
-    module.forward(inputVec, weight, bias)
+# class Conv2dQInt8Module(torch.nn.Module):
+#     def __init__(self):
+#         super().__init__()
+# 
+#     @export
+#     @annotate_args([
+#         None,
+#         ([-1, -1, -1, -1], torch.int8, True),
+#         ([-1, -1, -1, -1], torch.int8, True),
+#         ([-1], torch.float, True),
+#     ])
+#     def forward(self, inputVec, weight, bias):
+#         inputVec = torch._make_per_tensor_quantized_tensor(inputVec, 0.01, 7)
+#         inputVec = torch.dequantize(inputVec)
+# 
+#         weight = torch._make_per_tensor_quantized_tensor(weight, 0.01, 3)
+#         weight = torch.dequantize(weight)
+# 
+#         bias = torch.quantize_per_tensor(bias, 0.0001, 0, torch.qint32)
+#         bias = torch.dequantize(bias)
+# 
+#         return torch.ops.aten.conv2d(inputVec,
+#                                      weight,
+#                                      bias=bias,
+#                                      stride=[1, 1],
+#                                      padding=[0, 0],
+#                                      dilation=[1, 1],
+#                                      groups=1)
+# @register_test_case(module_factory=lambda: Conv2dQInt8Module())
+# def Conv2dQInt8Module_basic(module, tu: TestUtils):
+#     inputVec = tu.randint(2, 4, 7, 8, low=-128, high=127).to(torch.int8)
+#     weight = tu.randint(3, 4, 3, 2, low=-128, high=127).to(torch.int8)
+#     bias = torch.rand(3)
+#     module.forward(inputVec, weight, bias)

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
@@ -857,3 +857,38 @@ class ConvTbcModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ConvTbcModule())
 def ConvTbcModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(9, 4, 5), tu.rand(3, 5, 6), tu.rand(6))
+
+class Conv2dQInt8Module(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.int8, True),
+        ([-1, -1, -1, -1], torch.int8, True),
+        ([-1], torch.float, True),
+    ])
+    def forward(self, inputVec, weight, bias):
+        inputVec = torch._make_per_tensor_quantized_tensor(inputVec, 0.01, 7)
+        inputVec = torch.dequantize(inputVec)
+
+        weight = torch._make_per_tensor_quantized_tensor(weight, 0.01, 3)
+        weight = torch.dequantize(weight)
+
+        bias = torch.quantize_per_tensor(bias, 0.0001, 0, torch.qint32)
+        bias = torch.dequantize(bias)
+
+        return torch.ops.aten.conv2d(inputVec,
+                                     weight,
+                                     bias=bias,
+                                     stride=[1, 1],
+                                     padding=[0, 0],
+                                     dilation=[1, 1],
+                                     groups=1)
+@register_test_case(module_factory=lambda: Conv2dQInt8Module())
+def Conv2dQInt8Module_basic(module, tu: TestUtils):
+    inputVec = tu.randint(2, 4, 7, 8, low=-128, high=127).to(torch.int8)
+    weight = tu.randint(3, 4, 3, 2, low=-128, high=127).to(torch.int8)
+    bias = torch.rand(3)
+    module.forward(inputVec, weight, bias)

--- a/test/Dialect/Torch/fuse-quantized-ops.mlir
+++ b/test/Dialect/Torch/fuse-quantized-ops.mlir
@@ -43,20 +43,20 @@ func.func @convolution(%arg0: !torch.vtensor<[1,3,8,8],si8>, %arg1: !torch.vtens
   %15 = torch.prim.ListConstruct %zero, %zero : (!torch.int, !torch.int) -> !torch.list<int>
   %16 = torch.aten.convolution %7, %13, %arg2, %14, %15, %14, %false, %15, %one : !torch.vtensor<[1,3,8,8],f32>, !torch.vtensor<[3,3,2,2],f32>, !torch.vtensor<[3],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,3,7,7],f32>
 
-  // CHECK-DAG: %[[ZERO:.+]] = torch.constant.int 0
-  // CHECK-DAG: %[[SCALEO:.+]] = torch.constant.float 2.500000e-01
-  // CHECK-DAG: %[[DTYPE:.+]] = torch.constant.int 14
-  // CHECK-DAG: %[[HALF:.+]] = torch.constant.float 5.000000e-01
-  // CHECK-DAG: %[[FALSE:.+]] = torch.constant.bool false
-  // CHECK-DAG: %[[ONE:.+]] = torch.constant.int 1
-  // CHECK-DAG: %[[QLHS:.+]] = torch.aten._make_per_tensor_quantized_tensor %arg0, %[[HALF]], %[[ONE]] : !torch.vtensor<[1,3,8,8],si8>, !torch.float, !torch.int -> !torch.vtensor<[1,3,8,8],!torch.qint8>
-  // CHECK-DAG: %[[QRHS:.+]] = torch.aten._make_per_tensor_quantized_tensor %arg1, %[[HALF]], %[[ZERO]] : !torch.vtensor<[3,3,2,2],si8>, !torch.float, !torch.int -> !torch.vtensor<[3,3,2,2],!torch.qint8>
-  // CHECK-DAG: %[[ONES:.+]] = torch.prim.ListConstruct %[[ONE]], %[[ONE]] : (!torch.int, !torch.int) -> !torch.list<int>
-  // CHECK-DAG: %[[ZEROS:.+]] = torch.prim.ListConstruct %[[ZERO]], %[[ZERO]] : (!torch.int, !torch.int) -> !torch.list<int>
-  // CHECK-DAG: %[[QBIAS:.+]] = torch.aten.quantize_per_tensor %arg2, %[[SCALEO]], %[[ZERO]], %[[DTYPE]] : !torch.vtensor<[3],f32>, !torch.float, !torch.int, !torch.int -> !torch.vtensor<[3],!torch.qint32>
-  // CHECK-DAG: %[[CONV:.+]] = torch.aten.convolution %[[QLHS]], %[[QRHS]], %[[QBIAS]], %[[ONES]], %[[ZEROS]], %[[ONES]], %[[FALSE]], %[[ZEROS]], %[[ONE]] : !torch.vtensor<[1,3,8,8],!torch.qint8>, !torch.vtensor<[3,3,2,2],!torch.qint8>, !torch.vtensor<[3],!torch.qint32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,3,7,7],!torch.qint32>
-  // CHECK-DAG: %[[INT:.+]] = torch.aten.int_repr %[[CONV]] : !torch.vtensor<[1,3,7,7],!torch.qint32> -> !torch.vtensor<[1,3,7,7],si32>
-  // CHECK-DAG: %[[QOUT:.+]] = torch.aten._make_per_tensor_quantized_tensor %[[INT]], %[[SCALEO]], %[[ZERO]] : !torch.vtensor<[1,3,7,7],si32>, !torch.float, !torch.int -> !torch.vtensor<[1,3,7,7],!torch.qint32>
+  // CHECK: %[[DTYPE:.+]] = torch.constant.int 14
+  // CHECK: %[[SCALEO:.+]] = torch.constant.float 2.500000e-01
+  // CHECK: %[[HALF:.+]] = torch.constant.float 5.000000e-01
+  // CHECK: %[[FALSE:.+]] = torch.constant.bool false
+  // CHECK: %[[ZERO:.+]] = torch.constant.int 0
+  // CHECK: %[[ONE:.+]] = torch.constant.int 1
+  // CHECK: %[[QLHS:.+]] = torch.aten._make_per_tensor_quantized_tensor %arg0, %[[HALF]], %[[ONE]] : !torch.vtensor<[1,3,8,8],si8>, !torch.float, !torch.int -> !torch.vtensor<[1,3,8,8],!torch.qint8>
+  // CHECK: %[[QRHS:.+]] = torch.aten._make_per_tensor_quantized_tensor %arg1, %[[HALF]], %[[ZERO]] : !torch.vtensor<[3,3,2,2],si8>, !torch.float, !torch.int -> !torch.vtensor<[3,3,2,2],!torch.qint8>
+  // CHECK: %[[ONES:.+]] = torch.prim.ListConstruct %[[ONE]], %[[ONE]] : (!torch.int, !torch.int) -> !torch.list<int>
+  // CHECK: %[[ZEROS:.+]] = torch.prim.ListConstruct %[[ZERO]], %[[ZERO]] : (!torch.int, !torch.int) -> !torch.list<int>
+  // CHECK: %[[QBIAS:.+]] = torch.aten.quantize_per_tensor %arg2, %[[SCALEO]], %[[ZERO]], %[[DTYPE]] : !torch.vtensor<[3],f32>, !torch.float, !torch.int, !torch.int -> !torch.vtensor<[3],!torch.qint32>
+  // CHECK: %[[INT:.+]] = torch.aten.int_repr %[[QBIAS]] : !torch.vtensor<[3],!torch.qint32> -> !torch.vtensor<[3],i32>
+  // CHECK: %[[CONV:.+]] = torch.aten.convolution %[[QLHS]], %[[QRHS]], %[[INT]], %[[ONES]], %[[ZEROS]], %[[ONES]], %[[FALSE]], %[[ZEROS]], %[[ONE]] : !torch.vtensor<[1,3,8,8],!torch.qint8>, !torch.vtensor<[3,3,2,2],!torch.qint8>, !torch.vtensor<[3],i32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,3,7,7],i32>
+  // CHECK: %[[QOUT:.+]] = torch.aten._make_per_tensor_quantized_tensor %[[CONV]], %[[SCALEO]], %[[ZERO]] : !torch.vtensor<[1,3,7,7],i32>, !torch.float, !torch.int -> !torch.vtensor<[1,3,7,7],!torch.qint32>
   // CHECK: %[[FOUT:.+]] = torch.aten.dequantize.tensor %[[QOUT]] : !torch.vtensor<[1,3,7,7],!torch.qint32> -> !torch.vtensor<[1,3,7,7],f32>
   return %16 : !torch.vtensor<[1,3,7,7],f32>
 }

--- a/test/Dialect/Torch/fuse-quantized-ops.mlir
+++ b/test/Dialect/Torch/fuse-quantized-ops.mlir
@@ -54,9 +54,9 @@ func.func @convolution(%arg0: !torch.vtensor<[1,3,8,8],si8>, %arg1: !torch.vtens
   // CHECK: %[[ONES:.+]] = torch.prim.ListConstruct %[[ONE]], %[[ONE]] : (!torch.int, !torch.int) -> !torch.list<int>
   // CHECK: %[[ZEROS:.+]] = torch.prim.ListConstruct %[[ZERO]], %[[ZERO]] : (!torch.int, !torch.int) -> !torch.list<int>
   // CHECK: %[[QBIAS:.+]] = torch.aten.quantize_per_tensor %arg2, %[[SCALEO]], %[[ZERO]], %[[DTYPE]] : !torch.vtensor<[3],f32>, !torch.float, !torch.int, !torch.int -> !torch.vtensor<[3],!torch.qint32>
-  // CHECK: %[[INT:.+]] = torch.aten.int_repr %[[QBIAS]] : !torch.vtensor<[3],!torch.qint32> -> !torch.vtensor<[3],i32>
-  // CHECK: %[[CONV:.+]] = torch.aten.convolution %[[QLHS]], %[[QRHS]], %[[INT]], %[[ONES]], %[[ZEROS]], %[[ONES]], %[[FALSE]], %[[ZEROS]], %[[ONE]] : !torch.vtensor<[1,3,8,8],!torch.qint8>, !torch.vtensor<[3,3,2,2],!torch.qint8>, !torch.vtensor<[3],i32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,3,7,7],i32>
-  // CHECK: %[[QOUT:.+]] = torch.aten._make_per_tensor_quantized_tensor %[[CONV]], %[[SCALEO]], %[[ZERO]] : !torch.vtensor<[1,3,7,7],i32>, !torch.float, !torch.int -> !torch.vtensor<[1,3,7,7],!torch.qint32>
+  // CHECK: %[[INT:.+]] = torch.aten.int_repr %[[QBIAS]] : !torch.vtensor<[3],!torch.qint32> -> !torch.vtensor<[3],si32>
+  // CHECK: %[[CONV:.+]] = torch.aten.convolution %[[QLHS]], %[[QRHS]], %[[INT]], %[[ONES]], %[[ZEROS]], %[[ONES]], %[[FALSE]], %[[ZEROS]], %[[ONE]] : !torch.vtensor<[1,3,8,8],!torch.qint8>, !torch.vtensor<[3,3,2,2],!torch.qint8>, !torch.vtensor<[3],si32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,3,7,7],si32>
+  // CHECK: %[[QOUT:.+]] = torch.aten._make_per_tensor_quantized_tensor %[[CONV]], %[[SCALEO]], %[[ZERO]] : !torch.vtensor<[1,3,7,7],si32>, !torch.float, !torch.int -> !torch.vtensor<[1,3,7,7],!torch.qint32>
   // CHECK: %[[FOUT:.+]] = torch.aten.dequantize.tensor %[[QOUT]] : !torch.vtensor<[1,3,7,7],!torch.qint32> -> !torch.vtensor<[1,3,7,7],f32>
   return %16 : !torch.vtensor<[1,3,7,7],f32>
 }


### PR DESCRIPTION
Linalg has quantized specific operations. We can lower to these
operations when there is a known zeropoint and scale operations. This
allows the `convolution` to occur with lower bitwidth's, improving the
overall performance.