### PR TITLE
[NFC] Fix member cast change to global for landing collision

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -484,8 +484,8 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           return failure();
 
         auto dataTy = cast<Torch::ValueTensorType>(data.getType()),
-             cast<Torch::ValueTensorType>(indicesTy = indices.getType()),
-             cast<Torch::ValueTensorType>(updatesTy = updates.getType());
+             indicesTy = cast<Torch::ValueTensorType>(indices.getType()),
+             updatesTy = cast<Torch::ValueTensorType>(updates.getType());
 
         int64_t dataRank = dataTy.getSizes().size(),
                 indicesRank = indicesTy.getSizes().size(),

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -484,9 +484,9 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           binder.tensorResultType(resultTy))
         return failure();
 
-      auto dataTy = data.getType().cast<Torch::ValueTensorType>(), 
-            indicesTy = indices.getType().cast<Torch::ValueTensorType>(), 
-            updatesTy = updates.getType().cast<Torch::ValueTensorType>();
+      auto dataTy = cast<Torch::ValueTensorType>(data.getType()),
+           cast<Torch::ValueTensorType>(indicesTy = indices.getType()),
+           cast<Torch::ValueTensorType>(updatesTy = updates.getType());
 
       int64_t dataRank = dataTy.getSizes().size(), 
               indicesRank = indicesTy.getSizes().size(), 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -470,40 +470,39 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
                   return success();
                 });
   patterns.onOp(
-    "Scatter", 9,
-    [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-      int64_t axis;
-      if (binder.s64IntegerAttr(axis, "axis", {}))
-        return rewriter.notifyMatchFailure(binder.op, "axis bind failure");
+      "Scatter", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+        int64_t axis;
+        if (binder.s64IntegerAttr(axis, "axis", {}))
+          return rewriter.notifyMatchFailure(binder.op, "axis bind failure");
 
-      Torch::ValueTensorType resultTy;
-      Value data, indices, updates;
-      if (binder.tensorOperandAtIndex(data, 0) || 
-          binder.tensorOperandAtIndex(indices, 1) || 
-          binder.tensorOperandAtIndex(updates, 2) || 
-          binder.tensorResultType(resultTy))
-        return failure();
+        Torch::ValueTensorType resultTy;
+        Value data, indices, updates;
+        if (binder.tensorOperandAtIndex(data, 0) ||
+            binder.tensorOperandAtIndex(indices, 1) ||
+            binder.tensorOperandAtIndex(updates, 2) ||
+            binder.tensorResultType(resultTy))
+          return failure();
 
-      auto dataTy = cast<Torch::ValueTensorType>(data.getType()),
-           cast<Torch::ValueTensorType>(indicesTy = indices.getType()),
-           cast<Torch::ValueTensorType>(updatesTy = updates.getType());
+        auto dataTy = cast<Torch::ValueTensorType>(data.getType()),
+             cast<Torch::ValueTensorType>(indicesTy = indices.getType()),
+             cast<Torch::ValueTensorType>(updatesTy = updates.getType());
 
-      int64_t dataRank = dataTy.getSizes().size(), 
-              indicesRank = indicesTy.getSizes().size(), 
-              updatesRank = updatesTy.getSizes().size();
+        int64_t dataRank = dataTy.getSizes().size(),
+                indicesRank = indicesTy.getSizes().size(),
+                updatesRank = updatesTy.getSizes().size();
 
-      if ((dataRank < 1) || (indicesRank < 1) || (updatesRank < 1) || 
-          (axis < -dataRank) || (axis >= dataRank))
-        return failure();
+        if ((dataRank < 1) || (indicesRank < 1) || (updatesRank < 1) ||
+            (axis < -dataRank) || (axis >= dataRank))
+          return failure();
 
-      Value axisValue = rewriter.create<Torch::ConstantIntOp>(
-          binder.getLoc(), rewriter.getI64IntegerAttr(axis));
+        Value axisValue = rewriter.create<Torch::ConstantIntOp>(
+            binder.getLoc(), rewriter.getI64IntegerAttr(axis));
 
-      rewriter.replaceOpWithNewOp<Torch::AtenScatterSrcOp>(
-          binder.op, resultTy, data, axisValue, indices, updates);
+        rewriter.replaceOpWithNewOp<Torch::AtenScatterSrcOp>(
+            binder.op, resultTy, data, axisValue, indices, updates);
 
-      return success();
-    });
+        return success();
+      });
   patterns.onOp(
       "ScatterElements", 1,
       [](OpBinder binder, ConversionPatternRewriter &rewriter) {


### PR DESCRIPTION
A PR landed when moving away from a deprecated cast function. Updated the corresponding lines to pass.