### PR TITLE
[onnx][torch] Lower `onnx.grid_sampler` to the `torch` equivalents

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -98,13 +98,6 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         Torch::ValueTensorType resultType;
         Value input;
         Value grid;
-        std::string mode;
-        Value interpolationMode;
-        std::string padding;
-        Value paddingMode;
-        int64_t align;
-        Value alignCorners;
-
         if (binder.tensorOperandAtIndex(input, 0) ||
             binder.tensorOperandAtIndex(grid, 1) ||
             binder.tensorResultType(resultType))
@@ -130,17 +123,20 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         if (gridShape[3] != 2)
           return rewriter.notifyMatchFailure(binder.op,
                                              "gridShape[3] expected to be 2");
+        std::string mode;
         if (binder.customOpNameStringAttr(mode, "mode", "bilinear"))
           return rewriter.notifyMatchFailure(binder.op, "mode bind failure");
         if (mode != "bilinear")
           return rewriter.notifyMatchFailure(
               binder.op, "currently only mode : bilinear supported");
+        std::string padding;
         if (binder.customOpNameStringAttr(padding, "padding_mode", "zeros"))
           return rewriter.notifyMatchFailure(binder.op,
                                              "padding_mode bind failure");
         if (padding != "zeros")
           return rewriter.notifyMatchFailure(
               binder.op, "currently only padding_mode : zeros supported");
+        int64_t align;
         if (binder.s64IntegerAttr(align, "align_corners", 0))
           return rewriter.notifyMatchFailure(binder.op,
                                              "align_corners bind failure");
@@ -148,13 +144,13 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
           return rewriter.notifyMatchFailure(
               binder.op, "currently only align_corners : 0 supported");
 
-        interpolationMode = rewriter.create<Torch::ConstantIntOp>(
+        Value interpolationMode = rewriter.create<Torch::ConstantIntOp>(
             binder.getLoc(), rewriter.getType<Torch::IntType>(),
             rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
-        paddingMode = rewriter.create<Torch::ConstantIntOp>(
+        Value paddingMode = rewriter.create<Torch::ConstantIntOp>(
             binder.getLoc(), rewriter.getType<Torch::IntType>(),
             rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
-        alignCorners = rewriter.create<Torch::ConstantBoolOp>(
+        Value alignCorners = rewriter.create<Torch::ConstantBoolOp>(
             binder.getLoc(), rewriter.getType<Torch::BoolType>(),
             rewriter.getBoolAttr(false));
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -109,7 +109,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             binder.tensorOperandAtIndex(grid, 1) ||
             binder.tensorResultType(resultType))
           return rewriter.notifyMatchFailure(
-            binder.op, "operand grid_sampler bind failure");
+              binder.op, "operand grid_sampler bind failure");
 
         auto inputTensorType = input.getType().cast<Torch::ValueTensorType>();
         ArrayRef<int64_t> inputShape = inputTensorType.getSizes();

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -92,6 +92,79 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
                                                        operand, vApproximate);
         return success();
       });
+  patterns.onOp(
+      "GridSample", 20, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+        Torch::ValueTensorType resultType;
+        Value input;
+        Value grid;
+        std::string mode;
+        Value interpolationMode;
+        std::string padding;
+        Value paddingMode;
+        int64_t align;
+        Value alignCorners;
+
+        if (binder.tensorOperandAtIndex(input, 0) ||
+            binder.tensorOperandAtIndex(grid, 1) ||
+            binder.tensorResultType(resultType)
+            )
+          return failure();
+
+        auto inputTensorType = input.getType().cast<Torch::ValueTensorType>();
+        ArrayRef<int64_t> inputShape = inputTensorType.getSizes();
+        unsigned inputRank = inputShape.size();
+        auto gridTensorType = grid.getType().cast<Torch::ValueTensorType>();
+        ArrayRef<int64_t> gridShape = gridTensorType.getSizes();
+        unsigned gridRank = gridShape.size();
+
+        if(inputRank != 4) {
+          return rewriter.notifyMatchFailure(binder.op, "only input rank 4 supported");
+        }
+        if(gridRank != 4) {
+          return rewriter.notifyMatchFailure(binder.op, "only grid rank 4 supported");
+        }
+        if(inputShape[0] != gridShape[0]) {
+          return rewriter.notifyMatchFailure(binder.op, "N must be same for input and grid");
+        }
+        if(gridShape[3] != 2) {
+          return rewriter.notifyMatchFailure(binder.op, "gridShape[3] ,must be 2");
+        }
+
+        if (binder.customOpNameStringAttr(mode, "mode", "bilinear"))
+          return rewriter.notifyMatchFailure(binder.op,
+                                             "mode bind failure");
+        if (mode != "bilinear")
+          return rewriter.notifyMatchFailure(
+              binder.op, "currently only mode : bilinear supported");
+        interpolationMode = rewriter.create<Torch::ConstantIntOp>(
+            binder.getLoc(), rewriter.getType<Torch::IntType>(),
+            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+
+        if (binder.customOpNameStringAttr(padding, "padding_mode", "zeros"))
+          return rewriter.notifyMatchFailure(binder.op,
+                                             "padding_mode bind failure");
+        if (padding != "zeros")
+          return rewriter.notifyMatchFailure(
+              binder.op, "currently only padding_mode : zeros supported");
+        paddingMode = rewriter.create<Torch::ConstantIntOp>(
+              binder.getLoc(), rewriter.getType<Torch::IntType>(),
+              rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+
+        if (binder.s64IntegerAttr(align, "align_corners", 0))
+          return rewriter.notifyMatchFailure(binder.op,
+                                             "align_corners bind failure");
+        if (align != 0)
+          return rewriter.notifyMatchFailure(
+              binder.op, "currently only align_corners : 0 supported");
+        alignCorners = rewriter.create<Torch::ConstantBoolOp>(
+            binder.getLoc(), rewriter.getType<Torch::BoolType>(),
+            rewriter.getBoolAttr(false));
+
+        rewriter.replaceOpWithNewOp<Torch::AtenGridSamplerOp>(
+          binder.op, resultType, input, grid, interpolationMode,
+          paddingMode, alignCorners);
+        return success();
+      });
   patterns.onOp("Less", 13,
                 [](OpBinder binder, ConversionPatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -109,8 +109,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             binder.tensorOperandAtIndex(grid, 1) ||
             binder.tensorResultType(resultType))
           return rewriter.notifyMatchFailure(
-            binder.op,
-            "operand grid_sampler bind failure");
+            binder.op, "operand grid_sampler bind failure");
 
         auto inputTensorType = input.getType().cast<Torch::ValueTensorType>();
         ArrayRef<int64_t> inputShape = inputTensorType.getSizes();
@@ -142,7 +141,6 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         if (padding != "zeros")
           return rewriter.notifyMatchFailure(
               binder.op, "currently only padding_mode : zeros supported");
-        
         if (binder.s64IntegerAttr(align, "align_corners", 0))
           return rewriter.notifyMatchFailure(binder.op,
                                              "align_corners bind failure");
@@ -155,7 +153,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
         paddingMode = rewriter.create<Torch::ConstantIntOp>(
             binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));        
+            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
         alignCorners = rewriter.create<Torch::ConstantBoolOp>(
             binder.getLoc(), rewriter.getType<Torch::BoolType>(),
             rewriter.getBoolAttr(false));

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -93,7 +93,8 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         return success();
       });
   patterns.onOp(
-      "GridSample", 20, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "GridSample", 20,
+      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value input;
         Value grid;
@@ -106,8 +107,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
 
         if (binder.tensorOperandAtIndex(input, 0) ||
             binder.tensorOperandAtIndex(grid, 1) ||
-            binder.tensorResultType(resultType)
-            )
+            binder.tensorResultType(resultType))
           return failure();
 
         auto inputTensorType = input.getType().cast<Torch::ValueTensorType>();
@@ -118,21 +118,24 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         unsigned gridRank = gridShape.size();
 
         if(inputRank != 4) {
-          return rewriter.notifyMatchFailure(binder.op, "only input rank 4 supported");
+          return rewriter.notifyMatchFailure(binder.op,
+                                             "only input rank 4 supported");
         }
         if(gridRank != 4) {
-          return rewriter.notifyMatchFailure(binder.op, "only grid rank 4 supported");
+          return rewriter.notifyMatchFailure(binder.op,
+                                             "only grid rank 4 supported");
         }
         if(inputShape[0] != gridShape[0]) {
-          return rewriter.notifyMatchFailure(binder.op, "N must be same for input and grid");
+          return rewriter.notifyMatchFailure(
+              binder.op, "N must be same for input and grid");
         }
         if(gridShape[3] != 2) {
-          return rewriter.notifyMatchFailure(binder.op, "gridShape[3] ,must be 2");
+          return rewriter.notifyMatchFailure(binder.op,
+                                             "gridShape[3] ,must be 2");
         }
 
         if (binder.customOpNameStringAttr(mode, "mode", "bilinear"))
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "mode bind failure");
+          return rewriter.notifyMatchFailure(binder.op, "mode bind failure");
         if (mode != "bilinear")
           return rewriter.notifyMatchFailure(
               binder.op, "currently only mode : bilinear supported");
@@ -147,8 +150,8 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
           return rewriter.notifyMatchFailure(
               binder.op, "currently only padding_mode : zeros supported");
         paddingMode = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+            binder.getLoc(), rewriter.getType<Torch::IntType>(),
+            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
 
         if (binder.s64IntegerAttr(align, "align_corners", 0))
           return rewriter.notifyMatchFailure(binder.op,
@@ -161,8 +164,8 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             rewriter.getBoolAttr(false));
 
         rewriter.replaceOpWithNewOp<Torch::AtenGridSamplerOp>(
-          binder.op, resultType, input, grid, interpolationMode,
-          paddingMode, alignCorners);
+            binder.op, resultType, input, grid, interpolationMode, paddingMode,
+            alignCorners);
         return success();
       });
   patterns.onOp("Less", 13,

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -117,19 +117,19 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         ArrayRef<int64_t> gridShape = gridTensorType.getSizes();
         unsigned gridRank = gridShape.size();
 
-        if(inputRank != 4) {
+        if (inputRank != 4) {
           return rewriter.notifyMatchFailure(binder.op,
                                              "only input rank 4 supported");
         }
-        if(gridRank != 4) {
+        if (gridRank != 4) {
           return rewriter.notifyMatchFailure(binder.op,
                                              "only grid rank 4 supported");
         }
-        if(inputShape[0] != gridShape[0]) {
+        if (inputShape[0] != gridShape[0]) {
           return rewriter.notifyMatchFailure(
               binder.op, "N must be same for input and grid");
         }
-        if(gridShape[3] != 2) {
+        if (gridShape[3] != 2) {
           return rewriter.notifyMatchFailure(binder.op,
                                              "gridShape[3] ,must be 2");
         }

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
@@ -395,6 +395,18 @@ func.func @test_gelu_tanh_2(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtenso
 
 // -----
 
+// CHECK-LABEL: @test_grid_sampler
+// CHECK: %[[INT0:.*]] = torch.constant.int 0
+// CHECK: %[[INT0_0:.*]] = torch.constant.int 0
+// CHECK: %[[B0:.*]] = torch.constant.bool false
+// CHECK: %[[A0:.*]] = torch.aten.grid_sampler %arg0, %arg1, %[[INT0]], %[[INT0_0]], %[[B0]] : !torch.vtensor<[5,10,10,4],f32>
+func.func @test_grid_sampler(%arg0: !torch.vtensor<[5,10,10,4],f32>, %arg1: !torch.vtensor<[5,7,8,2],f32>) -> !torch.vtensor<[?,?,?,?],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 20 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  %4 = torch.operator "onnx.GridSample" (%arg0, %arg1) {torch.onnx.align_corners = 0 : si64, torch.onnx.padding_mode = "zeros"} : (!torch.vtensor<[5,10,10,4],f32>, !torch.vtensor<[5,7,8,2],f32>) -> !torch.vtensor<[?,?,?,?],f32>
+  return %4 : !torch.vtensor<[?,?,?,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @test_less_or_equal
 func.func @test_less_or_equal(%arg0: !torch.vtensor<[3,4,5],f32>, %arg1: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],i1> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 16 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
   // CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[3,4,5],f32>


### PR DESCRIPTION
This is the lowering of gridsampler from onnx to torch using our prior implementation of AtenGridSamplerOp. 
Here are several checks for cornercases implemented. We may decide to have part of these checks in AtenGridSamplerOp instead of the onnx lowering portion.  