### PR TITLE
Add missing dependency to TorchMLIRRefBackend target

### DIFF
--- a/lib/RefBackend/CMakeLists.txt
+++ b/lib/RefBackend/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_library(TorchMLIRRefBackend
   DEPENDS
   MLIRTorchTypesIncGen
   TorchMLIRRefBackendPassIncGen
+  MLIRTorchConversionOpsIncGen
 
   LINK_COMPONENTS
   Core


### PR DESCRIPTION
Discovered in https://github.com/llvm/torch-mlir/issues/3104
Most likely when building with stablehlo, while waiting for it missing dependency was generated to location shared with another dependency.