### PR TITLE
[FxImporter] remove dataclass slots to support python3.9

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -315,6 +315,7 @@ def is_builtin_function_or_method(obj: Any) -> bool:
     return isinstance(obj, (BuiltinMethodType, BuiltinFunctionType))
 
 
+# TODO: switch back to `slots=True` when py3.9 support is dropped
 @dataclass(frozen=True)
 class InputInfo:
     """Provides additional metadata when resolving inputs."""

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -315,15 +315,23 @@ def is_builtin_function_or_method(obj: Any) -> bool:
     return isinstance(obj, (BuiltinMethodType, BuiltinFunctionType))
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class InputInfo:
     """Provides additional metadata when resolving inputs."""
+
+    __slots__ = [
+        "program",
+        "input_spec",
+        "node",
+        "ir_type",
+        "mutable_producer_node_name",
+    ]
 
     program: torch.export.ExportedProgram
     input_spec: TypingInputSpec
     node: Node
     ir_type: IrType
-    mutable_producer_node_name: Optional[str] = None
+    mutable_producer_node_name: Optional[str]
 
 
 class FxImporterHooks:
@@ -546,7 +554,13 @@ class FxImporter:
                 node_ir_type = self._cc.node_val_to_type(node, mutable=False)
                 parameter_bindings[node] = (
                     value,
-                    InputInfo(prog, input_spec, node=node, ir_type=node_ir_type),
+                    InputInfo(
+                        prog,
+                        input_spec,
+                        node=node,
+                        ir_type=node_ir_type,
+                        mutable_producer_node_name=None,
+                    ),
                 )
             elif input_spec.kind == InputKind.BUFFER and isinstance(
                 arg, TensorArgument


### PR DESCRIPTION
* that `dataclass`'s `slots` is supported after python 3.10.