### PR TITLE
[stablehlo] support dynamic-shaped index in stablehlo conversion for aten.index-like ops

### DIFF
--- a/include/torch-mlir/Conversion/TorchToStablehlo/StablehloLegalizeUtils.h
+++ b/include/torch-mlir/Conversion/TorchToStablehlo/StablehloLegalizeUtils.h
@@ -52,8 +52,13 @@ Value scalarToStablehloTensor(ConversionPatternRewriter &rewriter,
 Value promoteType(PatternRewriter &rewriter, Location loc, Value input,
                   Type outElementType);
 
+FailureOr<Value> getBroadcastResultShape(PatternRewriter &rewriter,
+                                         Operation *op, ArrayRef<Value> tensors,
+                                         size_t dimSizeIndexBits);
+
 Value promoteAndBroadcast(ConversionPatternRewriter &rewriter, Value input,
-                          TensorType outType);
+                          TensorType outType,
+                          std::optional<Value> bcastSizeTensor);
 
 SmallVector<int64_t> toPositiveDims(ArrayRef<int64_t> dims, int64_t rank);
 

--- a/lib/Conversion/TorchToStablehlo/Basic.cpp
+++ b/lib/Conversion/TorchToStablehlo/Basic.cpp
@@ -768,7 +768,8 @@ LogicalResult ConvertAtenOp<AtenBroadcastToOp>::matchAndRewrite(
       getTypeConverter()->convertType(op->getResult(0).getType()));
 
   if (options.enableStaticShape && selfTy.hasStaticShape()) {
-    Value bcastOp = hlo::promoteAndBroadcast(rewriter, self, outType);
+    Value bcastOp =
+        hlo::promoteAndBroadcast(rewriter, self, outType, std::nullopt);
     rewriter.replaceOp(op, bcastOp);
     return success();
   }
@@ -1488,8 +1489,10 @@ LogicalResult ConvertAtenOp<AtenNativeLayerNormOp>::matchAndRewrite(
           .value());
 
   // Apply affine transform: output x weight + bias [element-wise]
-  auto bcastedWeight = hlo::promoteAndBroadcast(rewriter, weight, outputTy);
-  auto bcastedBias = hlo::promoteAndBroadcast(rewriter, bias, outputTy);
+  auto bcastedWeight =
+      hlo::promoteAndBroadcast(rewriter, weight, outputTy, std::nullopt);
+  auto bcastedBias =
+      hlo::promoteAndBroadcast(rewriter, bias, outputTy, std::nullopt);
   auto outputMulWeight =
       rewriter.create<stablehlo::MulOp>(op->getLoc(), output, bcastedWeight);
   auto finalOuput = rewriter.create<stablehlo::AddOp>(
@@ -1634,8 +1637,10 @@ LogicalResult ConvertAtenOp<AtenClampTensorOp>::matchAndRewrite(
     maxValue = *maxInfo;
   }
   if (inputType.hasStaticShape()) {
-    minValue = hlo::promoteAndBroadcast(rewriter, minValue, inputType);
-    maxValue = hlo::promoteAndBroadcast(rewriter, maxValue, inputType);
+    minValue =
+        hlo::promoteAndBroadcast(rewriter, minValue, inputType, std::nullopt);
+    maxValue =
+        hlo::promoteAndBroadcast(rewriter, maxValue, inputType, std::nullopt);
   }
   rewriter.replaceOpWithNewOp<stablehlo::ClampOp>(op, minValue, input,
                                                   maxValue);
@@ -2021,7 +2026,7 @@ LogicalResult ConvertAtenOp<AtenBitwiseLeftShiftTensorOp>::matchAndRewrite(
 
   auto resultType =
       cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
-  rhs = hlo::promoteAndBroadcast(rewriter, rhs, resultType);
+  rhs = hlo::promoteAndBroadcast(rewriter, rhs, resultType, std::nullopt);
   rewriter.replaceOpWithNewOp<stablehlo::ShiftLeftOp>(op, lhs, rhs);
   return success();
 }
@@ -2036,7 +2041,7 @@ LogicalResult ConvertAtenOp<AtenBitwiseRightShiftTensorOp>::matchAndRewrite(
 
   auto resultType =
       cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
-  rhs = hlo::promoteAndBroadcast(rewriter, rhs, resultType);
+  rhs = hlo::promoteAndBroadcast(rewriter, rhs, resultType, std::nullopt);
   rewriter.replaceOpWithNewOp<stablehlo::ShiftRightArithmeticOp>(op, lhs, rhs);
   return success();
 }


### PR DESCRIPTION
For now, at most one dynamic dim of index tensors in aten.index/aten.index_put-like op is supported.