### PR TITLE
Fix macOS package build

### DIFF
--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -88,7 +88,7 @@ function build_torch_mlir() {
   TORCH_MLIR_PYTHON_PACKAGE_VERSION=${TORCH_MLIR_PYTHON_PACKAGE_VERSION} \
   MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET \
   CMAKE_OSX_ARCHITECTURES=$CMAKE_OSX_ARCHITECTURES \
-  python"${python_version}" -m pip wheel -v -w "$output_dir" "$repo_root" --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+  python"${python_version}" -m pip wheel -v --no-build-isolation -w "$output_dir" "$repo_root" --extra-index-url https://download.pytorch.org/whl/nightly/cpu
   deactivate
   rm -rf "$output_dir"/build_venv
 }
@@ -107,7 +107,7 @@ function build_torch_mlir_core() {
   CMAKE_OSX_ARCHITECTURES=$CMAKE_OSX_ARCHITECTURES \
   TORCH_MLIR_ENABLE_JIT_IR_IMPORTER=0 \
   TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS=1 \
-  python"${python_version}" -m pip wheel -v -w "$output_dir" "$repo_root"
+  python"${python_version}" -m pip wheel -v --no-build-isolation -w "$output_dir" "$repo_root"
   deactivate
   rm -rf "$output_dir"/build_venv
 }

--- a/build_tools/python_deploy/install_macos_deps.sh
+++ b/build_tools/python_deploy/install_macos_deps.sh
@@ -19,14 +19,14 @@ if [[ "$(whoami)" != "root" ]]; then
 fi
 
 PYTHON_INSTALLER_URLS=(
-  "https://www.python.org/ftp/python/3.11.2/python-3.11.2-macos11.pkg"
-  "https://www.python.org/ftp/python/3.10.10/python-3.10.10-macos11.pkg"
+  "https://www.python.org/ftp/python/3.11.9/python-3.11.9-macos11.pkg"
+  "https://www.python.org/ftp/python/3.10.11/python-3.10.11-macos11.pkg"
   "https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg"
 )
 
 PYTHON_SPECS=(
-  3.11@https://www.python.org/ftp/python/3.11.2/python-3.11.2-macos11.pkg
-  3.10@https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
+  3.11@https://www.python.org/ftp/python/3.11.9/python-3.11.9-macos11.pkg
+  3.10@https://www.python.org/ftp/python/3.10.11/python-3.10.11-macos11.pkg
   3.9@https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg
 )
 


### PR DESCRIPTION
Without `--no-build-isolation` pip invokes `setup.py` in fresh environment, which doesn't have `torch` installed. But `setup.py` does `import torch` to check PyTorch version, so the build crashes. At the same time the script creates a disposable virtual environment with all required dependencies specifically to run wheel build. Note that Linux package build also runs with this option.

https://github.com/llvm/torch-mlir/blob/15cf7106c423019f30fef3cffefc4b4cf064934a/setup.py#L230

This was introduced by this commit: https://github.com/llvm/torch-mlir/commit/74f7a0c9d6ea5b3a6d37dd61d0a83557a90b1d03

And looks like macOS builds were not running in CI ever since.

I also updated Python versions in `install_macos_deps.sh`.