### PR TITLE
Add conversion operation for bool resolved_literal

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1585,6 +1585,10 @@ class GraphNodeImporter:
         user_value = self.fx_importer._hooks.resolve_literal(self, py_value)
         if user_value is not None:
             assert isinstance(user_value, Value)
+            if orig_value is not None:
+                user_value = self._convert_type(
+                    user_value, torch.Tensor, orig_value.dtype, orig_value.size()
+                )
             return user_value
 
         # Default conversion path.


### PR DESCRIPTION
Resolving `bool` literals can result in a type change to uint8. This needs to be converted back to the expected type before returning to the wrapped `torch` operators.