### PR TITLE
[build] Specify numpy < 2.0 in build.requirements.txt

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy < 2.0
 pybind11
 wheel
 setuptools


### PR DESCRIPTION
When running the e2e tests, specifically `python -m e2e_testing.main`, many tests fail when numpy-2.X.X is installed, and an error message stating numpy-1.X.X is required. We should reflect this in the build.requirements.txt.