### PR TITLE
[onnx] Fix OnnxToLinalg lowering issue for `onnx.Squeeze` and `onnx.Unsqueeze`

### DIFF
--- a/include/torch-mlir/Conversion/TorchOnnxToTorch/Utils.h
+++ b/include/torch-mlir/Conversion/TorchOnnxToTorch/Utils.h
@@ -10,10 +10,25 @@
 #ifndef TORCHMLIR_CONVERSION_TORCHONNXTOTORCH_UTILS_H
 #define TORCHMLIR_CONVERSION_TORCHONNXTOTORCH_UTILS_H
 
+#include "mlir/IR/DialectResourceBlobManager.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "torch-mlir/Conversion/TorchOnnxToTorch/Patterns.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+
+class Endian {
+private:
+  static constexpr uint32_t uint32_ = 0x01020304;
+  static constexpr uint8_t magic_ = (const uint8_t &)uint32_;
+
+public:
+  static constexpr bool little = magic_ == 0x04;
+  static constexpr bool big = magic_ == 0x01;
+  static_assert(little || big, "Cannot determine endianness!");
+
+private:
+  Endian() = delete;
+};
 
 namespace mlir::torch::onnx_c {
 
@@ -27,6 +42,50 @@ LogicalResult OnnxLstmExpander(OpBinder binder,
                                ConversionPatternRewriter &rewriter);
 
 bool areAllElementsDistinct(SmallVector<int64_t> array);
+
+namespace detail {
+/// Matches the constant integers stored in a `onnx.Constant`.
+struct onnx_list_of_constant_ints_op_binder {
+  SmallVectorImpl<int64_t> &bind_values;
+
+  /// Creates a matcher instance that binds the value to bvs if match succeeds.
+  onnx_list_of_constant_ints_op_binder(SmallVectorImpl<int64_t> &bvs)
+      : bind_values(bvs) {}
+
+  bool match(Operation *op) {
+    auto constOp = dyn_cast<Torch::OperatorOp>(op);
+    if (!constOp || !constOp.getName().equals("onnx.Constant"))
+      return false;
+
+    if (DenseResourceElementsAttr attr =
+            constOp->getAttr("torch.onnx.value")
+                .dyn_cast_or_null<DenseResourceElementsAttr>()) {
+      // Bytes are stored in little endian order. Big endian support will
+      // require swizzling.
+      if (!Endian::little) {
+        op->emitError("unimplemented: importing on big endian systems");
+        return false;
+      }
+
+      auto ty = cast<ShapedType>(attr.getType());
+      ElementsAttr denseAttr;
+      auto ptr = attr.getRawHandle().getBlob()->getData();
+      denseAttr = DenseElementsAttr::getFromRawBuffer(ty, ptr);
+      for (auto axis : denseAttr.getValues<llvm::APInt>()) {
+        bind_values.push_back(axis.getSExtValue());
+      }
+      return true;
+    }
+    return false;
+  }
+};
+} // namespace detail
+
+/// Matches the constant integers stored in a `onnx.Constant`.
+inline detail::onnx_list_of_constant_ints_op_binder
+m_OnnxListOfConstantInts(SmallVectorImpl<int64_t> &bind_values) {
+  return detail::onnx_list_of_constant_ints_op_binder(bind_values);
+}
 
 } // namespace mlir::torch::onnx_c
 

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
@@ -12,7 +12,6 @@
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/DialectResourceBlobManager.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
@@ -266,41 +265,6 @@ struct torch_tensor_size_int_op_binder {
 inline detail::torch_tensor_size_int_op_binder
 m_TorchTensorSizeInt(Value tensor, int64_t *dim) {
   return detail::torch_tensor_size_int_op_binder(tensor, dim);
-}
-
-namespace detail {
-/// Matches the constant integers stored in a `onnx.Constant`.
-struct onnx_list_of_constant_ints_op_binder {
-  SmallVectorImpl<int64_t> &bind_values;
-
-  /// Creates a matcher instance that binds the value to bvs if match succeeds.
-  onnx_list_of_constant_ints_op_binder(SmallVectorImpl<int64_t> &bvs)
-      : bind_values(bvs) {}
-
-  bool match(Operation *op) {
-    auto constOp = dyn_cast<Torch::OperatorOp>(op);
-    if (!constOp || !constOp.getName().equals("onnx.Constant"))
-      return false;
-
-    DenseResourceElementsAttr attr =
-        constOp->getAttr("torch.onnx.value")
-            .dyn_cast_or_null<DenseResourceElementsAttr>();
-    auto ty = cast<ShapedType>(attr.getType());
-    ElementsAttr denseAttr;
-    auto ptr = attr.getRawHandle().getBlob()->getData();
-    denseAttr = DenseElementsAttr::getFromRawBuffer(ty, ptr);
-    for (auto axis : denseAttr.getValues<llvm::APInt>()) {
-      bind_values.push_back(axis.getSExtValue());
-    }
-    return true;
-  }
-};
-} // namespace detail
-
-/// Matches the constant integers stored in a `onnx.Constant`.
-inline detail::onnx_list_of_constant_ints_op_binder
-m_OnnxListOfConstantInts(SmallVectorImpl<int64_t> &bind_values) {
-  return detail::onnx_list_of_constant_ints_op_binder(bind_values);
 }
 
 /// Create code to copy `tensor` to type `newType`.

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2701,10 +2701,6 @@ ONNX_XFAIL_SET = {
     "IndexTensorMultiInputContiguousOneDimDynamic_basic",
     "IndexTensorMultiInputNonContiguousOneDimDynamic_basic",
 
-    # Failure - torch.aten.mm lower (mixed signedness of qtypes)
-    "QuantizedMLP_basic",
-    "QuantizedSingleLayer_basic",
-
     # Failure - unknown
     "BernoulliModule_basic",
     "Conv2dWithPaddingDilationStrideStaticModule_depthwise_multiplier",
@@ -2769,6 +2765,6 @@ if torch_version_for_comparison() < version.parse('2.3.0.dev'):
 ONNX_CRASHING_SET = { 
     "FakeQuantizePerTensorAffineModule_basic",
     "FakeQuantizePerTensorAffineDynamicShapeModule_basic",
-
+    "ElementwisePreluModule_basic",
     "ViewDynamicExpandCollapseWithParallelUnknownDimModule_basic",
 }

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2643,12 +2643,8 @@ ONNX_XFAIL_SET = {
     # Failure - onnx_lowering: onnx.ScatterElements
     "ScatterReduceFloatMaxModuleIncludeSelf",
     "ScatterReduceFloatMinModuleIncludeSelf",
-    "ScatterReduceFloatProdModuleIncludeSelf",
-    "ScatterReduceFloatSumModuleIncludeSelf",
     "ScatterReduceIntMaxModuleIncludeSelf",
     "ScatterReduceIntMinModuleIncludeSelf",
-    "ScatterReduceIntProdModuleIncludeSelf",
-    "ScatterReduceIntSumModuleIncludeSelf",
     "ScatterValueFloatModule_basic",
     
     # Failure - onnx_lowering: onnx.ScatterND
@@ -2684,23 +2680,6 @@ ONNX_XFAIL_SET = {
     # RuntimeError: unsupported input type: Device
     "PrimsIotaModule_basic",
 
-    # Failure - incorrect dtype
-    "ReduceMaxAlongDimUnsignedInt_basic",
-    "ElementwiseToDtypeI64ToUI8Module_basic",
-
-    # Failure - torch.aten.view lower
-    "IndexTensorDyanmicInputContiguousWithNoneModule_basic",
-    "IndexTensorDyanmicInputNonContiguousWithNoneModule_basic",
-    "IndexTensorHackedTwinMultiInputNonContiguousMultipleStaticDims_basic",
-    "IndexTensorMultiInputContiguousCenter_basic",
-    "IndexTensorMultiInputNonContiguousMultipleStaticDims_basic",
-    "IndexTensorMultiInputNonContiguous_basic",
-    "IndexTensorMultiInputOneDim_basic",
-    "IndexTensorMultiInputThreeIndexers_basic",
-    "IndexTensorMultiInput_basic",
-    "IndexTensorMultiInputContiguousOneDimDynamic_basic",
-    "IndexTensorMultiInputNonContiguousOneDimDynamic_basic",
-
     # Failure - unknown
     "BernoulliModule_basic",
     "Conv2dWithPaddingDilationStrideStaticModule_depthwise_multiplier",
@@ -2724,29 +2703,11 @@ ONNX_XFAIL_SET = {
     "ElementwiseTanIntModule_basic",
     "ElementwiseToDtypeI64ToUI8Module_basic",
     "ElementwiseUnaryIntModule_basic",
-    "EmbeddingModuleF16_basic",
-    "EmbeddingModuleI32_basic",
-    "EmbeddingModuleI64_basic",
-    "FlattenDynamicModule_basic",
-    "GluStaticModule_basic",
-    "IndexTensorHackedTwinModule3dInput_basic",
-    "IndexTensorHackedTwinModule_basic",
-    "IndexTensorModule3dInput_basic",
-    "IndexTensorModule_basic",
-    "IndexTensorSelectDimModule_basic",
     "MaskedFillTensorFloatValueModule_basic",
     "NativeDropoutTrainModule_basic",
     "NativeDropoutTrainStaticShapeModule_basic",
     "ReduceMaxAlongDimUnsignedInt_basic",
     "ReduceMinAlongDimUnsignedInt_basic",
-
-    # Failure - "RuntimeError: linalg.cross: inputs dimension 1 must have length 3. Got 1 and 1"
-    "AtenLinalgCrossDynamic_basic",
-
-    # Failure - value not close to golden value (op is incorrectly truncating) 
-    "ElementwiseAtenFloorDivideTensorNegativeModule_basic",
-    "ElementwiseAtenFloorDivideScalarNegativeModule_basic",
-
 }
 
 if torch_version_for_comparison() >= version.parse("2.4.0.dev"):
@@ -2767,4 +2728,8 @@ ONNX_CRASHING_SET = {
     "FakeQuantizePerTensorAffineDynamicShapeModule_basic",
     "ElementwisePreluModule_basic",
     "ViewDynamicExpandCollapseWithParallelUnknownDimModule_basic",
+    "ScatterReduceFloatProdModuleIncludeSelf",
+    "ScatterReduceFloatSumModuleIncludeSelf",
+    "ScatterReduceIntProdModuleIncludeSelf",
+    "ScatterReduceIntSumModuleIncludeSelf",
 }

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2680,22 +2680,33 @@ ONNX_XFAIL_SET = {
     # Failure - onnx_lowering: onnx.SoftmaxCrossEntropyLoss
     "CrossEntropyLossModule_basic",
     "CrossEntropyLossNoReductionModule_basic",
-    
-    # Failure - onnx_lowering: onnx.Squeeze
-    "SqueezeModule_allUnitDim",
-    "SqueezeModule_broadcast",
-    "SqueezeModule_static",
 
     # RuntimeError: unsupported input type: Device
     "PrimsIotaModule_basic",
-    
+
+    # Failure - incorrect dtype
+    "ReduceMaxAlongDimUnsignedInt_basic",
+    "ElementwiseToDtypeI64ToUI8Module_basic",
+
+    # Failure - torch.aten.view lower
+    "IndexTensorDyanmicInputContiguousWithNoneModule_basic",
+    "IndexTensorDyanmicInputNonContiguousWithNoneModule_basic",
+    "IndexTensorHackedTwinMultiInputNonContiguousMultipleStaticDims_basic",
+    "IndexTensorMultiInputContiguousCenter_basic",
+    "IndexTensorMultiInputNonContiguousMultipleStaticDims_basic",
+    "IndexTensorMultiInputNonContiguous_basic",
+    "IndexTensorMultiInputOneDim_basic",
+    "IndexTensorMultiInputThreeIndexers_basic",
+    "IndexTensorMultiInput_basic",
+    "IndexTensorMultiInputContiguousOneDimDynamic_basic",
+    "IndexTensorMultiInputNonContiguousOneDimDynamic_basic",
+
+    # Failure - torch.aten.mm lower (mixed signedness of qtypes)
+    "QuantizedMLP_basic",
+    "QuantizedSingleLayer_basic",
+
     # Failure - unknown
     "BernoulliModule_basic",
-    "BucketizeTensorFloatModule_basic",
-    "BucketizeTensorModule_basic",
-    "BucketizeTensorOutInt32RightModule_basic",
-    "BucketizeTensorStaticFloatModule_basic",
-    "BucketizeTensorStaticModule_basic",
     "Conv2dWithPaddingDilationStrideStaticModule_depthwise_multiplier",
     "CopyWithDifferentDTypesAndSizesModule_basic",
     "CopyWithDifferentDTypesModule_basic",
@@ -2712,22 +2723,34 @@ ONNX_XFAIL_SET = {
     "ElementwiseErfIntModule_basic",
     "ElementwiseExpIntModule_basic",
     "ElementwiseLogIntModule_basic",
-    "ElementwisePreluModule_basic",
-    "ElementwisePreluStaticModule_basic",
     "ElementwiseSigmoidIntModule_basic",
     "ElementwiseSinIntModule_basic",
     "ElementwiseTanIntModule_basic",
     "ElementwiseToDtypeI64ToUI8Module_basic",
     "ElementwiseUnaryIntModule_basic",
-    "ElementwiseUnsqueezeNegDimsModule_basic",
-    "GroupNormModule_basic",
+    "EmbeddingModuleF16_basic",
+    "EmbeddingModuleI32_basic",
+    "EmbeddingModuleI64_basic",
+    "FlattenDynamicModule_basic",
+    "GluStaticModule_basic",
+    "IndexTensorHackedTwinModule3dInput_basic",
+    "IndexTensorHackedTwinModule_basic",
+    "IndexTensorModule3dInput_basic",
+    "IndexTensorModule_basic",
+    "IndexTensorSelectDimModule_basic",
     "MaskedFillTensorFloatValueModule_basic",
     "NativeDropoutTrainModule_basic",
     "NativeDropoutTrainStaticShapeModule_basic",
     "ReduceMaxAlongDimUnsignedInt_basic",
     "ReduceMinAlongDimUnsignedInt_basic",
-    "TensorsStackNegativeDimModule_basic",
-    "TensorsStackPromoteDTypeModule_basic",
+
+    # Failure - "RuntimeError: linalg.cross: inputs dimension 1 must have length 3. Got 1 and 1"
+    "AtenLinalgCrossDynamic_basic",
+
+    # Failure - value not close to golden value (op is incorrectly truncating) 
+    "ElementwiseAtenFloorDivideTensorNegativeModule_basic",
+    "ElementwiseAtenFloorDivideScalarNegativeModule_basic",
+
 }
 
 if torch_version_for_comparison() >= version.parse("2.4.0.dev"):


### PR DESCRIPTION
This commit also cleans up the OnnxToTorch lowering for the Squeeze and Unsqueeze op and adds the support for handling edge cases.

Signed-Off By: Vivek Khandelwal <vivekkhandelwal1424@gmail.com>