### PR TITLE
[Stablehlo] refactor amax, max, max.dim's lowering to stablehlo

### DIFF
--- a/projects/pt1/python/torch_mlir/torchscript.py
+++ b/projects/pt1/python/torch_mlir/torchscript.py
@@ -212,7 +212,9 @@ BACKEND_LEGAL_OPS = {
         "aten.adaptive_avg_pool2d",
         "aten.unflatten.int",
     ],
-    OutputType.STABLEHLO: [],
+    OutputType.STABLEHLO: [
+        "aten.amax"
+    ],
 }
 
 

--- a/projects/pt1/python/torch_mlir/torchscript.py
+++ b/projects/pt1/python/torch_mlir/torchscript.py
@@ -212,9 +212,7 @@ BACKEND_LEGAL_OPS = {
         "aten.adaptive_avg_pool2d",
         "aten.unflatten.int",
     ],
-    OutputType.STABLEHLO: [
-        "aten.amax"
-    ],
+    OutputType.STABLEHLO: ["aten.amax"],
 }
 
 


### PR DESCRIPTION
* not to decompose `aten.amax` on `stablehlo` backend. Because it could be lowering to `stablehlo.reduce` directly.
* lowering `aten.max.dim` to `stablehlo.reduce apply max` when `AtenMaxDimOp.getIndices()` doesn't have users. It's more simple.