### PR TITLE
[onnx] Import `onnx` constants as `onnx.Constant` instead of literals

### DIFF
--- a/python/torch_mlir/extras/onnx_importer.py
+++ b/python/torch_mlir/extras/onnx_importer.py
@@ -343,10 +343,14 @@ class NodeImporter:
         with InsertionPoint(self._b), Location.name(iname):
             value_attr = self._cc.tensor_proto_to_attr(initializer)
             vtensor_type = self._cc.tensor_proto_to_type(initializer)
+            attrs = {
+                "name": StringAttr.get(f"onnx.Constant"),
+                "torch.onnx.value": value_attr,
+            }
             literal_op = Operation.create(
-                name="torch.vtensor.literal",
+                name="torch.operator",
                 results=[vtensor_type],
-                attributes={"value": value_attr},
+                attributes=attrs,
             )
             self._nv_map[iname] = literal_op.result
         return literal_op.result


### PR DESCRIPTION
To handle the conversion from raw bytes to `DenseElementsAttr` we need
to handle the endianness conversion during `torch-onnx-to-torch`.
Therefore when importing `onnx.Constant` it is better to represent using
the `onnx` constant operation so that only one location requires the
endianness correction.