### PR TITLE
[torch] Support `aten.view` rank-0 collapse

### DIFF
--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -795,17 +795,19 @@ public:
     auto resultType =
         typeConverter->convertType(op.getType()).cast<RankedTensorType>();
     int64_t resultRank = resultType.getRank();
-    if (resultRank == 0)
-      return rewriter.notifyMatchFailure(op,
-                                         "result shape of rank 0 is invalid");
-
-    if (inputRank == 0) {
-      Value expanded =
+    if (resultRank == 0) {
           rewriter
-              .create<tensor::ExpandShapeOp>(loc, resultType, input,
+              .replaceOpWithNewOp<tensor::CollapseShapeOp>(op, resultType, input,
                                              ArrayRef<ReassociationIndices>())
               .getResult();
-      rewriter.replaceOp(op, expanded);
+      return success();
+    }
+
+    if (inputRank == 0) {
+          rewriter
+              .replaceOpWithNewOp<tensor::ExpandShapeOp>(op, resultType, input,
+                                             ArrayRef<ReassociationIndices>())
+              .getResult();
       return success();
     }
 

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -805,9 +805,10 @@ public:
 
     if (inputRank == 0) {
       llvm::SmallVector<int64_t> outshape(resultRank, 1);
-      auto expandTy = RankedTensorType::get(outshape, resultType.getElementType());
+      auto expandTy =
+          RankedTensorType::get(outshape, resultType.getElementType());
       Value expand = rewriter.create<tensor::ExpandShapeOp>(
-              op.getLoc(), expandTy, input, ArrayRef<ReassociationIndices>());
+          op.getLoc(), expandTy, input, ArrayRef<ReassociationIndices>());
       rewriter.replaceOpWithNewOp<tensor::CastOp>(op, resultType, expand);
       return success();
     }

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -804,10 +804,11 @@ public:
     }
 
     if (inputRank == 0) {
-      rewriter
-          .replaceOpWithNewOp<tensor::ExpandShapeOp>(
-              op, resultType, input, ArrayRef<ReassociationIndices>())
-          .getResult();
+      llvm::SmallVector<int64_t> outshape(resultRank, 1);
+      auto expandTy = RankedTensorType::get(outshape, resultType.getElementType());
+      Value expand = rewriter.create<tensor::ExpandShapeOp>(
+              op.getLoc(), expandTy, input, ArrayRef<ReassociationIndices>());
+      rewriter.replaceOpWithNewOp<tensor::CastOp>(op, resultType, expand);
       return success();
     }
 

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -796,18 +796,18 @@ public:
         typeConverter->convertType(op.getType()).cast<RankedTensorType>();
     int64_t resultRank = resultType.getRank();
     if (resultRank == 0) {
-          rewriter
-              .replaceOpWithNewOp<tensor::CollapseShapeOp>(op, resultType, input,
-                                             ArrayRef<ReassociationIndices>())
-              .getResult();
+      rewriter
+          .replaceOpWithNewOp<tensor::CollapseShapeOp>(
+              op, resultType, input, ArrayRef<ReassociationIndices>())
+          .getResult();
       return success();
     }
 
     if (inputRank == 0) {
-          rewriter
-              .replaceOpWithNewOp<tensor::ExpandShapeOp>(op, resultType, input,
-                                             ArrayRef<ReassociationIndices>())
-              .getResult();
+      rewriter
+          .replaceOpWithNewOp<tensor::ExpandShapeOp>(
+              op, resultType, input, ArrayRef<ReassociationIndices>())
+          .getResult();
       return success();
     }
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2141,7 +2141,6 @@ ONNX_XFAIL_SET = {
     "ReduceMaxUnsignedIntModule_basic",
 
     # Failure - torch.aten.view lower
-    "AddSizeIntModule_basic",
     "ElementwiseFlattenBroadcastModule_basic",
     "IndexTensorDyanmicInputContiguousWithNoneModule_basic",
     "IndexTensorDyanmicInputNonContiguousWithNoneModule_basic",


### PR DESCRIPTION
Collapsing to a rank-0 tensor using `aten.view` was currently bailing out. Added the special case.