### PR TITLE
add pre-commit hooks for some simple checks + clang format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    # -   id: check-added-large-files
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v15.0.7
+    hooks:
+    -   id: clang-format

--- a/build_tools/pre-commit.pyz
+++ b/build_tools/pre-commit.pyz
@@ -1,0 +1,1 @@
+pre-commit-3.6.0.pyz


### PR DESCRIPTION
I want to live in a world where I never even have to think of clang-format and it's just automatically done for me upon every commit.

This is a WIP proof-of-concept.

This currently clang-formats upon every commit and halts the commit and prompts you to review the clang-format changes.  Still figuring out how to make it just silently commit the formatted files.