### PR TITLE
Create shaped vtensors in decomposition of AtenTriuOp

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -9,9 +9,7 @@
 
 #include "PassDetail.h"
 
-#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/BuiltinDialect.h"
-#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
@@ -22,9 +20,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSet.h"
-#include "llvm/Support/Debug.h"
 #include <cstdint>
-#include <optional>
 
 using namespace mlir;
 using namespace mlir::torch;


### PR DESCRIPTION
The AtenTriuOp is decomposed into ops with shapeless and typeless vtensors, which causes some conversion failures in TorchToLinalg. This PR explicitly sets the shape and dtype on the resulting ops of the decomposition.