### PR TITLE
[torch] Add edgecase for aten.shape_to_tensor for rank-0 input

### DIFF
--- a/lib/Conversion/TorchToTensor/TorchToTensor.cpp
+++ b/lib/Conversion/TorchToTensor/TorchToTensor.cpp
@@ -84,6 +84,12 @@ public:
         getTypeConverter()->convertType(op.getType()).cast<RankedTensorType>();
 
     int64_t rank = operandTy.getRank();
+    if (rank == 0) {
+      rewriter.replaceOpWithNewOp<tensor::EmptyOp>(op, resultTy.getShape(),
+                                                   resultTy.getElementType());
+      return success();
+    }
+
     SmallVector<Value> dims;
     for (int i = 0; i < rank; ++i) {
       Value dim = rewriter.createOrFold<tensor::DimOp>(loc, operand, i);


### PR DESCRIPTION
Currently lowering uses `tensor.from_elements` which does not allow zero inputs. In this case we return a `tensor.empty` operation.