### PR TITLE
[ods] Allow all tensor returns to be optional.

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -31,7 +31,7 @@ def Torch_AtenHardtanhOp : Torch_Op<"aten.hardtanh", [
     AnyTorchScalarType:$max_val
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -55,7 +55,7 @@ def Torch_AtenHardtanh_Op : Torch_Op<"aten.hardtanh_", [
     AnyTorchScalarType:$max_val
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -81,7 +81,7 @@ def Torch_AtenEluOp : Torch_Op<"aten.elu", [
     AnyTorchScalarType:$input_scale
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -106,7 +106,7 @@ def Torch_AtenElu_Op : Torch_Op<"aten.elu_", [
     AnyTorchScalarType:$input_scale
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -129,7 +129,7 @@ def Torch_AtenReluOp : Torch_Op<"aten.relu", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -151,7 +151,7 @@ def Torch_AtenRelu_Op : Torch_Op<"aten.relu_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -174,7 +174,7 @@ def Torch_AtenRelu6Op : Torch_Op<"aten.relu6", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -196,7 +196,7 @@ def Torch_AtenRelu6_Op : Torch_Op<"aten.relu6_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -220,7 +220,7 @@ def Torch_AtenLeakyReluOp : Torch_Op<"aten.leaky_relu", [
     AnyTorchScalarType:$negative_slope
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -243,7 +243,7 @@ def Torch_AtenLeakyRelu_Op : Torch_Op<"aten.leaky_relu_", [
     AnyTorchScalarType:$negative_slope
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -266,7 +266,7 @@ def Torch_AtenLogOp : Torch_Op<"aten.log", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -288,7 +288,7 @@ def Torch_AtenLog_Op : Torch_Op<"aten.log_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -311,7 +311,7 @@ def Torch_AtenSeluOp : Torch_Op<"aten.selu", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -333,7 +333,7 @@ def Torch_AtenSelu_Op : Torch_Op<"aten.selu_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -356,7 +356,7 @@ def Torch_AtenSigmoidOp : Torch_Op<"aten.sigmoid", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -378,7 +378,7 @@ def Torch_AtenSigmoid_Op : Torch_Op<"aten.sigmoid_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -401,7 +401,7 @@ def Torch_AtenSignOp : Torch_Op<"aten.sign", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -423,7 +423,7 @@ def Torch_AtenSign_Op : Torch_Op<"aten.sign_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -446,7 +446,7 @@ def Torch_AtenSinhOp : Torch_Op<"aten.sinh", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -468,7 +468,7 @@ def Torch_AtenSinh_Op : Torch_Op<"aten.sinh_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -491,7 +491,7 @@ def Torch_AtenSgnOp : Torch_Op<"aten.sgn", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -513,7 +513,7 @@ def Torch_AtenSgn_Op : Torch_Op<"aten.sgn_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -536,7 +536,7 @@ def Torch_AtenHardsigmoidOp : Torch_Op<"aten.hardsigmoid", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -558,7 +558,7 @@ def Torch_AtenHardsigmoid_Op : Torch_Op<"aten.hardsigmoid_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -581,7 +581,7 @@ def Torch_AtenHardswishOp : Torch_Op<"aten.hardswish", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -603,7 +603,7 @@ def Torch_AtenHardswish_Op : Torch_Op<"aten.hardswish_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -626,7 +626,7 @@ def Torch_AtenErfOp : Torch_Op<"aten.erf", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -648,7 +648,7 @@ def Torch_AtenErf_Op : Torch_Op<"aten.erf_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -671,7 +671,7 @@ def Torch_AtenErfinvOp : Torch_Op<"aten.erfinv", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -693,7 +693,7 @@ def Torch_AtenErfinv_Op : Torch_Op<"aten.erfinv_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -716,7 +716,7 @@ def Torch_AtenSiluOp : Torch_Op<"aten.silu", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -738,7 +738,7 @@ def Torch_AtenSilu_Op : Torch_Op<"aten.silu_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -761,7 +761,7 @@ def Torch_AtenSinOp : Torch_Op<"aten.sin", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -783,7 +783,7 @@ def Torch_AtenSin_Op : Torch_Op<"aten.sin_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -806,7 +806,7 @@ def Torch_AtenAsinOp : Torch_Op<"aten.asin", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -828,7 +828,7 @@ def Torch_AtenAsin_Op : Torch_Op<"aten.asin_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -851,7 +851,7 @@ def Torch_AtenAsinhOp : Torch_Op<"aten.asinh", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -873,7 +873,7 @@ def Torch_AtenAsinh_Op : Torch_Op<"aten.asinh_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -896,7 +896,7 @@ def Torch_AtenExpOp : Torch_Op<"aten.exp", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -918,7 +918,7 @@ def Torch_AtenExp_Op : Torch_Op<"aten.exp_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -941,7 +941,7 @@ def Torch_AtenExpm1Op : Torch_Op<"aten.expm1", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -963,7 +963,7 @@ def Torch_AtenExpm1_Op : Torch_Op<"aten.expm1_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -986,7 +986,7 @@ def Torch_AtenCosOp : Torch_Op<"aten.cos", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1008,7 +1008,7 @@ def Torch_AtenCos_Op : Torch_Op<"aten.cos_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1031,7 +1031,7 @@ def Torch_AtenCoshOp : Torch_Op<"aten.cosh", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1053,7 +1053,7 @@ def Torch_AtenCosh_Op : Torch_Op<"aten.cosh_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1076,7 +1076,7 @@ def Torch_AtenAcosOp : Torch_Op<"aten.acos", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1098,7 +1098,7 @@ def Torch_AtenAcos_Op : Torch_Op<"aten.acos_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1121,7 +1121,7 @@ def Torch_AtenAcoshOp : Torch_Op<"aten.acosh", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1143,7 +1143,7 @@ def Torch_AtenAcosh_Op : Torch_Op<"aten.acosh_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1166,7 +1166,7 @@ def Torch_AtenTanOp : Torch_Op<"aten.tan", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1188,7 +1188,7 @@ def Torch_AtenTan_Op : Torch_Op<"aten.tan_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1211,7 +1211,7 @@ def Torch_AtenTanhOp : Torch_Op<"aten.tanh", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1233,7 +1233,7 @@ def Torch_AtenTanh_Op : Torch_Op<"aten.tanh_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1256,7 +1256,7 @@ def Torch_AtenAtanOp : Torch_Op<"aten.atan", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1278,7 +1278,7 @@ def Torch_AtenAtan_Op : Torch_Op<"aten.atan_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1301,7 +1301,7 @@ def Torch_AtenAtanhOp : Torch_Op<"aten.atanh", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1323,7 +1323,7 @@ def Torch_AtenAtanh_Op : Torch_Op<"aten.atanh_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1347,7 +1347,7 @@ def Torch_AtenAtan2Op : Torch_Op<"aten.atan2", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1370,7 +1370,7 @@ def Torch_AtenAtan2_Op : Torch_Op<"aten.atan2_", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1393,7 +1393,7 @@ def Torch_AtenNegOp : Torch_Op<"aten.neg", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1415,7 +1415,7 @@ def Torch_AtenNeg_Op : Torch_Op<"aten.neg_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1438,7 +1438,7 @@ def Torch_AtenBitwiseNotOp : Torch_Op<"aten.bitwise_not", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1460,7 +1460,7 @@ def Torch_AtenBitwiseNot_Op : Torch_Op<"aten.bitwise_not_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1484,7 +1484,7 @@ def Torch_AtenDivTensorOp : Torch_Op<"aten.div.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1507,7 +1507,7 @@ def Torch_AtenDiv_TensorOp : Torch_Op<"aten.div_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1531,7 +1531,7 @@ def Torch_AtenLogicalOrOp : Torch_Op<"aten.logical_or", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1554,7 +1554,7 @@ def Torch_AtenLogicalOr_Op : Torch_Op<"aten.logical_or_", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1578,7 +1578,7 @@ def Torch_AtenLogicalAndOp : Torch_Op<"aten.logical_and", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1601,7 +1601,7 @@ def Torch_AtenLogicalAnd_Op : Torch_Op<"aten.logical_and_", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1625,7 +1625,7 @@ def Torch_AtenLogicalXorOp : Torch_Op<"aten.logical_xor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1648,7 +1648,7 @@ def Torch_AtenLogicalXor_Op : Torch_Op<"aten.logical_xor_", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1671,7 +1671,7 @@ def Torch_AtenLogicalNotOp : Torch_Op<"aten.logical_not", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1693,7 +1693,7 @@ def Torch_AtenLogicalNot_Op : Torch_Op<"aten.logical_not_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1718,7 +1718,7 @@ def Torch_AtenLerpTensorOp : Torch_Op<"aten.lerp.Tensor", [
     AnyTorchTensorType:$weight
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1742,7 +1742,7 @@ def Torch_AtenLerp_TensorOp : Torch_Op<"aten.lerp_.Tensor", [
     Torch_NonValueTensorType:$weight
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1767,7 +1767,7 @@ def Torch_AtenLerpScalarOp : Torch_Op<"aten.lerp.Scalar", [
     AnyTorchScalarType:$weight
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1791,7 +1791,7 @@ def Torch_AtenLerp_ScalarOp : Torch_Op<"aten.lerp_.Scalar", [
     AnyTorchScalarType:$weight
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1815,7 +1815,7 @@ def Torch_AtenGtTensorOp : Torch_Op<"aten.gt.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1838,7 +1838,7 @@ def Torch_AtenGt_TensorOp : Torch_Op<"aten.gt_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1862,7 +1862,7 @@ def Torch_AtenGeTensorOp : Torch_Op<"aten.ge.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1885,7 +1885,7 @@ def Torch_AtenGe_TensorOp : Torch_Op<"aten.ge_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1909,7 +1909,7 @@ def Torch_AtenLtTensorOp : Torch_Op<"aten.lt.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1932,7 +1932,7 @@ def Torch_AtenLt_TensorOp : Torch_Op<"aten.lt_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1956,7 +1956,7 @@ def Torch_AtenLeTensorOp : Torch_Op<"aten.le.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -1979,7 +1979,7 @@ def Torch_AtenLe_TensorOp : Torch_Op<"aten.le_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2003,7 +2003,7 @@ def Torch_AtenNeTensorOp : Torch_Op<"aten.ne.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2026,7 +2026,7 @@ def Torch_AtenNe_TensorOp : Torch_Op<"aten.ne_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2050,7 +2050,7 @@ def Torch_AtenDivScalarOp : Torch_Op<"aten.div.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2073,7 +2073,7 @@ def Torch_AtenDiv_ScalarOp : Torch_Op<"aten.div_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2097,7 +2097,7 @@ def Torch_AtenFmodScalarOp : Torch_Op<"aten.fmod.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2120,7 +2120,7 @@ def Torch_AtenFmod_ScalarOp : Torch_Op<"aten.fmod_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2145,7 +2145,7 @@ def Torch_AtenMaskedFillScalarOp : Torch_Op<"aten.masked_fill.Scalar", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2169,7 +2169,7 @@ def Torch_AtenMaskedFill_ScalarOp : Torch_Op<"aten.masked_fill_.Scalar", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2194,7 +2194,7 @@ def Torch_AtenClampOp : Torch_Op<"aten.clamp", [
     AnyTorchOptionalScalarType:$max
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2218,7 +2218,7 @@ def Torch_AtenClamp_Op : Torch_Op<"aten.clamp_", [
     AnyTorchOptionalScalarType:$max
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2243,7 +2243,7 @@ def Torch_AtenClampTensorOp : Torch_Op<"aten.clamp.Tensor", [
     AnyTorchOptionalTensorType:$max
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2267,7 +2267,7 @@ def Torch_AtenClamp_TensorOp : Torch_Op<"aten.clamp_.Tensor", [
     AnyTorchOptionalNonValueTensorType:$max
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2291,7 +2291,7 @@ def Torch_AtenClampMinOp : Torch_Op<"aten.clamp_min", [
     AnyTorchScalarType:$min
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2314,7 +2314,7 @@ def Torch_AtenClampMin_Op : Torch_Op<"aten.clamp_min_", [
     AnyTorchScalarType:$min
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2338,7 +2338,7 @@ def Torch_AtenClampMinTensorOp : Torch_Op<"aten.clamp_min.Tensor", [
     AnyTorchTensorType:$min
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2361,7 +2361,7 @@ def Torch_AtenClampMin_TensorOp : Torch_Op<"aten.clamp_min_.Tensor", [
     Torch_NonValueTensorType:$min
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2385,7 +2385,7 @@ def Torch_AtenClampMaxOp : Torch_Op<"aten.clamp_max", [
     AnyTorchScalarType:$max
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2408,7 +2408,7 @@ def Torch_AtenClampMax_Op : Torch_Op<"aten.clamp_max_", [
     AnyTorchScalarType:$max
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2432,7 +2432,7 @@ def Torch_AtenClampMaxTensorOp : Torch_Op<"aten.clamp_max.Tensor", [
     AnyTorchTensorType:$max
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2455,7 +2455,7 @@ def Torch_AtenClampMax_TensorOp : Torch_Op<"aten.clamp_max_.Tensor", [
     Torch_NonValueTensorType:$max
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2478,7 +2478,7 @@ def Torch_AtenLog2Op : Torch_Op<"aten.log2", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2500,7 +2500,7 @@ def Torch_AtenLog2_Op : Torch_Op<"aten.log2_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2523,7 +2523,7 @@ def Torch_AtenLog10Op : Torch_Op<"aten.log10", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2545,7 +2545,7 @@ def Torch_AtenLog10_Op : Torch_Op<"aten.log10_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2568,7 +2568,7 @@ def Torch_AtenSqrtOp : Torch_Op<"aten.sqrt", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2590,7 +2590,7 @@ def Torch_AtenSqrt_Op : Torch_Op<"aten.sqrt_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2613,7 +2613,7 @@ def Torch_AtenLog1pOp : Torch_Op<"aten.log1p", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2635,7 +2635,7 @@ def Torch_AtenLog1p_Op : Torch_Op<"aten.log1p_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2659,7 +2659,7 @@ def Torch_AtenLogitOp : Torch_Op<"aten.logit", [
     AnyTorchOptionalFloatType:$eps
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2682,7 +2682,7 @@ def Torch_AtenLogit_Op : Torch_Op<"aten.logit_", [
     AnyTorchOptionalFloatType:$eps
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2705,7 +2705,7 @@ def Torch_AtenRsqrtOp : Torch_Op<"aten.rsqrt", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2727,7 +2727,7 @@ def Torch_AtenRsqrt_Op : Torch_Op<"aten.rsqrt_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2750,7 +2750,7 @@ def Torch_AtenAbsOp : Torch_Op<"aten.abs", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2772,7 +2772,7 @@ def Torch_AtenAbs_Op : Torch_Op<"aten.abs_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2795,7 +2795,7 @@ def Torch_AtenReciprocalOp : Torch_Op<"aten.reciprocal", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2817,7 +2817,7 @@ def Torch_AtenReciprocal_Op : Torch_Op<"aten.reciprocal_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2841,7 +2841,7 @@ def Torch_AtenBitwiseAndTensorOp : Torch_Op<"aten.bitwise_and.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2864,7 +2864,7 @@ def Torch_AtenBitwiseAnd_TensorOp : Torch_Op<"aten.bitwise_and_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2888,7 +2888,7 @@ def Torch_AtenBitwiseAndScalarOp : Torch_Op<"aten.bitwise_and.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2911,7 +2911,7 @@ def Torch_AtenBitwiseAnd_ScalarOp : Torch_Op<"aten.bitwise_and_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2935,7 +2935,7 @@ def Torch_AtenBitwiseOrTensorOp : Torch_Op<"aten.bitwise_or.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2958,7 +2958,7 @@ def Torch_AtenBitwiseOr_TensorOp : Torch_Op<"aten.bitwise_or_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -2982,7 +2982,7 @@ def Torch_AtenBitwiseXorTensorOp : Torch_Op<"aten.bitwise_xor.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3005,7 +3005,7 @@ def Torch_AtenBitwiseXor_TensorOp : Torch_Op<"aten.bitwise_xor_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3029,7 +3029,7 @@ def Torch_AtenBitwiseLeftShiftTensorOp : Torch_Op<"aten.bitwise_left_shift.Tenso
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3052,7 +3052,7 @@ def Torch_AtenBitwiseLeftShift_TensorOp : Torch_Op<"aten.bitwise_left_shift_.Ten
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3076,7 +3076,7 @@ def Torch_AtenBitwiseRightShiftTensorOp : Torch_Op<"aten.bitwise_right_shift.Ten
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3099,7 +3099,7 @@ def Torch_AtenBitwiseRightShift_TensorOp : Torch_Op<"aten.bitwise_right_shift_.T
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3124,7 +3124,7 @@ def Torch_AtenThresholdOp : Torch_Op<"aten.threshold", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3148,7 +3148,7 @@ def Torch_AtenThreshold_Op : Torch_Op<"aten.threshold_", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3171,7 +3171,7 @@ def Torch_AtenSquareOp : Torch_Op<"aten.square", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3193,7 +3193,7 @@ def Torch_AtenSquare_Op : Torch_Op<"aten.square_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3216,7 +3216,7 @@ def Torch_AtenZeroOp : Torch_Op<"aten.zero", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3238,7 +3238,7 @@ def Torch_AtenZero_Op : Torch_Op<"aten.zero_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3262,7 +3262,7 @@ def Torch_AtenFillScalarOp : Torch_Op<"aten.fill.Scalar", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3285,7 +3285,7 @@ def Torch_AtenFill_ScalarOp : Torch_Op<"aten.fill_.Scalar", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3309,7 +3309,7 @@ def Torch_AtenFillTensorOp : Torch_Op<"aten.fill.Tensor", [
     AnyTorchTensorType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3332,7 +3332,7 @@ def Torch_AtenFill_TensorOp : Torch_Op<"aten.fill_.Tensor", [
     Torch_NonValueTensorType:$value
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3355,7 +3355,7 @@ def Torch_AtenUnsqueezeOp : Torch_Op<"aten.unsqueeze", [
     Torch_IntType:$dim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3379,7 +3379,7 @@ def Torch_AtenUnsqueeze_Op : Torch_Op<"aten.unsqueeze_", [
     Torch_IntType:$dim
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3404,7 +3404,7 @@ def Torch_AtenDivTensorModeOp : Torch_Op<"aten.div.Tensor_mode", [
     AnyTorchOptionalStringType:$rounding_mode
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3429,7 +3429,7 @@ def Torch_AtenDiv_TensorModeOp : Torch_Op<"aten.div_.Tensor_mode", [
     AnyTorchOptionalStringType:$rounding_mode
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3453,7 +3453,7 @@ def Torch_AtenMulTensorOp : Torch_Op<"aten.mul.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3478,7 +3478,7 @@ def Torch_AtenMul_TensorOp : Torch_Op<"aten.mul_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3503,7 +3503,7 @@ def Torch_AtenAddTensorOp : Torch_Op<"aten.add.Tensor", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3529,7 +3529,7 @@ def Torch_AtenAdd_TensorOp : Torch_Op<"aten.add_.Tensor", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3554,7 +3554,7 @@ def Torch_AtenSubTensorOp : Torch_Op<"aten.sub.Tensor", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3580,7 +3580,7 @@ def Torch_AtenSub_TensorOp : Torch_Op<"aten.sub_.Tensor", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3605,7 +3605,7 @@ def Torch_AtenAddScalarOp : Torch_Op<"aten.add.Scalar", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3630,7 +3630,7 @@ def Torch_AtenAdd_ScalarOp : Torch_Op<"aten.add_.Scalar", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3655,7 +3655,7 @@ def Torch_AtenSubScalarOp : Torch_Op<"aten.sub.Scalar", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3680,7 +3680,7 @@ def Torch_AtenSub_ScalarOp : Torch_Op<"aten.sub_.Scalar", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3704,7 +3704,7 @@ def Torch_AtenMulScalarOp : Torch_Op<"aten.mul.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3728,7 +3728,7 @@ def Torch_AtenMul_ScalarOp : Torch_Op<"aten.mul_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3752,7 +3752,7 @@ def Torch_AtenEqTensorOp : Torch_Op<"aten.eq.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3776,7 +3776,7 @@ def Torch_AtenEq_TensorOp : Torch_Op<"aten.eq_.Tensor", [
     Torch_NonValueTensorType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3800,7 +3800,7 @@ def Torch_AtenLeScalarOp : Torch_Op<"aten.le.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3824,7 +3824,7 @@ def Torch_AtenLe_ScalarOp : Torch_Op<"aten.le_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3848,7 +3848,7 @@ def Torch_AtenLtScalarOp : Torch_Op<"aten.lt.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3872,7 +3872,7 @@ def Torch_AtenLt_ScalarOp : Torch_Op<"aten.lt_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3896,7 +3896,7 @@ def Torch_AtenGtScalarOp : Torch_Op<"aten.gt.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3920,7 +3920,7 @@ def Torch_AtenGt_ScalarOp : Torch_Op<"aten.gt_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3944,7 +3944,7 @@ def Torch_AtenGeScalarOp : Torch_Op<"aten.ge.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3968,7 +3968,7 @@ def Torch_AtenGe_ScalarOp : Torch_Op<"aten.ge_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -3992,7 +3992,7 @@ def Torch_AtenEqScalarOp : Torch_Op<"aten.eq.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4016,7 +4016,7 @@ def Torch_AtenEq_ScalarOp : Torch_Op<"aten.eq_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4040,7 +4040,7 @@ def Torch_AtenNeScalarOp : Torch_Op<"aten.ne.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4064,7 +4064,7 @@ def Torch_AtenNe_ScalarOp : Torch_Op<"aten.ne_.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4087,7 +4087,7 @@ def Torch_AtenFloorOp : Torch_Op<"aten.floor", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4110,7 +4110,7 @@ def Torch_AtenFloor_Op : Torch_Op<"aten.floor_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4133,7 +4133,7 @@ def Torch_AtenCeilOp : Torch_Op<"aten.ceil", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4156,7 +4156,7 @@ def Torch_AtenCeil_Op : Torch_Op<"aten.ceil_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4179,7 +4179,7 @@ def Torch_AtenRoundOp : Torch_Op<"aten.round", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4202,7 +4202,7 @@ def Torch_AtenRound_Op : Torch_Op<"aten.round_", [
     Torch_NonValueTensorType:$self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4227,7 +4227,7 @@ def Torch_AtenMaskedFillTensorOp : Torch_Op<"aten.masked_fill.Tensor", [
     AnyTorchTensorType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4252,7 +4252,7 @@ def Torch_AtenMaskedFill_TensorOp : Torch_Op<"aten.masked_fill_.Tensor", [
     Torch_NonValueTensorType:$value
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4278,7 +4278,7 @@ def Torch_AtenAddcmulOp : Torch_Op<"aten.addcmul", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4303,7 +4303,7 @@ def Torch_AtenAddcmul_Op : Torch_Op<"aten.addcmul_", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4329,7 +4329,7 @@ def Torch_AtenAddcdivOp : Torch_Op<"aten.addcdiv", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4354,7 +4354,7 @@ def Torch_AtenAddcdiv_Op : Torch_Op<"aten.addcdiv_", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4381,7 +4381,7 @@ def Torch_AtenFakeQuantizePerTensorAffineOp : Torch_Op<"aten.fake_quantize_per_t
     Torch_IntType:$quant_max
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4405,7 +4405,7 @@ def Torch_AtenMaximumOp : Torch_Op<"aten.maximum", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4429,7 +4429,7 @@ def Torch_AtenMinimumOp : Torch_Op<"aten.minimum", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4452,7 +4452,7 @@ def Torch_AtenMishOp : Torch_Op<"aten.mish", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4476,7 +4476,7 @@ def Torch_AtenXlogyTensorOp : Torch_Op<"aten.xlogy.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4501,7 +4501,7 @@ def Torch_AtenRsubScalarOp : Torch_Op<"aten.rsub.Scalar", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4526,7 +4526,7 @@ def Torch_AtenGeluOp : Torch_Op<"aten.gelu", [
     Torch_StringType:$approximate
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4550,7 +4550,7 @@ def Torch_AtenPowTensorScalarOp : Torch_Op<"aten.pow.Tensor_Scalar", [
     AnyTorchScalarType:$exponent
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4574,7 +4574,7 @@ def Torch_AtenPowTensorTensorOp : Torch_Op<"aten.pow.Tensor_Tensor", [
     AnyTorchTensorType:$exponent
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4598,7 +4598,7 @@ def Torch_AtenPowScalarOp : Torch_Op<"aten.pow.Scalar", [
     AnyTorchTensorType:$exponent
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4623,7 +4623,7 @@ def Torch_AtenThresholdBackwardOp : Torch_Op<"aten.threshold_backward", [
     AnyTorchScalarType:$threshold
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4647,7 +4647,7 @@ def Torch_AtenFloorDivideOp : Torch_Op<"aten.floor_divide", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4672,7 +4672,7 @@ def Torch_AtenSoftplusOp : Torch_Op<"aten.softplus", [
     AnyTorchScalarType:$threshold
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4696,7 +4696,7 @@ def Torch_AtenPreluOp : Torch_Op<"aten.prelu", [
     AnyTorchTensorType:$weight
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4718,7 +4718,7 @@ def Torch_AtenRealOp : Torch_Op<"aten.real", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4740,7 +4740,7 @@ def Torch_AtenImagOp : Torch_Op<"aten.imag", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4762,7 +4762,7 @@ def Torch_AtenViewAsComplexOp : Torch_Op<"aten.view_as_complex", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4784,7 +4784,7 @@ def Torch_AtenViewAsRealOp : Torch_Op<"aten.view_as_real", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4811,7 +4811,7 @@ def Torch_AtenIscloseOp : Torch_Op<"aten.isclose", [
     Torch_BoolType:$equal_nan
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4835,7 +4835,7 @@ def Torch_AtenGluOp : Torch_Op<"aten.glu", [
     Torch_IntType:$dim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4935,7 +4935,7 @@ def Torch_AtenUniformOp : Torch_Op<"aten.uniform", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4960,7 +4960,7 @@ def Torch_AtenUniform_Op : Torch_Op<"aten.uniform_", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -4988,7 +4988,7 @@ def Torch_AtenRandLikeOp : Torch_Op<"aten.rand_like", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5015,7 +5015,7 @@ def Torch_AtenRandOp : Torch_Op<"aten.rand", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5039,7 +5039,7 @@ def Torch_AtenBernoulliOp : Torch_Op<"aten.bernoulli", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5062,7 +5062,7 @@ def Torch_AtenBernoulli_FloatOp : Torch_Op<"aten.bernoulli_.float", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5087,7 +5087,7 @@ def Torch_AtenBernoulliPOp : Torch_Op<"aten.bernoulli.p", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5112,7 +5112,7 @@ def Torch_AtenExponentialOp : Torch_Op<"aten.exponential", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5138,7 +5138,7 @@ def Torch_AtenMultinomialOp : Torch_Op<"aten.multinomial", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5167,7 +5167,7 @@ def Torch_AtenRandintLowOp : Torch_Op<"aten.randint.low", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5195,7 +5195,7 @@ def Torch_AtenRandintOp : Torch_Op<"aten.randint", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5220,7 +5220,7 @@ def Torch_AtenBernoulliTensorOp : Torch_Op<"aten.bernoulli.Tensor", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5244,7 +5244,7 @@ def Torch_AtenBernoulli_TensorOp : Torch_Op<"aten.bernoulli_.Tensor", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5271,7 +5271,7 @@ def Torch_AtenRandnOp : Torch_Op<"aten.randn", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5299,7 +5299,7 @@ def Torch_AtenRandnGeneratorOp : Torch_Op<"aten.randn.generator", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5327,7 +5327,7 @@ def Torch_AtenRandnLikeOp : Torch_Op<"aten.randn_like", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5351,7 +5351,7 @@ def Torch_AtenRandomOp : Torch_Op<"aten.random", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5377,7 +5377,7 @@ def Torch_AtenRandomFromOp : Torch_Op<"aten.random.from", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5401,7 +5401,7 @@ def Torch_AtenTriuOp : Torch_Op<"aten.triu", [
     Torch_IntType:$diagonal
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5424,7 +5424,7 @@ def Torch_AtenTriu_Op : Torch_Op<"aten.triu_", [
     Torch_IntType:$diagonal
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5448,7 +5448,7 @@ def Torch_AtenTrilOp : Torch_Op<"aten.tril", [
     Torch_IntType:$diagonal
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5471,7 +5471,7 @@ def Torch_AtenTril_Op : Torch_Op<"aten.tril_", [
     Torch_IntType:$diagonal
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5497,7 +5497,7 @@ def Torch_AtenIndexPutOp : Torch_Op<"aten.index_put", [
     Torch_BoolType:$accumulate
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5522,7 +5522,7 @@ def Torch_AtenIndexPut_Op : Torch_Op<"aten.index_put_", [
     Torch_BoolType:$accumulate
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5548,7 +5548,7 @@ def Torch_AtenIndexPutHackedTwinOp : Torch_Op<"aten.index_put.hacked_twin", [
     Torch_BoolType:$accumulate
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5573,7 +5573,7 @@ def Torch_AtenIndexPut_HackedTwinOp : Torch_Op<"aten.index_put_.hacked_twin", [
     Torch_BoolType:$accumulate
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5599,7 +5599,7 @@ def Torch_Aten_UnsafeIndexPutHackedTwinOp : Torch_Op<"aten._unsafe_index_put.hac
     Torch_BoolType:$accumulate
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5624,7 +5624,7 @@ def Torch_AtenLinearOp : Torch_Op<"aten.linear", [
     AnyTorchOptionalTensorType:$bias
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5648,7 +5648,7 @@ def Torch_AtenMmOp : Torch_Op<"aten.mm", [
     AnyTorchTensorType:$mat2
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5675,7 +5675,7 @@ def Torch_AtenAddmmOp : Torch_Op<"aten.addmm", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5699,7 +5699,7 @@ def Torch_AtenMatmulOp : Torch_Op<"aten.matmul", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5723,7 +5723,7 @@ def Torch_AtenMvOp : Torch_Op<"aten.mv", [
     AnyTorchTensorType:$vec
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5749,7 +5749,7 @@ def Torch_AtenCosineSimilarityOp : Torch_Op<"aten.cosine_similarity", [
     Torch_FloatType:$eps
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5778,7 +5778,7 @@ def Torch_AtenConv3dOp : Torch_Op<"aten.conv3d", [
     Torch_IntType:$groups
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5807,7 +5807,7 @@ def Torch_AtenConv2dOp : Torch_Op<"aten.conv2d", [
     Torch_IntType:$groups
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5836,7 +5836,7 @@ def Torch_AtenConv1dOp : Torch_Op<"aten.conv1d", [
     Torch_IntType:$groups
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5866,7 +5866,7 @@ def Torch_AtenConvTranspose1dOp : Torch_Op<"aten.conv_transpose1d", [
     AnyTorchListOfTorchIntType:$dilation
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5896,7 +5896,7 @@ def Torch_AtenConvTranspose2dInputOp : Torch_Op<"aten.conv_transpose2d.input", [
     AnyTorchListOfTorchIntType:$dilation
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5926,7 +5926,7 @@ def Torch_AtenConvTranspose3dInputOp : Torch_Op<"aten.conv_transpose3d.input", [
     AnyTorchListOfTorchIntType:$dilation
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5952,7 +5952,7 @@ def Torch_AtenConvTbcOp : Torch_Op<"aten.conv_tbc", [
     Torch_IntType:$pad
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -5979,9 +5979,9 @@ def Torch_AtenConvTbcBackwardOp : Torch_Op<"aten.conv_tbc_backward", [
     Torch_IntType:$pad
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6012,7 +6012,7 @@ def Torch_AtenConvolutionOp : Torch_Op<"aten.convolution", [
     Torch_IntType:$groups
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6047,7 +6047,7 @@ def Torch_Aten_ConvolutionOp : Torch_Op<"aten._convolution", [
     Torch_BoolType:$allow_tf32
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6081,7 +6081,7 @@ def Torch_Aten_ConvolutionDeprecatedOp : Torch_Op<"aten._convolution.deprecated"
     Torch_BoolType:$cudnn_enabled
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6106,7 +6106,7 @@ def Torch_AtenRollOp : Torch_Op<"aten.roll", [
     AnyTorchListOfTorchIntType:$dims
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6139,9 +6139,9 @@ def Torch_AtenConvolutionBackwardOp : Torch_Op<"aten.convolution_backward", [
     AnyTorchListOfTorchBoolType:$output_mask
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6165,7 +6165,7 @@ def Torch_AtenFlipOp : Torch_Op<"aten.flip", [
     AnyTorchListOfTorchIntType:$dims
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6195,9 +6195,9 @@ def Torch_AtenNativeBatchNormOp : Torch_Op<"aten.native_batch_norm", [
     Torch_FloatType:$eps
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6228,7 +6228,7 @@ def Torch_AtenBatchNormOp : Torch_Op<"aten.batch_norm", [
     Torch_BoolType:$cudnn_enabled
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6259,7 +6259,7 @@ def Torch_AtenInstanceNormOp : Torch_Op<"aten.instance_norm", [
     Torch_BoolType:$cudnn_enabled
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6289,9 +6289,9 @@ def Torch_AtenNativeGroupNormOp : Torch_Op<"aten.native_group_norm", [
     Torch_FloatType:$eps
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6319,7 +6319,7 @@ def Torch_AtenGroupNormOp : Torch_Op<"aten.group_norm", [
     Torch_BoolType:$cudnn_enabled
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6347,7 +6347,7 @@ def Torch_AtenLayerNormOp : Torch_Op<"aten.layer_norm", [
     Torch_BoolType:$cudnn_enable
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6371,7 +6371,7 @@ def Torch_AtenNormScalarOp : Torch_Op<"aten.norm.Scalar", [
     AnyTorchScalarType:$p
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6398,7 +6398,7 @@ def Torch_AtenNormScalarOptDimOp : Torch_Op<"aten.norm.ScalarOpt_dim", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6424,7 +6424,7 @@ def Torch_AtenNormalFunctionalOp : Torch_Op<"aten.normal_functional", [
     AnyTorchOptionalGeneratorType:$generator
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6451,9 +6451,9 @@ def Torch_AtenNativeLayerNormOp : Torch_Op<"aten.native_layer_norm", [
     Torch_FloatType:$eps
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6481,7 +6481,7 @@ def Torch_AtenMaxPool2dOp : Torch_Op<"aten.max_pool2d", [
     Torch_BoolType:$ceil_mode
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6509,8 +6509,8 @@ def Torch_AtenMaxPool2dWithIndicesOp : Torch_Op<"aten.max_pool2d_with_indices", 
     Torch_BoolType:$ceil_mode
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6540,7 +6540,7 @@ def Torch_AtenMaxPool2dWithIndicesBackwardOp : Torch_Op<"aten.max_pool2d_with_in
     AnyTorchTensorType:$indices
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6568,7 +6568,7 @@ def Torch_AtenMaxPool3dOp : Torch_Op<"aten.max_pool3d", [
     Torch_BoolType:$ceil_mode
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6596,8 +6596,8 @@ def Torch_AtenMaxPool3dWithIndicesOp : Torch_Op<"aten.max_pool3d_with_indices", 
     Torch_BoolType:$ceil_mode
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6627,7 +6627,7 @@ def Torch_AtenMaxPool3dWithIndicesBackwardOp : Torch_Op<"aten.max_pool3d_with_in
     AnyTorchTensorType:$indices
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6655,7 +6655,7 @@ def Torch_AtenAvgPool1dOp : Torch_Op<"aten.avg_pool1d", [
     Torch_BoolType:$count_include_pad
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6684,7 +6684,7 @@ def Torch_AtenAvgPool2dOp : Torch_Op<"aten.avg_pool2d", [
     AnyTorchOptionalIntType:$divisor_override
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6714,7 +6714,7 @@ def Torch_AtenAvgPool2dBackwardOp : Torch_Op<"aten.avg_pool2d_backward", [
     AnyTorchOptionalIntType:$divisor_override
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6743,7 +6743,7 @@ def Torch_AtenAvgPool3dOp : Torch_Op<"aten.avg_pool3d", [
     AnyTorchOptionalIntType:$divisor_override
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6773,7 +6773,7 @@ def Torch_AtenAvgPool3dBackwardOp : Torch_Op<"aten.avg_pool3d_backward", [
     AnyTorchOptionalIntType:$divisor_override
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6798,7 +6798,7 @@ def Torch_AtenSoftmaxIntOp : Torch_Op<"aten.softmax.int", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6823,7 +6823,7 @@ def Torch_AtenLogSoftmaxIntOp : Torch_Op<"aten.log_softmax.int", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6848,7 +6848,7 @@ def Torch_Aten_LogSoftmaxOp : Torch_Op<"aten._log_softmax", [
     Torch_BoolType:$half_to_float
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6874,7 +6874,7 @@ def Torch_AtenScatterSrcOp : Torch_Op<"aten.scatter.src", [
     AnyTorchTensorType:$src
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6899,7 +6899,7 @@ def Torch_AtenScatter_SrcOp : Torch_Op<"aten.scatter_.src", [
     Torch_NonValueTensorType:$src
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6925,7 +6925,7 @@ def Torch_AtenScatterValueOp : Torch_Op<"aten.scatter.value", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6950,7 +6950,7 @@ def Torch_AtenScatter_ValueOp : Torch_Op<"aten.scatter_.value", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6975,7 +6975,7 @@ def Torch_AtenMaskedScatterOp : Torch_Op<"aten.masked_scatter", [
     AnyTorchTensorType:$source
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -6999,7 +6999,7 @@ def Torch_AtenMaskedScatter_Op : Torch_Op<"aten.masked_scatter_", [
     Torch_NonValueTensorType:$source
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7023,7 +7023,7 @@ def Torch_AtenAdaptiveAvgPool1dOp : Torch_Op<"aten.adaptive_avg_pool1d", [
     AnyTorchListOfTorchIntType:$output_size
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7047,7 +7047,7 @@ def Torch_AtenAdaptiveAvgPool2dOp : Torch_Op<"aten.adaptive_avg_pool2d", [
     AnyTorchListOfTorchIntType:$output_size
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7071,7 +7071,7 @@ def Torch_Aten_AdaptiveAvgPool2dOp : Torch_Op<"aten._adaptive_avg_pool2d", [
     AnyTorchListOfTorchIntType:$output_size
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7095,7 +7095,7 @@ def Torch_Aten_AdaptiveAvgPool2dBackwardOp : Torch_Op<"aten._adaptive_avg_pool2d
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7119,7 +7119,7 @@ def Torch_AtenAdaptiveAvgPool3dOp : Torch_Op<"aten.adaptive_avg_pool3d", [
     AnyTorchListOfTorchIntType:$output_size
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7143,7 +7143,7 @@ def Torch_Aten_AdaptiveAvgPool3dOp : Torch_Op<"aten._adaptive_avg_pool3d", [
     AnyTorchListOfTorchIntType:$output_size
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7167,7 +7167,7 @@ def Torch_Aten_AdaptiveAvgPool3dBackwardOp : Torch_Op<"aten._adaptive_avg_pool3d
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7191,8 +7191,8 @@ def Torch_AtenAdaptiveMaxPool1dOp : Torch_Op<"aten.adaptive_max_pool1d", [
     AnyTorchListOfTorchIntType:$output_size
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7216,8 +7216,8 @@ def Torch_AtenAdaptiveMaxPool2dOp : Torch_Op<"aten.adaptive_max_pool2d", [
     AnyTorchListOfTorchIntType:$output_size
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7241,8 +7241,8 @@ def Torch_AtenAdaptiveMaxPool3dOp : Torch_Op<"aten.adaptive_max_pool3d", [
     AnyTorchListOfTorchIntType:$output_size
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7269,8 +7269,8 @@ def Torch_AtenTopkOp : Torch_Op<"aten.topk", [
     Torch_BoolType:$sorted
   );
   let results = (outs
-    AnyTorchTensorType:$values,
-    AnyTorchTensorType:$indices
+    AnyTorchOptionalTensorType:$values,
+    AnyTorchOptionalTensorType:$indices
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7294,7 +7294,7 @@ def Torch_AtenTransposeIntOp : Torch_Op<"aten.transpose.int", [
     Torch_IntType:$dim1
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7318,7 +7318,7 @@ def Torch_AtenPixelShuffleOp : Torch_Op<"aten.pixel_shuffle", [
     Torch_IntType:$upscale_factor
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7341,7 +7341,7 @@ def Torch_AtenPermuteOp : Torch_Op<"aten.permute", [
     AnyTorchListOfTorchIntType:$dims
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7366,7 +7366,7 @@ def Torch_AtenMovedimIntOp : Torch_Op<"aten.movedim.int", [
     Torch_IntType:$destination
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7390,7 +7390,7 @@ def Torch_AtenBmmOp : Torch_Op<"aten.bmm", [
     AnyTorchTensorType:$mat2
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7415,7 +7415,7 @@ def Torch_AtenCumsumOp : Torch_Op<"aten.cumsum", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7440,7 +7440,7 @@ def Torch_AtenCumprodOp : Torch_Op<"aten.cumprod", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7464,7 +7464,7 @@ def Torch_AtenFloorDivideScalarOp : Torch_Op<"aten.floor_divide.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7489,7 +7489,7 @@ def Torch_AtenLogsumexpOp : Torch_Op<"aten.logsumexp", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7515,7 +7515,7 @@ def Torch_AtenMeanDimOp : Torch_Op<"aten.mean.dim", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7539,7 +7539,7 @@ def Torch_Aten__And__TensorOp : Torch_Op<"aten.__and__.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7563,7 +7563,7 @@ def Torch_Aten__Or__TensorOp : Torch_Op<"aten.__or__.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7589,7 +7589,7 @@ def Torch_Aten_SoftmaxOp : Torch_Op<"aten._softmax", [
     Torch_BoolType:$half_to_float
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7613,7 +7613,7 @@ def Torch_AtenMeanOp : Torch_Op<"aten.mean", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7637,7 +7637,7 @@ def Torch_AtenStdOp : Torch_Op<"aten.std", [
     Torch_BoolType:$unbiased
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7663,7 +7663,7 @@ def Torch_AtenStdDimOp : Torch_Op<"aten.std.dim", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7689,7 +7689,7 @@ def Torch_AtenStdCorrectionOp : Torch_Op<"aten.std.correction", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7713,7 +7713,7 @@ def Torch_AtenVarOp : Torch_Op<"aten.var", [
     Torch_BoolType:$unbiased
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7739,7 +7739,7 @@ def Torch_AtenVarDimOp : Torch_Op<"aten.var.dim", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7765,7 +7765,7 @@ def Torch_AtenVarCorrectionOp : Torch_Op<"aten.var.correction", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7791,8 +7791,8 @@ def Torch_AtenVarMeanCorrectionOp : Torch_Op<"aten.var_mean.correction", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7816,8 +7816,8 @@ def Torch_AtenVarMeanOp : Torch_Op<"aten.var_mean", [
     Torch_BoolType:$unbiased
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7843,8 +7843,8 @@ def Torch_AtenVarMeanDimOp : Torch_Op<"aten.var_mean.dim", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7871,8 +7871,8 @@ def Torch_AtenNllLoss2dForwardOp : Torch_Op<"aten.nll_loss2d_forward", [
     Torch_IntType:$ignore_index
   );
   let results = (outs
-    AnyTorchTensorType:$output,
-    AnyTorchTensorType:$total_weight
+    AnyTorchOptionalTensorType:$output,
+    AnyTorchOptionalTensorType:$total_weight
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7901,7 +7901,7 @@ def Torch_AtenNllLoss2dBackwardOp : Torch_Op<"aten.nll_loss2d_backward", [
     AnyTorchTensorType:$total_weight
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7928,8 +7928,8 @@ def Torch_AtenNllLossForwardOp : Torch_Op<"aten.nll_loss_forward", [
     Torch_IntType:$ignore_index
   );
   let results = (outs
-    AnyTorchTensorType:$output,
-    AnyTorchTensorType:$total_weight
+    AnyTorchOptionalTensorType:$output,
+    AnyTorchOptionalTensorType:$total_weight
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7958,7 +7958,7 @@ def Torch_AtenNllLossBackwardOp : Torch_Op<"aten.nll_loss_backward", [
     AnyTorchTensorType:$total_weight
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -7983,7 +7983,7 @@ def Torch_AtenBincountOp : Torch_Op<"aten.bincount", [
     Torch_IntType:$minlength
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8010,7 +8010,7 @@ def Torch_AtenLinalgVectorNormOp : Torch_Op<"aten.linalg_vector_norm", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8037,7 +8037,7 @@ def Torch_AtenLinalgNormOp : Torch_Op<"aten.linalg_norm", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8061,8 +8061,8 @@ def Torch_AtenLinalgQrOp : Torch_Op<"aten.linalg_qr", [
     Torch_StringType:$mode
   );
   let results = (outs
-    AnyTorchTensorType:$Q,
-    AnyTorchTensorType:$R
+    AnyTorchOptionalTensorType:$Q,
+    AnyTorchOptionalTensorType:$R
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8087,7 +8087,7 @@ def Torch_AtenFrobeniusNormDimOp : Torch_Op<"aten.frobenius_norm.dim", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8112,7 +8112,7 @@ def Torch_AtenMseLossOp : Torch_Op<"aten.mse_loss", [
     Torch_IntType:$reduction
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8138,7 +8138,7 @@ def Torch_AtenMseLossBackwardOp : Torch_Op<"aten.mse_loss_backward", [
     Torch_IntType:$reduction
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8165,7 +8165,7 @@ def Torch_AtenUpsampleNearest2dBackwardOp : Torch_Op<"aten.upsample_nearest2d_ba
     AnyTorchOptionalFloatType:$scales_w
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8193,7 +8193,7 @@ def Torch_AtenCrossEntropyLossOp : Torch_Op<"aten.cross_entropy_loss", [
     Torch_FloatType:$label_smoothing
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8216,7 +8216,7 @@ def Torch_AtenNonzeroOp : Torch_Op<"aten.nonzero", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8264,7 +8264,7 @@ def Torch_AtenNonzeroStaticOp : Torch_Op<"aten.nonzero_static", [
     Torch_IntType:$fill_value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8290,7 +8290,7 @@ def Torch_AtenBinaryCrossEntropyOp : Torch_Op<"aten.binary_cross_entropy", [
     Torch_IntType:$reduction
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8317,7 +8317,7 @@ def Torch_AtenBinaryCrossEntropyBackwardOp : Torch_Op<"aten.binary_cross_entropy
     Torch_IntType:$reduction
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8340,8 +8340,8 @@ def Torch_AtenLogSigmoidForwardOp : Torch_Op<"aten.log_sigmoid_forward", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$output,
-    AnyTorchTensorType:$buffer
+    AnyTorchOptionalTensorType:$output,
+    AnyTorchOptionalTensorType:$buffer
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8366,7 +8366,7 @@ def Torch_AtenLogSigmoidBackwardOp : Torch_Op<"aten.log_sigmoid_backward", [
     AnyTorchTensorType:$buffer
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8390,7 +8390,7 @@ def Torch_AtenSigmoidBackwardOp : Torch_Op<"aten.sigmoid_backward", [
     AnyTorchTensorType:$output
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8417,7 +8417,7 @@ def Torch_AtenCosineEmbeddingLossOp : Torch_Op<"aten.cosine_embedding_loss", [
     Torch_IntType:$reduction
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8443,7 +8443,7 @@ def Torch_AtenDiagEmbedOp : Torch_Op<"aten.diag_embed", [
     Torch_IntType:$dim2
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8468,7 +8468,7 @@ def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
     AnyTorchScalarType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8492,7 +8492,7 @@ def Torch_AtenReplicationPad2dOp : Torch_Op<"aten.replication_pad2d", [
     AnyTorchListOfTorchIntType:$padding
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8516,7 +8516,7 @@ def Torch_AtenReflectionPad1dOp : Torch_Op<"aten.reflection_pad1d", [
     AnyTorchListOfTorchIntType:$padding
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8540,7 +8540,7 @@ def Torch_AtenReflectionPad2dOp : Torch_Op<"aten.reflection_pad2d", [
     AnyTorchListOfTorchIntType:$padding
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8566,7 +8566,7 @@ def Torch_AtenPadOp : Torch_Op<"aten.pad", [
     AnyTorchOptionalFloatType:$value
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8589,7 +8589,7 @@ def Torch_AtenSqueezeDimOp : Torch_Op<"aten.squeeze.dim", [
     Torch_IntType:$dim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8612,7 +8612,7 @@ def Torch_AtenSqueezeOp : Torch_Op<"aten.squeeze", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8637,7 +8637,7 @@ def Torch_AtenFlattenUsingIntsOp : Torch_Op<"aten.flatten.using_ints", [
     Torch_IntType:$end_dim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8661,7 +8661,7 @@ def Torch_AtenUnflattenIntOp : Torch_Op<"aten.unflatten.int", [
     AnyTorchListOfTorchIntType:$sizes
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8783,7 +8783,7 @@ def Torch_AtenOnesOp : Torch_Op<"aten.ones", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8812,7 +8812,7 @@ def Torch_AtenNewOnesOp : Torch_Op<"aten.new_ones", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8839,7 +8839,7 @@ def Torch_AtenZerosOp : Torch_Op<"aten.zeros", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8868,7 +8868,7 @@ def Torch_AtenNewZerosOp : Torch_Op<"aten.new_zeros", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8895,7 +8895,7 @@ def Torch_AtenEyeOp : Torch_Op<"aten.eye", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8923,7 +8923,7 @@ def Torch_AtenEyeMOp : Torch_Op<"aten.eye.m", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8949,7 +8949,7 @@ def Torch_AtenTensorOp : Torch_Op<"aten.tensor", [
     Torch_BoolType:$requires_grad
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -8976,7 +8976,7 @@ def Torch_AtenTensorBoolOp : Torch_Op<"aten.tensor.bool", [
     Torch_BoolType:$requires_grad
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9002,7 +9002,7 @@ def Torch_AtenTensorIntOp : Torch_Op<"aten.tensor.int", [
     Torch_BoolType:$requires_grad
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9029,7 +9029,7 @@ def Torch_AtenScalarTensorOp : Torch_Op<"aten.scalar_tensor", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9052,7 +9052,7 @@ def Torch_Aten_ShapeAsTensorOp : Torch_Op<"aten._shape_as_tensor", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9076,7 +9076,7 @@ def Torch_AtenIsnanOp : Torch_Op<"aten.isnan", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9099,7 +9099,7 @@ def Torch_AtenIsinfOp : Torch_Op<"aten.isinf", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9122,7 +9122,7 @@ def Torch_AtenIsneginfOp : Torch_Op<"aten.isneginf", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9145,7 +9145,7 @@ def Torch_AtenIsposinfOp : Torch_Op<"aten.isposinf", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9168,7 +9168,7 @@ def Torch_AtenAllOp : Torch_Op<"aten.all", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9216,7 +9216,7 @@ def Torch_AtenAllDimOp : Torch_Op<"aten.all.dim", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9239,7 +9239,7 @@ def Torch_AtenAnyOp : Torch_Op<"aten.any", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9264,7 +9264,7 @@ def Torch_AtenAnyDimOp : Torch_Op<"aten.any.dim", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9291,7 +9291,7 @@ def Torch_AtenArangeOp : Torch_Op<"aten.arange", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9319,7 +9319,7 @@ def Torch_AtenArangeStartOp : Torch_Op<"aten.arange.start", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9348,7 +9348,7 @@ def Torch_AtenArangeStartStepOp : Torch_Op<"aten.arange.start_step", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9372,7 +9372,7 @@ def Torch_AtenArangeStartOutOp : Torch_Op<"aten.arange.start_out", [
     AnyTorchTensorType:$out
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9397,7 +9397,7 @@ def Torch_AtenArgmaxOp : Torch_Op<"aten.argmax", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9422,7 +9422,7 @@ def Torch_AtenArgminOp : Torch_Op<"aten.argmin", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9446,7 +9446,7 @@ def Torch_AtenOneHotOp : Torch_Op<"aten.one_hot", [
     Torch_IntType:$num_classes
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9471,7 +9471,7 @@ def Torch_AtenEinsumOp : Torch_Op<"aten.einsum", [
     AnyTorchOptionalListOfTorchIntType:$path
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9494,7 +9494,7 @@ def Torch_AtenTraceOp : Torch_Op<"aten.trace", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9520,7 +9520,7 @@ def Torch_AtenBucketizeTensorOp : Torch_Op<"aten.bucketize.Tensor", [
     Torch_BoolType:$right
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9544,7 +9544,7 @@ def Torch_AtenCloneOp : Torch_Op<"aten.clone", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9568,7 +9568,7 @@ def Torch_AtenLiftFreshCopyOp : Torch_Op<"aten.lift_fresh_copy", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9591,7 +9591,7 @@ def Torch_AtenContiguousOp : Torch_Op<"aten.contiguous", [
     Torch_IntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9616,7 +9616,7 @@ def Torch_AtenCopyOp : Torch_Op<"aten.copy", [
     Torch_BoolType:$non_blocking
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9640,7 +9640,7 @@ def Torch_AtenCopy_Op : Torch_Op<"aten.copy_", [
     Torch_BoolType:$non_blocking
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9669,7 +9669,7 @@ def Torch_Aten_ToCopyOp : Torch_Op<"aten._to_copy", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9691,7 +9691,7 @@ def Torch_AtenDetachOp : Torch_Op<"aten.detach", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9739,7 +9739,7 @@ def Torch_AtenCudaOp : Torch_Op<"aten.cuda", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9767,7 +9767,7 @@ def Torch_AtenEmbeddingOp : Torch_Op<"aten.embedding", [
     Torch_BoolType:$sparse
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9798,10 +9798,10 @@ def Torch_AtenEmbeddingBagPaddingIdxOp : Torch_Op<"aten.embedding_bag.padding_id
     AnyTorchOptionalIntType:$padding_idx
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2,
-    AnyTorchTensorType:$result3
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2,
+    AnyTorchOptionalTensorType:$result3
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9832,10 +9832,10 @@ def Torch_Aten_EmbeddingBagOp : Torch_Op<"aten._embedding_bag", [
     Torch_IntType:$padding_idx
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2,
-    AnyTorchTensorType:$result3
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2,
+    AnyTorchOptionalTensorType:$result3
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9863,7 +9863,7 @@ def Torch_AtenEmptyLikeOp : Torch_Op<"aten.empty_like", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9891,7 +9891,7 @@ def Torch_AtenNewEmptyOp : Torch_Op<"aten.new_empty", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9920,7 +9920,7 @@ def Torch_AtenNewEmptyStridedOp : Torch_Op<"aten.new_empty_strided", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9948,7 +9948,7 @@ def Torch_AtenZerosLikeOp : Torch_Op<"aten.zeros_like", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -9976,7 +9976,7 @@ def Torch_AtenOnesLikeOp : Torch_Op<"aten.ones_like", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10004,7 +10004,7 @@ def Torch_AtenEmptyMemoryFormatOp : Torch_Op<"aten.empty.memory_format", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10032,7 +10032,7 @@ def Torch_AtenEmptyStridedOp : Torch_Op<"aten.empty_strided", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10056,7 +10056,7 @@ def Torch_AtenExpandOp : Torch_Op<"aten.expand", [
     Torch_BoolType:$implicit
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10079,7 +10079,7 @@ def Torch_AtenExpandAsOp : Torch_Op<"aten.expand_as", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10102,7 +10102,7 @@ def Torch_AtenBroadcastToOp : Torch_Op<"aten.broadcast_to", [
     AnyTorchListOfTorchIntType:$size
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10127,7 +10127,7 @@ def Torch_AtenIndexTensorOp : Torch_Op<"aten.index.Tensor", [
     AnyTorchListOfOptionalTensorType:$indices
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10151,7 +10151,7 @@ def Torch_AtenIndexTensorHackedTwinOp : Torch_Op<"aten.index.Tensor_hacked_twin"
     AnyTorchListOfTensorType:$indices
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10176,7 +10176,7 @@ def Torch_AtenIndexSelectOp : Torch_Op<"aten.index_select", [
     AnyTorchTensorType:$index
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10204,7 +10204,7 @@ def Torch_Aten_IndexPutImplOp : Torch_Op<"aten._index_put_impl", [
     Torch_BoolType:$unsafe
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10230,7 +10230,7 @@ def Torch_Aten_IndexPutImpl_Op : Torch_Op<"aten._index_put_impl_", [
     Torch_BoolType:$unsafe
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10278,7 +10278,7 @@ def Torch_AtenMaskedSelectOp : Torch_Op<"aten.masked_select", [
     AnyTorchTensorType:$mask
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10326,7 +10326,7 @@ def Torch_AtenRepeatOp : Torch_Op<"aten.repeat", [
     AnyTorchListOfTorchIntType:$repeats
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10350,7 +10350,7 @@ def Torch_AtenTileOp : Torch_Op<"aten.tile", [
     AnyTorchListOfTorchIntType:$dims
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10373,7 +10373,7 @@ def Torch_AtenReshapeOp : Torch_Op<"aten.reshape", [
     AnyTorchListOfTorchIntType:$shape
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10396,7 +10396,7 @@ def Torch_AtenReshapeAsOp : Torch_Op<"aten.reshape_as", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10420,7 +10420,7 @@ def Torch_Aten_ReshapeAliasOp : Torch_Op<"aten._reshape_alias", [
     AnyTorchListOfTorchIntType:$stride
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10445,7 +10445,7 @@ def Torch_AtenResizeOp : Torch_Op<"aten.resize", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10468,7 +10468,7 @@ def Torch_AtenResize_Op : Torch_Op<"aten.resize_", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10492,7 +10492,7 @@ def Torch_AtenSelectIntOp : Torch_Op<"aten.select.int", [
     Torch_IntType:$index
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10542,7 +10542,7 @@ def Torch_AtenSumOp : Torch_Op<"aten.sum", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10568,7 +10568,7 @@ def Torch_AtenSumDimIntListOp : Torch_Op<"aten.sum.dim_IntList", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10594,7 +10594,7 @@ def Torch_AtenProdDimIntOp : Torch_Op<"aten.prod.dim_int", [
     AnyTorchOptionalIntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10617,7 +10617,7 @@ def Torch_AtenMaxOp : Torch_Op<"aten.max", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10641,7 +10641,7 @@ def Torch_AtenMaxOtherOp : Torch_Op<"aten.max.other", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10667,8 +10667,8 @@ def Torch_AtenMaxDimOp : Torch_Op<"aten.max.dim", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$values,
-    AnyTorchTensorType:$indices
+    AnyTorchOptionalTensorType:$values,
+    AnyTorchOptionalTensorType:$indices
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10693,7 +10693,7 @@ def Torch_AtenAmaxOp : Torch_Op<"aten.amax", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10716,7 +10716,7 @@ def Torch_AtenMinOp : Torch_Op<"aten.min", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10740,7 +10740,7 @@ def Torch_AtenMinOtherOp : Torch_Op<"aten.min.other", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10766,8 +10766,8 @@ def Torch_AtenMinDimOp : Torch_Op<"aten.min.dim", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$values,
-    AnyTorchTensorType:$indices
+    AnyTorchOptionalTensorType:$values,
+    AnyTorchOptionalTensorType:$indices
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10792,7 +10792,7 @@ def Torch_AtenAminOp : Torch_Op<"aten.amin", [
     Torch_BoolType:$keepdim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10818,7 +10818,7 @@ def Torch_AtenToDtypeOp : Torch_Op<"aten.to.dtype", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10848,7 +10848,7 @@ def Torch_AtenToDtypeLayoutOp : Torch_Op<"aten.to.dtype_layout", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10876,7 +10876,7 @@ def Torch_AtenToOtherOp : Torch_Op<"aten.to.other", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10903,7 +10903,7 @@ def Torch_AtenToPrimDeviceOp : Torch_Op<"aten.to.prim_Device", [
     Torch_BoolType:$copy
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10930,7 +10930,7 @@ def Torch_AtenToDeviceOp : Torch_Op<"aten.to.device", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10954,7 +10954,7 @@ def Torch_AtenTypeAsOp : Torch_Op<"aten.type_as", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -10977,7 +10977,7 @@ def Torch_AtenViewOp : Torch_Op<"aten.view", [
     AnyTorchListOfTorchIntType:$size
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11002,7 +11002,7 @@ def Torch_Aten_UnsafeViewOp : Torch_Op<"aten._unsafe_view", [
     AnyTorchListOfTorchIntType:$size
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11027,7 +11027,7 @@ def Torch_AtenWhereSelfOp : Torch_Op<"aten.where.self", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11053,7 +11053,7 @@ def Torch_AtenWhereScalarOp : Torch_Op<"aten.where.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11079,7 +11079,7 @@ def Torch_AtenWhereScalarOtherOp : Torch_Op<"aten.where.ScalarOther", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11105,7 +11105,7 @@ def Torch_AtenWhereScalarSelfOp : Torch_Op<"aten.where.ScalarSelf", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11132,7 +11132,7 @@ def Torch_AtenNanToNumOp : Torch_Op<"aten.nan_to_num", [
     AnyTorchOptionalFloatType:$neginf
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11158,7 +11158,7 @@ def Torch_AtenSliceTensorOp : Torch_Op<"aten.slice.Tensor", [
     Torch_IntType:$step
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11204,7 +11204,7 @@ def Torch_AtenCpuOp : Torch_Op<"aten.cpu", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11230,7 +11230,7 @@ def Torch_AtenGatherOp : Torch_Op<"aten.gather", [
     Torch_BoolType:$sparse_grad
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11256,7 +11256,7 @@ def Torch_AtenScatterAddOp : Torch_Op<"aten.scatter_add", [
     AnyTorchTensorType:$src
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11281,7 +11281,7 @@ def Torch_AtenScatterAdd_Op : Torch_Op<"aten.scatter_add_", [
     Torch_NonValueTensorType:$src
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11309,7 +11309,7 @@ def Torch_AtenScatterReduceTwoOp : Torch_Op<"aten.scatter_reduce.two", [
     Torch_BoolType:$include_self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11336,7 +11336,7 @@ def Torch_AtenScatterReduce_TwoOp : Torch_Op<"aten.scatter_reduce_.two", [
     Torch_BoolType:$include_self
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11410,7 +11410,7 @@ def Torch_AtenTensorFloatOp : Torch_Op<"aten.tensor.float", [
     Torch_BoolType:$requires_grad
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11483,7 +11483,7 @@ def Torch_AtenDropoutOp : Torch_Op<"aten.dropout", [
     Torch_BoolType:$train
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11507,7 +11507,7 @@ def Torch_AtenDropout_Op : Torch_Op<"aten.dropout_", [
     Torch_BoolType:$train
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11532,8 +11532,8 @@ def Torch_AtenNativeDropoutOp : Torch_Op<"aten.native_dropout", [
     AnyTorchOptionalBoolType:$train
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11555,7 +11555,7 @@ def Torch_AtenTOp : Torch_Op<"aten.t", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11577,7 +11577,7 @@ def Torch_AtenNumpyTOp : Torch_Op<"aten.numpy_T", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11605,7 +11605,7 @@ def Torch_AtenFullOp : Torch_Op<"aten.full", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11635,7 +11635,7 @@ def Torch_AtenFullLikeOp : Torch_Op<"aten.full_like", [
     AnyTorchOptionalIntType:$memory_format
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11664,7 +11664,7 @@ def Torch_AtenNewFullOp : Torch_Op<"aten.new_full", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11691,7 +11691,7 @@ def Torch_AtenBaddbmmOp : Torch_Op<"aten.baddbmm", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11717,7 +11717,7 @@ def Torch_AtenBaddbmm_Op : Torch_Op<"aten.baddbmm_", [
     AnyTorchScalarType:$alpha
   );
   let results = (outs
-    Torch_NonValueTensorType:$result
+    AnyTorchOptionalNonValueTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11743,7 +11743,7 @@ def Torch_AtenFftFftOp : Torch_Op<"aten.fft_fft", [
     AnyTorchOptionalStringType:$norm
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11767,7 +11767,7 @@ def Torch_AtenFmodTensorOp : Torch_Op<"aten.fmod.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11793,9 +11793,9 @@ def Torch_AtenUniqueConsecutiveOp : Torch_Op<"aten.unique_consecutive", [
     AnyTorchOptionalIntType:$dim
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11824,7 +11824,7 @@ def Torch_AtenLinspaceOp : Torch_Op<"aten.linspace", [
     AnyTorchOptionalBoolType:$pin_memory
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11849,7 +11849,7 @@ def Torch_AtenLinalgCrossOp : Torch_Op<"aten.linalg_cross", [
     Torch_IntType:$dim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11873,7 +11873,7 @@ def Torch_AtenAliasCopyOp : Torch_Op<"aten.alias_copy", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11895,7 +11895,7 @@ def Torch_AtenAliasOp : Torch_Op<"aten.alias", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11922,7 +11922,7 @@ def Torch_AtenAsStridedCopyOp : Torch_Op<"aten.as_strided_copy", [
     AnyTorchOptionalIntType:$storage_offset
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11947,7 +11947,7 @@ def Torch_AtenDiagonalOp : Torch_Op<"aten.diagonal", [
     Torch_IntType:$dim2
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11973,7 +11973,7 @@ def Torch_AtenDiagonalCopyOp : Torch_Op<"aten.diagonal_copy", [
     Torch_IntType:$dim2
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -11998,7 +11998,7 @@ def Torch_AtenExpandCopyOp : Torch_Op<"aten.expand_copy", [
     Torch_BoolType:$implicit
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12022,7 +12022,7 @@ def Torch_AtenPermuteCopyOp : Torch_Op<"aten.permute_copy", [
     AnyTorchListOfTorchIntType:$dims
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12047,7 +12047,7 @@ def Torch_Aten_ReshapeAliasCopyOp : Torch_Op<"aten._reshape_alias_copy", [
     AnyTorchListOfTorchIntType:$stride
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12072,7 +12072,7 @@ def Torch_AtenSelectCopyIntOp : Torch_Op<"aten.select_copy.int", [
     Torch_IntType:$index
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12095,7 +12095,7 @@ def Torch_AtenDetachCopyOp : Torch_Op<"aten.detach_copy", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12122,7 +12122,7 @@ def Torch_AtenSliceCopyTensorOp : Torch_Op<"aten.slice_copy.Tensor", [
     Torch_IntType:$step
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12145,7 +12145,7 @@ def Torch_AtenSqueezeCopyOp : Torch_Op<"aten.squeeze_copy", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12169,7 +12169,7 @@ def Torch_AtenSqueezeCopyDimOp : Torch_Op<"aten.squeeze_copy.dim", [
     Torch_IntType:$dim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12192,7 +12192,7 @@ def Torch_AtenTCopyOp : Torch_Op<"aten.t_copy", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12217,7 +12217,7 @@ def Torch_AtenTransposeCopyIntOp : Torch_Op<"aten.transpose_copy.int", [
     Torch_IntType:$dim1
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12241,7 +12241,7 @@ def Torch_AtenUnsqueezeCopyOp : Torch_Op<"aten.unsqueeze_copy", [
     Torch_IntType:$dim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12265,7 +12265,7 @@ def Torch_AtenViewCopyOp : Torch_Op<"aten.view_copy", [
     AnyTorchListOfTorchIntType:$size
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12289,7 +12289,7 @@ def Torch_AtenViewCopyDtypeOp : Torch_Op<"aten.view_copy.dtype", [
     Torch_IntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12315,7 +12315,7 @@ def Torch_AtenUnfoldCopyOp : Torch_Op<"aten.unfold_copy", [
     Torch_IntType:$step
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12342,7 +12342,7 @@ def Torch_AtenIm2colOp : Torch_Op<"aten.im2col", [
     AnyTorchListOfTorchIntType:$stride
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12369,7 +12369,7 @@ def Torch_AtenScatterReduceOp : Torch_Op<"aten.scatter.reduce", [
     Torch_StringType:$reduce
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12395,7 +12395,7 @@ def Torch_AtenSelectScatterOp : Torch_Op<"aten.select_scatter", [
     Torch_IntType:$index
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12423,7 +12423,7 @@ def Torch_AtenSliceScatterOp : Torch_Op<"aten.slice_scatter", [
     Torch_IntType:$step
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12450,7 +12450,7 @@ def Torch_AtenDiagonalScatterOp : Torch_Op<"aten.diagonal_scatter", [
     Torch_IntType:$dim2
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12477,7 +12477,7 @@ def Torch_AtenAsStridedScatterOp : Torch_Op<"aten.as_strided_scatter", [
     AnyTorchOptionalIntType:$storage_offset
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12503,7 +12503,7 @@ def Torch_AtenUpsampleNearest2dOp : Torch_Op<"aten.upsample_nearest2d", [
     AnyTorchOptionalFloatType:$scales_w
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12532,7 +12532,7 @@ def Torch_AtenScaledDotProductAttentionOp : Torch_Op<"aten.scaled_dot_product_at
     AnyTorchOptionalFloatType:$scale
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12559,7 +12559,7 @@ def Torch_AtenGridSamplerOp : Torch_Op<"aten.grid_sampler", [
     Torch_BoolType:$align_corners
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12746,7 +12746,7 @@ def Torch_AtenCatOp : Torch_Op<"aten.cat", [
     Torch_IntType:$dim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -12772,7 +12772,7 @@ def Torch_AtenStackOp : Torch_Op<"aten.stack", [
     Torch_IntType:$dim
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -13011,8 +13011,8 @@ def Torch_AtenSortOp : Torch_Op<"aten.sort", [
     Torch_BoolType:$descending
   );
   let results = (outs
-    AnyTorchTensorType:$values,
-    AnyTorchTensorType:$indices
+    AnyTorchOptionalTensorType:$values,
+    AnyTorchOptionalTensorType:$indices
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -13684,7 +13684,7 @@ def Torch_AtenRemainderScalarOp : Torch_Op<"aten.remainder.Scalar", [
     AnyTorchScalarType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -13708,7 +13708,7 @@ def Torch_AtenRemainderTensorOp : Torch_Op<"aten.remainder.Tensor", [
     AnyTorchTensorType:$other
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14662,7 +14662,7 @@ def Torch_AtenNarrowOp : Torch_Op<"aten.narrow", [
     Torch_IntType:$length
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14687,7 +14687,7 @@ def Torch_AtenNarrowTensorOp : Torch_Op<"aten.narrow.Tensor", [
     Torch_IntType:$length
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14737,7 +14737,7 @@ def Torch_Aten_SoftmaxBackwardDataOp : Torch_Op<"aten._softmax_backward_data", [
     Torch_IntType:$input_dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14761,7 +14761,7 @@ def Torch_AtenTanhBackwardOp : Torch_Op<"aten.tanh_backward", [
     AnyTorchTensorType:$output
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14787,7 +14787,7 @@ def Torch_AtenHardtanhBackwardOp : Torch_Op<"aten.hardtanh_backward", [
     AnyTorchScalarType:$max_val
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14812,7 +14812,7 @@ def Torch_AtenGeluBackwardOp : Torch_Op<"aten.gelu_backward", [
     Torch_StringType:$approximate
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14838,7 +14838,7 @@ def Torch_Aten_LogSoftmaxBackwardDataOp : Torch_Op<"aten._log_softmax_backward_d
     Torch_IntType:$input_dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14868,9 +14868,9 @@ def Torch_AtenNativeLayerNormBackwardOp : Torch_Op<"aten.native_layer_norm_backw
     AnyTorchListOfTorchBoolType:$output_mask
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14897,7 +14897,7 @@ def Torch_AtenEmbeddingDenseBackwardOp : Torch_Op<"aten.embedding_dense_backward
     Torch_BoolType:$scale_grad_by_freq
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14929,9 +14929,9 @@ def Torch_AtenNativeBatchNormBackwardOp : Torch_Op<"aten.native_batch_norm_backw
     AnyTorchListOfTorchBoolType:$output_mask
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14963,9 +14963,9 @@ def Torch_AtenNativeGroupNormBackwardOp : Torch_Op<"aten.native_group_norm_backw
     AnyTorchListOfTorchBoolType:$output_mask
   );
   let results = (outs
-    AnyTorchTensorType:$result0,
-    AnyTorchTensorType:$result1,
-    AnyTorchTensorType:$result2
+    AnyTorchOptionalTensorType:$result0,
+    AnyTorchOptionalTensorType:$result1,
+    AnyTorchOptionalTensorType:$result2
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -14990,7 +14990,7 @@ def Torch_AtenNativeDropoutBackwardOp : Torch_Op<"aten.native_dropout_backward",
     Torch_FloatType:$scale
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15018,7 +15018,7 @@ def Torch_AtenEluBackwardOp : Torch_Op<"aten.elu_backward", [
     AnyTorchTensorType:$self_or_result
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15044,7 +15044,7 @@ def Torch_AtenLeakyReluBackwardOp : Torch_Op<"aten.leaky_relu_backward", [
     Torch_BoolType:$self_is_result
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15071,7 +15071,7 @@ def Torch_AtenQuantizePerChannelOp : Torch_Op<"aten.quantize_per_channel", [
     Torch_IntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15097,7 +15097,7 @@ def Torch_AtenQuantizePerTensorOp : Torch_Op<"aten.quantize_per_tensor", [
     Torch_IntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15120,7 +15120,7 @@ def Torch_AtenDequantizeSelfOp : Torch_Op<"aten.dequantize.self", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15143,7 +15143,7 @@ def Torch_AtenDequantizeTensorOp : Torch_Op<"aten.dequantize.tensor", [
     AnyTorchTensorType:$qtensor
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15166,7 +15166,7 @@ def Torch_AtenIntReprOp : Torch_Op<"aten.int_repr", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15192,7 +15192,7 @@ def Torch_Aten_MakePerChannelQuantizedTensorOp : Torch_Op<"aten._make_per_channe
     Torch_IntType:$axis
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15217,7 +15217,7 @@ def Torch_Aten_MakePerTensorQuantizedTensorOp : Torch_Op<"aten._make_per_tensor_
     Torch_IntType:$zero_point
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15351,7 +15351,7 @@ def Torch_PrimNumToTensorScalarOp : Torch_Op<"prim.NumToTensor.Scalar", [
     AnyTorchScalarType:$a
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15594,7 +15594,7 @@ def Torch_PrimsConvertElementTypeOp : Torch_Op<"prims.convert_element_type", [
     Torch_IntType:$dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15620,7 +15620,7 @@ def Torch_PrimsVarOp : Torch_Op<"prims.var", [
     AnyTorchOptionalIntType:$output_dtype
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15643,7 +15643,7 @@ def Torch_PrimsSqrtOp : Torch_Op<"prims.sqrt", [
     AnyTorchTensorType:$self
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15668,7 +15668,7 @@ def Torch_PrimsCollapseOp : Torch_Op<"prims.collapse", [
     Torch_IntType:$end
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15692,7 +15692,7 @@ def Torch_PrimsSplitDimOp : Torch_Op<"prims.split_dim", [
     Torch_IntType:$outer_length
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15715,7 +15715,7 @@ def Torch_PrimsSqueezeOp : Torch_Op<"prims.squeeze", [
     AnyTorchListOfTorchIntType:$dimensions
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15737,7 +15737,7 @@ def Torch_PrimsViewOfOp : Torch_Op<"prims.view_of", [
     AnyTorchTensorType:$a
   );
   let results = (outs
-    AnyTorchTensorType:$result
+    AnyTorchOptionalTensorType:$result
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{
@@ -15765,7 +15765,7 @@ def Torch_QuantizedLinearOp : Torch_Op<"quantized.linear", [
     Torch_IntType:$Y_zero_point_i
   );
   let results = (outs
-    AnyTorchTensorType:$Y
+    AnyTorchOptionalTensorType:$Y
   );
   let hasCustomAssemblyFormat = 1;
   let extraClassDefinition = [{


### PR DESCRIPTION
This was found while tracing backwards graphs: the convolution_backwards op will return None if the first result is not needed. Confirmed by defining a custom op with a `Tensor` return signature and having its meta kernel return None.