### PR TITLE
[fx] Support mutation in ExportedProgram.

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -42,7 +42,9 @@ from torch._subclasses import (
 from torch.fx import (
     Graph,
     GraphModule,
+    Node,
 )
+
 try:
     import ml_dtypes
 except ModuleNotFoundError:
@@ -344,6 +346,27 @@ class FxImporter:
                     f"The MLIR context {self._c} is missing required dialect '{dname}'"
                 )
 
+    def resolve_literal(self, literal: Any, gni: "GraphNodeImporter", mutable: bool):
+        """User overridable hook to resolve a literal value.
+
+        This will typically be a Parameter or Buffer from some containing nn.Module.
+        In that case, the hook can perform any desired IR manipulation to result in
+        a value. If `mutable` is True, then it is expected that the result supports
+        mutation and it must be a `!torch.tensor` value. Otherwise, it must be a
+        `!torch.vtensor`. The implementation must verify this constraint and error
+        if not met.
+
+        By default, this base implementation delegates to the
+        `literal_resolver_callback` passed to the constructor, which is the legacy
+        mechanism. It does not support mutable literals.
+        """
+        if self._literal_resolver_callback:
+            if mutable:
+                # Mutable not supported for legacy callback mechanism.
+                return None
+            return self._literal_resolver_callback(literal, gni)
+        return None
+
     @property
     def module(self) -> Module:
         return self._m
@@ -351,6 +374,182 @@ class FxImporter:
     @property
     def module_op(self) -> Operation:
         return self._m.operation
+
+    def import_program(
+        self, prog: torch.export.ExportedProgram, *, func_name: str = "main"
+    ):
+        """Imports an ExportedProgram according to our chosen canonical representation.
+
+        This mechanism is the fully general solution for handling an ExportedProgram
+        and should eventually supercede all others. However, it depends on the
+        PyTorch 2.3 release to function properly (specifically, this patch
+        made ExportedProgram minimally correct for mutation:
+        https://github.com/pytorch/pytorch/pull/118969).        
+
+        For stateless programs, the result of this import is a normal function
+        defined for immutable `!torch.vtensors`.
+
+        However, if the program mutates its inputs or buffers, then it will be imported
+        with those parameters as `!torch.tensor` and appropriate copies and overwrites
+        will be done on the inside. Note that the function is still mostly stateless,
+        but with `torch.copy.to_vtensor` and `torch.overwrite.tensor.contents`
+        ops at the earliest consumer or latest producer to update an argument or
+        buffer.
+
+        It is recommended that integrators subclass and override the `resolve_literal`
+        method to control access to mutable buffers and parameters. Without that, the
+        default policy is to capture them as frozen values.
+        """
+        # Create lookaside table of placeholders/outputs.
+        placeholder_nodes: dict[str, Node] = {}
+        all_producer_nodes: dict[str, Node] = {}
+        loc: Optional[Location] = None
+        for node in prog.graph.nodes:
+            if loc is None:
+                loc = self._cc.get_node_location(node)
+            if node.op == "placeholder":
+                placeholder_nodes[node.name] = node
+            elif node.op == "call_function":
+                all_producer_nodes[node.name] = node
+        if loc is None:
+            loc = Location.unknown(self._c)
+
+        # This API is fast evolving. We keep these imports local for now so that we
+        # can disable this entire function if needed.
+        from torch.export.graph_signature import (
+            InputKind,
+            OutputKind,
+            TensorArgument,
+            SymIntArgument,
+        )
+
+        sig = prog.graph_signature
+
+        # Invert the (producer, node_name) maps for mutated user inputs and mutated
+        # buffers. This is because we hit-detect based on the input node name.
+        mutated_user_inputs = {
+            node_name: producer
+            for producer, node_name in sig.user_inputs_to_mutate.items()
+        }
+
+        # Additional bindings that we need to set up after the function is created.
+        mutable_buffer_target_producers: dict[str, str] = {}
+        constant_tensors: dict[Node, torch.Tensor] = {}
+        parameter_bindings: dict[Node, Any] = {}
+        buffer_bindings: dict[
+            Node, tuple[Any, Optional[str]]
+        ] = {}  # Node to (buffer, mutable_producer)
+
+        # Derive user outputs that we preserve. These will be nodes of the
+        # producer for the output.
+        user_outputs: list[Node] = []
+        user_output_types: list[IrType] = []
+        for output_spec in sig.output_specs:
+            kind = output_spec.kind
+            arg = output_spec.arg
+            if kind == OutputKind.USER_OUTPUT:
+                if not isinstance(arg, (TensorArgument, SymIntArgument)):
+                    raise NotImplementedError(
+                        f"OutputKind.USER_OUTPUT for {type(arg)}: {arg}"
+                    )
+                output_producer_node = all_producer_nodes[arg.name]
+                user_outputs.append(output_producer_node)
+                user_output_types.append(
+                    self._cc.node_val_to_type(output_producer_node)
+                )
+            elif kind == OutputKind.BUFFER_MUTATION and isinstance(arg, TensorArgument):
+                mutable_buffer_target_producers[output_spec.target] = arg.name
+
+        # Derive user inputs. These will be op=='placeholder' nodes.
+        user_inputs: list[Node] = []
+        user_input_types: list[IrType] = []
+        for input_spec in sig.input_specs:
+            arg = input_spec.arg
+            if input_spec.kind == InputKind.USER_INPUT:
+                # Set up user input.
+                if not isinstance(arg, (TensorArgument, SymIntArgument)):
+                    raise NotImplementedError(
+                        f"InputKind.USER_INPUT for {type(arg)}: {arg}"
+                    )
+                placeholder_node = placeholder_nodes[arg.name]
+                mutable = placeholder_node.name in mutated_user_inputs
+                user_inputs.append(placeholder_node)
+                user_input_types.append(
+                    self._cc.node_val_to_type(placeholder_node, mutable=mutable)
+                )
+            elif input_spec.kind == InputKind.CONSTANT_TENSOR and isinstance(
+                arg, TensorArgument
+            ):
+                # Remember constant tensor binding.
+                constant_tensors[placeholder_nodes[arg.name]] = prog.constants[
+                    input_spec.target
+                ]
+            elif input_spec.kind == InputKind.PARAMETER and isinstance(
+                arg, TensorArgument
+            ):
+                # Remember parameter binding.
+                parameter_bindings[placeholder_nodes[arg.name]] = prog.state_dict[
+                    input_spec.target
+                ]
+            elif input_spec.kind == InputKind.BUFFER and isinstance(
+                arg, TensorArgument
+            ):
+                # Remember buffer binding.
+                buffer_bindings[placeholder_nodes[arg.name]] = (
+                    prog.state_dict[input_spec.target],
+                    mutable_buffer_target_producers.get(input_spec.target),
+                )
+            else:
+                raise NotImplementedError(
+                    f"InputSpec not of a known kind: {input_spec}"
+                )
+
+        ftype = FunctionType.get(user_input_types, user_output_types, context=self._c)
+
+        # Create the function.
+        with loc:
+            func_op = func_dialect.FuncOp(func_name, ftype, ip=self._m_ip)
+            entry_block = Block.create_at_start(func_op.body, ftype.inputs)
+
+        node_importer = GraphNodeImporter(
+            self,
+            self._c,
+            self._cc,
+            entry_block,
+        )
+
+        # Bind constants to IR values.
+        for constant_node, constant_tensor in constant_tensors.items():
+            node_importer.import_constant(loc, constant_node, constant_tensor)
+
+        # Bind user inputs to IR values.
+        for user_input_node, block_arg_value in zip(user_inputs, entry_block.arguments):
+            if user_input_node.name in mutated_user_inputs:
+                # Materialize
+                node_importer.import_mutable_to_vtensor(
+                    loc,
+                    user_input_node,
+                    block_arg_value,
+                    mutated_user_inputs[user_input_node.name],
+                )
+            else:
+                # Normal value tensor binding.
+                node_importer.bind_node_value(user_input_node, block_arg_value)
+
+        # Lazy bind buffer and parameter inputs.
+        for node, parameter_value in parameter_bindings.items():
+            node_importer.lazy_import_parameter(loc, node, parameter_value)
+        for node, (buffer_value, buffer_mutation_producer) in buffer_bindings.items():
+            node_importer.lazy_import_buffer(
+                loc, node, buffer_value, buffer_mutation_producer
+            )
+        
+        # Import all nodes and return.
+        node_importer.import_nodes(
+            all_producer_nodes.values(), skip_placeholders_outputs=True
+        )
+        node_importer.return_node_values(loc, user_outputs)
+        self.symbol_table.insert(func_op)
 
     def import_frozen_exported_program(self, prog: torch.export.ExportedProgram):
         """Imports a consolidated torch.export.ExportedProgram instance.
@@ -377,6 +576,10 @@ class FxImporter:
         As we anticipate more nuanced treatment options in the future, we name this
         method to indicate that it is producing "frozen" modules. Additional top-level
         approaches to handling state can be introduced later as an addition.
+
+        TODO: This mechanism should be eventually replaced by `import_program` with
+        hooks set on the subclass to freeze parameters and buffers. However, that is
+        waiting for the Torch 2.3 release cut.
         """
         sig = prog.graph_signature
         state_dict = prog.state_dict
@@ -391,7 +594,9 @@ class FxImporter:
                 try:
                     state_value = constants[state_name]
                 except KeyError as e:
-                    raise AssertionError("Could not find state mapping for tensor constants") from e
+                    raise AssertionError(
+                        "Could not find state mapping for tensor constants"
+                    ) from e
                 arg_replacements[input_name] = state_value
         else:
             # Lift buffers.
@@ -399,7 +604,9 @@ class FxImporter:
                 try:
                     state_value = state_dict[state_name]
                 except KeyError as e:
-                    raise AssertionError("Could not find state mapping for buffer") from e
+                    raise AssertionError(
+                        "Could not find state mapping for buffer"
+                    ) from e
                 arg_replacements[input_name] = state_value
 
         # Lift parameters.
@@ -426,11 +633,19 @@ class FxImporter:
         self.import_stateless_graph(g)
 
     def import_graph_module(self, gm: GraphModule):
-        """Low-level import of a GraphModule assuming that it has been functionalized."""
+        """Low-level import of a GraphModule assuming that it has been functionalized.
+        
+        TODO: This mechanism is deprecated by the `import_program` entry-point and
+        it should be removed when no longer required for backwards compatibility.
+        """
         self.import_stateless_graph(gm.graph)
 
     def import_stateless_graph(self, g: Graph, func_name: str = "main"):
-        """Low-level import of a functionalized, assumed stateless Graph as a func."""
+        """Low-level import of a functionalized, assumed stateless Graph as a func.
+        
+        TODO: This mechanism is deprecated by the `import_program` entry-point and
+        it should be removed when no longer required for backwards compatibility.
+        """
         ftype, loc = self._graph_to_function_meta(g)
         # TODO: The FuncOp constructor requires a context-manager context.
         # Fix upstream and then unnest.
@@ -447,7 +662,6 @@ class FxImporter:
             self._c,
             self._cc,
             entry_block,
-            literal_resolver_callback=self._literal_resolver_callback,
         )
         node_importer.import_nodes(g.nodes)
         self.symbol_table.insert(func)
@@ -507,7 +721,9 @@ class ContextCache:
     ):
         self._c = context
         self._dtype_to_type: Dict[TorchDtype, IrType] = {}
-        self._tensor_metadata_cache: Dict[Tuple[torch.Size, torch.dtype], IrType] = {}
+        self._tensor_metadata_cache: Dict[
+            Tuple[torch.Size, torch.dtype, Optional[SparsityMeta], bool], IrType
+        ] = {}
         self._py_attr_tracker = py_attr_tracker or RefTracker()
 
         # Common types.
@@ -523,34 +739,34 @@ class ContextCache:
         c = self._c
         return IntegerAttr.get(IntegerType.get_signless(bits, c), value)
 
-    """Strips symbolic elements from a torch.Size object and returns shape asm"""
-
     def format_asm_shape(self, shape: torch.Size) -> str:
+        """Strips symbolic elements from a torch.Size object and returns shape asm"""
         return ",".join("?" if is_symbolic(d) else str(d) for d in list(shape))
-
-    """Return IrType for !torch.vtensor with the given shape and dtype"""
 
     def get_vtensor_type(
         self,
         shape: torch.Size,
         dtype: torch.dtype,
         *,
-        sparsity: Optional[SparsityMeta] = None,  # keyword-only
+        sparsity: Optional[SparsityMeta] = None,
+        mutable: bool = False,
     ):
+        """Return IrType for !torch.vtensor with the given shape and dtype"""
+        stem = "torch.tensor" if mutable else "torch.vtensor"
         shape_asm = self.format_asm_shape(shape)
         mlir_dtype = str(self.dtype_to_type(dtype))
         if sparsity is not None:
             encoding = sparsity_encoding(shape, sparsity)
             assert encoding is not None
             return IrType.parse(
-                f"!torch.vtensor<[{shape_asm}],{str(mlir_dtype)},{encoding}>",
+                f"!{stem}<[{shape_asm}],{str(mlir_dtype)},{encoding}>",
                 context=self._c,
             )
         return IrType.parse(
-            f"!torch.vtensor<[{shape_asm}],{str(mlir_dtype)}>", context=self._c
+            f"!{stem}<[{shape_asm}],{str(mlir_dtype)}>", context=self._c
         )
 
-    def node_val_to_type(self, node: torch_fx.Node) -> IrType:
+    def node_val_to_type(self, node: torch_fx.Node, *, mutable: bool = False) -> IrType:
         try:
             tensor_meta = node.meta.get("tensor_meta")
             val = node.meta.get("val")
@@ -564,13 +780,15 @@ class ContextCache:
                         f"Quantized tensor meta data is not supported."
                     )
                 else:
-                    return self.tensor_metadata_to_type(tensor_meta, sparsity=sparsity)
+                    return self.tensor_metadata_to_type(
+                        tensor_meta, sparsity=sparsity, mutable=mutable
+                    )
             elif val is not None:
                 # some nodes with symbolic inputs pass a 'val' attribute rather than
                 # tensor_meta
                 if isinstance(val, TorchFakeTensor):
                     return self.get_vtensor_type(
-                        val.size(), val.dtype, sparsity=sparsity
+                        val.size(), val.dtype, sparsity=sparsity, mutable=mutable
                     )
 
                 t = SCALAR_TYPE_TO_TORCH_MLIR_TYPE.get(type(val))
@@ -590,16 +808,19 @@ class ContextCache:
         self,
         tm: TensorMetadata,
         *,
-        sparsity: Optional[SparsityMeta] = None,  # keyword-only
+        sparsity: Optional[SparsityMeta] = None,
+        mutable: bool = False,
     ) -> IrType:
         tm_shape = tuple(
             item.node if is_symbolic(item) else item for item in list(tm.shape)
         )
 
-        key = (tm_shape, tm.dtype, sparsity)
+        key = (tm_shape, tm.dtype, sparsity, mutable)
         t = self._tensor_metadata_cache.get(key)
         if t is None:
-            t = self.get_vtensor_type(tm.shape, tm.dtype, sparsity=sparsity)
+            t = self.get_vtensor_type(
+                tm.shape, tm.dtype, sparsity=sparsity, mutable=mutable
+            )
             self._tensor_metadata_cache[key] = t
         return t
 
@@ -644,7 +865,7 @@ class GraphNodeImporter:
         "_b",
         "_c",
         "_cc",
-        "_literal_resolver_callback",
+        "_on_node_produced",
         "_v",
         "_multi_result_nodes",
         "fx_importer",
@@ -656,21 +877,138 @@ class GraphNodeImporter:
         context: Context,
         context_cache: ContextCache,
         block: Block,
-        *,
-        literal_resolver_callback: Optional[LiteralResolverCallback] = None,
     ):
         self.fx_importer = fx_importer
         self._c = context
         self._cc = context_cache
         self._b = block
-        # Map of (Node, result_index) to MLIR Value.
-        self._v: Dict[Tuple[torch_fx.Node, int], Value] = {}
+        # Map of (Node, result_index) to MLIR Value or a callback that lazily
+        # constructs and returns a value.
+        self._v: Dict[Union[Callable[[], Value], Tuple[torch_fx.Node, int]], Value] = {}
+        # Map of node name to hook that should be called when it is produced.
+        self._on_node_produced: dict[str, Callable[[Value], None]] = {}
         # Statically multi-result nodes which we have de-tupled are noted here.
         # They will have their getitem calls short-circuited.
         self._multi_result_nodes: Set[torch_fx.Node] = set()
-        self._literal_resolver_callback = literal_resolver_callback
 
-    def import_nodes(self, nodes: Sequence[torch_fx.Node]):
+    def bind_node_value(
+        self,
+        node: Node,
+        value: Union[Value, Callable[[], Value]],
+        result_index: int = 0,
+    ):
+        """Binds a node to a value (and asserts if already bound).
+
+        This is used by outside callers. Many internal callers poke directly
+        into the dict.
+        """
+        key = (node, result_index)
+        assert key not in self._v, f"Node already has a value: {node}"
+        self._v[key] = value
+
+        producer_callback = self._on_node_produced.get(node.name)
+        if producer_callback is not None:
+            producer_callback(value)
+
+    def resolve_node_value(self, node: Node, result_index: int = 0) -> Value:
+        """Resolves a node to a value."""
+        key = (node, result_index)
+        try:
+            binding = self._v[key]
+        except KeyError:
+            raise KeyError(f"FX Node {node} has not been bound to an MLIR value")
+        if isinstance(binding, Value):
+            return binding
+
+        # It is a lazy callback.
+        value = binding()
+        self._v[key] = value
+        return value
+
+    def import_mutable_to_vtensor(
+        self, loc: Location, node: Node, mutable_value: Value, producer_node_name: str
+    ) -> Value:
+        """Imports a node that is represented by a mutable IR value.
+
+        This will generate and associate the following with the node:
+          %0 = torch.copy.to_vtensor {mutable_value}
+
+        Then it will also add a trigger such that when `producer_node_name` is
+        produced, the following will be generated:
+          torch.overwrite.tensor.contents {producer}, {mutable_value}
+        """
+        with loc, InsertionPoint(self._b):
+            immutable_type = self._cc.node_val_to_type(node)
+            copy_result = Operation.create(
+                "torch.copy.to_vtensor",
+                results=[immutable_type],
+                operands=[mutable_value],
+            ).result
+            self.bind_node_value(node, copy_result)
+
+        # Add the producer trigger.
+        def on_produced(value: Value):
+            with loc, InsertionPoint(self._b):
+                Operation.create(
+                    "torch.overwrite.tensor.contents",
+                    results=[],
+                    operands=[value, mutable_value],
+                )
+
+        self._on_node_produced[producer_node_name] = on_produced
+        return copy_result
+
+    def import_constant(self, loc: Location, node: Node, constant: Any) -> Value:
+        with loc, InsertionPoint(self._b):
+            value = self._import_literal(constant)
+            self.bind_node_value(node, value)
+        return value
+
+    def lazy_import_parameter(self, loc, node: Node, parameter_value: Any):
+        def _on_access() -> Value:
+            with loc, InsertionPoint(self._b):
+                # TODO: Should go to a parameter binding hook.
+                return self._import_literal(parameter_value)
+
+        self.bind_node_value(node, _on_access)
+
+    def lazy_import_buffer(
+        self,
+        loc,
+        node: Node,
+        buffer_value: Any,
+        mutating_producer_node_name: Optional[str],
+    ):
+        def _on_access() -> Value:
+            with loc, InsertionPoint(self._b):
+                # TODO: Should go to a buffer binding hook.
+                return self._import_literal(
+                    buffer_value, mutable=mutating_producer_node_name is not None
+                )
+
+        self.bind_node_value(node, _on_access)
+
+        if mutating_producer_node_name is not None:
+
+            def on_produced(value: Value):
+                mutable_buffer_value = self.resolve_node_value(node)
+                with loc, InsertionPoint(self._b):
+                    Operation.create(
+                        "torch.overwrite.tensor.contents",
+                        results=[],
+                        operands=[value, mutable_buffer_value],
+                    )
+
+            self._on_node_produced[mutating_producer_node_name] = on_produced
+
+    def return_node_values(self, loc, nodes: list[Node]):
+        with loc, InsertionPoint(self._b):
+            operands = [self.resolve_node_value(n) for n in nodes]
+            func_dialect.ReturnOp(operands, loc=loc)
+
+    def import_nodes(
+        self, nodes: Sequence[Node], *, skip_placeholders_outputs: bool = False
+    ):
         with InsertionPoint(self._b):
             loc = Location.unknown()
             num_placeholders = 0
@@ -681,10 +1019,10 @@ class GraphNodeImporter:
                 new_loc = self._cc.get_node_location(node)
                 if new_loc is not None:
                     loc = new_loc
-                if op == "placeholder":
+                if op == "placeholder" and not skip_placeholders_outputs:
                     # Associate the placeholder node with corresponding block
                     # argument.
-                    self._v[(node, 0)] = self._b.arguments[num_placeholders]
+                    self.bind_node_value(node, self._b.arguments[num_placeholders])
                     num_placeholders += 1
                 elif op == "call_function":
                     target = node.target
@@ -696,9 +1034,10 @@ class GraphNodeImporter:
                         getitem_ref, getitem_index = node.args
                         if getitem_ref in self._multi_result_nodes:
                             try:
-                                self._v[(node, 0)] = self._v[
-                                    (getitem_ref, getitem_index)
-                                ]
+                                self.bind_node_value(
+                                    node,
+                                    self.resolve_node_value(getitem_ref, getitem_index),
+                                )
                             except IndexError:
                                 raise RuntimeError(
                                     f"getitem de-aliasing failed. This likely "
@@ -723,7 +1062,7 @@ class GraphNodeImporter:
                         raise NotImplementedError(
                             f"FIX ME: Unimplemented call_function: target={node.target}, {node.meta}"
                         )
-                elif op == "output":
+                elif op == "output" and not skip_placeholders_outputs:
                     # args[0] is a singleton tuple that we flatten into multiple
                     # results.
                     operands = [self._import_argument(loc, arg) for arg in node.args[0]]
@@ -731,7 +1070,7 @@ class GraphNodeImporter:
 
     def _promote_symbolic_scalar_int_float(self, loc, graph, param):
         temp_target = torch.ops.aten.Float.Scalar
-        temp_node = torch.fx.Node(
+        temp_node = Node(
             graph=graph,
             name=f"{str(param)}_as_float",
             op="call_function",
@@ -756,11 +1095,7 @@ class GraphNodeImporter:
         # operations on symbolic arguments as regular python expressions rather than as torch ops
         if is_builtin_function_or_method(target):
             arg_types = [
-                (
-                    arg.meta["val"].node.pytype
-                    if isinstance(arg, torch.fx.Node)
-                    else type(arg)
-                )
+                (arg.meta["val"].node.pytype if isinstance(arg, Node) else type(arg))
                 for arg in node.args
             ]
             is_int = [item == int for item in arg_types]
@@ -776,7 +1111,7 @@ class GraphNodeImporter:
                     # promote int argument to float - following torch-mlir convention
                     arg0, arg1 = node.args
                     if is_int[0]:
-                        if isinstance(arg0, torch.fx.Node):
+                        if isinstance(arg0, Node):
                             prom_arg = self._promote_symbolic_scalar_int_float(
                                 loc, node.graph, arg0
                             )
@@ -785,7 +1120,7 @@ class GraphNodeImporter:
                             arg0 = float(arg0)
                             new_args = (arg0, arg1)
                     else:
-                        if isinstance(arg1, torch.fx.Node):
+                        if isinstance(arg1, Node):
                             prom_arg = self._promote_symbolic_scalar_int_float(
                                 loc, node.graph, arg1
                             )
@@ -923,7 +1258,7 @@ class GraphNodeImporter:
 
         # Record value mapping.
         for i, value in enumerate(operation.results):
-            self._v[(node, i)] = value
+            self.bind_node_value(node, value, i)
 
     def _import_argument(
         self, loc: Location, arg: NodeArgument, expected_jit_type=None
@@ -943,9 +1278,9 @@ class GraphNodeImporter:
                 ), f"Attempting to retrieve attribute '{arg.target}' from module, but no such attribute exists"
                 obj = getattr(gm, arg.target)
                 with loc:
-                    self._v[(arg, 0)] = self._import_literal(obj)
+                    self.bind_node_value(arg, self._import_literal(obj))
 
-            return self._v[(arg, 0)]
+            return self.resolve_node_value(arg)
         elif isinstance(arg, torch_fx.immutable_collections.immutable_list):
             return self._import_list_argument(loc, arg, expected_jit_type)
         elif isinstance(expected_jit_type, torch.TensorType) and not isinstance(
@@ -957,16 +1292,16 @@ class GraphNodeImporter:
             with loc:
                 return self._import_literal(arg)
 
-    def _import_literal(self, py_value: Any) -> Value:
+    def _import_literal(self, py_value: Any, *, mutable: bool = False) -> Value:
         # Apply the conversion callback.
-        user_callback = self._literal_resolver_callback
-        if user_callback:
-            user_value = user_callback(py_value, self)
-            if user_value is not None:
-                assert isinstance(user_value, Value)
-                return user_value
+        user_value = self.fx_importer.resolve_literal(py_value, self, mutable=True)
+        if user_value is not None:
+            assert isinstance(user_value, Value)
+            return user_value
 
         # Default conversion path.
+        if mutable:
+            raise ValueError(f"Default literal resolution cannot support mutation.")
         converter = LITERAL_CONVERTER_MAP.lookup(type(py_value))
         if converter is None:
             raise TypeError(
@@ -1020,10 +1355,10 @@ class GraphNodeImporter:
 
         for operand in arg:
             operand_type = type(operand)
-            if isinstance(operand, torch.fx.Node):
+            if isinstance(operand, Node):
                 if operand in self._multi_result_nodes:
                     raise RuntimeError(f"Attempt to de-reference a multi-result node")
-                val = self._v[(operand, 0)]
+                val = self.resolve_node_value(operand)
                 val_type = str(val.type)
                 assert (
                     isinstance(element_type, str) and element_type in val_type
@@ -1099,8 +1434,8 @@ def _make_vtensor_literal_op(
     mapping = py_attr_tracker.track(tensor)
     if mapping.is_empty:
         # check support for bfloat16
-        assert (
-            not (tensor.dtype == torch.bfloat16 and ml_dtypes is None)
+        assert not (
+            tensor.dtype == torch.bfloat16 and ml_dtypes is None
         ), f"torch.bfloat16 requires the ml_dtypes package, please run:\n\npip install ml_dtypes\n"
         # Resolve the attribute.
         npy_dtype = TORCH_DTYPE_TO_NPY_TYPE.get(tensor.dtype)

--- a/python/torch_mlir/fx.py
+++ b/python/torch_mlir/fx.py
@@ -1,10 +1,17 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
 from typing import Optional
+
+import warnings
 
 import torch
 import torch.export
 import torch.nn as nn
 
-from torch_mlir.extras.fx_importer import FxImporter
+from torch_mlir.extras.fx_importer import FxImporter, FxImporterHooks
 from torch_mlir import ir
 from torch_mlir.dialects import torch as torch_d
 from torch_mlir.extras.fx_decomp_util import get_decomposition_table
@@ -14,16 +21,23 @@ def export_and_import(
     *args,
     fx_importer: Optional[FxImporter] = None,
     constraints: Optional[torch.export.Constraint] = None,
+    experimental_support_mutation: bool = False,
+    hooks: Optional[FxImporterHooks] = None,
     **kwargs,
 ):
     context = ir.Context()
     torch_d.register_dialect(context)
 
     if fx_importer is None:
-        fx_importer = FxImporter(context=context)
+        fx_importer = FxImporter(context=context, hooks=hooks)
     prog = torch.export.export(f, args, kwargs, constraints=constraints)
-    #import IPython; IPython.embed()
     decomp_table = get_decomposition_table()
     prog = prog.run_decompositions(decomp_table)
-    fx_importer.import_program(prog)
+    if experimental_support_mutation:
+        if torch.__version__ < "2.3.0.dev20240207":
+            warnings.warn("Mutable program import only supported on PyTorch 2.3+")
+        fx_importer.import_program(prog)
+    else:
+        fx_importer.import_frozen_program(prog)
+
     return fx_importer.module_op

--- a/python/torch_mlir/fx.py
+++ b/python/torch_mlir/fx.py
@@ -22,7 +22,8 @@ def export_and_import(
     if fx_importer is None:
         fx_importer = FxImporter(context=context)
     prog = torch.export.export(f, args, kwargs, constraints=constraints)
+    #import IPython; IPython.embed()
     decomp_table = get_decomposition_table()
     prog = prog.run_decompositions(decomp_table)
-    fx_importer.import_frozen_exported_program(prog)
+    fx_importer.import_program(prog)
     return fx_importer.module_op

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -50,15 +50,9 @@ def test_import_frozen_exported_program():
             super().__init__()
             self.b = torch.randn(3, 1)
             self.p = nn.Parameter(torch.randn(1, 1))
-            self.register_buffer("a_buffer", torch.rand(3, 1))
 
-        def forward(self, x, y):
-            value = torch.tanh(x) * get_a() * self.b * self.p * self.a_buffer
-            y[0, 0] = value[0, 0]
-            y[1, 0] = value[1, 0]
-            #self.a_buffer[0, 0] = value[0, 0]
-            return value
+        def forward(self, x):
+            return torch.tanh(x) * get_a() * self.b * self.p
 
-    with torch.no_grad():
-        m = fx.export_and_import(Basic(), torch.randn(3, 4), torch.randn(3, 4))
+    m = fx.export_and_import(Basic(), torch.randn(3, 4))
     print(m)

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -50,9 +50,15 @@ def test_import_frozen_exported_program():
             super().__init__()
             self.b = torch.randn(3, 1)
             self.p = nn.Parameter(torch.randn(1, 1))
+            self.register_buffer("a_buffer", torch.rand(3, 1))
 
-        def forward(self, x):
-            return torch.tanh(x) * get_a() * self.b * self.p
+        def forward(self, x, y):
+            value = torch.tanh(x) * get_a() * self.b * self.p * self.a_buffer
+            y[0, 0] = value[0, 0]
+            y[1, 0] = value[1, 0]
+            #self.a_buffer[0, 0] = value[0, 0]
+            return value
 
-    m = fx.export_and_import(Basic(), torch.randn(3, 4))
+    with torch.no_grad():
+        m = fx.export_and_import(Basic(), torch.randn(3, 4), torch.randn(3, 4))
     print(m)

--- a/test/python/fx_importer/sparse_test.py
+++ b/test/python/fx_importer/sparse_test.py
@@ -130,7 +130,7 @@ def export_and_import(f, *args, **kwargs):
     torch_d.register_dialect(context)
     fx_importer = FxImporter(context=context)
     prog = sparse_export(f, args, kwargs)
-    fx_importer.import_frozen_exported_program(prog)
+    fx_importer.import_frozen_program(prog)
     return fx_importer.module
 
 

--- a/test/python/fx_importer/v2.3/lit.local.cfg
+++ b/test/python/fx_importer/v2.3/lit.local.cfg
@@ -1,0 +1,9 @@
+config.unsupported = True
+
+try:
+  import torch
+  if torch.__version__ >= "2.3.0.dev20240207":
+    print("Enabling Torch v2.3+ tests")
+    config.unsupported = False  
+except ModuleNotFoundError:
+  ...

--- a/test/python/fx_importer/v2.3/mutation_import.py
+++ b/test/python/fx_importer/v2.3/mutation_import.py
@@ -1,0 +1,163 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+# RUN: %PYTHON %s | FileCheck %s
+
+from typing import Optional
+
+import torch
+import torch.export
+import torch.nn as nn
+
+from torch_mlir import fx
+
+from torch_mlir.ir import (
+    Operation,
+)
+
+
+def run(f):
+    print(f"{f.__name__}")
+    print("-" * len(f.__name__))
+    f()
+    print()
+
+
+@run
+# Tests that constants and parameters work generally with the mutation path.
+# This doesn't do mutation but ensures that the basics remain functional.
+# CHECK-LABEL: test_import_frozen_exported_program
+# CHECK:     func.func @main(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32>
+# CHECK-DAG: %[[a:.+]] = torch.vtensor.literal(dense_resource<torch_tensor_1_4_torch.float32> : tensor<1x4xf32>) : !torch.vtensor<[1,4],f32>
+# CHECK-DAG: %[[b:.+]] = torch.vtensor.literal(dense_resource<torch_tensor_3_1_torch.float32> : tensor<3x1xf32>) : !torch.vtensor<[3,1],f32>
+# CHECK-DAG: %[[p:.+]] = torch.vtensor.literal(dense<{{.*>+}} : tensor<1x1xf32>) : !torch.vtensor<[1,1],f32>
+# CHECK-DAG: %[[tanh:.+]] = torch.aten.tanh %[[ARG0]]
+# CHECK-DAG: %[[mul_a:.+]] = torch.aten.mul.Tensor %[[tanh]], %[[a]]
+# CHECK-DAG: %[[mul_b:.+]] = torch.aten.mul.Tensor %[[mul_a]], %[[b]]
+# CHECK-DAG: %[[mul_p:.+]] = torch.aten.mul.Tensor %[[mul_b]], %[[p]]
+# CHECK:     return %[[mul_p]]
+def test_import_frozen_exported_program():
+    @torch._dynamo.assume_constant_result
+    def get_a():
+        return torch.randn(1, 4)
+
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.b = torch.randn(3, 1)
+            self.p = nn.Parameter(torch.randn(1, 1))
+
+        def forward(self, x):
+            return torch.tanh(x) * get_a() * self.b * self.p
+
+    m = fx.export_and_import(
+        Basic(), torch.randn(3, 4), experimental_support_mutation=True
+    )
+    print(m)
+    m.operation.verify()
+
+
+@run
+# CHECK-LABEL: test_user_input_mutate
+# CHECK:     func.func @main(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.tensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32>
+# CHECK-DAG: %[[arg1_copy:.+]] = torch.copy.to_vtensor %arg1 : !torch.vtensor<[3,4],f32>
+# CHECK-DAG: %[[arg1_mul:.+]] = torch.aten.mul.Tensor %[[arg1_copy]], %arg0
+# CHECK-DAG: torch.overwrite.tensor.contents %[[arg1_mul]] overwrites %arg1
+# CHECK-DAG: %[[arg0_mul:.+]] = torch.aten.mul.Tensor %arg0, %[[arg1_mul]]
+# CHECK:     return %[[arg0_mul]]
+def test_user_input_mutate():
+    class Basic(nn.Module):
+        def forward(self, x, y):
+            y.mul_(x)
+            return x * y
+
+    m = fx.export_and_import(
+        Basic(),
+        torch.randn(3, 4),
+        torch.randn(3, 4),
+        experimental_support_mutation=True,
+    )
+    print(m)
+    m.operation.verify()
+
+
+@run
+# CHECK-LABEL: test_frozen_buffer
+# CHECK: %[[buffer_literal:.+]] = torch.vtensor.literal
+# CHECK: %[[mul:.+]] = torch.aten.mul.Tensor %arg0, %0
+# CHECK: return %[[mul]]
+def test_frozen_buffer():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("buffer", torch.randn(3, 4))
+
+        def forward(self, x):
+            return x * self.buffer
+
+    m = fx.export_and_import(
+        Basic(), torch.randn(3, 4), experimental_support_mutation=True
+    )
+    print(m)
+    m.operation.verify()
+
+
+class ExternalBufferHooks(fx.FxImporterHooks):
+    def prepare_module(self, module_op: Operation):
+        module_op.context.allow_unregistered_dialects = True
+
+    def resolve_input(self, gni, value, info):
+        return Operation.create(
+            "my_dialect.import_buffer", results=[info.ir_type]
+        ).result
+
+
+@run
+# CHECK-LABEL: test_mutable_buffer
+# CHECK: %[[buffer:.+]] = "my_dialect.import_buffer"() : () -> !torch.tensor<[3,4],f32>
+# CHECK: %[[mul:.+]] = torch.aten.mul.Tensor %[[buffer]], %arg0
+# CHECK: torch.overwrite.tensor.contents %[[mul]] overwrites %[[buffer]]
+# CHECK: return %arg0
+def test_mutable_buffer():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("buffer", torch.randn(3, 4))
+
+        def forward(self, x):
+            self.buffer.mul_(x)
+            return x
+
+    m = fx.export_and_import(
+        Basic(),
+        torch.randn(3, 4),
+        experimental_support_mutation=True,
+        hooks=ExternalBufferHooks(),
+    )
+    print(m)
+    m.operation.verify()
+
+
+@run
+# CHECK-LABEL: test_mutable_buffer_not_supported_from_literal
+# CHECK: ERROR: Cannot import {{.*}} as a literal because it is mutable
+def test_mutable_buffer_not_supported_from_literal():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("buffer", torch.randn(3, 4))
+
+        def forward(self, x):
+            self.buffer.mul_(x)
+            return x
+
+    try:
+        m = fx.export_and_import(
+            Basic(),
+            torch.randn(3, 4),
+            experimental_support_mutation=True,
+        )
+    except ValueError as e:
+        print("ERROR:", e)


### PR DESCRIPTION
As of https://github.com/pytorch/pytorch/pull/118969, `ExportedProgram` has the long awaited fixes to correctly categorize various things relating to parameters, buffers, mutated inputs and constants.

With this additional modeling, we are finally able to implement (safely/soundly) the mutable semantics that were attempted on the TorchScript path. The difference is that on that path, we had to conservatively treat everything as mutable and run some dodgy heuristics (which have been the cause of many bugs relating to "MaximizeValueSemantics") to try to get back to an immutable state.

The new model supports mutability at the graph edges, allowing both user inputs and buffers to be mutated (there is some more support than that, but that is all I fully tracked through to implementation).

Therefore, when we receive programs like this, we now can selectively enable mutation at the edges. This happens to be the mutability model that IREE supports, which I expect to be a primary beneficiary. However, there is nothing stopping anyone else from handling the `!torch.tensor` types and the existing copy/overwrite ops that will be selectively added.

Since this relies on API changes that will not release until 2.3, I'm being a bit cautious about not refactoring existing facilities.
