### PR TITLE
Add support for bfloat16 in fximporter

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1045,10 +1045,12 @@ def _make_vtensor_literal_op(
 ) -> Operation:
     mapping = py_attr_tracker.track(tensor)
     if mapping.is_empty:
+        # check support for bfloat16
+        assert (
+            not (tensor.dtype == torch.bfloat16 and ml_dtypes is None)
+        ), f'torch.bfloat16 requires the mldtypes package, please run:\n\npip install ml_dtypes\n')
         # Resolve the attribute.
         npy_dtype = TORCH_DTYPE_TO_NPY_TYPE.get(tensor.dtype)
-        if tensor.dtype == torch.bfloat16 and ml_dtypes is None:
-            print(f'torch.bfloat16 requires the mldtypes package, please run:\n\npip install ml_dtypes\n')
         assert (
             npy_dtype is not None
         ), f"Can not create literal tensor for unsupported datatype: {tensor.dtype}"

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1048,7 +1048,7 @@ def _make_vtensor_literal_op(
         # check support for bfloat16
         assert (
             not (tensor.dtype == torch.bfloat16 and ml_dtypes is None)
-        ), f"torch.bfloat16 requires the ml_dtypes package, please run:\n\npip install ml_dtypes\n")
+        ), f"torch.bfloat16 requires the ml_dtypes package, please run:\n\npip install ml_dtypes\n"
         # Resolve the attribute.
         npy_dtype = TORCH_DTYPE_TO_NPY_TYPE.get(tensor.dtype)
         assert (

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -42,7 +42,6 @@ from torch.fx import (
     Graph,
     GraphModule,
 )
-import ml_dtypes
 try:
     import ml_dtypes
 except ModuleNotFoundError:

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1047,6 +1047,8 @@ def _make_vtensor_literal_op(
     if mapping.is_empty:
         # Resolve the attribute.
         npy_dtype = TORCH_DTYPE_TO_NPY_TYPE.get(tensor.dtype)
+        if tensor.dtype == torch.bfloat16 and ml_dtypes is None:
+            print(f'torch.bfloat16 requires the mldtypes package, please run:\n\npip install ml_dtypes\n')
         assert (
             npy_dtype is not None
         ), f"Can not create literal tensor for unsupported datatype: {tensor.dtype}"

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1048,7 +1048,7 @@ def _make_vtensor_literal_op(
         # check support for bfloat16
         assert (
             not (tensor.dtype == torch.bfloat16 and ml_dtypes is None)
-        ), f'torch.bfloat16 requires the mldtypes package, please run:\n\npip install ml_dtypes\n')
+        ), f"torch.bfloat16 requires the mldtypes package, please run:\n\npip install ml_dtypes\n")
         # Resolve the attribute.
         npy_dtype = TORCH_DTYPE_TO_NPY_TYPE.get(tensor.dtype)
         assert (

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -42,7 +42,14 @@ from torch.fx import (
     Graph,
     GraphModule,
 )
-import ml_dtypes as mld
+import ml_dtypes
+try:
+    import ml_dtypes
+except ModuleNotFoundError:
+    # The third-party ml_dtypes package provides some optional
+    # low precision data-types. If used in this file, it is
+    # conditional.
+    ml_dtypes = None
 
 from torch.fx.node import (
     Argument as NodeArgument,
@@ -137,7 +144,6 @@ TORCH_DTYPE_TO_NPY_TYPE = {
     torch.int16: np.int16,
     torch.int32: np.int32,
     torch.int64: np.int64,
-    torch.bfloat16: mld.bfloat16,# , there's no equivalent np datatype so this isn't supported right now
     torch.float16: np.float16,
     torch.float32: np.float32,
     torch.float64: np.float64,
@@ -146,6 +152,8 @@ TORCH_DTYPE_TO_NPY_TYPE = {
     torch.complex64: np.complex64,
     torch.complex128: np.complex128,
 }
+if ml_dtypes is not None:
+    TORCH_DTYPE_TO_NPY_TYPE[torch.bfloat16] = ml_dtypes.bfloat16
 
 TORCH_DTYPE_TO_INT = {
     torch.uint8: 0,

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -42,6 +42,7 @@ from torch.fx import (
     Graph,
     GraphModule,
 )
+import ml_dtypes as mld
 
 from torch.fx.node import (
     Argument as NodeArgument,
@@ -136,7 +137,7 @@ TORCH_DTYPE_TO_NPY_TYPE = {
     torch.int16: np.int16,
     torch.int32: np.int32,
     torch.int64: np.int64,
-    # torch.bf16: None, there's no equivalent np datatype so this isn't supported right now
+    torch.bfloat16: mld.bfloat16,# , there's no equivalent np datatype so this isn't supported right now
     torch.float16: np.float16,
     torch.float32: np.float32,
     torch.float64: np.float64,
@@ -1061,7 +1062,7 @@ def _make_vtensor_literal_op(
                 type=element_type, array=np_tensor, shape=np_tensor.shape
             )
         else:
-            bytes_view = memoryview(np_tensor)
+            bytes_view = np_tensor.view(npy_dtype)
             tensor_type = create_mlir_tensor_type(tensor)
             shape_desc = "_".join([str(d) for d in tensor.shape])
             blob_name = f"torch_tensor_{shape_desc}_{str(tensor.dtype)}"

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1048,7 +1048,7 @@ def _make_vtensor_literal_op(
         # check support for bfloat16
         assert (
             not (tensor.dtype == torch.bfloat16 and ml_dtypes is None)
-        ), f"torch.bfloat16 requires the mldtypes package, please run:\n\npip install ml_dtypes\n")
+        ), f"torch.bfloat16 requires the ml_dtypes package, please run:\n\npip install ml_dtypes\n")
         # Resolve the attribute.
         npy_dtype = TORCH_DTYPE_TO_NPY_TYPE.get(tensor.dtype)
         assert (

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ pillow
 dill
 multiprocess
 onnx==1.15.0
+ml_dtypes

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,3 @@ pillow
 dill
 multiprocess
 onnx==1.15.0
-ml_dtypes


### PR DESCRIPTION
this introduces an additional soft dependency on the python ml_dtypes python packages in order to support bfloat16

Addresses #2843 