### PR TITLE
[Bazel] Use bazel 6 to support dict select union

### DIFF
--- a/utils/bazel/docker/Dockerfile
+++ b/utils/bazel/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN echo $REPO_NAME >> /etc/apt/sources.list.d/llvm.list && \
 
 # Install bazel
 ARG ARCH="x86_64"
-ARG BAZEL_VERSION=5.2.0
+ARG BAZEL_VERSION=6.4.0
 RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${ARCH} -O /usr/bin/bazel \
     && chmod a+x /usr/bin/bazel
 

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -738,6 +738,7 @@ cc_library(
         "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:Dialect",
         "@llvm-project//mlir:DialectUtils",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:ViewLikeInterface",
     ],


### PR DESCRIPTION
Bazel builds broke with the recent LLVM bump due to union select of dictionaries: 
```bazel
    substitutions = {
        "#cmakedefine01 MLIR_DEPRECATED_GPU_SERIALIZATION_ENABLE": "#define MLIR_DEPRECATED_GPU_SERIALIZATION_ENABLE 0",
        "#cmakedefine01 MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS": "#define MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS 0",
        "#cmakedefine MLIR_GREEDY_REWRITE_RANDOMIZER_SEED ${MLIR_GREEDY_REWRITE_RANDOMIZER_SEED}": "/* #undef MLIR_GREEDY_REWRITE_RANDOMIZER_SEED */",
        "#cmakedefine01 MLIR_ENABLE_NVPTXCOMPILER": "#define MLIR_ENABLE_NVPTXCOMPILER 0",
        "#cmakedefine01 MLIR_ENABLE_PDL_IN_PATTERNMATCH": "#define MLIR_ENABLE_PDL_IN_PATTERNMATCH 1",
        "#cmakedefine01 MLIR_ENABLE_ROCM_CONVERSIONS": "#define MLIR_ENABLE_ROCM_CONVERSIONS 0",
    } | if_cuda_available(
        {"#cmakedefine01 MLIR_ENABLE_CUDA_CONVERSIONS": "#define MLIR_ENABLE_CUDA_CONVERSIONS 1"},
        {"#cmakedefine01 MLIR_ENABLE_CUDA_CONVERSIONS": "#define MLIR_ENABLE_CUDA_CONVERSIONS 0"},
    ),
```
```
Analyzing: target @torch-mlir//:torch-mlir-opt (1 packages loaded, 0 targets configured)
ERROR: Traceback (most recent call last):
	File "/root/.cache/bazel/_bazel_root/b89349c08f7224396763d[14](https://github.com/llvm/torch-mlir/actions/runs/8515127977/job/23322023669#step:8:15)fe35cba11/external/llvm-project/mlir/BUILD.bazel", line 41, column 7, in <toplevel>
		} | if_cuda_available(
Error: unsupported binary operation: dict | select
```

Bazel 6 supports dict select union https://github.com/bazelbuild/bazel/commit/ebae4860db44c754d41768698024732979132705 after starlark added support for union over dictionaries. This PR bumps bazel to 6.4.

torch-mlir's bazel build: https://github.com/sjain-stanford/torch-mlir/actions/runs/8530438588/job/23368225180