### PR TITLE
Enable post commit run of pre-commit hooks over all files.

### DIFF
--- a/.github/workflows/pre-commit-all.yml
+++ b/.github/workflows/pre-commit-all.yml
@@ -1,0 +1,15 @@
+name: pre-commit (all files on push)
+
+on:
+  push:
+    branches: [main, post-commit-test]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --color=always --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: "GeneratedTorchOps\\.td|abstract_interp_lib_gen\\.py|\\.excalidraw"
+exclude: "GeneratedTorchOps\\.td|abstract_interp_lib_gen\\.py|\\.excalidraw|\\.ipynb"
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0


### PR DESCRIPTION
The pre-commit hook will only run on changed files, whereas this runs on push and will check everything.