### PR TITLE
Fixed installation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ python -m pip install --upgrade pip
 Then, we can install torch-mlir with the corresponding torch and torchvision nightlies.
 ```
 pip install --pre torch-mlir torchvision \
-  --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-pip install torch-mlir -f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
+  --extra-index-url https://download.pytorch.org/whl/nightly/cpu \
+  -f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
 ```
 
 ## Demos


### PR DESCRIPTION
Current pip installation command raises error
```
ERROR: Could not find a version that satisfies the requirement torch-mlir (from versions: none)
ERROR: No matching distribution found for torch-mlir
```
(checked on Ubuntu 22.04.2 LTS with `venv` and with `conda`)

Because it is trying to install torch-mlir from pytorch repository. The installation command was wrongly split into 2 in #3073. I just merged them back to 1 installation command with both pytorch and llvm/torch-mlir channels.