### PR TITLE
[torch-mlir][sparse] inline sparse helper methods

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -139,6 +139,7 @@ LOWERING_PIPELINE = "builtin.module(" + ",".join([
     "sparse-assembler",
     "sparsification-and-bufferization",
     "sparse-storage-specifier-to-llvm",
+    "inline",  # inline sparse helper methods where useful
     # Bufferize.
     "func.func(scf-bufferize)",
     "func.func(tm-tensor-bufferize)",


### PR DESCRIPTION
Even though the reference compiler is not about performance, inlining the generated sparse helper methods has a rather big positive impact on performance, leaving a much better first impression. Therefore, we added this inlining pass (which leaves all other PyTorch modules unaffected, since they tend to be one big main() method to start with).

testing:

$./tools/e2e_test.sh --config linalg

Summary:
    Passed: 1164
    Expectedly Failed: 8

$ python -m e2e_testing.main --config=torchdynamo

Summary:
    Passed: 976
    Expectedly Failed: 162