### PR TITLE
Add support for multiple dynamic reassociation dims for unflatten.int

### DIFF
--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -707,9 +707,9 @@ public:
           reassociations[i - numSizes + 1].push_back(i);
       }
       expand = rewriter
-                    .create<tensor::ExpandShapeOp>(
-                        loc, expandTy, adaptor.getSelf(), reassociations)
-                    .getResult();
+                   .create<tensor::ExpandShapeOp>(
+                       loc, expandTy, adaptor.getSelf(), reassociations)
+                   .getResult();
     } else {
       reassocSizes = getTypeConvertedValues(rewriter, loc, getTypeConverter(),
                                             reassocSizes);
@@ -717,7 +717,7 @@ public:
           getTensorSizes(rewriter, loc, adaptor.getSelf());
       inputShape = castIndexVectorToInt64Vector(rewriter, loc, inputShape);
       SmallVector<Value> outputShape(inputShape.begin(),
-                                      inputShape.begin() + dimInt);
+                                     inputShape.begin() + dimInt);
       if (inputRank > 0) {
         for (int i = 0; i < numSizes; ++i)
           outputShape.push_back(reassocSizes[i]);
@@ -727,12 +727,12 @@ public:
 
       RankedTensorType shapeType = RankedTensorType::get(
           ArrayRef<int64_t>{outputRank}, rewriter.getIntegerType(64));
-      Value shapeValue = rewriter.create<tensor::FromElementsOp>(
-          loc, shapeType, outputShape);
+      Value shapeValue =
+          rewriter.create<tensor::FromElementsOp>(loc, shapeType, outputShape);
       expand = rewriter
-                    .create<tensor::ReshapeOp>(loc, expandTy,
-                                              adaptor.getSelf(), shapeValue)
-                    .getResult();
+                   .create<tensor::ReshapeOp>(loc, expandTy, adaptor.getSelf(),
+                                              shapeValue)
+                   .getResult();
     }
     rewriter.replaceOp(op, expand);
     return success();

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2195,17 +2195,6 @@ LTC_XFAIL_SET = {
 ONNX_XFAIL_SET = {
     # Failure - cast error
     "PermuteNegativeIndexModule_basic",
-    # Failure - expand multiple dynamic dims
-    "EmbeddingModuleF16_basic",
-    "EmbeddingModuleI32_basic",
-    "EmbeddingModuleI64_basic",
-    "IndexTensorHackedTwinModule3dInput_basic",
-    "IndexTensorHackedTwinModule_basic",
-    "IndexTensorModule3dInput_basic",
-    "IndexTensorModule_basic",
-    "IndexTensorMultiInputContiguousOneDimDynamic_basic",
-    "IndexTensorMultiInputNonContiguousOneDimDynamic_basic",
-    "IndexTensorSelectDimModule_basic",
     # Failure - incorrect numerics
     "AvgPool2dDivisorOverrideModule_basic",
     "BroadcastDynamicDimModule_basic",


### PR DESCRIPTION
Addresses an issue with onnx.Gather lowering to linalg: <https://github.com/nod-ai/SHARK-Turbine/issues/242>

The builder for tensor.expand_shape, without an explicitly provided output shape, fails to infer an output shape in the case of multiple dynamic reassociation dims. I tried adding the output shape explicitly for tensor.expand_shape, but ran into compilation issues later on (see <https://github.com/iree-org/iree/issues/17760>). 

This PR adds support by lowering this op to tensor.reshape when multiple dynamic reassociation dims are provided. 