### PR TITLE
Allow custom ops to return an array of tensors

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1099,9 +1099,10 @@ class ContextCache:
                 return self.get_vtensor_type(
                     val.size(), val.dtype, sparsity=sparsity, mutable=mutable
                 )
-            elif isinstance(val, list) and all(isinstance(x, TorchFakeTensor) for x in val):
+            elif isinstance(val, list) and all(
+                isinstance(x, TorchFakeTensor) for x in val
+            ):
                 return IrType.parse("!torch.list<vtensor>", context=self._c)
-
 
         # Note that None is a valid scalar here, so it is important that this
         # is always checked as the last fallback.
@@ -2031,15 +2032,12 @@ class GraphNodeImporter:
                     self._unpack_list_values[ref_node] = tuple(operation.results)
 
             try:
-                self.bind_node_value(
-                    node,
-                    self._unpack_list_values[ref_node][index]
-                )
+                self.bind_node_value(node, self._unpack_list_values[ref_node][index])
             except IndexError:
                 raise RuntimeError(
                     f"getitem failed. "
-                    f"getitem only supports lists of known length. (at {loc})")
-
+                    f"getitem only supports lists of known length. (at {loc})"
+                )
 
     def _unpack_node_result_types(
         self, node: torch.fx.Node, schema: FunctionSchema
@@ -2371,9 +2369,9 @@ PY_TYPE_TO_TORCH_OPTIONAL_LIST_TYPE = {
     "vtensor": "!torch.list<optional<vtensor>>",
 }
 
-TORCH_LIST_TYPES = (
-    set(PY_TYPE_TO_TORCH_LIST_TYPE.values()) |
-    set(PY_TYPE_TO_TORCH_OPTIONAL_LIST_TYPE.values()))
+TORCH_LIST_TYPES = set(PY_TYPE_TO_TORCH_LIST_TYPE.values()) | set(
+    PY_TYPE_TO_TORCH_OPTIONAL_LIST_TYPE.values()
+)
 
 SCALAR_TYPE_TO_TORCH_MLIR_TYPE = {
     torch.SymInt: "!torch.int",

--- a/test/python/fx_importer/custom_op_test.py
+++ b/test/python/fx_importer/custom_op_test.py
@@ -19,6 +19,7 @@ def run(f):
     f()
     print()
 
+
 @run
 # CHECK-LABEL: test_tanh_sigmoid_cat_custom_op
 # CHECK:      func.func @main(
@@ -112,7 +113,7 @@ def test_custom_op_array_output():
         def forward(self, a):
             return torch.ops.my_custom_library.array_output_op(4, a)
 
-    a = torch.rand(2,3)
+    a = torch.rand(2, 3)
     m = fx.export_and_import(
         ArrayOutputCustomOp(),
         a,

--- a/test/python/fx_importer/custom_op_test.py
+++ b/test/python/fx_importer/custom_op_test.py
@@ -89,7 +89,7 @@ def test_tanh_sigmoid_cat_custom_op():
 @run
 # CHECK-LABEL: test_custom_op_array_output
 # CHECK:  func.func @main(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[?,3],f32>)
-# CHECK:  %[[S0:.+]] = torch.symbolic_int "s0" {min_val = 1, max_val = 10} : !torch.int
+# CHECK:  %[[S0:.+]] = torch.symbolic_int "s0" {min_val = {{[0-9]+}}, max_val = 10} : !torch.int
 # CHECK:  %[[int:.+]] = torch.constant.int 4
 # CHECK:  %[[V0:.+]] = torch.operator "torch.my_custom_library.array_output_op"(%[[int]], %[[ARG0]]) : (!torch.int, !torch.vtensor<[?,3],f32>) -> !torch.list<vtensor>
 # CHECK: %[[V1:.+]]:4 = torch.prim.ListUnpack %[[V0]] : !torch.list<vtensor> -> !torch.vtensor<[?,3],f32>, !torch.vtensor<[?,3],f32>, !torch.vtensor<[?,3],f32>, !torch.vtensor<[?,3],f32>
@@ -118,7 +118,7 @@ def test_custom_op_array_output():
         def forward(self, a):
             return torch.ops.my_custom_library.array_output_op(4, a)
 
-    dim = Dim("n", min=1, max=10)
+    dim = Dim("n", max=10)
     dynamic_shapes = {
         "a": {0: dim},
     }

--- a/test/python/fx_importer/custom_op_test.py
+++ b/test/python/fx_importer/custom_op_test.py
@@ -86,6 +86,12 @@ def test_tanh_sigmoid_cat_custom_op():
 
 
 @run
+# CHECK-LABEL: test_custom_op_array_output
+# CHECK:  func.func @main(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[2,3],f32>)
+# CHECK:  %[[int:.+]] = torch.constant.int 4
+# CHECK:  %[[V0:.+]] = torch.operator "torch.my_custom_library.array_output_op"(%[[int]], %[[ARG0]]) : (!torch.int, !torch.vtensor<[2,3],f32>) -> !torch.list<vtensor>
+# CHECK: %[[V1:.+]]:4 = torch.prim.ListUnpack %[[V0]] : !torch.list<vtensor> -> !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>
+# CHECK: return %[[V1]]#0, %[[V1]]#1, %[[V1]]#2, %[[V1]]#3 : !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>
 def test_custom_op_array_output():
     m = Library("my_custom_library", "DEF")
     m.define("array_output_op(int num_outs, Tensor a) -> Tensor[]")
@@ -104,7 +110,7 @@ def test_custom_op_array_output():
             super().__init__()
 
         def forward(self, a):
-            return torch.ops.my_custom_library.array_output_op(10, a)
+            return torch.ops.my_custom_library.array_output_op(4, a)
 
     a = torch.rand(2,3)
     m = fx.export_and_import(
@@ -113,4 +119,3 @@ def test_custom_op_array_output():
         import_symbolic_shape_expressions=True,
     )
     print(m)
-


### PR DESCRIPTION
This PR adds support to `fx_importer.py` for handling custom ops that return an array of tensors.  As long as the length of the array is consistent across runs (determined statically), then this patch will work.  This does not require that the number of tensors returned is determined by the op's definition.

CC @sjain-stanford