### PR TITLE
[onnx] Adding lowering for `onnx.Size` operation

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1984,7 +1984,6 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
       "Size", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value operand;
-        Value repeatDims;
         if (binder.tensorOperand(operand) ||
             binder.tensorResultType(resultType))
           return failure();

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -2006,8 +2006,8 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         }
 
         Value cstFalse =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
-        Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+            rewriter.create<Torch::ConstantBoolOp>(loc, false);
+        Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
 
         if (dims.empty()) {
           Value one = rewriter.create<Torch::ConstantIntOp>(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -2005,8 +2005,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           dims.push_back(dim);
         }
 
-        Value cstFalse =
-            rewriter.create<Torch::ConstantBoolOp>(loc, false);
+        Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(loc, false);
         Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
 
         if (dims.empty()) {

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -1593,3 +1593,24 @@ func.func @test_sign(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,
   %0 = torch.operator "onnx.Sign"(%arg0) : (!torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],f32>
   return %0 : !torch.vtensor<[3,4,5],f32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @test_size
+func.func @test_size(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[],si32> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 9 : si64} {
+  // CHECK-DAG  %[[INT0:.+]] = torch.constant.int 0
+  // CHECK-DAG  %[[INT1:.+]] = torch.constant.int 1
+  // CHECK-DAG  %[[INT2:.+]] = torch.constant.int 2
+  // CHECK-DAG  %[[D0:.+]] = torch.aten.size.int %arg0, %[[INT0]]
+  // CHECK-DAG  %[[D1:.+]] = torch.aten.size.int %arg0, %[[INT1]]
+  // CHECK-DAG  %[[D2:.+]] = torch.aten.size.int %arg0, %[[INT2]]
+  // CHECK-DAG  %[[FALSE:.+]] = torch.constant.bool false
+  // CHECK-DAG  %[[NONE:.+]] = torch.constant.none
+  // CHECK-DAG  %[[MUL0:.+]] = torch.aten.mul.int %[[D0]], %[[D1]]
+  // CHECK-DAG  %[[MUL1:.+]] = torch.aten.mul.int %[[MUL0]], %[[D3]]
+  // CHECK-DAG  %[[TENSOR:.+]] = torch.aten.tensor.int %[[MUL1]], %[[NONE]], %[[NONE]], %[[FALSE]]
+  // CHECK      return %[[TENSOR]]
+  %0 = torch.operator "onnx.Size"(%arg0) : (!torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[],si32>
+  return %0 : !torch.vtensor<[],si32>
+}
+


### PR DESCRIPTION
We can support `onnx.Size` by requesing the size of each dimensions and taking the product of the results, then packing it into a tensor.