### PR TITLE
Add complex support for aten.norm and similar operations

### DIFF
--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -12,10 +12,10 @@
 #include "../PassDetail.h"
 #include "PopulatePatterns.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
-#include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
@@ -284,7 +284,8 @@ public:
 
 } // namespace
 
-static Value createAbsOpForNormOps(OpBuilder &b, Location loc, Value elem, Type resultElementType) {
+static Value createAbsOpForNormOps(OpBuilder &b, Location loc, Value elem,
+                                   Type resultElementType) {
   if (elem.getType().isa<mlir::ComplexType>()) {
     return b.create<complex::AbsOp>(loc, elem);
   }
@@ -432,7 +433,7 @@ static Value createLinalgPayloadForReduceOp(OpBuilder &b, Location loc,
   } else if (isa<AtenFrobeniusNormDimOp>(op)) {
     Value elem = payloadArgs[0];
     Value result = payloadArgs[1];
-    
+
     TypedAttr twoAttr = b.getFloatAttr(resultElementType, 2.0);
     auto ord = b.create<arith::ConstantOp>(loc, twoAttr);
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1733,8 +1733,13 @@ ONNX_XFAIL_SET = {
     "NllLossModule_mean_basic",
     "NllLossModule_sum_basic",
     "NormScalarModule_basic",
+    "NormScalarComplexModule_basic",
     "NormScalarOptDimKeepDimModule_basic",
     "NormScalarOptDimModule_basic",
+    "NormScalarOptDimKeepDimComplexModule_basic",
+    "LinalgNormKeepDimComplexModule_basic",
+    "LinalgVectorNormComplexModule_basic",
+    "ReduceFrobeniusNormComplexModule_basic",
     "NormalFunctionalModule_basic",
     "NumToTensorFloatModule_basic",
     "NumToTensorIntModule_basic",
@@ -1978,9 +1983,17 @@ ONNX_XFAIL_SET = {
     # Failure - onnx_lowering: onnx.ReduceL1
     "ReduceL1NormModule_basic",
     "ReduceL1NormWithDTypeModule_basic",
+    "ReduceL1NormComplexModule_basic",
 
     # Failure - onnx_lowering: onnx.ReduceL2
     "ReduceL2NormModule_basic",
+    "ReduceL2NormComplexModule_basic",
+
+    # Failure - onnx_lowering: onnx.ReduceL3
+    "ReduceL3NormAllDimsModule_basic",
+    "ReduceL3NormKeepDimModule_basic",
+    "ReduceL3NormKeepDimComplexModule_basic",
+
 
     # Failure - onnx_lowering: onnx.ReduceProd
     "BernoulliModule_basic",
@@ -1994,8 +2007,6 @@ ONNX_XFAIL_SET = {
 
     # Failure - onnx_lowering: onnx.ReduceSum
     "MseLossSumReductionWithDifferentElemTypeModule_basic",
-    "ReduceL3NormAllDimsModule_basic",
-    "ReduceL3NormKeepDimModule_basic",
     "ReduceSumDtypeFloatModule_basic",
     "ReduceSumDtypeIntModule_basic",
     "ReduceSumElementTypeBoolModule_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/reduction.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/reduction.py
@@ -1027,6 +1027,24 @@ def ReduceL1NormWithDTypeModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5).to(torch.float32))
 
 # ==============================================================================
+    
+class ReduceL1NormComplexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.cfloat, True),
+    ])
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=0, ord=1)
+
+@register_test_case(module_factory=lambda: ReduceL1NormComplexModule())
+def ReduceL1NormComplexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.cfloat))
+
+# ==============================================================================
 
 class ReduceL2NormModule(torch.nn.Module):
     def __init__(self):
@@ -1043,6 +1061,24 @@ class ReduceL2NormModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceL2NormModule())
 def ReduceL2NormModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+    
+class ReduceL2NormComplexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.cdouble, True),
+    ])
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=0)
+
+@register_test_case(module_factory=lambda: ReduceL2NormComplexModule())
+def ReduceL2NormComplexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.cdouble))
 
 # ==============================================================================
 
@@ -1099,6 +1135,24 @@ def ReduceL3NormKeepDimModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
 
 # ==============================================================================
+    
+class ReduceL3NormKeepDimComplexModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.complex128, True),
+    ])
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, keepdim=True, ord=3)
+
+@register_test_case(module_factory=lambda: ReduceL3NormKeepDimComplexModule())
+def ReduceL3NormKeepDimComplexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.complex128))
+
+# ==============================================================================
 
 class NormScalarModule(torch.nn.Module):
     def __init__(self) -> None:
@@ -1116,6 +1170,25 @@ class NormScalarModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: NormScalarModule())
 def NormScalarModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+    
+class NormScalarComplexModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.p = 3.0
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.complex64, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.norm(a, self.p)
+
+@register_test_case(module_factory=lambda: NormScalarComplexModule())
+def NormScalarComplexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.complex64))
 
 # ==============================================================================
 
@@ -1156,6 +1229,26 @@ def NormScalarOptDimKeepDimModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
 
 # ==============================================================================
+    
+class NormScalarOptDimKeepDimComplexModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.p = 3.0
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.cfloat, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.norm(a, self.p, dim=[0, 1], keepdim=True)
+
+@register_test_case(module_factory=lambda: NormScalarOptDimKeepDimComplexModule())
+def NormScalarOptDimKeepDimComplexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.cfloat))
+
+# ==============================================================================
+
 class ReduceFrobeniusNormModule(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -1189,6 +1282,24 @@ class ReduceFrobeniusNormKeepDimModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ReduceFrobeniusNormKeepDimModule())
 def ReduceFrobeniusNormKeepDimModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+    
+class ReduceFrobeniusNormComplexModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.cdouble, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.frobenius_norm(a, dim=[0, 1], keepdim=False)
+
+@register_test_case(module_factory=lambda: ReduceFrobeniusNormComplexModule())
+def ReduceFrobeniusNormComplexModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5).to(torch.cdouble))
 
 # ==============================================================================
 
@@ -1227,6 +1338,24 @@ def LinalgVectorNormKeepDimModule_basic(module, tu: TestUtils):
     module.forward(torch.rand(3, 4, 5))
 
 # ==============================================================================
+    
+class LinalgVectorNormComplexModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.complex128, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.linalg_vector_norm(a, ord=3.0, dim=[0, 1], keepdim=False)
+
+@register_test_case(module_factory=lambda: LinalgVectorNormComplexModule())
+def LinalgVectorNormComplexModule_basic(module, tu: TestUtils):
+    module.forward(torch.rand(3, 4, 5).to(torch.complex128))
+
+# ==============================================================================
 
 class LinalgNormModule(torch.nn.Module):
     def __init__(self) -> None:
@@ -1261,6 +1390,24 @@ class LinalgNormKeepDimModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: LinalgNormKeepDimModule())
 def LinalgNormKeepDimModule_basic(module, tu: TestUtils):
     module.forward(torch.rand(3, 4, 5))
+
+# ==============================================================================
+    
+class LinalgNormKeepDimComplexModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.complex64, True),
+    ])
+    def forward(self, a):
+        return torch.ops.aten.linalg_norm(a, ord=None, dim=[0], keepdim=True)
+
+@register_test_case(module_factory=lambda: LinalgNormKeepDimComplexModule())
+def LinalgNormKeepDimComplexModule_basic(module, tu: TestUtils):
+    module.forward(torch.rand(3, 4, 5).to(torch.complex64))
 
 # ==============================================================================
 


### PR DESCRIPTION
Add support for complex-type input tensors for norm, vector norm, and Frobenius norm operations.