### PR TITLE
Replace c10::optional with std::optional

### DIFF
--- a/build_tools/ci/build_posix.sh
+++ b/build_tools/ci/build_posix.sh
@@ -50,6 +50,7 @@ cmake -S "$repo_root/externals/llvm-project/llvm" -B "$build_dir" \
   -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$repo_root" \
   -DLLVM_TARGETS_TO_BUILD=host \
   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DTORCH_MLIR_ENABLE_LTC=ON
 echo "::endgroup::"
 
 echo "::group::Build"

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -434,8 +434,6 @@ function clean_build() {
 }
 
 function build_torch_mlir() {
-  # Disable LTC build for releases to avoid linker issues
-  export TORCH_MLIR_ENABLE_LTC=0
   local torch_version="$1"
   case $torch_version in
     nightly)

--- a/projects/ltc/csrc/base_lazy_backend/backend_impl.cpp
+++ b/projects/ltc/csrc/base_lazy_backend/backend_impl.cpp
@@ -117,7 +117,7 @@ TorchMlirBackendImpl::GetComputationDataFromNode(const Node *node) const {
 
 at::Tensor TorchMlirBackendImpl::MakeTensorFromComputationData(
     const BackendDataPtr data,
-    c10::optional<at::ScalarType> logical_scalar_type) const {
+    std::optional<at::ScalarType> logical_scalar_type) const {
   PRINT_FUNCTION();
 
   TorchMlirBackendData *torch_mlir_data =

--- a/projects/ltc/csrc/base_lazy_backend/backend_impl.h
+++ b/projects/ltc/csrc/base_lazy_backend/backend_impl.h
@@ -30,7 +30,7 @@ class TORCH_API TorchMlirBackendData : public BackendData {
 public:
   struct Info : public BackendData::Info {
     at::Tensor tensor;
-    c10::optional<at::Scalar> scalar;
+    std::optional<at::Scalar> scalar;
     bool requires_grad;
     std::string name;
 
@@ -111,7 +111,7 @@ public:
 
   virtual at::Tensor MakeTensorFromComputationData(
       const BackendDataPtr data,
-      c10::optional<at::ScalarType> logical_scalar_type) const override;
+      std::optional<at::ScalarType> logical_scalar_type) const override;
 
   /**
    * Lowering, Compilation, Execution

--- a/projects/ltc/csrc/base_lazy_backend/ir_builder.h
+++ b/projects/ltc/csrc/base_lazy_backend/ir_builder.h
@@ -34,7 +34,7 @@ struct TorchMlirIrBuilder : IrBuilder {
   NodePtr MakeDeviceData(const std::shared_ptr<BackendData>& data) const override { return MakeNode<DeviceData>(data); }
   NodePtr MakeScalar(const at::Scalar& value, const at::ScalarType& type) const override { return MakeNode<Scalar>(value, type); }
   NodePtr MakeExpand(const Value& input0, const std::vector<int64_t>& size, const bool& is_scalar_expand) const override { return MakeNode<Expand>(input0, size, is_scalar_expand); }
-  NodePtr MakeCast(const Value& input0, const at::ScalarType& dtype, const c10::optional<at::ScalarType>& stype = c10::nullopt) const override { return MakeNode<Cast>(input0, dtype, stype); }
+  NodePtr MakeCast(const Value& input0, const at::ScalarType& dtype, const std::optional<at::ScalarType>& stype = c10::nullopt) const override { return MakeNode<Cast>(input0, dtype, stype); }
   NodePtr MakeTensorList(const OpList& inputs) const override { return MakeNode<TorchMlirTensorList>(inputs); }
   NodePtr MakeGeneric(const OpKind& op, const OpList& operands, const Shape& shape, const size_t& num_outputs = 1, const hash_t& hash_seed = static_cast<uint32_t>(0x5a2d296e9)) const override { return MakeNode<Generic>(op, operands, shape, num_outputs, hash_seed); }
 

--- a/projects/ltc/csrc/base_lazy_backend/mlir_node_lowering.cpp
+++ b/projects/ltc/csrc/base_lazy_backend/mlir_node_lowering.cpp
@@ -159,7 +159,7 @@ c10::TensorType &cast_tensor_type(c10::TypePtr value_type) {
   return *tensor_type.get();
 }
 
-c10::optional<std::vector<int64_t>>
+std::optional<std::vector<int64_t>>
 get_tensor_type_shape(c10::TensorType &tensor_type) {
   auto &symbolic_shape = tensor_type.symbolic_sizes();
   if (!symbolic_shape.rank()) {

--- a/projects/ltc/csrc/base_lazy_backend/ops/to_copy.h
+++ b/projects/ltc/csrc/base_lazy_backend/ops/to_copy.h
@@ -25,11 +25,11 @@ namespace lazy {
 class ToCopy : public torch::lazy::TorchMlirNode {
 public:
   ToCopy(const torch::lazy::Value &self,
-         const c10::optional<at::ScalarType> &dtype,
-         const c10::optional<at::Layout> &layout,
-         const c10::optional<at::Device> &device,
-         const c10::optional<bool> &pin_memory, const bool &non_blocking,
-         const c10::optional<at::MemoryFormat> &memory_format,
+         const std::optional<at::ScalarType> &dtype,
+         const std::optional<at::Layout> &layout,
+         const std::optional<at::Device> &device,
+         const std::optional<bool> &pin_memory, const bool &non_blocking,
+         const std::optional<at::MemoryFormat> &memory_format,
          std::vector<torch::lazy::Shape> &&shapes)
       : torch::lazy::TorchMlirNode(
             torch::lazy::OpKind(at::aten::_to_copy), {self}, std::move(shapes),
@@ -95,12 +95,12 @@ public:
     return _to_copy_out;
   }
 
-  c10::optional<at::ScalarType> dtype;
-  c10::optional<at::Layout> layout;
-  c10::optional<at::Device> device;
-  c10::optional<bool> pin_memory;
+  std::optional<at::ScalarType> dtype;
+  std::optional<at::Layout> layout;
+  std::optional<at::Device> device;
+  std::optional<bool> pin_memory;
   bool non_blocking;
-  c10::optional<at::MemoryFormat> memory_format;
+  std::optional<at::MemoryFormat> memory_format;
 };
 } // namespace lazy
 } // namespace torch

--- a/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
+++ b/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
@@ -149,15 +149,22 @@ std::vector<torch::lazy::Shape> compute_shape_mul(const at::Tensor &self,
 
 std::vector<torch::lazy::Shape>
 compute_shape_var(const at::Tensor &self, at::OptionalIntArrayRef dim,
-                  const c10::optional<at::Scalar> &correction, bool keepdim) {
+                  const ::std::optional<at::Scalar> &correction, bool keepdim) {
   // Result of variance is scalar tensor.
   return {Shape(self.scalar_type(), {})};
 }
 
 std::vector<torch::lazy::Shape>
-compute_shape_nan_to_num(const at::Tensor &self, c10::optional<double> nan,
-                         c10::optional<double> posinf,
-                         c10::optional<double> neginf) {
+compute_shape_var(const at::Tensor &self, at::OptionalIntArrayRef dim,
+                  ::std::optional<at::Scalar> &correction, bool keepdim) {
+  // Result of variance is scalar tensor.
+  return {Shape(self.scalar_type(), {})};
+}
+
+std::vector<torch::lazy::Shape>
+compute_shape_nan_to_num(const at::Tensor &self, ::std::optional<double> nan,
+                         ::std::optional<double> posinf,
+                         ::std::optional<double> neginf) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
@@ -226,8 +233,8 @@ std::vector<torch::lazy::Shape> compute_shape_fmod(const at::Tensor &self,
 }
 
 std::vector<torch::lazy::Shape> compute_shape_native_group_norm(
-    const at::Tensor &input, const c10::optional<at::Tensor> &weight,
-    const c10::optional<at::Tensor> &bias, int64_t N, int64_t C, int64_t HxW,
+    const at::Tensor &input, const ::std::optional<at::Tensor> &weight,
+    const ::std::optional<at::Tensor> &bias, int64_t N, int64_t C, int64_t HxW,
     int64_t group, double eps) {
 
   TORCH_CHECK(input.sizes().size() >= 2,
@@ -263,8 +270,9 @@ compute_shape_im2col(const at::Tensor &self, at::IntArrayRef kernel_size,
 
 std::vector<torch::lazy::Shape> compute_shape_native_group_norm_backward(
     const at::Tensor &grad_out, const at::Tensor &input, const at::Tensor &mean,
-    const at::Tensor &rstd, const c10::optional<at::Tensor> &weight, int64_t N,
-    int64_t C, int64_t HxW, int64_t group, ::std::array<bool, 3> output_mask) {
+    const at::Tensor &rstd, const ::std::optional<at::Tensor> &weight,
+    int64_t N, int64_t C, int64_t HxW, int64_t group,
+    ::std::array<bool, 3> output_mask) {
 
   TORCH_CHECK(input.sizes().size() >= 2,
               "Input tensor must have at least batch and channel dimensions!");
@@ -317,20 +325,20 @@ compute_shape_reflection_pad2d(const at::Tensor &self,
 
 std::vector<torch::lazy::Shape>
 compute_shape_uniform(const at::Tensor &self, double from, double to,
-                      c10::optional<at::Generator> generator) {
+                      ::std::optional<at::Generator> generator) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
 std::vector<torch::lazy::Shape>
 compute_shape_normal_functional(const at::Tensor &self, double mean, double std,
-                                c10::optional<at::Generator> generator) {
+                                ::std::optional<at::Generator> generator) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
 std::vector<torch::lazy::Shape>
 compute_shape_multinomial(const at::Tensor &self, int64_t num_samples,
                           bool replacement,
-                          c10::optional<at::Generator> generator) {
+                          ::std::optional<at::Generator> generator) {
   // Input tensor can be either 1D or 2D. The last dim of output
   // should be 'num_samples'. So the output shape can be either
   // [num_samples] or [m, num_samples].
@@ -341,30 +349,29 @@ compute_shape_multinomial(const at::Tensor &self, int64_t num_samples,
 }
 
 std::vector<torch::lazy::Shape>
-compute_shape_eye(int64_t n, c10::optional<at::ScalarType> dtype,
-                  c10::optional<at::Layout> layout,
-                  c10::optional<at::Device> device,
-                  c10::optional<bool> pin_memory) {
+compute_shape_eye(int64_t n, ::std::optional<at::ScalarType> dtype,
+                  ::std::optional<at::Layout> layout,
+                  ::std::optional<at::Device> device,
+                  ::std::optional<bool> pin_memory) {
   auto out_meta =
       at::eye(n, dtype, layout, c10::Device(c10::kMeta), pin_memory);
   return {Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
 }
 
 std::vector<torch::lazy::Shape>
-compute_shape_eye(int64_t n, int64_t m, c10::optional<at::ScalarType> dtype,
-                  c10::optional<at::Layout> layout,
-                  c10::optional<at::Device> device,
-                  c10::optional<bool> pin_memory) {
+compute_shape_eye(int64_t n, int64_t m, ::std::optional<at::ScalarType> dtype,
+                  ::std::optional<at::Layout> layout,
+                  ::std::optional<at::Device> device,
+                  ::std::optional<bool> pin_memory) {
   auto out_meta =
       at::eye(n, m, dtype, layout, c10::Device(c10::kMeta), pin_memory);
   return {Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
 }
 
-std::vector<torch::lazy::Shape>
-compute_shape_arange(const at::Scalar &end, c10::optional<at::ScalarType> dtype,
-                     c10::optional<at::Layout> layout,
-                     c10::optional<at::Device> device,
-                     c10::optional<bool> pin_memory) {
+std::vector<torch::lazy::Shape> compute_shape_arange(
+    const at::Scalar &end, ::std::optional<at::ScalarType> dtype,
+    ::std::optional<at::Layout> layout, ::std::optional<at::Device> device,
+    ::std::optional<bool> pin_memory) {
   auto out_meta =
       at::arange(end, dtype, layout, c10::Device(c10::kMeta), pin_memory);
   return {Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
@@ -372,8 +379,8 @@ compute_shape_arange(const at::Scalar &end, c10::optional<at::ScalarType> dtype,
 
 std::vector<torch::lazy::Shape> compute_shape_arange(
     const at::Scalar &start, const at::Scalar &end,
-    c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
-    c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
+    ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout,
+    ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
   auto out_meta = at::arange(start, end, dtype, layout, c10::Device(c10::kMeta),
                              pin_memory);
   return {Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
@@ -381,8 +388,8 @@ std::vector<torch::lazy::Shape> compute_shape_arange(
 
 std::vector<torch::lazy::Shape> compute_shape_arange(
     const at::Scalar &start, const at::Scalar &end, const at::Scalar &step,
-    c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
-    c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
+    ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout,
+    ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
   auto out_meta = at::arange(start, end, step, dtype, layout,
                              c10::Device(c10::kMeta), pin_memory);
   return {Shape(out_meta.scalar_type(), out_meta.sizes().vec())};
@@ -390,44 +397,44 @@ std::vector<torch::lazy::Shape> compute_shape_arange(
 
 std::vector<torch::lazy::Shape> compute_shape_full(
     at::IntArrayRef size, const at::Scalar &fill_value,
-    c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
-    c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
+    ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout,
+    ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
 
 std::vector<torch::lazy::Shape>
-compute_shape_ones(at::IntArrayRef size, c10::optional<at::ScalarType> dtype,
-                   c10::optional<at::Layout> layout,
-                   c10::optional<at::Device> device,
-                   c10::optional<bool> pin_memory) {
+compute_shape_ones(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype,
+                   ::std::optional<at::Layout> layout,
+                   ::std::optional<at::Device> device,
+                   ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
 
 std::vector<torch::lazy::Shape>
-compute_shape_zeros(at::IntArrayRef size, c10::optional<at::ScalarType> dtype,
-                    c10::optional<at::Layout> layout,
-                    c10::optional<at::Device> device,
-                    c10::optional<bool> pin_memory) {
+compute_shape_zeros(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype,
+                    ::std::optional<at::Layout> layout,
+                    ::std::optional<at::Device> device,
+                    ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
 
 std::vector<torch::lazy::Shape>
-compute_shape_empty(at::IntArrayRef size, c10::optional<at::ScalarType> dtype,
-                    c10::optional<at::Layout> layout,
-                    c10::optional<at::Device> device,
-                    c10::optional<bool> pin_memory,
-                    c10::optional<at::MemoryFormat> memory_format) {
+compute_shape_empty(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype,
+                    ::std::optional<at::Layout> layout,
+                    ::std::optional<at::Device> device,
+                    ::std::optional<bool> pin_memory,
+                    ::std::optional<at::MemoryFormat> memory_format) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
 
 std::vector<torch::lazy::Shape> compute_shape_empty_strided(
     at::IntArrayRef size, at::IntArrayRef stride,
-    c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
-    c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
+    ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout,
+    ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
@@ -443,46 +450,46 @@ std::vector<torch::lazy::Shape> compute_shape_fill(const at::Tensor &self,
 }
 
 std::vector<torch::lazy::Shape>
-compute_shape_randn(at::IntArrayRef size, c10::optional<at::ScalarType> dtype,
-                    c10::optional<at::Layout> layout,
-                    c10::optional<at::Device> device,
-                    c10::optional<bool> pin_memory) {
+compute_shape_randn(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype,
+                    ::std::optional<at::Layout> layout,
+                    ::std::optional<at::Device> device,
+                    ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
 
 std::vector<torch::lazy::Shape> compute_shape_randint(
-    int64_t high, at::IntArrayRef size, c10::optional<at::ScalarType> dtype,
-    c10::optional<at::Layout> layout, c10::optional<at::Device> device,
-    c10::optional<bool> pin_memory) {
+    int64_t high, at::IntArrayRef size, ::std::optional<at::ScalarType> dtype,
+    ::std::optional<at::Layout> layout, ::std::optional<at::Device> device,
+    ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
 
 std::vector<torch::lazy::Shape> compute_shape_randint(
     int64_t low, int64_t high, at::IntArrayRef size,
-    c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
-    c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
+    ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout,
+    ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
 
 std::vector<torch::lazy::Shape>
 compute_shape_resize(const at::Tensor &self, at::IntArrayRef size,
-                     c10::optional<at::MemoryFormat> memory_format) {
+                     ::std::optional<at::MemoryFormat> memory_format) {
   return {Shape(self.scalar_type(), size.vec())};
 }
 
 std::vector<torch::lazy::Shape>
 compute_shape_bernoulli(const at::Tensor &self, const at::Tensor &p,
-                        c10::optional<at::Generator> generator) {
+                        ::std::optional<at::Generator> generator) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
 std::vector<torch::lazy::Shape> compute_shape_scalar_tensor(
-    const at::Scalar &s, c10::optional<at::ScalarType> dtype,
-    c10::optional<at::Layout> layout, c10::optional<at::Device> device,
-    c10::optional<bool> pin_memory) {
+    const at::Scalar &s, ::std::optional<at::ScalarType> dtype,
+    ::std::optional<at::Layout> layout, ::std::optional<at::Device> device,
+    ::std::optional<bool> pin_memory) {
   return {Shape(dtype.value_or(s.type()), c10::ArrayRef<int64_t>{})};
 }
 
@@ -494,8 +501,8 @@ std::vector<torch::lazy::Shape> compute_shape_roll(const at::Tensor &self,
 
 std::vector<torch::lazy::Shape> compute_shape_linspace(
     const at::Scalar &start, const at::Scalar &end, int64_t steps,
-    c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
-    c10::optional<at::Device> device, c10::optional<bool> pin_memory) {
+    ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout,
+    ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
   auto out_meta = at::linspace(start, end, steps, dtype, layout,
                                c10::Device(c10::kMeta), pin_memory);
   return {Shape(out_meta.scalar_type(), out_meta.sizes().vec())};

--- a/projects/ltc/csrc/base_lazy_backend/utils/tensor_utils.cpp
+++ b/projects/ltc/csrc/base_lazy_backend/utils/tensor_utils.cpp
@@ -75,7 +75,7 @@ torch::lazy::DeviceData *device_data_cast(const torch::lazy::Value &value) {
 
 torch::lazy::DeviceData *
 device_data_cast(const at::Tensor &tensor,
-                 c10::optional<torch::lazy::BackendDevice> device) {
+                 std::optional<torch::lazy::BackendDevice> device) {
   if (!device) {
     device = torch::lazy::GetBackendDevice(tensor);
   }

--- a/projects/ltc/csrc/base_lazy_backend/utils/tensor_utils.h
+++ b/projects/ltc/csrc/base_lazy_backend/utils/tensor_utils.h
@@ -22,7 +22,7 @@ TORCH_API torch::lazy::DeviceData *
 device_data_cast(const torch::lazy::Value &value);
 TORCH_API torch::lazy::DeviceData *device_data_cast(
     const at::Tensor &tensor,
-    c10::optional<torch::lazy::BackendDevice> device = c10::nullopt);
+    std::optional<torch::lazy::BackendDevice> device = c10::nullopt);
 
 } // namespace lazy
 } // namespace torch


### PR DESCRIPTION
They replaced all `c10::optional` usages with `std::optional` in torchgen'd code in https://github.com/pytorch/pytorch/commit/fb90b4d4b25f0ebdd7d8c12b9963769774ef4873 causing the LTC build to break.

Replacing all usages of `c10::optional` with `std::optional` in `projects/ltc` has fixed the issue

Issue: #3120 