### PR TITLE
[cmake] link TorchMLIRTorchConversionPasses to TorchMLIRConversionPasses

### DIFF
--- a/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
@@ -7,14 +7,9 @@ set(LinkedLibs
   MLIRTosaTransforms
   MLIRVectorTransforms
   TorchMLIRTorchConversionDialect
-  TorchMLIRTorchConversionToMLProgram
   TorchMLIRTorchDialect
   TorchMLIRTorchPasses
-  TorchMLIRTorchToArith
-  TorchMLIRTorchToLinalg
-  TorchMLIRTorchToSCF
-  TorchMLIRTorchToTMTensor
-  TorchMLIRTorchToTosa
+  TorchMLIRConversionPasses
   )
 
 if(TORCH_MLIR_ENABLE_STABLEHLO)


### PR DESCRIPTION
* as that `TorchMLIRTorchConversionPasses` missing dependencies of `TorchMLIRTorchToStablehlo` and `TorchMLIRTorchToTensor`.
* use `TorchMLIRConversionPasses` instead of scattered targets.