### PR TITLE
[TorchToLinalg] Adds Support for Remaining Quantized Matmul Cases

### DIFF
--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -323,6 +323,8 @@ TORCHDYNAMO_XFAIL_SET = {
     "AtenMatmulQMixedSigni8Transpose_basic",
     "AtenMatmulQMixedSigni8_basic",
     "AtenMatmulQint8MV_basic",
+    "AtenMatmulQint8VV_basic",
+    "AtenMatmulQint8VM_basic",
     "AtenMatmulQint8_basic",
     "Conv2dQInt8Module_basic",
 
@@ -1966,6 +1968,8 @@ ONNX_XFAIL_SET = {
     "AtenMatmulQMixedSigni8Transpose_basic",
     "AtenMatmulQMixedSigni8_basic",
     "AtenMatmulQint8MV_basic",
+    "AtenMatmulQint8VV_basic",
+    "AtenMatmulQint8VM_basic",
     "AtenMatmulQint8_basic",
     "AtenRealView128Module_basic",
     "AtenRealView64Module_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/__init__.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/__init__.py
@@ -14,7 +14,6 @@ COMMON_TORCH_MLIR_LOWERING_XFAILS = {
     "QuantizedMLP_basic",
     "QuantizedSingleLayer_basic",
     "QuantizedBatchedInputSingleLayer_basic",
-    "AtenMatmulQint8MV_basic",
     "ReduceMaxAlongDimUnsignedInt_basic",
     "ReduceMinAlongDimUnsignedInt_basic",
     "ElementwiseToDtypeI64ToUI8Module_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -344,6 +344,56 @@ def AtenMmQMixedSigni8_basic(module, tu: TestUtils):
     
 # ==============================================================================
 
+class AtenMatmulQint8VM(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int8, True),
+        ([-1,-1], torch.int8, True),
+    ])
+    def forward(self, x, y):
+        qx = torch._make_per_tensor_quantized_tensor(x, 0.0215, -25)
+        qx = torch.dequantize(qx)
+        qy = torch._make_per_tensor_quantized_tensor(y, 0.0176, 18)
+        qy = torch.dequantize(qy)
+        qz =  torch.matmul(qx, qy)
+        return qz
+
+@register_test_case(module_factory=lambda: AtenMatmulQint8VM())
+def AtenMatmulQint8VM_basic(module, tu: TestUtils):
+    module.forward(tu.randint(9, low=-128, high=127).to(torch.int8),
+                   tu.randint(9, 4, low=-128, high=127).to(torch.int8))
+    
+# ==============================================================================
+class AtenMatmulQint8VV(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int8, True),
+        ([-1], torch.int8, True),
+    ])
+    def forward(self, x, y):
+        qx = torch._make_per_tensor_quantized_tensor(x, 0.0215, -25)
+        qx = torch.dequantize(qx)
+        qy = torch._make_per_tensor_quantized_tensor(y, 0.0176, 18)
+        qy = torch.dequantize(qy)
+        qz =  torch.matmul(qx, qy)
+        return qz
+
+@register_test_case(module_factory=lambda: AtenMatmulQint8VV())
+def AtenMatmulQint8VV_basic(module, tu: TestUtils):
+    module.forward(tu.randint(9, low=-128, high=127).to(torch.int8),
+                   tu.randint(9, low=-128, high=127).to(torch.int8))
+    
+# ==============================================================================
 class AtenMatmulQint8MV(torch.nn.Module):
 
     def __init__(self):
@@ -352,8 +402,8 @@ class AtenMatmulQint8MV(torch.nn.Module):
     @export
     @annotate_args([
         None,
-        ([3, 4], torch.int8, True),
-        ([4], torch.int8, True),
+        ([-1, -1], torch.int8, True),
+        ([-1], torch.int8, True),
     ])
     def forward(self, x, y):
         qx = torch._make_per_tensor_quantized_tensor(x, 0.0215, -25)


### PR DESCRIPTION
The new cases added for quantized matmuls are:

1. vec-vec
2. vec-mat
3. mat-vec

each of which are now lowered to expand(s), quantized_matmul, and collapse. 