### PR TITLE
support both option -v and TORCH_MLIR_TEST_VERBOSE

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -361,7 +361,7 @@ def run_tests(
     try:
         env_verbose = os.getenv("TORCH_MLIR_TEST_VERBOSE", "0")
         if env_verbose is not None:
-            verbose = verbose | bool(int(env_verbose))
+            verbose = verbose or bool(int(env_verbose))
     except ValueError as e:
         raise ValueError(
             "Bad value for TORCH_MLIR_TEST_VERBOSE env var: " "Expected integer."

--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -361,7 +361,7 @@ def run_tests(
     try:
         env_verbose = os.getenv("TORCH_MLIR_TEST_VERBOSE", "0")
         if env_verbose is not None:
-            verbose = bool(int(env_verbose))
+            verbose = verbose | bool(int(env_verbose))
     except ValueError as e:
         raise ValueError(
             "Bad value for TORCH_MLIR_TEST_VERBOSE env var: " "Expected integer."


### PR DESCRIPTION
so that we could run `python3 -m e2e_testing.main -v` to specify `verbose=True`