### PR TITLE
[ONNX] Add averagepool dilations support

### DIFF
--- a/lib/Conversion/TorchToLinalg/Pooling.cpp
+++ b/lib/Conversion/TorchToLinalg/Pooling.cpp
@@ -612,6 +612,16 @@ public:
                                                   strideInts, paddingInts)))
       return rewriter.notifyMatchFailure(op, "invalid pooling parameters");
 
+    // Decode strideInts into strideInts and dilation
+    if (strideInts.size() == 2 * Dim) {
+      for (int i = 0; i < Dim; i++) {
+        dilationInts[i] = strideInts[Dim + i];
+      }
+      for (int i = 0; i < Dim; i++) {
+        strideInts.pop_back();
+      }
+    }
+
     // TODO: Add support for count_include_pad equal to `False`.
     bool countIncludePad;
     if (!matchPattern(op.getCountIncludePad(),


### PR DESCRIPTION
To fix dilations issue: https://github.com/llvm/torch-mlir/issues/3428

Test by: https://github.com/nod-ai/SHARK-TestSuite/pull/268
Status report for run: test-run using mode:onnx todtype:default backend:llvm-cpu
| tests                      | model-run   | onnx-import   | torch-mlir   | iree-compile   | inference   |
|:---------------------------|:------------|:--------------|:-------------|:---------------|:------------|
| onnx/operators/AveragePool | passed      | passed        | passed       | passed         | passed      |

