### PR TITLE
[ci] Fix mpmath 1.14 error by forcing 1.13

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ pillow
 dill
 multiprocess
 onnx==1.15.0
+mpmath==1.3.0


### PR DESCRIPTION
mpmath 1.14 changes some import locations breaking `torch`. Torching to `1.13` to avoid breaking on `python 3.11`