### PR TITLE
[Stablehlo] lowering chlo to stablehlo in torch-to-stablehlo pipeline

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,7 +32,7 @@ set(LinkedLibs
 )
 
 if(TORCH_MLIR_ENABLE_STABLEHLO)
-list(APPEND LinkedLibs StablehloPasses StablehloLinalgTransforms)
+list(APPEND LinkedLibs StablehloLinalgTransforms)
 endif()
 
 if(TORCH_MLIR_ENABLE_REFBACKEND)

--- a/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LinkedLibs
 if(TORCH_MLIR_ENABLE_STABLEHLO)
   list(APPEND LinkedLibs
     StablehloOps
+    StablehloPasses
   )
 endif()
 

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -25,6 +25,7 @@
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
+#include "stablehlo/transforms/Passes.h"
 #include "torch-mlir/Conversion/TorchToStablehlo/TorchToStablehlo.h"
 #endif
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
@@ -134,9 +135,14 @@ void TorchConversion::createTorchBackendToTosaBackendPipeline(
 void TorchConversion::createTorchBackendToStablehloBackendPipeline(
     OpPassManager &pm,
     const TorchConversion::StablehloBackendPipelineOptions &options) {
-  // Generate Stablehlo ops.
+  // Generate Stablehlo & Chlo ops.
   pm.addNestedPass<func::FuncOp>(createConvertTorchToStablehloPass(
       options.enableStaticShape, options.enableI32Index));
+  // Lowering Chlo ops to Stablehlo
+  pm.addNestedPass<func::FuncOp>(
+      stablehlo::createChloLegalizeToStablehloPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+
   // Lowering remained ops to Arith
   pm.addNestedPass<func::FuncOp>(createConvertTorchToArithPass());
 

--- a/lib/InitAll.cpp
+++ b/lib/InitAll.cpp
@@ -31,7 +31,6 @@
 
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
 #include "stablehlo/conversions/linalg/transforms/Passes.h"
-#include "stablehlo/transforms/Passes.h"
 #endif
 
 void mlir::torch::registerAllDialects(mlir::DialectRegistry &registry) {
@@ -58,7 +57,6 @@ void mlir::torch::registerAllPasses() {
   mlir::torch::TMTensor::registerPasses();
 
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
-  mlir::stablehlo::registerChloLegalizeToStablehloPass();
   mlir::stablehlo::registerStablehloLegalizeToLinalgPass();
 #endif
 

--- a/projects/pt1/python/torch_mlir_e2e_test/stablehlo_backends/linalg_on_tensors.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/stablehlo_backends/linalg_on_tensors.py
@@ -18,8 +18,6 @@ __all__ = [
 # The pipeline of func.func passes that lower the STABLEHLO backend contract to the
 # Linalg-on-Tensors backend contract accepted by RefBackend.
 STABLEHLO_TO_LINALG_FUNC_PIPELINE = ",".join([
-    "func.func(chlo-legalize-to-stablehlo)",
-    "canonicalize",
     "stablehlo-legalize-to-linalg"
 ])
 


### PR DESCRIPTION
as that stablehlo is better than chlo as the boundary between frontend compiler and backend compiler.