### PR TITLE
Update development.md to use ld.lld

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -71,10 +71,10 @@ cmake -GNinja -Bbuild \
   `# use ccache to cache build results` \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   `# use LLD to link in seconds, rather than minutes` \
-  `# if using clang <= 13, replace --ld-path=lld with -fuse-ld=lld` \
-  -DCMAKE_EXE_LINKER_FLAGS_INIT="--ld-path=lld" \
-  -DCMAKE_MODULE_LINKER_FLAGS_INIT="--ld-path=lld" \
-  -DCMAKE_SHARED_LINKER_FLAGS_INIT="--ld-path=lld" \
+  `# if using clang <= 13, replace --ld-path=ld.lld with -fuse-ld=lld` \
+  -DCMAKE_EXE_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
+  -DCMAKE_MODULE_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
+  -DCMAKE_SHARED_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
   `# Enabling libtorch binary cache instead of downloading the latest libtorch everytime.` \
   `# Testing against a mismatched version of libtorch may cause failures` \
   -DLIBTORCH_CACHE=ON \


### PR DESCRIPTION
@kuhar mentioned in the previous PR that we should use ld.lld. I kept using ld because for my LLD version, it worked.

After updating to a new LLD version, that became necessary.