### PR TITLE
fximporter: support newer torch versions

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -225,9 +225,11 @@ PY_BUILTIN_TO_TORCH_OP = {
 _IS_TORCH_2_1_OR_EARLIER = torch.__version__.split("+")[0] <= "2.1.0"
 
 # The following are maps from symbolic ops to their non symbolic equivalents.
-# In <=2.1.0, imported fx graphs come with torch.ops.aten.sym_size and a number
-# identifying either default or int for the types we include here. Later
-# versions drop this in favor of torch.ops.aten.sym_size.<type>.
+# In <=2.1.0, imported fx graphs come with a type inspecific torch.ops.aten.sym_size
+# We identify it using the number of args in the node, 1 being default, 2 being int
+# In the mapping below (torch.aten.sym_size, 2) indicates len(args)=2 therefore
+# map to torch.aten.size.int.
+# Thankfully, newer versions provide a specific torch.ops.aten.sym_size.<type>.
 # Once we drop support for <2.1.0, we can get rid of the the SYMBOLIC_TORCH_OPS
 # set and just check key existence in SYMBOLIC_OP_TO_TORCH_OP
 

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -222,33 +222,33 @@ PY_BUILTIN_TO_TORCH_OP = {
 
 # this allows stripping of cuda versions like: "+cu113"
 if torch.__version__.split("+")[0] <= "2.1.0":
-	SYMBOLIC_TORCH_OPS = {
-		torch.ops.aten.sym_size,
-		torch.ops.aten.sym_stride,
-		torch.ops.aten.sym_numel,
-	}
+    SYMBOLIC_TORCH_OPS = {
+        torch.ops.aten.sym_size,
+        torch.ops.aten.sym_stride,
+        torch.ops.aten.sym_numel,
+    }
 
-	SYMBOLIC_OP_TO_TORCH_OP = {
-		(torch.ops.aten.sym_size, 1): torch.ops.aten.size.default,
-		(torch.ops.aten.sym_size, 2): torch.ops.aten.size.int,
-		(torch.ops.aten.sym_stride, 1): torch.ops.aten.stride.default,
-		(torch.ops.aten.sym_stride, 2): torch.ops.aten.stride.int,
-		(torch.ops.aten.sym_numel, 1): torch.ops.aten.numel.default,
-	}
+    SYMBOLIC_OP_TO_TORCH_OP = {
+        (torch.ops.aten.sym_size, 1): torch.ops.aten.size.default,
+        (torch.ops.aten.sym_size, 2): torch.ops.aten.size.int,
+        (torch.ops.aten.sym_stride, 1): torch.ops.aten.stride.default,
+        (torch.ops.aten.sym_stride, 2): torch.ops.aten.stride.int,
+        (torch.ops.aten.sym_numel, 1): torch.ops.aten.numel.default,
+    }
 else:
-	SYMBOLIC_TORCH_OPS = {
-		torch.ops.aten.sym_size.int,
-		torch.ops.aten.sym_stride.int,
-		torch.ops.aten.sym_numel.default,
-	}
+    SYMBOLIC_TORCH_OPS = {
+        torch.ops.aten.sym_size.int,
+        torch.ops.aten.sym_stride.int,
+        torch.ops.aten.sym_numel.default,
+    }
 
-	SYMBOLIC_OP_TO_TORCH_OP = {
-		torch.ops.aten.sym_size.default: torch.ops.aten.size.default,
-		torch.ops.aten.sym_size.int : torch.ops.aten.size.int,
-		torch.ops.aten.sym_stride.default : torch.ops.aten.stride.default,
-		torch.ops.aten.sym_stride.int : torch.ops.aten.stride.int,
-		torch.ops.aten.sym_numel.default : torch.ops.aten.numel.default,
-	}
+    SYMBOLIC_OP_TO_TORCH_OP = {
+        torch.ops.aten.sym_size.default: torch.ops.aten.size.default,
+        torch.ops.aten.sym_size.int: torch.ops.aten.size.int,
+        torch.ops.aten.sym_stride.default: torch.ops.aten.stride.default,
+        torch.ops.aten.sym_stride.int: torch.ops.aten.stride.int,
+        torch.ops.aten.sym_numel.default: torch.ops.aten.numel.default,
+    }
 
 
 @dataclass(frozen=True)
@@ -639,7 +639,9 @@ class FxImporter:
         node_importer.return_node_values(loc, user_outputs)
         self.symbol_table.insert(func_op)
 
-    def import_frozen_program(self, prog: torch.export.ExportedProgram, func_name: str = "main"):
+    def import_frozen_program(
+        self, prog: torch.export.ExportedProgram, func_name: str = "main"
+    ):
         """Imports a consolidated torch.export.ExportedProgram instance.
 
         If using the new torch.export path (vs a lower level precursor), then this is
@@ -1632,8 +1634,7 @@ class TypeSubclassMap:
 
 # Opaque value to indicate something is empty. Used in cases where 'None'
 # may have a different meaning.
-class EmptyType:
-    ...
+class EmptyType: ...
 
 
 Empty = EmptyType()


### PR DESCRIPTION
uses version checking since attributes exist in both versions, the only thing that changes is what we're receiving as an fx graph