### PR TITLE
Disable LTC from release builds to bypass linker issue

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -434,6 +434,8 @@ function clean_build() {
 }
 
 function build_torch_mlir() {
+  # Disable LTC build for releases to avoid linker issues
+  export TORCH_MLIR_ENABLE_LTC=0
   local torch_version="$1"
   case $torch_version in
     nightly)


### PR DESCRIPTION
Workaround for https://github.com/llvm/torch-mlir/issues/3120. This should bring prebuilt releases back to green: https://github.com/llvm/torch-mlir-release/actions.