### PR TITLE
[Bazel] Add dep from `TorchPasses` to `TorchBackendTypeConversion`

### DIFF
--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -180,6 +180,7 @@ cc_library(
     deps = [
         ":TorchMLIRTorchDialect",
         ":TorchMLIRTorchPassesIncGen",
+        ":TorchMLIRTorchBackendTypeConversion",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -178,9 +178,9 @@ cc_library(
     ],
     strip_include_prefix = "include",
     deps = [
+        ":TorchMLIRTorchBackendTypeConversion",
         ":TorchMLIRTorchDialect",
         ":TorchMLIRTorchPassesIncGen",
-        ":TorchMLIRTorchBackendTypeConversion",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",


### PR DESCRIPTION
https://github.com/llvm/torch-mlir/pull/3055 adds `lib/Dialect/Torch/Transforms/ScalarizeShapes.cpp`, which depends on `torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h`. 
```
ERROR: /root/.cache/bazel/_bazel_root/b89349c08f7224396763d14fe35cba11/external/torch-mlir/BUILD.bazel:170:11: Compiling lib/Dialect/Torch/Transforms/ScalarizeShapes.cpp failed: (Exit 1): clang failed: error executing command /usr/lib/llvm-16/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer ... (remaining 101 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/torch-mlir/lib/Dialect/Torch/Transforms/ScalarizeShapes.cpp:18:10: fatal error: 'torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h' file not found
#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
Target @torch-mlir//:torch-mlir-opt failed to build
```

This PR adds the dependency and brings bazel builds back to green.

CI: https://github.com/sjain-stanford/torch-mlir/actions/runs/8445558053/job/23132941876