### PR TITLE
[torch-mlir][sparse] sparsity metadata refinement

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -210,7 +210,7 @@ SYMBOLIC_OP_TO_TORCH_OP = {
 
 
 @dataclass(frozen=True)
-class Sparsity:
+class SparsityMeta:
     """Class for keeping track of sparsity meta data."""
 
     layout: torch.layout
@@ -221,7 +221,7 @@ class Sparsity:
     crd_width: int
 
 
-def sparsity_encoding(shape: torch.Size, sparsity: Sparsity) -> str:
+def sparsity_encoding(shape: torch.Size, sparsity: SparsityMeta) -> str:
     """Returns sparse tensor encoding for the given sparse layout as string."""
     assert sparsity is not None
 
@@ -514,7 +514,7 @@ class ContextCache:
         shape: torch.Size,
         dtype: torch.dtype,
         *,
-        sparsity: Optional[Sparsity] = None,  # keyword-only
+        sparsity: Optional[SparsityMeta] = None,  # keyword-only
     ):
         shape_asm = self.format_asm_shape(shape)
         mlir_dtype = str(self.dtype_to_type(dtype))
@@ -569,7 +569,7 @@ class ContextCache:
         self,
         tm: TensorMetadata,
         *,
-        sparsity: Optional[Sparsity] = None,  # keyword-only
+        sparsity: Optional[SparsityMeta] = None,  # keyword-only
     ) -> IrType:
         tm_shape = tuple(
             item.node if is_symbolic(item) else item for item in list(tm.shape)

--- a/test/python/fx_importer/sparse_test.py
+++ b/test/python/fx_importer/sparse_test.py
@@ -12,7 +12,7 @@ import torch.export
 import torch.nn as nn
 
 from torch_mlir.extras.fx_importer import FxImporter
-from torch_mlir.extras.fx_importer import Sparsity
+from torch_mlir.extras.fx_importer import SparsityMeta
 from torch_mlir import ir
 from torch_mlir.dialects import torch as torch_d
 from torch_mlir.compiler_utils import run_pipeline_with_repro_report
@@ -44,13 +44,13 @@ def sparse_overhead_width(d: torch.dtype) -> int:
     raise RuntimeError(f"Unsupported overhead type {d}")
 
 
-def sparse_metadata(a: torch.Tensor) -> Sparsity:
+def sparse_metadata(a: torch.Tensor) -> SparsityMeta:
     """Returns a meta data tuple for the given sparse tensor."""
     sparse_dim = a.sparse_dim()
     dense_dim = a.dense_dim()
     batch_dim = a.ndim - dense_dim - sparse_dim
     if a.layout is torch.sparse_coo:
-        return Sparsity(
+        return SparsityMeta(
             a.layout,
             batch_dim,
             sparse_dim,
@@ -59,7 +59,7 @@ def sparse_metadata(a: torch.Tensor) -> Sparsity:
             sparse_overhead_width(a.indices().dtype),
         )
     elif a.layout is torch.sparse_csr or a.layout is torch.sparse_bsr:
-        return Sparsity(
+        return SparsityMeta(
             a.layout,
             batch_dim,
             sparse_dim,
@@ -68,7 +68,7 @@ def sparse_metadata(a: torch.Tensor) -> Sparsity:
             sparse_overhead_width(a.col_indices().dtype),
         )
     elif a.layout is torch.sparse_csc or a.layout is torch.sparse_bsc:
-        return Sparsity(
+        return SparsityMeta(
             a.layout,
             batch_dim,
             sparse_dim,

--- a/test/python/fx_importer/sparse_test.py
+++ b/test/python/fx_importer/sparse_test.py
@@ -12,6 +12,7 @@ import torch.export
 import torch.nn as nn
 
 from torch_mlir.extras.fx_importer import FxImporter
+from torch_mlir.extras.fx_importer import Sparsity
 from torch_mlir import ir
 from torch_mlir.dialects import torch as torch_d
 from torch_mlir.compiler_utils import run_pipeline_with_repro_report
@@ -43,23 +44,35 @@ def sparse_overhead_width(d: torch.dtype) -> int:
     raise RuntimeError(f"Unsupported overhead type {d}")
 
 
-def sparse_metadata(a: torch.Tensor) -> tuple[torch.layout, int, int]:
+def sparse_metadata(a: torch.Tensor) -> Sparsity:
     """Returns a meta data tuple for the given sparse tensor."""
+    sparse_dim = a.sparse_dim()
+    dense_dim = a.dense_dim()
+    batch_dim = a.ndim - dense_dim - sparse_dim
     if a.layout is torch.sparse_coo:
-        return (
+        return Sparsity(
             a.layout,
+            batch_dim,
+            sparse_dim,
+            dense_dim,
             sparse_overhead_width(a.indices().dtype),
             sparse_overhead_width(a.indices().dtype),
         )
     elif a.layout is torch.sparse_csr or a.layout is torch.sparse_bsr:
-        return (
+        return Sparsity(
             a.layout,
+            batch_dim,
+            sparse_dim,
+            dense_dim,
             sparse_overhead_width(a.crow_indices().dtype),
             sparse_overhead_width(a.col_indices().dtype),
         )
     elif a.layout is torch.sparse_csc or a.layout is torch.sparse_bsc:
-        return (
+        return Sparsity(
             a.layout,
+            batch_dim,
+            sparse_dim,
+            dense_dim,
             sparse_overhead_width(a.ccol_indices().dtype),
             sparse_overhead_width(a.row_indices().dtype),
         )
@@ -93,11 +106,21 @@ def sparse_export(
     # Build the regular FX traced graph with only dense arguments
     # (the current version would crash otherwise, see issue above).
     prog = torch.export.export(f, dargs, kwargs, constraints=None)
-    # Annotate sparse arguments in the graph.
-    alen = len(args)
+    # Annotate sparse arguments in the graph. Note that we currently
+    # only account for sparsity defined by the user inputs to the model.
+    # TODO: support sparsity in model parameters (weights, biases)
+    # TODO: propagate sparsity into the layers
+    specs = prog.graph_signature.input_specs
+    alen = len(specs)
+    k = 0
     for i, node in enumerate(prog.graph.nodes):
-        if node.op == "placeholder" and i < alen and mask[i]:
-            node.meta["sparsity"] = sparse_metadata(args[i])
+        if i >= alen:
+            break
+        spec = specs[i]
+        if spec.kind is torch.export.graph_signature.InputKind.USER_INPUT:
+            if mask[k]:
+                node.meta["sparsity"] = sparse_metadata(args[k])
+            k = k + 1
     return prog
 
 
@@ -233,3 +256,38 @@ def test_sparse_SpMM():
     print(res1)
     print("torch.mlir")
     print(res2)
+
+
+@run
+# CHECK-LABEL: test_sparse_eltwise
+# CHECK:       #[[$BCSR:.*]] = #sparse_tensor.encoding<{ map = (d0, d1, d2) -> (d0 : dense, d1 : dense, d2 : compressed), posWidth = 64, crdWidth = 64 }>
+# CHECK:       func.func @main(
+# CHECK-SAME:    %[[A:.*]]: !torch.vtensor<[8,4,2],f32,#[[$BCSR]]>) -> !torch.vtensor<[8,4,2],f32> {
+# CHECK:         %[[R:.*]] = torch.aten.neg %arg0 : !torch.vtensor<[8,4,2],f32,#[[$BCSR]]> -> !torch.vtensor<[8,4,2],f32>
+# CHECK:         return %[[R]] : !torch.vtensor<[8,4,2],f32>
+# CHECK:       }
+# CHECK:       #[[$CSRD:.*]] = #sparse_tensor.encoding<{ map = (d0, d1, d2) -> (d0 : dense, d1 : compressed, d2 : dense), posWidth = 64, crdWidth = 64 }>
+# CHECK:       func.func @main(
+# CHECK-SAME:    %[[A:.*]]: !torch.vtensor<[8,4,2],f32,#[[$CSRD]]>) -> !torch.vtensor<[8,4,2],f32> {
+# CHECK:         %[[R:.*]] = torch.aten.neg %arg0 : !torch.vtensor<[8,4,2],f32,#[[$CSRD]]> -> !torch.vtensor<[8,4,2],f32>
+# CHECK:         return %[[R]] : !torch.vtensor<[8,4,2],f32>
+# CHECK:       }
+def test_sparse_eltwise():
+    class EltNet(torch.nn.Module):
+        def __init__(self):
+            super(EltNet, self).__init__()
+
+        def forward(self, x):
+            return -x
+
+    dense_input = torch.ones(8, 4, 2)
+
+    # This yields a **batched** CSR.
+    sparse_input = dense_input.to_sparse_csr(dense_dim=0)
+    m = export_and_import(EltNet(), sparse_input)
+    print(m)
+
+    # This yields a plain CSR with dense **sub**tensor
+    sparse_input = dense_input.to_sparse_csr(dense_dim=1)
+    m = export_and_import(EltNet(), sparse_input)
+    print(m)


### PR DESCRIPTION
Various improvements on sparsity metadata:

(1) define single data structure for all sparsity related metadata 
(2) handle batched dense dimensions, as well as dense subtensor dimensions
(3) refine sparsity propagation for deeper networks