### PR TITLE
[torch] Support rank-0 index for torch index select

### DIFF
--- a/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
@@ -488,8 +488,8 @@ public:
     if (indicesTy.getRank() == 0) {
       llvm::SmallVector<ReassociationIndices> reassociations;
       indicesTy = RankedTensorType::get({1}, indicesTy.getElementType());
-      indices = rewriter.create<tensor::ExpandShapeOp>(
-        loc, indicesTy, indices, reassociations);
+      indices = rewriter.create<tensor::ExpandShapeOp>(loc, indicesTy, indices,
+                                                       reassociations);
     }
 
     SmallVector<Value> resultShape = getTensorSizes(rewriter, loc, input);

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/index_select.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/index_select.py
@@ -31,6 +31,24 @@ def IndexSelectSingleIdxModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(4, 5, 6), torch.tensor([2]))
 
 
+class IndexSelectRank0IdxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([4, 5, 6], torch.float32, True),
+        ([], torch.int64, True),
+    ])
+
+    def forward(self, input, indices):
+        return torch.index_select(input, 1, indices)
+
+@register_test_case(module_factory=lambda: IndexSelectRank0IdxModule())
+def IndexSelectRank0IdxModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 5, 6), torch.tensor(2))
+
 class IndexSelectNegativeDimModule(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Need to perform an expand in the case where the indices is rank-0.