### PR TITLE
[onnx] Fix expand operation for dynamic shape max

### DIFF
--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1507,8 +1507,6 @@ ONNX_XFAIL_SET = {
     "ArangeStartOutDtypeModule_basic",
     "ArangeStartOutViewModule_basic",
     "BroadcastDynamicDimModule_basic",
-    "BroadcastToModule_basic",
-    "ExpandModule_basic",
     "MoveDimIntNegativeIndexModule_basic",
     "ViewSizeFromOtherTensor_basic",
 


### PR DESCRIPTION
If the broadcast shape is length-1 at a dim while `?` in the input dim then we need to broadcast to the dynamic dim. This is equivalent to taking a max of two dimensions.