### PR TITLE
[onnx] Fix `onnx.Hardmax` lowering to torch

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -2802,7 +2802,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         }
 
         auto argmaxTy = rewriter.getType<Torch::ValueTensorType>(
-            argmaxShape, rewriter.getI32Type());
+            argmaxShape, rewriter.getIntegerType(32, IntegerType::Signed));
         Value argmax = rewriter.create<Torch::AtenArgmaxOp>(
             loc, argmaxTy, input, axis, constKeepDims);
 


### PR DESCRIPTION
The lowering to torch makes assumption about the dimensions / types of reduce max and onehot. We need to correct for expected torch behavior.