### PR TITLE
[torch-mlir][sparse] add sparsification mini-pipeline to linalg reference backend

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -131,8 +131,13 @@ LOWERING_PIPELINE = "builtin.module(" + ",".join([
     # This is likely because if things are naturally fusable we usually already
     # emit things in that form from the high level (e.g. single linalg-generic).
     # Other backends are likely to benefit more.
+    "func.func(linalg-generalize-named-ops)",
     "func.func(linalg-fuse-elementwise-ops)",
     "convert-shape-to-std",
+    # MLIR Sparsifier mini-pipeline. Note that this is the bare minimum
+    # to ensure operations on sparse tensors are lowered to loops.
+    "sparsification-and-bufferization",
+    "sparse-storage-specifier-to-llvm",
     # Bufferize.
     "func.func(scf-bufferize)",
     "func.func(tm-tensor-bufferize)",
@@ -196,10 +201,11 @@ class RefBackendLinalgOnTensorsBackend(LinalgOnTensorsBackend):
           An opaque, backend specific compiled artifact object that can be
           passed to `load`.
         """
-
         run_pipeline_with_repro_report(
             imported_module, LOWERING_PIPELINE,
-            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend")
+            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend",
+            enable_ir_printing=False,
+        )
         return imported_module
 
     def load(self, module) -> RefBackendInvoker:


### PR DESCRIPTION
This adds a few passes that will ensure linalg with sparse tensors are properly lowered to loops and can run using the ExecutionEngine for testing (a few details on parameter passing from PyTorch still TBD)

Running the tests as

$ ./tools/e2e_test.sh --config linalg

with the extra passes still yields

Summary:
    Passed: 1144
    Expectedly Failed: 8