### PR TITLE
[onnx] Extend op version number of `onnx.ScatterElements`

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -478,7 +478,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
                   return success();
                 });
   patterns.onOp(
-      "ScatterElements", 18,
+      "ScatterElements", 1,
       [](OpBinder binder, ConversionPatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         SmallVector<Value> valList;

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2647,10 +2647,7 @@ ONNX_XFAIL_SET = {
     "ScatterReduceIntMinModuleIncludeSelf",
     "ScatterReduceIntProdModuleIncludeSelf",
     "ScatterReduceIntSumModuleIncludeSelf",
-    "ScatterSrcModule_basic",
-    "ScatterSrcStaticModule_basic",
     "ScatterValueFloatModule_basic",
-    "ScatterValueIntModule_basic",
     
     # Failure - onnx_lowering: onnx.ScatterND
     "IndexPut1DFloatAccumulateModule_basic",


### PR DESCRIPTION
Version number was set too high. Lowered to support more cases allows more tests to pass.