### PR TITLE
[MLIR][TORCH]Add support lowing aten.Int.bool to arith

### DIFF
--- a/lib/Conversion/TorchToArith/TorchToArith.cpp
+++ b/lib/Conversion/TorchToArith/TorchToArith.cpp
@@ -240,11 +240,13 @@ public:
 } // namespace
 
 namespace {
-class ConvertAtenFloatScalarOp : public OpConversionPattern<AtenFloatScalarOp> {
+template <typename AtenOp>
+class ConvertAtenCastOp : public OpConversionPattern<AtenOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  using OpConversionPattern<AtenOp>::OpConversionPattern;
   LogicalResult
-  matchAndRewrite(AtenFloatScalarOp op, OpAdaptor adaptor,
+  matchAndRewrite(AtenOp op,
+                  typename OpConversionPattern<AtenOp>::OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType =
         this->getTypeConverter()->convertType(op->getResult(0).getType());
@@ -430,8 +432,9 @@ public:
     target.addIllegalOp<Torch::ConstantIntOp>();
     patterns.add<ConvertTorchConstantIntOp>(typeConverter, context);
 
-    target.addIllegalOp<AtenFloatScalarOp>();
-    patterns.add<ConvertAtenFloatScalarOp>(typeConverter, context);
+    target.addIllegalOp<AtenIntBoolOp, AtenFloatScalarOp>();
+    patterns.add<ConvertAtenCastOp<AtenIntBoolOp>>(typeConverter, context);
+    patterns.add<ConvertAtenCastOp<AtenFloatScalarOp>>(typeConverter, context);
 
     target.addIllegalOp<AtenAddOp>();
     patterns.add<ConvertAtenAddOp>(typeConverter, context);

--- a/lib/Conversion/TorchToArith/TorchToArith.cpp
+++ b/lib/Conversion/TorchToArith/TorchToArith.cpp
@@ -443,9 +443,6 @@ public:
     patterns.add<ConvertAtenCastOp<AtenIntBoolOp>>(typeConverter, context);
     patterns.add<ConvertAtenCastOp<AtenFloatScalarOp>>(typeConverter, context);
 
-    target.addIllegalOp<AtenIntBoolOp>();
-    patterns.add<ConvertAtenIntBoolOp>(typeConverter, context);
-
     target.addIllegalOp<AtenAddOp>();
     patterns.add<ConvertAtenAddOp>(typeConverter, context);
 

--- a/test/Conversion/TorchToArith/basic.mlir
+++ b/test/Conversion/TorchToArith/basic.mlir
@@ -288,3 +288,14 @@ func.func @torch.aten.Bool.int(%arg0: !torch.int) -> !torch.bool {
   %0 = torch.aten.Bool.int %arg0 : !torch.int -> !torch.bool
   return %0 : !torch.bool
 }
+
+// CHECK-LABEL:   func.func @torch.aten.Int.bool(
+// CHECK-SAME:                            %[[ARG:.*]]: !torch.bool) -> !torch.int {
+// CHECK:           %[[ARG_I1:.*]] = torch_c.to_i1 %[[ARG]]
+// CHECK:           %[[EXTUI:.*]] = arith.extui %[[ARG_I1:.*]] : i1 to i64
+// CHECK:           %[[OUT]] = torch_c.from_i64 %[[EXTUI:.*]]
+// CHECK:           return %[[OUT]] : !torch.int
+func.func @torch.aten.Int.bool(%arg0: !torch.bool) -> !torch.int {
+  %0 = torch.aten.Int.bool %arg0 : !torch.bool -> !torch.int
+  return %0 : !torch.int
+}

--- a/test/Conversion/TorchToArith/basic.mlir
+++ b/test/Conversion/TorchToArith/basic.mlir
@@ -319,8 +319,8 @@ func.func @torch.aten.Bool.int(%arg0: !torch.int) -> !torch.bool {
 // CHECK-LABEL:   func.func @torch.aten.Int.bool(
 // CHECK-SAME:                            %[[ARG:.*]]: !torch.bool) -> !torch.int {
 // CHECK:           %[[ARG_I1:.*]] = torch_c.to_i1 %[[ARG]]
-// CHECK:           %[[EXTUI:.*]] = arith.extui %[[ARG_I1:.*]] : i1 to i64
-// CHECK:           %[[OUT]] = torch_c.from_i64 %[[EXTUI:.*]]
+// CHECK:           %[[EXTUI:.*]] = arith.extui %[[ARG_I1]] : i1 to i64
+// CHECK:           %[[OUT:.*]] = torch_c.from_i64 %[[EXTUI]]
 // CHECK:           return %[[OUT]] : !torch.int
 func.func @torch.aten.Int.bool(%arg0: !torch.bool) -> !torch.int {
   %0 = torch.aten.Int.bool %arg0 : !torch.bool -> !torch.int


### PR DESCRIPTION
Now there no lowing for `aten.Int.bool` in `convert-torch-to-arith` pass. this PR add this support.

Below is the UT.
```
func.func @torch.aten.Int.bool(%arg0: !torch.bool) -> !torch.int {
  %0 = torch.aten.Int.bool %arg0 : !torch.bool -> !torch.int
  return %0 : !torch.int
}
```
