### PR TITLE
[Release Builds] Use `-no-build-isolation` to decouple from `pyproject.toml`

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -432,6 +432,8 @@ function clean_build() {
 }
 
 function build_torch_mlir() {
+  # Disable LTC build for releases
+  export TORCH_MLIR_ENABLE_LTC=0
   local torch_version="$1"
   case $torch_version in
     nightly)
@@ -440,7 +442,7 @@ function build_torch_mlir() {
         --extra-index-url https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
       CMAKE_GENERATOR=Ninja \
       TORCH_MLIR_PYTHON_PACKAGE_VERSION=${TORCH_MLIR_PYTHON_PACKAGE_VERSION} \
-      python -m pip wheel -v -w /wheelhouse /main_checkout/torch-mlir \
+      python -m pip wheel -v --no-build-isolation -w /wheelhouse /main_checkout/torch-mlir \
         -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html \
         -r /main_checkout/torch-mlir/whl-requirements.txt
       ;;
@@ -450,7 +452,7 @@ function build_torch_mlir() {
       python3 -m pip install --no-cache-dir -r /main_checkout/torch-mlir/build-requirements.txt
       CMAKE_GENERATOR=Ninja \
       TORCH_MLIR_PYTHON_PACKAGE_VERSION=${TORCH_MLIR_PYTHON_PACKAGE_VERSION} \
-      python -m pip wheel -v -w /wheelhouse /main_checkout/torch-mlir
+      python -m pip wheel -v --no-build-isolation -w /wheelhouse /main_checkout/torch-mlir
       ;;
     *)
       echo "Unrecognized torch version '$torch_version'"
@@ -474,7 +476,7 @@ function build_torch_mlir_core() {
   TORCH_MLIR_PYTHON_PACKAGE_VERSION=${TORCH_MLIR_PYTHON_PACKAGE_VERSION} \
   TORCH_MLIR_ENABLE_JIT_IR_IMPORTER=0 \
   TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS=1 \
-  python -m pip wheel -v -w /wheelhouse /main_checkout/torch-mlir
+  python -m pip wheel -v --no-build-isolation -w /wheelhouse /main_checkout/torch-mlir
 }
 
 function clean_wheels() {


### PR DESCRIPTION
Fixes https://github.com/llvm/torch-mlir/issues/3258

In addition disabling the LTC builds since they are already covered in CI (build_posix.sh) and I am not aware of a consumer of this flow in the binary releases of torch-mlir (the main dependency there is from source). 