### PR TITLE
[FxImporter] Fix torch.fill value type

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1420,6 +1420,13 @@ class GraphNodeImporter:
                 for key_node in node.users:
                     if key_node.target == torch.ops.aten.baddbmm.default:
                         node.target = target = torch.ops.aten.zeros.default
+        elif target == torch.ops.aten.full.default or target == torch.ops.aten.fill.Scalar:
+            # TODO: Essentially, it is because the py_type (e.g. bool)
+            #  and schema type (e.g. torch.number) do not match,
+            #  but how to convert them may depend on the op,
+            #  perhaps it can be implemented automatically, perhaps not.
+            if node.args[1] in {True, False}:
+                node.args = tuple([int(v) if i == 1 else v for i, v in enumerate(node.args)])
 
         schema = target._schema
         assert isinstance(schema, FunctionSchema)

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -14,6 +14,7 @@ from torch._dynamo.backends.common import aot_autograd
 from torch._functorch.aot_autograd import make_boxed_compiler, get_aot_graph_name, set_model_name
 
 from torch_mlir import fx
+from torch_mlir.compiler_utils import run_pipeline_with_repro_report
 
 
 def run(f):
@@ -118,3 +119,24 @@ def test_stateless_fx_import():
         return torch.tanh(x)
 
     basic_forward(torch.randn(3, 4))
+
+
+@run
+# CHECK-LABEL: test_full
+# CHECK:    %2 = torch.aten.fill.Scalar %1, %int0 : !torch.vtensor<[],i1>, !torch.int -> !torch.vtensor<[],i1>
+def test_full():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self):
+            return torch.full([], False, dtype=torch.bool, layout=torch.strided, device='cpu',
+                              pin_memory=False)
+
+    m = fx.export_and_import(Basic(), func_name="test_full")
+    run_pipeline_with_repro_report(
+        m,
+        f"builtin.module(torch-simplification-pipeline)",
+        "torch-simplification-pipeline",
+    )
+    print(m)


### PR DESCRIPTION
'torch.aten.fill.Scalar' op operand 1 must be Any Python numeric type compatible with being the scalar type of a tensor, but got '!torch.bool'