### PR TITLE
Align Quantization Rounding Scheme with ONNX/Pytorch

### DIFF
--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -1442,7 +1442,7 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
     scale = b.create<arith::TruncFOp>(loc, valueTy, scale);
 
     value = b.create<arith::DivFOp>(loc, value, scale);
-    value = b.create<math::RoundOp>(loc, value);
+    value = b.create<math::RoundEvenOp>(loc, value);
     value = b.create<arith::AddFOp>(loc, value, zp);
 
     auto destTy = payloadArgs[1].getType();


### PR DESCRIPTION
Pytorch and ONNX apparently round to nearest, ties go to nearest even, but we were using `math::round` for the torch-to-linalg conversion of `quantize_per_tensor`, which rounds away from zero on ties. 