### PR TITLE
[onnx] Fix `onnx.Shape` to include `start` and `end` processing

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1611,12 +1611,6 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         Value shape = rewriter.create<Torch::Aten_ShapeAsTensorOp>(
             binder.getLoc(), shapeType, operand);
 
-        int64_t start = 0;
-        int64_t end = -1;
-        if (binder.optionalS64IntegerAttr(start, "start") ||
-            binder.optionalS64IntegerAttr(end, "end"))
-          return failure();
-
         if (start == 0 && end == -1) {
           rewriter.replaceOp(binder.op, shape);
           return success();

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1627,20 +1627,16 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           end += inputRank;
 
         Value sv = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getI64IntegerAttr(start));
+            binder.getLoc(), rewriter.getI64IntegerAttr(start));
 
         Value ev = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getI64IntegerAttr(end));
+            binder.getLoc(), rewriter.getI64IntegerAttr(end));
 
         Value step = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getI64IntegerAttr(1));
+            binder.getLoc(), 1);
 
         Value dim = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getI64IntegerAttr(0));
+            binder.getLoc(), 0);
 
         shape = rewriter.create<Torch::AtenSliceTensorOp>(
             binder.getLoc(), resultType, shape, dim, sv, ev, step);

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1610,11 +1610,9 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
 
         int64_t start = 0;
         int64_t end = -1;
-        if (binder.optionalS64IntegerAttr(start, "start", 0) &&
-            binder.optionalS64IntegerAttr(end, "end", -1)) {
-          rewriter.replaceOp(binder.op, shape);
-          return success();
-        }
+        if (binder.optionalS64IntegerAttr(start, "start", 0) ||
+            binder.optionalS64IntegerAttr(end, "end", -1))
+          return failure();
 
         if (start == 0 && end == -1) {
           rewriter.replaceOp(binder.op, shape);

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1594,8 +1594,11 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
       "Shape", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value operand;
+        int64_t start, end;
         if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType))
+            binder.tensorResultType(resultType) ||
+            binder.s64IntegerAttr(start, "start", 0) ||
+            binder.s64IntegerAttr(end, "end", -1))
           return failure();
 
         auto inputType = dyn_cast<Torch::ValueTensorType>(operand.getType());

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1616,6 +1616,11 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           return success();
         }
 
+        if (start == 0 && end == -1) {
+          rewriter.replaceOp(binder.op, shape);
+          return success();
+        }
+
         if (start < 0)
           start += inputRank;
         if (end < 0)

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1610,8 +1610,8 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
 
         int64_t start = 0;
         int64_t end = -1;
-        if (binder.s64IntegerAttr(start, "start", {}) &&
-            binder.s64IntegerAttr(end, "end", {})) {
+        if (binder.optionalS64IntegerAttr(start, "start", 0) &&
+            binder.optionalS64IntegerAttr(end, "end", -1)) {
           rewriter.replaceOp(binder.op, shape);
           return success();
         }
@@ -1620,11 +1620,6 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           rewriter.replaceOp(binder.op, shape);
           return success();
         }
-
-        if (start < 0)
-          start += inputRank;
-        if (end < 0)
-          end += inputRank;
 
         Value sv = rewriter.create<Torch::ConstantIntOp>(
             binder.getLoc(), rewriter.getI64IntegerAttr(start));

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1627,11 +1627,9 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         Value ev = rewriter.create<Torch::ConstantIntOp>(
             binder.getLoc(), rewriter.getI64IntegerAttr(end));
 
-        Value step = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), 1);
+        Value step = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), 1);
 
-        Value dim = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), 0);
+        Value dim = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), 0);
 
         shape = rewriter.create<Torch::AtenSliceTensorOp>(
             binder.getLoc(), resultType, shape, dim, sv, ev, step);

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1610,8 +1610,8 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
 
         int64_t start = 0;
         int64_t end = -1;
-        if (binder.optionalS64IntegerAttr(start, "start", 0) ||
-            binder.optionalS64IntegerAttr(end, "end", -1))
+        if (binder.optionalS64IntegerAttr(start, "start") ||
+            binder.optionalS64IntegerAttr(end, "end"))
           return failure();
 
         if (start == 0 && end == -1) {

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3109,7 +3109,7 @@ func.func @test_scatternd_min(%arg0: !torch.vtensor<[4,4,4],f32>, %arg1: !torch.
     return %0 : !torch.vtensor<[4,4,4],f32>
 }
 
-// ----
+// -----
 
 // CHECK-LABEL: func.func @test_split_to_sequence_1
 func.func @test_split_to_sequence_1(%arg0: !torch.vtensor<[3,6],f32>, %arg1: !torch.vtensor<[1],si64>) -> !torch.list<vtensor<[3,6],f32>> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
@@ -3127,7 +3127,7 @@ func.func @test_split_to_sequence_1(%arg0: !torch.vtensor<[3,6],f32>, %arg1: !to
   return %1 : !torch.list<vtensor<[3,6],f32>>
 }
 
-// ----
+// -----
 
 // CHECK-LABEL: func.func @test_split_to_sequence_2
 func.func @test_split_to_sequence_2(%arg0: !torch.vtensor<[2,6],f32>, %arg1: !torch.vtensor<[],si64>) -> !torch.list<vtensor<[1,6],f32>> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
@@ -3145,7 +3145,7 @@ func.func @test_split_to_sequence_2(%arg0: !torch.vtensor<[2,6],f32>, %arg1: !to
   return %1 : !torch.list<vtensor<[1,6],f32>>
 }
 
-// ----
+// -----
 
 // CHECK-LABEL:   func.func @test_split_to_sequence_with_list(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: !torch.vtensor<[4,6],f32>,

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -2693,6 +2693,21 @@ func.func @test_sequence_map_extract_shapes(%arg0: !torch.list<vtensor<[?,?,?],f
 
 // -----
 
+// CHECK-LABEL: @test_shape_start_1_end_negative_1
+func.func @test_shape_start_1_end_negative_1(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[1],si64> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
+  // CHECK: %[[SHAPE:.+]] = torch.aten._shape_as_tensor %arg0
+  // CHECK: %[[INT1_0:.+]] = torch.constant.int 1
+  // CHECK: %[[INT2_0:.+]] = torch.constant.int 2
+  // CHECK: %[[INT1_1:.+]] = torch.constant.int 1
+  // CHECK: %[[INT0_0:.+]] = torch.constant.int 0
+  // CHECK: %[[SLICE:.+]] = torch.aten.slice.Tensor %[[SHAPE]], %[[INT0_0]], %[[INT1_0]], %[[INT2]], %[[INT1_1]]
+  %0 = torch.operator "onnx.Shape"(%arg0) {torch.onnx.end = -1 : si64, torch.onnx.start = 1 : si64} : (!torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[1],si64>
+  return %0 : !torch.vtensor<[1],si64>
+}
+
+
+// -----
+
 // CHECK-LABEL: func.func @test_upsample_nearest
 func.func @test_upsample_nearest(%arg0: !torch.vtensor<[1,1,2,2],f32>, %arg1: !torch.vtensor<[4],f32>) -> !torch.vtensor<[1,1,4,6],f32> attributes {torch.onnx_meta.ir_version = 4 : si64, torch.onnx_meta.opset_version = 9 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
   // CHECK: %[[INT0:.*]] = torch.constant.int 0
@@ -3293,18 +3308,4 @@ func.func @test_unique_sorted_with_negative_axis(%arg0: !torch.vtensor<[3,3],f32
   // CHECK: return %[[UNIQUEOUTPUT]], %[[SCATTER]], %[[INVERSEINDEX]], %[[COUNTS]] : !torch.vtensor<[2,3],f32>, !torch.vtensor<[2],si64>, !torch.vtensor<[3],si64>, !torch.vtensor<[2],si64>
   %0:4 = torch.operator "onnx.Unique"(%arg0) {torch.onnx.axis = -1 : si64, torch.onnx.sorted = 1 : si64} : (!torch.vtensor<[3,3],f32>) -> (!torch.vtensor<[2,3],f32>, !torch.vtensor<[2],si64>, !torch.vtensor<[3],si64>, !torch.vtensor<[2],si64>)
   return %0#0, %0#1, %0#2, %0#3 : !torch.vtensor<[2,3],f32>, !torch.vtensor<[2],si64>, !torch.vtensor<[3],si64>, !torch.vtensor<[2],si64>
-}
-
-// -----
-
-// CHECK-LABEL: @test_shape_start_1_end_negative_1
-func.func @test_shape_start_1_end_negative_1(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[1],si64> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
-  // CHECK: %[[SHAPE:.+]] = torch.aten._shape_as_tensor %arg0
-  // CHECK: %[[INT1_0:.+]] = torch.constant.int 1
-  // CHECK: %[[INT2_0:.+]] = torch.constant.int 2
-  // CHECK: %[[INT1_1:.+]] = torch.constant.int 1
-  // CHECK: %[[INT0_0:.+]] = torch.constant.int 0
-  // CHECK: %[[SLICE:.+]] = torch.aten.slice.Tensor %[[SHAPE]], %[[INT0_0]], %[[INT1_0]], %[[INT2]], %[[INT1_1]]
-  %0 = torch.operator "onnx.Shape"(%arg0) {torch.onnx.end = -1 : si64, torch.onnx.start = 1 : si64} : (!torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[1],si64>
-  return %0 : !torch.vtensor<[1],si64>
 }

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -2697,10 +2697,10 @@ func.func @test_sequence_map_extract_shapes(%arg0: !torch.list<vtensor<[?,?,?],f
 func.func @test_shape_start_1_end_negative_1(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[1],si64> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
   // CHECK: %[[SHAPE:.+]] = torch.aten._shape_as_tensor %arg0
   // CHECK: %[[INT1_0:.+]] = torch.constant.int 1
-  // CHECK: %[[INT2_0:.+]] = torch.constant.int 2
+  // CHECK: %[[INT2_0:.+]] = torch.constant.int -1
   // CHECK: %[[INT1_1:.+]] = torch.constant.int 1
   // CHECK: %[[INT0_0:.+]] = torch.constant.int 0
-  // CHECK: %[[SLICE:.+]] = torch.aten.slice.Tensor %[[SHAPE]], %[[INT0_0]], %[[INT1_0]], %[[INT2]], %[[INT1_1]]
+  // CHECK: %[[SLICE:.+]] = torch.aten.slice.Tensor %[[SHAPE]], %[[INT0_0]], %[[INT1_0]], %[[INT2_0]], %[[INT1_1]]
   %0 = torch.operator "onnx.Shape"(%arg0) {torch.onnx.end = -1 : si64, torch.onnx.start = 1 : si64} : (!torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[1],si64>
   return %0 : !torch.vtensor<[1],si64>
 }

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -2693,7 +2693,7 @@ func.func @test_sequence_map_extract_shapes(%arg0: !torch.list<vtensor<[?,?,?],f
 
 // -----
 
-// CHECK-LABEL: @test_shape_start_1_end_negative_1
+// CHECK-LABEL: func.func @test_shape_start_1_end_negative_1
 func.func @test_shape_start_1_end_negative_1(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[1],si64> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
   // CHECK: %[[SHAPE:.+]] = torch.aten._shape_as_tensor %arg0
   // CHECK: %[[INT1_0:.+]] = torch.constant.int 1

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3294,3 +3294,17 @@ func.func @test_unique_sorted_with_negative_axis(%arg0: !torch.vtensor<[3,3],f32
   %0:4 = torch.operator "onnx.Unique"(%arg0) {torch.onnx.axis = -1 : si64, torch.onnx.sorted = 1 : si64} : (!torch.vtensor<[3,3],f32>) -> (!torch.vtensor<[2,3],f32>, !torch.vtensor<[2],si64>, !torch.vtensor<[3],si64>, !torch.vtensor<[2],si64>)
   return %0#0, %0#1, %0#2, %0#3 : !torch.vtensor<[2,3],f32>, !torch.vtensor<[2],si64>, !torch.vtensor<[3],si64>, !torch.vtensor<[2],si64>
 }
+
+// -----
+
+// CHECK-LABEL: @test_shape_start_1_end_negative_1
+func.func @test_shape_start_1_end_negative_1(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[1],si64> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
+  // CHECK: %[[SHAPE:.+]] = torch.aten._shape_as_tensor %arg0
+  // CHECK: %[[INT1_0:.+]] = torch.constant.int 1
+  // CHECK: %[[INT2_0:.+]] = torch.constant.int 2
+  // CHECK: %[[INT1_1:.+]] = torch.constant.int 1
+  // CHECK: %[[INT0_0:.+]] = torch.constant.int 0
+  // CHECK: %[[SLICE:.+]] = torch.aten.slice.Tensor %[[SHAPE]], %[[INT0_0]], %[[INT1_0]], %[[INT2]], %[[INT1_1]]
+  %0 = torch.operator "onnx.Shape"(%arg0) {torch.onnx.end = -1 : si64, torch.onnx.start = 1 : si64} : (!torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[1],si64>
+  return %0 : !torch.vtensor<[1],si64>
+}


### PR DESCRIPTION
`onnx.Shape` can select only a subset of indices using attributes. Add support for these attributes.