### PR TITLE
[torch-mlir][sparse] minor tweaks in sparse tests

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -90,10 +90,7 @@ def get_ctype_func(func_name):
 
 class RefBackendInvoker:
     def __init__(self, module):
-        libs = [
-            "/usr/local/google/home/ajcbik/TORCHMLIR/torch-mlir/buildx/build/lib/libmlir_c_runner_utils.so"
-        ]
-        self.ee = ExecutionEngine(module, opt_level=3, shared_libs=libs)
+        self.ee = ExecutionEngine(module)
         self.result = None
 
         return_funcs = get_return_funcs(module)
@@ -128,10 +125,8 @@ class RefBackendInvoker:
                     ctypes.pointer(ctypes.pointer(get_unranked_memref_descriptor(arg)))
                 )
 
-            #print("INVOKE EE", args)
             self.ee.invoke(function_name, *ffi_args)
             result = self.result
-            #print("INVOKED EE", result)
             assert result is not None, "Invocation didn't produce a result"
             self.result = None
             return result
@@ -143,7 +138,6 @@ LOWERING_PIPELINE = (
     "builtin.module("
     + ",".join(
         [
-            #    "func.func(linalg-fold-unit-extent-dims)",
             "func.func(refback-generalize-tensor-pad)",
             "func.func(refback-generalize-tensor-concat)",
             # Apply some optimizations. It would be great if MLIR had more useful
@@ -237,7 +231,6 @@ class RefBackendLinalgOnTensorsBackend(LinalgOnTensorsBackend):
             imported_module,
             LOWERING_PIPELINE,
             "Lowering Linalg-on-Tensors IR to LLVM with RefBackend",
-            # BIK
             enable_ir_printing=False,
         )
         return imported_module

--- a/test/python/fx_importer/sparse_test.py
+++ b/test/python/fx_importer/sparse_test.py
@@ -573,10 +573,10 @@ def test_sparse_network():
                 mem = mem * self.decay + X[..., t]
                 spike = self.act(mem - self.thresh)
                 mem = mem * (1.0 - spike)
+                spike = spike.to_sparse().to_dense()  # prop hack
                 spike_pot.append(spike)
             spike_pot = torch.stack(spike_pot, dim=-1)
-            # Hack to get to_sparse() through propagation.
-            return spike_pot.to_sparse().to_dense()
+            return spike_pot
 
     class tdLayer(nn.Module):
         def __init__(self, layer):

--- a/test/python/fx_importer/sparse_test.py
+++ b/test/python/fx_importer/sparse_test.py
@@ -128,7 +128,7 @@ def sparse_export(
                 node.meta["sparsity"] = SparsityMeta(
                     torch.sparse_coo, 0, dim, 0, None, torch.int64, torch.int64
                 )
-            # Uncomment this to hack sparsity into the network.
+            # TODO: Uncomment this to hack sparsity into the network.
             # elif node.name == "_to_dense":
             #     # hack (assumes we never really want the to_dense for now)
             #     node.meta["sparsity"] = node.args[0].meta.get("sparsity", None)
@@ -575,8 +575,7 @@ def test_sparse_network():
                 mem = mem * (1.0 - spike)
                 spike_pot.append(spike)
             spike_pot = torch.stack(spike_pot, dim=-1)
-            # TODO: hack to get to_sparse() through propagation.
-            print(spike_pot)
+            # Hack to get to_sparse() through propagation.
             return spike_pot.to_sparse().to_dense()
 
     class tdLayer(nn.Module):


### PR DESCRIPTION
(1) test full pytorch output for eltwise
(2) use "random" input for LIF, to get general sparse tensor 
(3) introduce way to get true sparsity into network (needs backend fix first)