### PR TITLE
[torch] Support diagonal `einsum.Diagonal`

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -333,9 +333,9 @@ diagonalizeInputAndRewriteEquation(Location loc, PatternRewriter &rewriter,
         continue;
 
       // Remove the ID and move to the end:
-      for (int i = d0 + 1; i < d1; ++i)
+      for (size_t i = d0 + 1; i < d1; ++i)
         inputStr[i - 1] = inputStr[i];
-      for (int i = d1 + 1, s = inputStr.size(); i < s; ++i)
+      for (size_t i = d1 + 1, s = inputStr.size(); i < s; ++i)
         inputStr[i - 2] = inputStr[i];
 
       inputStr[inputStr.size() - 2] = id;
@@ -343,7 +343,7 @@ diagonalizeInputAndRewriteEquation(Location loc, PatternRewriter &rewriter,
 
       auto inputTy = cast<ValueTensorType>(input.getType());
       llvm::SmallVector<int64_t> newShape;
-      for (int i = 0, s = inputTy.getSizes().size(); i < s; ++i) {
+      for (size_t i = 0, s = inputTy.getSizes().size(); i < s; ++i) {
         if (i == d0 || i == d1)
           continue;
         newShape.push_back(inputTy.getSizes()[i]);

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -315,11 +315,11 @@ diagonalizeInputAndRewriteEquation(Location loc, PatternRewriter &rewriter,
     return false;
   }
 
-  for (int i = 0, d = inputTokens.size(); i < d; ++i) {
+  for (size_t i = 0, d = inputTokens.size(); i < d; ++i) {
     SmallVector<char> inputStr = inputTokens[i];
     Value input = inputTensors[i];
 
-    for (int d0 = 0; d0 < inputStr.size(); ++d0) {
+    for (size_t d0 = 0; d0 < inputStr.size(); ++d0) {
       char id = inputStr[d0];
 
       int d1;

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -322,7 +322,7 @@ diagonalizeInputAndRewriteEquation(Location loc, PatternRewriter &rewriter,
     for (size_t d0 = 0; d0 < inputStr.size(); ++d0) {
       char id = inputStr[d0];
 
-      int d1;
+      size_t d1;
       for (d1 = d0 + 1; d1 < inputStr.size(); d1++) {
         if (id == inputStr[d1])
           break;

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/reshape_like.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/reshape_like.py
@@ -1303,6 +1303,27 @@ def EinsumStaticFourDimensionModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 5, 6), tu.rand(3, 7, 5, 6))
 
 
+class EinsumStaticDiagonalDimensionModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([5, 5, 4, 4], torch.float32, True),
+            ([5, 4, 5, 4], torch.float32, True),
+        ]
+    )
+    def forward(self, tensor1, tensor2):
+        return torch.ops.aten.einsum("iijj,ijij->ji", [tensor1, tensor2])
+
+
+@register_test_case(module_factory=lambda: EinsumStaticDiagonalDimensionModule())
+def EinsumStaticDiagonalDimensionModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5, 5, 4, 4), tu.rand(5, 4, 5, 4))
+
+
 class EinsumStaticContractRhsModule(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
The einsum lowering was missing the behavior for duplicate indices in the equation. This amounts to a diagonalization along duplicate pairs of indices in the equation.