### PR TITLE
build: find Protobuf using config mode search

### DIFF
--- a/projects/onnx_c_importer/CMakeLists.txt
+++ b/projects/onnx_c_importer/CMakeLists.txt
@@ -2,17 +2,7 @@ message(STATUS "Enabling onnx_c_importer...")
 
 include(FetchContent)
 
-find_package(Protobuf)
-if(NOT Protobuf_FOUND)
-    message(FATAL_ERROR 
-        "In order to build C ONNX support, the Protobuf package must be installed "
-        "on the system. Without this ONNX will attempt to build it in the project "
-        "and the dependent ABSEIL build system is incompatible. "
-        "On Ubuntu, install with: "
-        "apt install libprotobuf-dev protobuf-compiler\n\n"
-        "(or this entire component can be disabled with "
-        "-DTORCH_MLIR_ENABLE_ONNX_C_IMPORTER=OFF)")
-endif()
+find_package(Protobuf REQUIRED CONFIG)
 
 option(ONNX_DISABLE_EXCEPTIONS "For compatibility with LLVM build" ON)
 


### PR DESCRIPTION
This patch makes the Protobuf package mandatory in addition to forcing a
config mode search.  The (default) module mode search looks for the
CMake-provided FindProtobuf.cmake file, but this file does not list
Abseil as a dependency, causing linker issues like the one below:

```
ld: Undefined symbols:
  absl::lts_20230802::log_internal::LogMessageFatal::LogMessageFatal(char const*, int, std::__1::basic_string_view<char, std::__1::char_traits<char>>), referenced from:
      google::protobuf::RepeatedPtrField<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>::TypeHandler::Type const& google::protobuf::internal::RepeatedPtrFieldBase::Get<google::protobuf::RepeatedPtrField<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>::TypeHandler>(int) const (.cold.1) in OnnxImporter.cpp.o
```

By forcing a config mode search, CMake looks for the file that is
installed as part of the protobuf package and which does contain the
Abseil dependency.  This workaround is also mentioned in a GitHub issue
for Protobuf:
https://github.com/protocolbuffers/protobuf/issues/12292#issuecomment-1529680040.