### PR TITLE
[torch] Add Canonicalize Pattern for embedding op

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -10106,6 +10106,7 @@ def Torch_AtenEmbeddingOp : Torch_Op<"aten.embedding", [
       printDefaultTorchOp(printer, *this, 5, 1);
     }
   }];
+  let hasCanonicalizer = 1;
 }
 
 def Torch_AtenEmbeddingBagPaddingIdxOp : Torch_Op<"aten.embedding_bag.padding_idx", [

--- a/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
+++ b/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
@@ -777,7 +777,10 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::detach : (Tensor) -> (Tensor)", has_folder=True)
     emit("aten::device.with_index : (str, int) -> (Device)", has_canonicalizer=True)
     emit("aten::cuda : (Tensor) -> (Tensor)", has_canonicalizer=True)
-    emit("aten::embedding : (Tensor, Tensor, int, bool, bool) -> (Tensor)")
+    emit(
+        "aten::embedding : (Tensor, Tensor, int, bool, bool) -> (Tensor)",
+        has_canonicalizer=True,
+    )
     emit(
         "aten::embedding_bag.padding_idx : (Tensor, Tensor, Tensor, bool, int, bool, Tensor?, bool, int?) -> (Tensor, Tensor, Tensor, Tensor)"
     )


### PR DESCRIPTION
Converts PrimConvertOp followed by Embedding -> Embedding followed by PrimConvertOp. We don't need to cast the entire matrix; just the output of the embedding op.

Issue: https://github.com/iree-org/iree/issues/17226#issuecomment-2089655421