### PR TITLE
[torch] Fix clamp ranges on quantize_per_tensor on unsigned

### DIFF
--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -1504,12 +1504,12 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
     APInt max = isUnsigned ? APInt::getMaxValue(bitwidth)
                            : APInt::getSignedMaxValue(bitwidth);
 
+    double minI = isUnsigned ? static_cast<double>(min.getZExtValue()) : static_cast<double>(min.getSExtValue());
+    double maxI = isUnsigned ? static_cast<double>(max.getZExtValue()) : static_cast<double>(max.getSExtValue());
     Value minVal = b.create<arith::ConstantOp>(
-        loc, b.getFloatAttr(valueTy, isUnsigned ? min.getZExtValue()
-                                                : min.getSExtValue()));
+        loc, b.getFloatAttr(valueTy, minI));
     Value maxVal = b.create<arith::ConstantOp>(
-        loc, b.getFloatAttr(valueTy, isUnsigned ? max.getZExtValue()
-                                                : max.getSExtValue()));
+        loc, b.getFloatAttr(valueTy, maxI));
     Value minCmp =
         b.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ULT, value, minVal);
     Value maxCmp =

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -1504,12 +1504,14 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
     APInt max = isUnsigned ? APInt::getMaxValue(bitwidth)
                            : APInt::getSignedMaxValue(bitwidth);
 
-    double minI = isUnsigned ? static_cast<double>(min.getZExtValue()) : static_cast<double>(min.getSExtValue());
-    double maxI = isUnsigned ? static_cast<double>(max.getZExtValue()) : static_cast<double>(max.getSExtValue());
-    Value minVal = b.create<arith::ConstantOp>(
-        loc, b.getFloatAttr(valueTy, minI));
-    Value maxVal = b.create<arith::ConstantOp>(
-        loc, b.getFloatAttr(valueTy, maxI));
+    double minI = isUnsigned ? static_cast<double>(min.getZExtValue())
+                             : static_cast<double>(min.getSExtValue());
+    double maxI = isUnsigned ? static_cast<double>(max.getZExtValue())
+                             : static_cast<double>(max.getSExtValue());
+    Value minVal =
+        b.create<arith::ConstantOp>(loc, b.getFloatAttr(valueTy, minI));
+    Value maxVal =
+        b.create<arith::ConstantOp>(loc, b.getFloatAttr(valueTy, maxI));
     Value minCmp =
         b.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ULT, value, minVal);
     Value maxCmp =

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -1505,9 +1505,11 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
                            : APInt::getSignedMaxValue(bitwidth);
 
     Value minVal = b.create<arith::ConstantOp>(
-        loc, b.getFloatAttr(valueTy, min.getSExtValue()));
+        loc, b.getFloatAttr(valueTy, isUnsigned ? min.getZExtValue()
+                                                : min.getSExtValue()));
     Value maxVal = b.create<arith::ConstantOp>(
-        loc, b.getFloatAttr(valueTy, max.getSExtValue()));
+        loc, b.getFloatAttr(valueTy, isUnsigned ? max.getZExtValue()
+                                                : max.getSExtValue()));
     Value minCmp =
         b.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ULT, value, minVal);
     Value maxCmp =

--- a/lib/Conversion/TorchToTensor/TorchToTensor.cpp
+++ b/lib/Conversion/TorchToTensor/TorchToTensor.cpp
@@ -50,7 +50,7 @@ public:
         op.getLoc(), operandTy.getElementType(), operand, indices);
     auto extractTy = extract.getType();
     if (isa<mlir::IntegerType>(extractTy) && !extractTy.isInteger(64)) {
-      if (torchDTy.isSignlessInteger()) {
+      if (torchDTy.isUnsignedInteger()) {
         extract = rewriter.create<arith::ExtUIOp>(
             op.getLoc(), rewriter.getIntegerType(64), extract);
       } else {

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -296,6 +296,7 @@ TORCHDYNAMO_XFAIL_SET = {
     "ElementwiseDequantizePerChannelModule_basic",
     "ElementwiseDequantizePerTensorModule_basic",
     "ElementwiseQuantizePerTensorModule_basic",
+    "ElementwiseQuantizePerTensorUIntModule_basic",
     "AtenMmQuint8_basic",
     "Conv2dQInt8Module_basic",
 
@@ -1595,6 +1596,7 @@ ONNX_XFAIL_SET = {
     "ElementwiseOrTensorModule_basic",
     "ElementwiseOrTensorStaticShapeModule_basic",
     "ElementwiseQuantizePerTensorModule_basic",
+    "ElementwiseQuantizePerTensorUIntModule_basic",
     "ElementwiseRemainderTensorModule_Int_basic",
     "ElementwiseFmodTensor_Float_basic",
     "ElementwiseFmodTensor_Int_Float_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -4675,6 +4675,31 @@ class ElementwiseQuantizePerTensorModule(torch.nn.Module):
 def ElementwiseQuantizePerTensorModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
 
+# ==============================================================================
+
+class ElementwiseQuantizePerTensorUIntModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float, True),
+    ])
+    def forward(self, x):
+        scale = 0.04
+        zp = 11
+        dtype = torch.quint8
+        # We return the int representation as we can not map to quint8 type yet on boundaries.
+        q = torch.quantize_per_tensor(x, scale, zp, dtype).int_repr()
+        q = q.to(torch.int8)
+        return q
+
+@register_test_case(module_factory=lambda: ElementwiseQuantizePerTensorUIntModule())
+def ElementwiseQuantizePerTensorUIntModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+
 
 # ==============================================================================
 


### PR DESCRIPTION
SExtValue was used for `int` and `uint` clamp values. This caused the result to always be outputed as `zero`.