### PR TITLE
[linalg] Implement strict mode lowering for aten.view.

### DIFF
--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -1347,7 +1347,7 @@ public:
       totalSize = b.create<arith::MulIOp>(totalSize, dim);
     }
 
-    Value inferredSize = b.create<arith::DivSIOp>(totalSize, knownSize);
+    Value inferredSize = b.create<arith::DivUIOp>(totalSize, knownSize);
     for (auto &size : sizes) {
       Value isNeg =
           b.create<arith::CmpIOp>(arith::CmpIPredicate::slt, size, zero);

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -1347,7 +1347,7 @@ public:
       totalSize = b.create<arith::MulIOp>(totalSize, dim);
     }
 
-    Value inferredSize = b.create<arith::DivUIOp>(totalSize, knownSize);
+    Value inferredSize = b.create<arith::DivSIOp>(totalSize, knownSize);
     for (auto &size : sizes) {
       Value isNeg =
           b.create<arith::CmpIOp>(arith::CmpIPredicate::slt, size, zero);
@@ -1496,7 +1496,7 @@ public:
       }
 
       Value inferredSize =
-          rewriter.create<arith::DivSIOp>(loc, selfProduct, sizeProduct);
+          rewriter.create<arith::DivUIOp>(loc, selfProduct, sizeProduct);
       for (int i = 0, e = sizeValues.size(); i < e; ++i) {
         if (i == inferredDim) {
           outputDimValues.push_back(inferredSize);

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -103,6 +103,7 @@ from ..ir import (
     StringAttr,
     SymbolTable,
     Type as IrType,
+    UnitAttr,
     Value,
 )
 
@@ -642,6 +643,10 @@ class FxImporter:
             func_op = func_dialect.FuncOp(
                 func_name, ftype, ip=self._m_ip, visibility=func_visibility
             )
+            # Programs imported from FX have strong guarantees. Setting this attribute
+            # causes various lowerings to be able to emit more efficient code or
+            # handle more cases. See isAssumingStrictSymbolicShapes().
+            func_op.attributes["torch.assume_strict_symbolic_shapes"] = UnitAttr.get()
             entry_block = Block.create_at_start(func_op.body, ftype.inputs)
 
         node_importer = GraphNodeImporter(

--- a/test/Conversion/TorchToLinalg/view.mlir
+++ b/test/Conversion/TorchToLinalg/view.mlir
@@ -1,7 +1,4 @@
 // RUN: torch-mlir-opt <%s -convert-torch-to-linalg -split-input-file -verify-diagnostics | FileCheck %s
-// This test file verifies both the legacy and strict view patterns together.
-// It can be deleted entirely when/if the legacy patterns are deleted (the
-// sibling view_strict.mlir test verifies strict patterns in isolation).
 // -----
 
 // CHECK-LABEL:   func.func @torch.aten.view$twotothree(

--- a/test/Conversion/TorchToLinalg/view_strict.mlir
+++ b/test/Conversion/TorchToLinalg/view_strict.mlir
@@ -132,7 +132,7 @@ func.func @torch.aten.view$expandInferredDim(%arg0: !torch.vtensor<[2,6],f32>) -
 // CHECK-DAG:   %[[DIM2_INDEX:.*]] = tensor.dim %[[SELF]], %[[INDEX2]] : tensor<?x?x?xf32>
 // CHECK-DAG:   %[[DIM2:.*]] = arith.index_cast %[[DIM2_INDEX]] : index to i64
 // CHECK-DAG:   %[[KNOWN2:.*]] = arith.muli %[[KNOWN1]], %[[DIM2]] : i64
-// CHECK-DAG:   %[[DIMINFER:.*]] = arith.divsi %[[KNOWN2]], %[[PROD4]] : i64
+// CHECK-DAG:   %[[DIMINFER:.*]] = arith.divui %[[KNOWN2]], %[[PROD4]] : i64
 // CHECK:       %[[DIM0:.*]] = torch_c.to_i64 %arg1
 // CHECK:       %[[DIM1:.*]] = torch_c.to_i64 %[[CONSTANT1]]
 // CHECK:       %[[DIM3:.*]] = torch_c.to_i64 %[[CONSTANT1]]


### PR DESCRIPTION
* Enables assume_strict_symbolic_shapes on fx_importer imported programs, indicating strict shape semantics.
* Reworks the view->reshape lowering to take advantage of strict mode and do one of:
  * Collapse to 0D
  * Flatten/Unflatten when there is an inferred dim.
  * Fallback to tensor.reshape
* Splits some test cases up and adds an attribute to control the old pattern (so new corners can be tested in strict mode in isolation).
* Dynamic inferred mode needs upstream work to generalize expand_shape (so that case is suppressed here).
* Deletes the assert from the existing tensor.reshape lowering if strict shape mode is enabled (since the condition it is dynamically asserting cannot happen).
