### PR TITLE
[ONNX] Add support for reduceprod with axes given

### DIFF
--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -1228,14 +1228,14 @@ func.func @test_reduce_prod_default_axes_keepdims_random(%arg0: !torch.vtensor<[
 // -----
 
 // CHECK-LABEL: func.func @test_reduce_prod_keepdims_random
-func.func @test_reduce_prod_keepdims_random(%arg0: !torch.vtensor<[3,2,2],f32>, %arg1: !torch.vtensor<[1],si64>) -> !torch.vtensor<[3,1,2],f32> attributes {torch.onnx_meta.ir_version = 8 : si64, torch.onnx_meta.opset_version = 18 : si64} {
+func.func @test_reduce_prod_keepdims_random(%arg0: !torch.vtensor<[3,2,4],f32>, %arg1: !torch.vtensor<[1],si64>) -> !torch.vtensor<[3,1,4],f32> attributes {torch.onnx_meta.ir_version = 8 : si64, torch.onnx_meta.opset_version = 18 : si64} {
   // CHECK: %[[INT1:.*]] = torch.constant.int 1
   // CHECK: %[[TRUE:.*]] = torch.constant.bool true
   // CHECK: %[[NONE:.*]] = torch.constant.none
-  // CHECK: %[[PROD:.*]] = torch.aten.prod.dim_int %arg0, %[[INT1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[3,2,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[3,1,2],f32>
-  // CHECK: return %[[PROD]] : !torch.vtensor<[3,1,2],f32>
-  %0 = torch.operator "onnx.ReduceProd"(%arg0, %arg1) {torch.onnx.keepdims = 1 : si64} : (!torch.vtensor<[3,2,2],f32>, !torch.vtensor<[1],si64>) -> !torch.vtensor<[3,1,2],f32>
-  return %0 : !torch.vtensor<[3,1,2],f32>
+  // CHECK: %[[PROD:.*]] = torch.aten.prod.dim_int %arg0, %[[INT1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[3,2,4],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[3,1,4],f32>
+  // CHECK: return %[[PROD]] : !torch.vtensor<[3,1,4],f32>
+  %0 = torch.operator "onnx.ReduceProd"(%arg0, %arg1) {torch.onnx.keepdims = 1 : si64} : (!torch.vtensor<[3,2,4],f32>, !torch.vtensor<[1],si64>) -> !torch.vtensor<[3,1,4],f32>
+  return %0 : !torch.vtensor<[3,1,4],f32>
 }
 
 // -----

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -1213,27 +1213,13 @@ func.func @test_reduce_min_attr(%arg0: !torch.vtensor<[4,2],i1>) -> !torch.vtens
 // CHECK-LABEL: func.func @test_reduce_prod_default_axes_keepdims_random
 func.func @test_reduce_prod_default_axes_keepdims_random(%arg0: !torch.vtensor<[3,2,2],f32>) -> !torch.vtensor<[1,1,1],f32> attributes {torch.onnx_meta.ir_version = 8 : si64, torch.onnx_meta.opset_version = 18 : si64} {
   // CHECK: %[[INT0:.*]] = torch.constant.int 0
-  // CHECK: %[[INT0_0:.*]] = torch.constant.int 0
   // CHECK: %[[INT1:.*]] = torch.constant.int 1
   // CHECK: %[[INT2:.*]] = torch.constant.int 2
-  // CHECK: %[[RANK:.*]] = torch.aten.dim %arg0 : !torch.vtensor<[3,2,2],f32> -> !torch.int
-  // CHECK: %[[LT:.*]] = torch.aten.lt.int %[[INT0_0]], %[[INT0]] : !torch.int, !torch.int -> !torch.bool
-  // CHECK: %[[BOOL:.*]] = torch.aten.Int.bool %[[LT]] : !torch.bool -> !torch.int
-  // CHECK: %[[MUL:.*]] = torch.aten.mul.int %[[BOOL]], %[[RANK]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[ADD:.*]] = torch.aten.add.int %[[INT0_0]], %[[MUL]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[LT_0:.*]] = torch.aten.lt.int %[[INT1]], %[[INT0]] : !torch.int, !torch.int -> !torch.bool
-  // CHECK: %[[BOOL_0:.*]] = torch.aten.Int.bool %[[LT_0]] : !torch.bool -> !torch.int
-  // CHECK: %[[MUL_0:.*]] = torch.aten.mul.int %[[BOOL_0]], %[[RANK]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[ADD_0:.*]] = torch.aten.add.int %[[INT1]], %[[MUL_0]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[LT_1:.*]] = torch.aten.lt.int %[[INT2]], %[[INT0]] : !torch.int, !torch.int -> !torch.bool
-  // CHECK: %[[BOOL_1:.*]] = torch.aten.Int.bool %[[LT_1]] : !torch.bool -> !torch.int
-  // CHECK: %[[MUL_1:.*]] = torch.aten.mul.int %[[BOOL_1]], %[[RANK]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[ADD_1:.*]] = torch.aten.add.int %[[INT2]], %[[MUL_1]] : !torch.int, !torch.int -> !torch.int
   // CHECK: %[[TRUE:.*]] = torch.constant.bool true
   // CHECK: %[[NONE:.*]] = torch.constant.none
-  // CHECK: %[[PROD_0:.*]] = torch.aten.prod.dim_int %arg0, %[[ADD]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[3,2,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?],f32>
-  // CHECK: %[[PROD_1:.*]] = torch.aten.prod.dim_int %[[PROD_0]], %[[ADD_0]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[?,?,?],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?],f32>
-  // CHECK: %[[PROD_2:.*]] = torch.aten.prod.dim_int %[[PROD_1]], %[[ADD_1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[?,?,?],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[1,1,1],f32>
+  // CHECK: %[[PROD_0:.*]] = torch.aten.prod.dim_int %arg0, %[[INT0]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[3,2,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[1,2,2],f32>
+  // CHECK: %[[PROD_1:.*]] = torch.aten.prod.dim_int %[[PROD_0]], %[[INT1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[1,2,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[1,1,2],f32>
+  // CHECK: %[[PROD_2:.*]] = torch.aten.prod.dim_int %[[PROD_1]], %[[INT2]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[1,1,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[1,1,1],f32>
   // CHECK: return %[[PROD_2]] : !torch.vtensor<[1,1,1],f32>
   %0 = torch.operator "onnx.ReduceProd"(%arg0) {torch.onnx.keepdims = 1 : si64} : (!torch.vtensor<[3,2,2],f32>) -> !torch.vtensor<[1,1,1],f32>
   return %0 : !torch.vtensor<[1,1,1],f32>
@@ -1243,21 +1229,30 @@ func.func @test_reduce_prod_default_axes_keepdims_random(%arg0: !torch.vtensor<[
 
 // CHECK-LABEL: func.func @test_reduce_prod_keepdims_random
 func.func @test_reduce_prod_keepdims_random(%arg0: !torch.vtensor<[3,2,2],f32>, %arg1: !torch.vtensor<[1],si64>) -> !torch.vtensor<[3,1,2],f32> attributes {torch.onnx_meta.ir_version = 8 : si64, torch.onnx_meta.opset_version = 18 : si64} {
-// CHECK: %[[INT0:.*]] = torch.constant.int 0
-// CHECK: %[[INT0_0:.*]] = torch.constant.int 0
-// CHECK: %[[SELECT:.*]] = torch.aten.select.int %arg1, %[[INT0]], %[[INT0_0]] : !torch.vtensor<[1],si64>, !torch.int, !torch.int -> !torch.vtensor<[1],si64>
-// CHECK: %[[ITEM:.*]] = torch.aten.item %[[SELECT]] : !torch.vtensor<[1],si64> -> !torch.int
-// CHECK: %[[DIM:.*]] = torch.aten.dim %arg0 : !torch.vtensor<[3,2,2],f32> -> !torch.int
-// CHECK: %[[LT:.*]] = torch.aten.lt.int %[[ITEM]], %[[INT0]] : !torch.int, !torch.int -> !torch.bool
-// CHECK: %[[BOOL:.*]] = torch.aten.Int.bool %[[LT]] : !torch.bool -> !torch.int
-// CHECK: %[[MUL:.*]] = torch.aten.mul.int %[[BOOL]], %[[DIM]] : !torch.int, !torch.int -> !torch.int
-// CHECK: %[[ADD:.*]] = torch.aten.add.int %[[ITEM]], %[[MUL]] : !torch.int, !torch.int -> !torch.int
-// CHECK: %[[BOOL:.*]] = torch.constant.bool true
-// CHECK: %[[NONE:.*]] = torch.constant.none
-// CHECK: %[[PROD:.*]] = torch.aten.prod.dim_int %arg0, %[[ADD]], %[[BOOL]], %[[NONE]] : !torch.vtensor<[3,2,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[3,1,2],f32>
-// CHECK: return %[[PROD]] : !torch.vtensor<[3,1,2],f32>
+  // CHECK: %[[INT1:.*]] = torch.constant.int 1
+  // CHECK: %[[TRUE:.*]] = torch.constant.bool true
+  // CHECK: %[[NONE:.*]] = torch.constant.none
+  // CHECK: %[[PROD:.*]] = torch.aten.prod.dim_int %arg0, %[[INT1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[3,2,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[3,1,2],f32>
+  // CHECK: return %[[PROD]] : !torch.vtensor<[3,1,2],f32>
   %0 = torch.operator "onnx.ReduceProd"(%arg0, %arg1) {torch.onnx.keepdims = 1 : si64} : (!torch.vtensor<[3,2,2],f32>, !torch.vtensor<[1],si64>) -> !torch.vtensor<[3,1,2],f32>
   return %0 : !torch.vtensor<[3,1,2],f32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_reduce_prod_keepdims0
+func.func @test_reduce_prod_keepdims0(%arg0: !torch.vtensor<[2,3,4],f32>, %arg1: !torch.vtensor<[1],si64>) -> !torch.vtensor<[2,4],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 19 : si64} {
+  // CHECK: %[[INT1:.*]] = torch.constant.int 1
+  // CHECK: %[[TRUE:.*]] = torch.constant.bool true
+  // CHECK: %[[NONE:.*]] = torch.constant.none
+  // CHECK: %[[PROD:.*]] = torch.aten.prod.dim_int %arg0, %[[INT1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[2,3,4],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[2,1,4],f32>
+  // CHECK: %[[INT2:.*]] = torch.constant.int 2
+  // CHECK: %[[INT4:.*]] = torch.constant.int 4
+  // CHECK: %[[RESULTSHAPE:.*]] = torch.prim.ListConstruct %[[INT2]], %[[INT4]] : (!torch.int, !torch.int) -> !torch.list<int>
+  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[PROD]], %[[RESULTSHAPE]] : !torch.vtensor<[2,1,4],f32>, !torch.list<int> -> !torch.vtensor<[2,4],f32>
+  // CHECK: return %[[RESULT]] : !torch.vtensor<[2,4],f32>
+  %0 = torch.operator "onnx.ReduceProd"(%arg0, %arg1) {torch.onnx.keepdims = 0 : si64, torch.onnx.noop_with_empty_axes = 0 : si64} : (!torch.vtensor<[2,3,4],f32>, !torch.vtensor<[1],si64>) -> !torch.vtensor<[2,4],f32> 
+  return %0 : !torch.vtensor<[2,4],f32>
 }
 
 // -----

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -1217,9 +1217,9 @@ func.func @test_reduce_prod_default_axes_keepdims_random(%arg0: !torch.vtensor<[
   // CHECK: %[[INT2:.*]] = torch.constant.int 2
   // CHECK: %[[TRUE:.*]] = torch.constant.bool true
   // CHECK: %[[NONE:.*]] = torch.constant.none
-  // CHECK: %[[PROD_0:.*]] = torch.aten.prod.dim_int %arg0, %[[INT0]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[3,2,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[1,2,2],f32>
-  // CHECK: %[[PROD_1:.*]] = torch.aten.prod.dim_int %[[PROD_0]], %[[INT1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[1,2,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[1,1,2],f32>
-  // CHECK: %[[PROD_2:.*]] = torch.aten.prod.dim_int %[[PROD_1]], %[[INT2]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[1,1,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[1,1,1],f32>
+  // CHECK: %[[PROD_0:.*]] = torch.aten.prod.dim_int %arg0, %[[INT0]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[3,2,2],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?],f32>
+  // CHECK: %[[PROD_1:.*]] = torch.aten.prod.dim_int %[[PROD_0]], %[[INT1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[?,?,?],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?],f32>
+  // CHECK: %[[PROD_2:.*]] = torch.aten.prod.dim_int %[[PROD_1]], %[[INT2]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[?,?,?],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[1,1,1],f32>
   // CHECK: return %[[PROD_2]] : !torch.vtensor<[1,1,1],f32>
   %0 = torch.operator "onnx.ReduceProd"(%arg0) {torch.onnx.keepdims = 1 : si64} : (!torch.vtensor<[3,2,2],f32>) -> !torch.vtensor<[1,1,1],f32>
   return %0 : !torch.vtensor<[1,1,1],f32>
@@ -1245,11 +1245,11 @@ func.func @test_reduce_prod_keepdims0(%arg0: !torch.vtensor<[2,3,4],f32>, %arg1:
   // CHECK: %[[INT1:.*]] = torch.constant.int 1
   // CHECK: %[[TRUE:.*]] = torch.constant.bool true
   // CHECK: %[[NONE:.*]] = torch.constant.none
-  // CHECK: %[[PROD:.*]] = torch.aten.prod.dim_int %arg0, %[[INT1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[2,3,4],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[2,1,4],f32>
+  // CHECK: %[[PROD:.*]] = torch.aten.prod.dim_int %arg0, %[[INT1]], %[[TRUE]], %[[NONE]] : !torch.vtensor<[2,3,4],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[?,?,?],f32>
   // CHECK: %[[INT2:.*]] = torch.constant.int 2
   // CHECK: %[[INT4:.*]] = torch.constant.int 4
   // CHECK: %[[RESULTSHAPE:.*]] = torch.prim.ListConstruct %[[INT2]], %[[INT4]] : (!torch.int, !torch.int) -> !torch.list<int>
-  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[PROD]], %[[RESULTSHAPE]] : !torch.vtensor<[2,1,4],f32>, !torch.list<int> -> !torch.vtensor<[2,4],f32>
+  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[PROD]], %[[RESULTSHAPE]] : !torch.vtensor<[?,?,?],f32>, !torch.list<int> -> !torch.vtensor<[2,4],f32>
   // CHECK: return %[[RESULT]] : !torch.vtensor<[2,4],f32>
   %0 = torch.operator "onnx.ReduceProd"(%arg0, %arg1) {torch.onnx.keepdims = 0 : si64, torch.onnx.noop_with_empty_axes = 0 : si64} : (!torch.vtensor<[2,3,4],f32>, !torch.vtensor<[1],si64>) -> !torch.vtensor<[2,4],f32> 
   return %0 : !torch.vtensor<[2,4],f32>


### PR DESCRIPTION
Rewrite the reduceprod to derive the chosen axes by the input data size and result data size.
Add keepdims = 0 new lit test.
Pass keepdims = 0/1 new Shark-TestSuite e2e tests. https://github.com/nod-ai/SHARK-TestSuite/pull/158
