### PR TITLE
[dynamo] Verify the default value is passed by kwargs

### DIFF
--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -252,12 +252,6 @@ TORCHDYNAMO_XFAIL_SET = {
     # ERROR: Exception: Unsupported: missing default value for argument 0 in schema for aten.div.Tensor_mode
     "ElementwiseAtenFloorDivideScalarNegativeModule_basic",
     "ElementwiseAtenFloorDivideScalarModule_basic",
-    "ElementwiseDivTensorRoundingModeFloorModule_basic",
-    "ElementwiseDivTensorRoundingModeTruncModule_basic",
-    "ElementwiseDivTensorRoundingModeFloorStaticModule_basic",
-    "ElementwiseDivTensorRoundingModeTruncStaticModule_basic",
-    "ElementwiseDivTensorRoundingModeFloorIntStaticModule_basic",
-    "ElementwiseDivTensorRoundingModeTruncIntStaticModule_basic",
     "ElementwiseDivScalarRoundingModeFloorModule_basic",
     "ElementwiseDivScalarRoundingModeTruncModule_basic",
     "ElementwiseDivScalarRoundingModeFloorStaticModule_basic",
@@ -341,8 +335,10 @@ TORCHDYNAMO_XFAIL_SET = {
     "IntImplicitModule_basic",
 
     # Others
+    "ExponentialModule_basic",
     "GridSamplerBasic1_basic",
     "GridSamplerBasic2_basic",
+    "GridSamplerBasic3_basic",
     "FakeQuantizePerTensorAffineModule_basic",
     "FakeQuantizePerTensorAffineDynamicShapeModule_basic",
     "FakeQuantizePerTensorAffineRoundToEvenModule_basic",

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -264,6 +264,8 @@ TORCHDYNAMO_XFAIL_SET = {
     "ElementwiseDivScalarRoundingModeTruncStaticModule_basic",
     "ElementwiseDivScalarRoundingModeFloorIntStaticModule_basic",
     "ElementwiseDivScalarRoundingModeTruncIntStaticModule_basic",
+
+    # ERROR: 'torch.aten.mul.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.int'
     "AdaptiveAvgPool1dStaticLargerOutput_basic",
     "AdaptiveAvgPool1dGeneralDynamic_basic",
     "AdaptiveAvgPool1dGeneralDynamicNoBatches_basic",
@@ -275,10 +277,6 @@ TORCHDYNAMO_XFAIL_SET = {
     "NumToTensorIntModule_basic",
     "TensorFloatModule_basic",
     "TensorIntModule_basic",
-
-    # ERROR: Exception: Unsupported: missing default value for argument 0 in schema for aten.randn.generator
-    "RandnGeneratorF64Module_basic",
-    "RandnGeneratorModule_basic",
 
     # START tests failing due to: complex floating point ops
     # END tests failing due to: complex floating point ops

--- a/projects/pt1/python/torch_mlir/_dynamo_fx_importer.py
+++ b/projects/pt1/python/torch_mlir/_dynamo_fx_importer.py
@@ -78,7 +78,7 @@ def _verify_fx_graph_conforms_to_subset(g: torch.fx.Graph):
                     assert len(node.args) < len(node.target._schema.arguments)
                     for i, argument in enumerate(
                             node.target._schema.arguments[len(node.args):]):
-                        if not argument.has_default_value():
+                        if not argument.has_default_value() and argument.name not in node.kwargs:
                             raise Exception(
                                 f"Unsupported: missing default value for argument {i} in schema for {node.target}"
                             )


### PR DESCRIPTION
Four xfailed cases due to this reason. They can pass after fixing it.
```
ElementwiseDivRoundingModeFloorModule_basic
ElementwiseDivRoundingModeTruncModule_basic
RandnGeneratorF64Module_basic
RandnGeneratorModule_basic
```