### PR TITLE
[torch] Fix lowering for `onnx.Split` equal parts variant

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1695,9 +1695,9 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         if (binder.s64IntegerAttr(axis, "axis", 0))
           return rewriter.notifyMatchFailure(binder.op,
                                              "Failed to get axis attribute");
-
-        numOutputs = binder.op->getNumResults();
-        if (binder.s64IntegerAttr(numOutputs, "num_outputs", numOutputs))
+        if (binder.s64IntegerAttr(
+                numOutputs, "num_outputs",
+                static_cast<int64_t>(binder.op->getResults().size())))
           return rewriter.notifyMatchFailure(
               binder.op, "Failed to get num_outputs attribute");
 


### PR DESCRIPTION
The TorchOnnxToTorch lowering for `onnx.Split`, equal parts variant, hardcodes the value `2` for `num_outputs`. When the `num_outputs` attr is not passed in, and the resultType, which returns variadic outputs, has number of outputs not equal to 2, the op does not successfully lower to `linalg`.

This patch replaces the hard-coded value of 2 with `binder.op->getResults().size()`, so that the difference in the number of outputs which causes assertions failures inside of LLVM, is fixed.