### PR TITLE
Re-enable LTC Build

### DIFF
--- a/build_tools/ci/build_posix.sh
+++ b/build_tools/ci/build_posix.sh
@@ -50,6 +50,7 @@ cmake -S "$repo_root/externals/llvm-project/llvm" -B "$build_dir" \
   -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$repo_root" \
   -DLLVM_TARGETS_TO_BUILD=host \
   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DTORCH_MLIR_ENABLE_LTC=ON
 echo "::endgroup::"
 
 echo "::group::Build"


### PR DESCRIPTION
The LTC Build was disabled in https://github.com/llvm/torch-mlir/pull/3210 due to a regression in the packaging of the torch nightly wheels (https://github.com/pytorch/pytorch/issues/124941) which is now resolved.

So, re-enabling LTC build in this PR