### PR TITLE
[torch-mlir][sparse] add a few missing passes to the ref pipeline

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -138,6 +138,7 @@ LOWERING_PIPELINE = (
     "builtin.module("
     + ",".join(
         [
+            "func.func(linalg-fold-unit-extent-dims)",
             "func.func(refback-generalize-tensor-pad)",
             "func.func(refback-generalize-tensor-concat)",
             # Apply some optimizations. It would be great if MLIR had more useful
@@ -180,6 +181,7 @@ LOWERING_PIPELINE = (
             "func.func(tm-tensor-to-loops)",
             "func.func(refback-munge-memref-copy)",
             "func.func(convert-linalg-to-loops)",
+            "func.func(expand-realloc)",
             "func.func(lower-affine)",
             "convert-scf-to-cf",
             "func.func(refback-expand-ops-for-llvm)",
@@ -193,6 +195,7 @@ LOWERING_PIPELINE = (
             "convert-bufferization-to-memref",
             "finalize-memref-to-llvm",
             "func.func(convert-arith-to-llvm)",
+            "convert-vector-to-llvm",
             "convert-func-to-llvm",
             "convert-cf-to-llvm",
             "convert-complex-to-llvm",

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -138,7 +138,6 @@ LOWERING_PIPELINE = (
     "builtin.module("
     + ",".join(
         [
-            "func.func(linalg-fold-unit-extent-dims)",
             "func.func(refback-generalize-tensor-pad)",
             "func.func(refback-generalize-tensor-concat)",
             # Apply some optimizations. It would be great if MLIR had more useful


### PR DESCRIPTION
For some sparse programs (and I am sure other not-seen corner cases for dense), some passes were missing in the reference pipeline, eventually resulting in e.g. a unresolved unrealized cast issue. This PR adds some very obvious missing passes to avoid this situation.