### PR TITLE
[torch-mlir][sparse] recognize sparse tensor conversion

### DIFF
--- a/test/Conversion/TorchToLinalg/sparse.mlir
+++ b/test/Conversion/TorchToLinalg/sparse.mlir
@@ -34,3 +34,35 @@ func.func @SpMM(%arg0: !torch.vtensor<[8,16],f32,#CSR>,
        !torch.vtensor<[16,8],f32> -> !torch.vtensor<[8,8],f32>
   return %0 : !torch.vtensor<[8,8],f32>
 }
+
+// -----
+
+#sparse = #sparse_tensor.encoding<{
+  map = (d0, d1, d2, d3, d4) ->
+    (d0 : compressed(nonunique),
+     d1 : singleton(nonunique, soa),
+     d2 : singleton(nonunique, soa),
+     d3 : singleton(nonunique, soa),
+     d4 : singleton(soa)
+    ),
+    posWidth = 64,
+    crdWidth = 64
+}>
+
+// CHECK: #[[$ST:.*]] = #sparse_tensor.encoding<{ map = (d0, d1, d2, d3, d4) -> (d0 : compressed(nonunique), d1 : singleton(nonunique, soa), d2 : singleton(nonunique, soa), d3 : singleton(nonunique, soa), d4 : singleton(soa)), posWidth = 64, crdWidth = 64 }>
+// CHECK-LABEL: func.func @activate(
+// CHECK-SAME:  %[[A:.*]]: !torch.vtensor<[128,64,30,30,6], f32>)
+// CHECK:       %[[D:.*]] = torch_c.to_builtin_tensor %arg0 : !torch.vtensor<[128,64,30,30,6],f32> -> tensor<128x64x30x30x6xf32>
+// CHECK:       %[[C:.*]] = tensor.cast %0 : tensor<128x64x30x30x6xf32> to tensor<128x64x30x30x6xf32, #[[ST]]>
+// CHECK:       %[[R:.*]] = torch_c.from_builtin_tensor %cast : tensor<128x64x30x30x6xf32, #[[ST]]>
+// CHECK:       return %[[R]] : !torch.vtensor<[128,64,30,30,6],f32,#[[ST]]>
+func.func @activate(%arg0: !torch.vtensor<[128,64,30,30,6],f32>)
+                        -> !torch.vtensor<[128,64,30,30,6],f32,#sparse> {
+  %none_0 = torch.constant.none
+  %none_1 = torch.constant.none
+  %none_2 = torch.constant.none
+  %result = torch.operator "torch.aten._to_sparse"(%arg0, %none_0, %none_1, %none_2)
+    : (!torch.vtensor<[128,64,30,30,6],f32>, !torch.none, !torch.none, !torch.none)
+    -> !torch.vtensor<[128,64,30,30,6],f32,#sparse>
+  return %result : !torch.vtensor<[128,64,30,30,6],f32,#sparse>
+}


### PR DESCRIPTION
Sparse tensor conversions are represented by special aten operators. This PR ensures the conversions are recognized (instead of failing the full torch aten lowering to linalg).