### PR TITLE
[Stablehlo] Enhance broadcast pattern in matmul Ops

### DIFF
--- a/lib/Conversion/TorchToStablehlo/Linear.cpp
+++ b/lib/Conversion/TorchToStablehlo/Linear.cpp
@@ -181,15 +181,12 @@ void getBmmBroadcast(PatternRewriter &rewriter, Operation *op, Value &inpLhs,
   rhsShape = rhs.getType().cast<RankedTensorType>().getShape();
 
   // check shape compatibility, check if we should broadcast
-
-  // first, we should got a new shape. Check from (0, shape - 2)
+  // first, we should got a new batch shape. Check from (0, nBatchDims)
   SmallVector<int64_t> lhsBroadcastDims;
   SmallVector<int64_t> rhsBroadcastDims;
   SmallVector<int64_t> newBatchShape;
 
   for (int64_t i = 0; i < nBatchDims; i++) {
-    llvm::errs() << "lhsShape[i] == " << lhsShape[i] << "\n";
-    llvm::errs() << "rhsShape[i] == " << rhsShape[i] << "\n";
     if (lhsShape[i] != rhsShape[i]) {
       if (lhsShape[i] == 1) {
         lhsBroadcastDims.push_back(i);
@@ -198,7 +195,7 @@ void getBmmBroadcast(PatternRewriter &rewriter, Operation *op, Value &inpLhs,
         rhsBroadcastDims.push_back(i);
         newBatchShape.push_back(lhsShape[i]);
       } else {
-        assert(false && "shape mismatch");
+        assert(false && "shape mismatch in matmul op");
       }
     } else {
       newBatchShape.push_back(lhsShape[i]);

--- a/lib/Conversion/TorchToStablehlo/Linear.cpp
+++ b/lib/Conversion/TorchToStablehlo/Linear.cpp
@@ -183,7 +183,7 @@ void getBmmBroadcast(PatternRewriter &rewriter, Operation *op, Value &inpLhs,
   SmallVector<int64_t> lhsBroadcastDims;
   SmallVector<int64_t> rhsBroadcastDims;
   SmallVector<int64_t> newBatchShape;
-  for (size_t i = 0; i < resultRank - 2; i++) {
+  for (int64_t i = 0; i < resultRank - 2; i++) {
     if (lhsShape[i] != rhsShape[i]) {
       if (lhsShape[i] == 1) {
         lhsBroadcastDims.push_back(i);

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -894,6 +894,7 @@ STABLEHLO_PASS_SET = {
     "Matmul_dot",
     "Matmul_matvec",
     "Matmul_vecmat",
+    "MatmulStaticBroadcast_basic",
     "MaxPool2dStaticModule_basic",
     "MeanDimAllReduceModule_basic",
     "MeanDimEmptyDimModule_basic",


### PR DESCRIPTION
To pass test "MatmulStaticBroadcast_basic" in stablehlo:
```python
class MatmulStaticBroadcast(torch.nn.Module):
    def __init__(self):
        super().__init__()

    @export
    @annotate_args([
        None,
        ([4, 1, 6, 7], torch.float32, True),
        ([8, 1, 5, 7, 6], torch.float32, True),
    ])
    def forward(self, lhs, rhs):
        return torch.matmul(lhs, rhs)


@register_test_case(module_factory=lambda: MatmulStaticBroadcast())
def MatmulStaticBroadcast_basic(module, tu: TestUtils):
    module.forward(tu.rand(4, 1, 6, 7), tu.rand(8, 1, 5, 7, 6))
```
