### PR TITLE
[onnx] Print all `onnx` op conversion failures

### DIFF
--- a/include/torch-mlir/Conversion/TorchOnnxToTorch/Utils.h
+++ b/include/torch-mlir/Conversion/TorchOnnxToTorch/Utils.h
@@ -35,25 +35,20 @@ namespace mlir::torch::onnx_c {
 Value createActivationByName(ImplicitLocOpBuilder &b, StringRef name,
                              Value input);
 
-Value createConstantIntList(OpBinder binder,
-                            ConversionPatternRewriter &rewriter,
+Value createConstantIntList(OpBinder binder, PatternRewriter &rewriter,
                             ArrayRef<int64_t> cstInput);
 
 Torch::ValueTensorType getQTorchTypeFromTorchIntType(Type ty);
 
 template <typename T>
-Value getItemOp(OpBinder binder, ConversionPatternRewriter &rewriter,
-                Value &ofItem) {
+Value getItemOp(OpBinder binder, PatternRewriter &rewriter, Value &ofItem) {
   return rewriter.create<Torch::AtenItemOp>(binder.getLoc(),
                                             rewriter.getType<T>(), ofItem);
 }
 
-LogicalResult OnnxLstmExpander(OpBinder binder,
-                               ConversionPatternRewriter &rewriter);
-LogicalResult OnnxGruExpander(OpBinder binder,
-                              ConversionPatternRewriter &rewriter);
-LogicalResult OnnxRnnExpander(OpBinder binder,
-                              ConversionPatternRewriter &rewriter);
+LogicalResult OnnxLstmExpander(OpBinder binder, PatternRewriter &rewriter);
+LogicalResult OnnxGruExpander(OpBinder binder, PatternRewriter &rewriter);
+LogicalResult OnnxRnnExpander(OpBinder binder, PatternRewriter &rewriter);
 
 bool areAllElementsDistinct(SmallVector<int64_t> array);
 
@@ -109,12 +104,11 @@ m_OnnxListOfConstantInts(SmallVectorImpl<int64_t> &bind_values) {
 
 std::optional<int64_t> onnxDtypeIntToTorchDtypeInt(int64_t dtypeIntOnnx);
 
-LogicalResult createTorchTransposeOp(ConversionPatternRewriter &rewriter,
-                                     Location loc, Value input, int64_t dimA,
-                                     int64_t dimB, Value &transposed);
+LogicalResult createTorchTransposeOp(PatternRewriter &rewriter, Location loc,
+                                     Value input, int64_t dimA, int64_t dimB,
+                                     Value &transposed);
 
-LogicalResult createTorchPermuteOp(OpBinder binder,
-                                   ConversionPatternRewriter &rewriter,
+LogicalResult createTorchPermuteOp(OpBinder binder, PatternRewriter &rewriter,
                                    Location loc, Value input,
                                    SmallVector<int64_t> permuteDims,
                                    Value &permuted);

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
@@ -20,8 +20,7 @@ using namespace mlir::torch;
 using namespace mlir::torch::onnx_c;
 
 namespace {
-LogicalResult windowFunctionImpl(OpBinder binder,
-                                 ConversionPatternRewriter &rewriter,
+LogicalResult windowFunctionImpl(OpBinder binder, PatternRewriter &rewriter,
                                  Value size, Value a0, Value a1, Value a2,
                                  Torch::ValueTensorType resultType,
                                  int64_t output_datatype, int64_t periodic) {
@@ -135,213 +134,186 @@ LogicalResult windowFunctionImpl(OpBinder binder,
 // thing here, so we simplify.
 void mlir::torch::onnx_c::populateDefaultDomainAtoF(
     OnnxCustomOpConversionPattern &patterns) {
-  patterns.onOp("Abs", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenAbsOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
+  patterns.onOp("Abs", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenAbsOp>(binder.op, resultType,
+                                                  operand);
+    return success();
+  });
   // Add became forward compatible with Torch in version 7.
-  patterns.onOp("Add", 7,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value lhs, rhs;
-                  if (binder.tensorOperands(lhs, rhs) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  Value const1 = rewriter.create<Torch::ConstantIntOp>(
-                      binder.getLoc(), rewriter.getType<Torch::IntType>(),
-                      rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
-                  rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
-                      binder.op, resultType, lhs, rhs, const1);
-                  return success();
-                });
+  patterns.onOp("Add", 7, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    if (binder.tensorOperands(lhs, rhs) || binder.tensorResultType(resultType))
+      return failure();
+    Value const1 = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
+    rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(binder.op, resultType,
+                                                        lhs, rhs, const1);
+    return success();
+  });
   // TODO: AffineGrid
-  patterns.onOp("And", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value lhs, rhs;
-                  if (binder.tensorOperands(lhs, rhs) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenLogicalAndOp>(
-                      binder.op, resultType, lhs, rhs);
-                  return success();
-                });
+  patterns.onOp("And", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    if (binder.tensorOperands(lhs, rhs) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenLogicalAndOp>(binder.op, resultType,
+                                                         lhs, rhs);
+    return success();
+  });
+  patterns.onOp("ArgMax", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    bool keepDims;
+    int64_t axis;
+    bool selectLastIndex;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType) ||
+        binder.s64BoolAttr(keepDims, "keepdims", true) ||
+        binder.s64IntegerAttr(axis, "axis", 0) ||
+        binder.s64BoolAttr(selectLastIndex, "select_last_index", false))
+      return failure();
+
+    // ONNX allows negative axis.
+    auto operandSizes =
+        cast<Torch::ValueTensorType>(operand.getType()).getSizes();
+    if (axis < 0)
+      axis += operandSizes.size();
+
+    Value constAxis = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), axis));
+    Value constKeepDims = rewriter.create<Torch::ConstantBoolOp>(
+        binder.getLoc(), rewriter.getType<Torch::BoolType>(),
+        rewriter.getBoolAttr(keepDims));
+
+    if (selectLastIndex) {
+      Value dims = createConstantIntList(binder, rewriter, {axis});
+      auto operandTy = dyn_cast<Torch::ValueTensorType>(operand.getType());
+      operand = rewriter.create<Torch::AtenFlipOp>(binder.getLoc(), operandTy,
+                                                   operand, dims);
+      Value argmax = rewriter.create<Torch::AtenArgmaxOp>(
+          binder.getLoc(), resultType, operand, constAxis, constKeepDims);
+      Value offset = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(operandSizes[axis] - 1));
+      Value alpha = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(1));
+      Value sub = rewriter.create<Torch::AtenSubScalarOp>(
+          binder.getLoc(), resultType, argmax, offset, alpha);
+      rewriter.replaceOpWithNewOp<Torch::AtenAbsOp>(binder.op, resultType, sub);
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<Torch::AtenArgmaxOp>(
+        binder.op, resultType, operand, constAxis, constKeepDims);
+    return success();
+  });
+  patterns.onOp("ArgMin", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    bool keepDims;
+    int64_t axis;
+    bool selectLastIndex;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType) ||
+        binder.s64BoolAttr(keepDims, "keepdims", true) ||
+        binder.s64IntegerAttr(axis, "axis", 0) ||
+        binder.s64BoolAttr(selectLastIndex, "select_last_index", false))
+      return failure();
+
+    // ONNX allows negative axis.
+    auto operandSizes =
+        cast<Torch::ValueTensorType>(operand.getType()).getSizes();
+    if (axis < 0)
+      axis += operandSizes.size();
+
+    Value constAxis = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), axis));
+    Value constKeepDims = rewriter.create<Torch::ConstantBoolOp>(
+        binder.getLoc(), rewriter.getType<Torch::BoolType>(),
+        rewriter.getBoolAttr(keepDims));
+
+    if (selectLastIndex) {
+      Value dims = createConstantIntList(binder, rewriter, {axis});
+      auto operandTy = dyn_cast<Torch::ValueTensorType>(operand.getType());
+      operand = rewriter.create<Torch::AtenFlipOp>(binder.getLoc(), operandTy,
+                                                   operand, dims);
+      Value argmin = rewriter.create<Torch::AtenArgminOp>(
+          binder.getLoc(), resultType, operand, constAxis, constKeepDims);
+      Value offset = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(operandSizes[axis] - 1));
+      Value alpha = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(1));
+      Value sub = rewriter.create<Torch::AtenSubScalarOp>(
+          binder.getLoc(), resultType, argmin, offset, alpha);
+      rewriter.replaceOpWithNewOp<Torch::AtenAbsOp>(binder.op, resultType, sub);
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<Torch::AtenArgminOp>(
+        binder.op, resultType, operand, constAxis, constKeepDims);
+    return success();
+  });
+  patterns.onOp("Asin", 7, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenAsinOp>(binder.op, resultType,
+                                                   operand);
+    return success();
+  });
+  patterns.onOp("Asinh", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenAsinhOp>(binder.op, resultType,
+                                                    operand);
+    return success();
+  });
+  patterns.onOp("Atan", 7, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenAtanOp>(binder.op, resultType,
+                                                   operand);
+    return success();
+  });
+  patterns.onOp("Atanh", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenAtanhOp>(binder.op, resultType,
+                                                    operand);
+    return success();
+  });
+  patterns.onOp("Acos", 7, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenAcosOp>(binder.op, resultType,
+                                                   operand);
+    return success();
+  });
+  patterns.onOp("Acosh", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenAcoshOp>(binder.op, resultType,
+                                                    operand);
+    return success();
+  });
   patterns.onOp(
-      "ArgMax", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        bool keepDims;
-        int64_t axis;
-        bool selectLastIndex;
-        if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType) ||
-            binder.s64BoolAttr(keepDims, "keepdims", true) ||
-            binder.s64IntegerAttr(axis, "axis", 0) ||
-            binder.s64BoolAttr(selectLastIndex, "select_last_index", false))
-          return failure();
-
-        // ONNX allows negative axis.
-        auto operandSizes =
-            cast<Torch::ValueTensorType>(operand.getType()).getSizes();
-        if (axis < 0)
-          axis += operandSizes.size();
-
-        Value constAxis = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), axis));
-        Value constKeepDims = rewriter.create<Torch::ConstantBoolOp>(
-            binder.getLoc(), rewriter.getType<Torch::BoolType>(),
-            rewriter.getBoolAttr(keepDims));
-
-        if (selectLastIndex) {
-          Value dims = createConstantIntList(binder, rewriter, {axis});
-          auto operandTy = dyn_cast<Torch::ValueTensorType>(operand.getType());
-          operand = rewriter.create<Torch::AtenFlipOp>(
-              binder.getLoc(), operandTy, operand, dims);
-          Value argmax = rewriter.create<Torch::AtenArgmaxOp>(
-              binder.getLoc(), resultType, operand, constAxis, constKeepDims);
-          Value offset = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(),
-              rewriter.getI64IntegerAttr(operandSizes[axis] - 1));
-          Value alpha = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(1));
-          Value sub = rewriter.create<Torch::AtenSubScalarOp>(
-              binder.getLoc(), resultType, argmax, offset, alpha);
-          rewriter.replaceOpWithNewOp<Torch::AtenAbsOp>(binder.op, resultType,
-                                                        sub);
-          return success();
-        }
-
-        rewriter.replaceOpWithNewOp<Torch::AtenArgmaxOp>(
-            binder.op, resultType, operand, constAxis, constKeepDims);
-        return success();
-      });
-  patterns.onOp(
-      "ArgMin", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        bool keepDims;
-        int64_t axis;
-        bool selectLastIndex;
-        if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType) ||
-            binder.s64BoolAttr(keepDims, "keepdims", true) ||
-            binder.s64IntegerAttr(axis, "axis", 0) ||
-            binder.s64BoolAttr(selectLastIndex, "select_last_index", false))
-          return failure();
-
-        // ONNX allows negative axis.
-        auto operandSizes =
-            cast<Torch::ValueTensorType>(operand.getType()).getSizes();
-        if (axis < 0)
-          axis += operandSizes.size();
-
-        Value constAxis = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), axis));
-        Value constKeepDims = rewriter.create<Torch::ConstantBoolOp>(
-            binder.getLoc(), rewriter.getType<Torch::BoolType>(),
-            rewriter.getBoolAttr(keepDims));
-
-        if (selectLastIndex) {
-          Value dims = createConstantIntList(binder, rewriter, {axis});
-          auto operandTy = dyn_cast<Torch::ValueTensorType>(operand.getType());
-          operand = rewriter.create<Torch::AtenFlipOp>(
-              binder.getLoc(), operandTy, operand, dims);
-          Value argmin = rewriter.create<Torch::AtenArgminOp>(
-              binder.getLoc(), resultType, operand, constAxis, constKeepDims);
-          Value offset = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(),
-              rewriter.getI64IntegerAttr(operandSizes[axis] - 1));
-          Value alpha = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(1));
-          Value sub = rewriter.create<Torch::AtenSubScalarOp>(
-              binder.getLoc(), resultType, argmin, offset, alpha);
-          rewriter.replaceOpWithNewOp<Torch::AtenAbsOp>(binder.op, resultType,
-                                                        sub);
-          return success();
-        }
-
-        rewriter.replaceOpWithNewOp<Torch::AtenArgminOp>(
-            binder.op, resultType, operand, constAxis, constKeepDims);
-        return success();
-      });
-  patterns.onOp("Asin", 7,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenAsinOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("Asinh", 9,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenAsinhOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("Atan", 7,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenAtanOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("Atanh", 9,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenAtanhOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("Acos", 7,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenAcosOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("Acosh", 9,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenAcoshOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp(
-      "BatchNormalization", 15,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "BatchNormalization", 15, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value input, weight, bias, inputMean, inputVar;
         bool training;
@@ -456,8 +428,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         return success();
       });
   patterns.onOp(
-      "AveragePool", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "AveragePool", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         std::string autoPad;
         SmallVector<int64_t> dilations;
         if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
@@ -589,8 +560,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         return failure();
       });
   patterns.onOp(
-      "Bernoulli", 15,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "Bernoulli", 15, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value input;
         int64_t dtypeIntOnnx;
@@ -634,26 +604,25 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
             /*memory_format=*/none);
         return success();
       });
-  patterns.onOp(
-      "BitShift", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value lhs, rhs;
-        std::string direction;
-        if (binder.tensorOperands(lhs, rhs) ||
-            binder.tensorResultType(resultType) ||
-            binder.customOpNameStringAttr(direction, "direction", ""))
-          return failure();
-        if (direction == "LEFT") {
-          rewriter.replaceOpWithNewOp<Torch::AtenBitwiseLeftShiftTensorOp>(
-              binder.op, resultType, lhs, rhs);
-        } else {
-          rewriter.replaceOpWithNewOp<Torch::AtenBitwiseRightShiftTensorOp>(
-              binder.op, resultType, lhs, rhs);
-        }
-        return success();
-      });
+  patterns.onOp("BitShift", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    std::string direction;
+    if (binder.tensorOperands(lhs, rhs) ||
+        binder.tensorResultType(resultType) ||
+        binder.customOpNameStringAttr(direction, "direction", ""))
+      return failure();
+    if (direction == "LEFT") {
+      rewriter.replaceOpWithNewOp<Torch::AtenBitwiseLeftShiftTensorOp>(
+          binder.op, resultType, lhs, rhs);
+    } else {
+      rewriter.replaceOpWithNewOp<Torch::AtenBitwiseRightShiftTensorOp>(
+          binder.op, resultType, lhs, rhs);
+    }
+    return success();
+  });
   patterns.onOp("BitwiseAnd", 18,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;
                   Value lhs, rhs;
                   std::string direction;
@@ -665,7 +634,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
                   return success();
                 });
   patterns.onOp("BitwiseOr", 18,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;
                   Value lhs, rhs;
                   std::string direction;
@@ -677,7 +646,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
                   return success();
                 });
   patterns.onOp("BitwiseNot", 18,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;
                   Value operand;
                   if (binder.tensorOperand(operand) ||
@@ -688,7 +657,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
                   return success();
                 });
   patterns.onOp("BitwiseXor", 18,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;
                   Value lhs, rhs;
                   std::string direction;
@@ -699,119 +668,110 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
                       binder.op, resultType, lhs, rhs);
                   return success();
                 });
-  patterns.onOp(
-      "Cast", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        int64_t dtypeIntOnnx;
-        if (binder.tensorOperand(operand) ||
-            binder.s64IntegerAttr(dtypeIntOnnx, "to") ||
-            binder.tensorResultType(resultType))
-          return failure();
+  patterns.onOp("Cast", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    int64_t dtypeIntOnnx;
+    if (binder.tensorOperand(operand) ||
+        binder.s64IntegerAttr(dtypeIntOnnx, "to") ||
+        binder.tensorResultType(resultType))
+      return failure();
 
-        std::optional<int64_t> dtypeIntTorch =
-            onnxDtypeIntToTorchDtypeInt(dtypeIntOnnx);
-        if (!dtypeIntTorch.has_value()) {
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "unimplemented support for the given dtype conversion");
-        }
-        Value constDtype = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(dtypeIntTorch.value()));
-        Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        Value cstFalse =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
-        rewriter.replaceOpWithNewOp<Torch::AtenToDtypeOp>(
-            binder.op, resultType, operand, constDtype,
-            /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
-            /*memory_format=*/none);
-        return success();
-      });
-  patterns.onOp(
-      "CastLike", 15, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value input, target;
-        if (binder.tensorOperands(input, target) ||
-            binder.tensorResultType(resultType))
-          return failure();
+    std::optional<int64_t> dtypeIntTorch =
+        onnxDtypeIntToTorchDtypeInt(dtypeIntOnnx);
+    if (!dtypeIntTorch.has_value()) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented support for the given dtype conversion");
+    }
+    Value constDtype = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(dtypeIntTorch.value()));
+    Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    Value cstFalse =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
+    rewriter.replaceOpWithNewOp<Torch::AtenToDtypeOp>(
+        binder.op, resultType, operand, constDtype,
+        /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
+        /*memory_format=*/none);
+    return success();
+  });
+  patterns.onOp("CastLike", 15, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value input, target;
+    if (binder.tensorOperands(input, target) ||
+        binder.tensorResultType(resultType))
+      return failure();
 
-        // TODO: Add support to handle the `saturate` attribute.
-        // Ignoring it right now, since it's only using during the float8
-        // conversions which are not supported in Torch-MLIR right now.
+    // TODO: Add support to handle the `saturate` attribute.
+    // Ignoring it right now, since it's only using during the float8
+    // conversions which are not supported in Torch-MLIR right now.
 
-        Torch::ValueTensorType targetTy =
-            cast<Torch::ValueTensorType>(target.getType());
-        if (!targetTy.hasDtype()) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "target tensor must have a dtype");
-        }
-        Type targetDtype = targetTy.getDtype();
-        Value constDtype = Torch::getDtypeIntValueForType(
-            rewriter, binder.getLoc(), targetDtype);
-        Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        Value cstFalse =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
-        rewriter.replaceOpWithNewOp<Torch::AtenToDtypeOp>(
-            binder.op, resultType, input, constDtype,
-            /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
-            /*memory_format=*/none);
-        return success();
-      });
-  patterns.onOp("Ceil", 13,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenCeilOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp(
-      "Celu", 12, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        float alpha;
-        if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType) ||
-            binder.f32FloatAttr(alpha, "alpha", 1.0f))
-          return failure();
-        // exp(x/alpha)
-        Value constAlpha = rewriter.create<Torch::ConstantFloatOp>(
-            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-            rewriter.getF64FloatAttr(alpha));
-        Value xDivAlpha = rewriter.create<Torch::AtenDivScalarOp>(
-            binder.getLoc(), resultType, operand, constAlpha);
-        Value expXDivAlpha = rewriter.create<Torch::AtenExpOp>(
-            binder.getLoc(), resultType, xDivAlpha);
-        // alpha * (exp(x/alpha) - 1)
-        Value constantOne = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(1));
-        Value subOne = rewriter.create<Torch::AtenSubScalarOp>(
-            binder.getLoc(), resultType, expXDivAlpha, constantOne,
-            constantOne);
-        Value mulAlpha = rewriter.create<Torch::AtenMulScalarOp>(
-            binder.getLoc(), resultType, subOne, constAlpha);
-        Value constantZero = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(0));
-        Value zeroTensor = createRank0Tensor(rewriter, binder.getLoc(),
-                                             resultType, constantZero);
-        // min(0, alpha * (exp(x/alpha) - 1))
-        Value minExpression = rewriter.create<Torch::AtenMinimumOp>(
-            binder.getLoc(), resultType, zeroTensor, mulAlpha);
+    Torch::ValueTensorType targetTy =
+        cast<Torch::ValueTensorType>(target.getType());
+    if (!targetTy.hasDtype()) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "target tensor must have a dtype");
+    }
+    Type targetDtype = targetTy.getDtype();
+    Value constDtype =
+        Torch::getDtypeIntValueForType(rewriter, binder.getLoc(), targetDtype);
+    Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    Value cstFalse =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
+    rewriter.replaceOpWithNewOp<Torch::AtenToDtypeOp>(
+        binder.op, resultType, input, constDtype,
+        /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
+        /*memory_format=*/none);
+    return success();
+  });
+  patterns.onOp("Ceil", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenCeilOp>(binder.op, resultType,
+                                                   operand);
+    return success();
+  });
+  patterns.onOp("Celu", 12, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    float alpha;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType) ||
+        binder.f32FloatAttr(alpha, "alpha", 1.0f))
+      return failure();
+    // exp(x/alpha)
+    Value constAlpha = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getF64FloatAttr(alpha));
+    Value xDivAlpha = rewriter.create<Torch::AtenDivScalarOp>(
+        binder.getLoc(), resultType, operand, constAlpha);
+    Value expXDivAlpha = rewriter.create<Torch::AtenExpOp>(
+        binder.getLoc(), resultType, xDivAlpha);
+    // alpha * (exp(x/alpha) - 1)
+    Value constantOne = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(1));
+    Value subOne = rewriter.create<Torch::AtenSubScalarOp>(
+        binder.getLoc(), resultType, expXDivAlpha, constantOne, constantOne);
+    Value mulAlpha = rewriter.create<Torch::AtenMulScalarOp>(
+        binder.getLoc(), resultType, subOne, constAlpha);
+    Value constantZero = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(0));
+    Value zeroTensor =
+        createRank0Tensor(rewriter, binder.getLoc(), resultType, constantZero);
+    // min(0, alpha * (exp(x/alpha) - 1))
+    Value minExpression = rewriter.create<Torch::AtenMinimumOp>(
+        binder.getLoc(), resultType, zeroTensor, mulAlpha);
 
-        // max(0, x)
-        Value maxExpression = rewriter.create<Torch::AtenMaximumOp>(
-            binder.getLoc(), resultType, zeroTensor, operand);
-        // max(0,x) + min(0, alpha * (exp(x/alpha) - 1))
-        rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
-            binder.op, resultType, maxExpression, minExpression, constantOne);
-        return success();
-      });
+    // max(0, x)
+    Value maxExpression = rewriter.create<Torch::AtenMaximumOp>(
+        binder.getLoc(), resultType, zeroTensor, operand);
+    // max(0,x) + min(0, alpha * (exp(x/alpha) - 1))
+    rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
+        binder.op, resultType, maxExpression, minExpression, constantOne);
+    return success();
+  });
   patterns.onOp(
-      "CenterCropPad", 18,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "CenterCropPad", 18, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value input, shape;
         if (binder.tensorOperands(input, shape) ||
@@ -933,592 +893,570 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         rewriter.replaceOp(binder.op, input);
         return success();
       });
-  patterns.onOp(
-      "Clip", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // https://onnx.ai/onnx/operators/onnx__Clip.html
+  patterns.onOp("Clip", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    // https://onnx.ai/onnx/operators/onnx__Clip.html
 
-        // Inputs and outputs must be tensors.
-        Value source;
-        Torch::ValueTensorType resultType;
-        if (binder.tensorOperandAtIndex(source, 0) ||
-            binder.tensorResultType(resultType)) {
-          return failure();
-        }
+    // Inputs and outputs must be tensors.
+    Value source;
+    Torch::ValueTensorType resultType;
+    if (binder.tensorOperandAtIndex(source, 0) ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
 
-        // Min and max can be args (version 11+) or attributes (version 6-).
-        // They default to numeric_limits::lowest() and numeric_limits::max().
-        Value min;
-        Value max;
-        if (binder.op->getNumOperands() >= 2)
-          min = binder.op->getOperand(1);
-        if (binder.op->getNumOperands() == 3)
-          max = binder.op->getOperand(2);
+    // Min and max can be args (version 11+) or attributes (version 6-).
+    // They default to numeric_limits::lowest() and numeric_limits::max().
+    Value min;
+    Value max;
+    if (binder.op->getNumOperands() >= 2)
+      min = binder.op->getOperand(1);
+    if (binder.op->getNumOperands() == 3)
+      max = binder.op->getOperand(2);
 
-        // Note: attribute versions of the op only support float types.
-        auto resultDtype = resultType.getDtype();
-        if (!min && binder.op->hasAttr("torch.onnx.min")) {
-          float minValue;
-          if (binder.f32FloatAttr(minValue, "min",
-                                  std::numeric_limits<float>::lowest()))
-            return failure();
-          auto minSplatAttr = SplatElementsAttr::get(
-              resultType.toBuiltinTensor(),
-              rewriter.getFloatAttr(resultDtype, minValue));
-          min = rewriter.create<Torch::ValueTensorLiteralOp>(
-              binder.getLoc(), resultType, minSplatAttr);
-        }
-        if (!max && binder.op->hasAttr("torch.onnx.max")) {
-          float maxValue;
-          if (binder.f32FloatAttr(maxValue, "max",
-                                  std::numeric_limits<float>::max()))
-            return failure();
-          auto maxSplatAttr = SplatElementsAttr::get(
-              resultType.toBuiltinTensor(),
-              rewriter.getFloatAttr(resultDtype, maxValue));
-          max = rewriter.create<Torch::ValueTensorLiteralOp>(
-              binder.getLoc(), resultType, maxSplatAttr);
-        }
-
-        if (!min && !max) {
-          // Cliping with no limits is a no-op.
-          rewriter.replaceOp(binder.op, source);
-          return success();
-        }
-
-        if (!max) {
-          rewriter.replaceOpWithNewOp<Torch::AtenClampMinTensorOp>(
-              binder.op, resultType, source, min);
-          return success();
-        }
-
-        rewriter.replaceOpWithNewOp<Torch::AtenClampTensorOp>(
-            binder.op, resultType, source, min, max);
-        return success();
-      });
-  patterns.onOp(
-      "Compress", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand, conditionTensor;
-        int64_t axis;
-        if (binder.tensorOperands(operand, conditionTensor) ||
-            binder.s64IntegerAttr(axis, "axis", INT64_MAX) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        auto shapeSizes =
-            dyn_cast<Torch::ValueTensorType>(operand.getType()).getSizes();
-        auto resultSizes = resultType.getSizes();
-
-        // flatten input tensor if using default axis
-        if (axis == INT64_MAX) {
-          SmallVector<int64_t> nonzeroShape = {resultSizes[0]};
-          auto dtype =
-              dyn_cast<Torch::ValueTensorType>(conditionTensor.getType())
-                  .getDtype();
-          auto nonzeroType =
-              rewriter.getType<Torch::ValueTensorType>(nonzeroShape, dtype);
-          Value indexVal = rewriter.create<Torch::AtenNonzeroOp>(
-              binder.getLoc(), nonzeroType, conditionTensor);
-          Value cstZero = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(0));
-          Value cstNegOne = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(-1));
-          int64_t numElements = 1;
-          for (auto i : shapeSizes) {
-            numElements *= i;
-          }
-          SmallVector<int64_t> flattenShape = {numElements};
-          auto flattenType = rewriter.getType<Torch::ValueTensorType>(
-              flattenShape, resultType.getDtype());
-          Value flattenTensor = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
-              binder.getLoc(), flattenType, operand, cstZero, cstNegOne);
-          rewriter.replaceOpWithNewOp<Torch::AtenIndexSelectOp>(
-              binder.op, resultType, flattenTensor, cstZero, indexVal);
-          return success();
-        }
-
-        // Negative axis value means counting dimensions from the back
-        if (axis < 0)
-          axis += shapeSizes.size();
-        SmallVector<int64_t> nonzeroShape = {resultSizes[axis]};
-        auto dtype = dyn_cast<Torch::ValueTensorType>(conditionTensor.getType())
-                         .getDtype();
-        auto nonzeroType =
-            rewriter.getType<Torch::ValueTensorType>(nonzeroShape, dtype);
-        Value indexVal = rewriter.create<Torch::AtenNonzeroOp>(
-            binder.getLoc(), nonzeroType, conditionTensor);
-        Value dimVal = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(axis));
-        rewriter.replaceOpWithNewOp<Torch::AtenIndexSelectOp>(
-            binder.op, resultType, operand, dimVal, indexVal);
-        return success();
-      });
-  patterns.onOp(
-      "Concat", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        SmallVector<Value> tensors;
-        int64_t dim;
-        if (binder.tensorOperands(tensors, binder.op->getNumOperands()) ||
-            binder.s64IntegerAttr(dim, "axis", 0) ||
-            binder.tensorResultType(resultType))
-          return failure();
-        Type listElemType =
-            cast<Torch::BaseTensorType>(tensors[0].getType())
-                .getWithSizesAndDtype(/*optionalSizes=*/std::nullopt,
-                                      /*optionalDtype=*/nullptr);
-        Type listType = Torch::ListType::get(listElemType);
-        Value tensorList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.op->getLoc(), listType, tensors);
-        Value cstDim = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(dim));
-        rewriter.replaceOpWithNewOp<Torch::AtenCatOp>(binder.op, resultType,
-                                                      tensorList, cstDim);
-        return success();
-      });
-  patterns.onOp(
-      "Constant", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        if (binder.tensorResultType(resultType))
-          return failure();
-        auto dtype = resultType.getDtype();
-
-        float floatValue;
-        if (binder.op->hasAttr("torch.onnx.value_float") &&
-            !binder.f32FloatAttr(floatValue, "value_float", 0.0)) {
-          auto splatAttr =
-              SplatElementsAttr::get(resultType.toBuiltinTensor(),
-                                     rewriter.getFloatAttr(dtype, floatValue));
-          rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
-              binder.op, resultType, splatAttr);
-          return success();
-        }
-
-        int64_t intValue;
-        if (binder.op->hasAttr("torch.onnx.value_int") &&
-            !binder.s64IntegerAttr(intValue, "value_int", 0)) {
-          auto splatAttr =
-              SplatElementsAttr::get(resultType.toBuiltinTensor(),
-                                     rewriter.getIntegerAttr(dtype, intValue));
-          rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
-              binder.op, resultType, splatAttr);
-          return success();
-        }
-
-        if (DenseResourceElementsAttr attr =
-                dyn_cast_or_null<DenseResourceElementsAttr>(
-                    binder.op->getAttr("torch.onnx.value"))) {
-          // Bytes are stored in little endian order. Big endian support will
-          // require swizzling.
-          if (!Endian::little) {
-            binder.op->emitError(
-                "unimplemented: importing on big endian systems");
-            return failure();
-          }
-
-          auto ty = cast<ShapedType>(attr.getType());
-          ElementsAttr denseAttr;
-          auto ptr = attr.getRawHandle().getBlob();
-          if (!ptr) {
-            denseAttr = DenseResourceElementsAttr::get(
-                ty, "__onnx_constant_not_found_possibly_due_to_being_elided__",
-                AsmResourceBlob());
-            rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
-                binder.op, resultType, denseAttr);
-            return success();
-          }
-          auto data = ptr->getData();
-          if (cast<ShapedType>(attr.getType()).getElementType().isInteger(1)) {
-            llvm::SmallVector<APInt> newContents;
-            for (auto val : data) {
-              APInt apval(1, val);
-              newContents.push_back(apval);
-            }
-            denseAttr = DenseElementsAttr::get(ty, newContents);
-          } else {
-            denseAttr = DenseElementsAttr::getFromRawBuffer(ty, data);
-          }
-
-          rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
-              binder.op, resultType, denseAttr);
-          return success();
-        }
-
-        if (ElementsAttr attr = dyn_cast_or_null<ElementsAttr>(
-                binder.op->getAttr("torch.onnx.value"))) {
-          rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
-              binder.op, resultType, attr);
-          return success();
-        }
-
-        llvm::SmallVector<int64_t> intValues;
-        if (!binder.s64IntegerArrayAttr(intValues, "value_ints", {}) &&
-            !intValues.empty()) {
-          llvm::SmallVector<APInt> apValues;
-          for (auto intVal : intValues) {
-            apValues.push_back(APInt(dtype.getIntOrFloatBitWidth(), intVal));
-          }
-          auto attr =
-              DenseElementsAttr::get(resultType.toBuiltinTensor(), apValues);
-          rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
-              binder.op, resultType, attr);
-          return success();
-        }
-
+    // Note: attribute versions of the op only support float types.
+    auto resultDtype = resultType.getDtype();
+    if (!min && binder.op->hasAttr("torch.onnx.min")) {
+      float minValue;
+      if (binder.f32FloatAttr(minValue, "min",
+                              std::numeric_limits<float>::lowest()))
         return failure();
-      });
-  patterns.onOp(
-      "Col2Im", 18, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value input, blockShape, imageShape;
-        SmallVector<int64_t> dilations, strides, pads;
+      auto minSplatAttr =
+          SplatElementsAttr::get(resultType.toBuiltinTensor(),
+                                 rewriter.getFloatAttr(resultDtype, minValue));
+      min = rewriter.create<Torch::ValueTensorLiteralOp>(
+          binder.getLoc(), resultType, minSplatAttr);
+    }
+    if (!max && binder.op->hasAttr("torch.onnx.max")) {
+      float maxValue;
+      if (binder.f32FloatAttr(maxValue, "max",
+                              std::numeric_limits<float>::max()))
+        return failure();
+      auto maxSplatAttr =
+          SplatElementsAttr::get(resultType.toBuiltinTensor(),
+                                 rewriter.getFloatAttr(resultDtype, maxValue));
+      max = rewriter.create<Torch::ValueTensorLiteralOp>(
+          binder.getLoc(), resultType, maxSplatAttr);
+    }
 
-        // TODO: The length of dilations should be len(imageShape), and the same
-        // goes for strides. The length of pads should be 2 * len(imageShape).
-        // But, as at the moment we are only supporting 3D or 4D input,
-        // len(imageShape) must necessarily be 2, hence the lengths of the
-        // default values.
-        if (binder.tensorOperandAtIndex(input, 0) ||
-            binder.tensorOperandAtIndex(imageShape, 1) ||
-            binder.tensorOperandAtIndex(blockShape, 2) ||
-            binder.tensorResultType(resultType) ||
-            binder.s64IntegerArrayAttr(dilations, "dilations",
-                                       SmallVector<int64_t>{1, 1}) ||
-            binder.s64IntegerArrayAttr(strides, "strides",
-                                       SmallVector<int64_t>{1, 1}) ||
-            binder.s64IntegerArrayAttr(pads, "pads",
-                                       SmallVector<int64_t>{0, 0, 0, 0}))
-          return failure();
+    if (!min && !max) {
+      // Cliping with no limits is a no-op.
+      rewriter.replaceOp(binder.op, source);
+      return success();
+    }
 
-        auto imageShapeTy = cast<Torch::ValueTensorType>(imageShape.getType());
-        auto imageShapeSizes = imageShapeTy.getSizes();
+    if (!max) {
+      rewriter.replaceOpWithNewOp<Torch::AtenClampMinTensorOp>(
+          binder.op, resultType, source, min);
+      return success();
+    }
 
-        auto blockShapeTy = cast<Torch::ValueTensorType>(blockShape.getType());
-        auto blockShapeSizes = blockShapeTy.getSizes();
+    rewriter.replaceOpWithNewOp<Torch::AtenClampTensorOp>(binder.op, resultType,
+                                                          source, min, max);
+    return success();
+  });
+  patterns.onOp("Compress", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand, conditionTensor;
+    int64_t axis;
+    if (binder.tensorOperands(operand, conditionTensor) ||
+        binder.s64IntegerAttr(axis, "axis", INT64_MAX) ||
+        binder.tensorResultType(resultType))
+      return failure();
 
-        // Check that neither imageShape nor blockShape have dynamic shapes.
-        if (imageShapeSizes[0] == Torch::kUnknownSize ||
-            blockShapeSizes[0] == Torch::kUnknownSize) {
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "Dynamic shapes are not allowed for imageShape and blockShape");
-        }
+    auto shapeSizes =
+        dyn_cast<Torch::ValueTensorType>(operand.getType()).getSizes();
+    auto resultSizes = resultType.getSizes();
 
-        // TODO: Add support for 5D input tensors.
-        if (imageShapeSizes[0] != 2) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "Expected length of imageShape to be equal to 2");
-        }
-        if (blockShapeSizes[0] != 2) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "Expected length of blockShape to be equal to 2");
-        }
-        if (dilations.size() != 2) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "Expected length of dilations to be equal to 2");
-        }
-        if (strides.size() != 2) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "Expected length of strides to be equal to 2");
-        }
+    // flatten input tensor if using default axis
+    if (axis == INT64_MAX) {
+      SmallVector<int64_t> nonzeroShape = {resultSizes[0]};
+      auto dtype = dyn_cast<Torch::ValueTensorType>(conditionTensor.getType())
+                       .getDtype();
+      auto nonzeroType =
+          rewriter.getType<Torch::ValueTensorType>(nonzeroShape, dtype);
+      Value indexVal = rewriter.create<Torch::AtenNonzeroOp>(
+          binder.getLoc(), nonzeroType, conditionTensor);
+      Value cstZero = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(0));
+      Value cstNegOne = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(-1));
+      int64_t numElements = 1;
+      for (auto i : shapeSizes) {
+        numElements *= i;
+      }
+      SmallVector<int64_t> flattenShape = {numElements};
+      auto flattenType = rewriter.getType<Torch::ValueTensorType>(
+          flattenShape, resultType.getDtype());
+      Value flattenTensor = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
+          binder.getLoc(), flattenType, operand, cstZero, cstNegOne);
+      rewriter.replaceOpWithNewOp<Torch::AtenIndexSelectOp>(
+          binder.op, resultType, flattenTensor, cstZero, indexVal);
+      return success();
+    }
 
-        // TODO: Disable this check and add support for different
-        // paddings on lower and higher ends of each axis.
-        // Because we have already checked that imageShape has 2 elements,
-        // we can safely assume that len(padding) will be 4.
-        if (pads[0] != pads[2] || pads[1] != pads[3])
-          return rewriter.notifyMatchFailure(
-              binder.op, "padding on the lower end and the higher end "
-                         "on each axis should be the same");
+    // Negative axis value means counting dimensions from the back
+    if (axis < 0)
+      axis += shapeSizes.size();
+    SmallVector<int64_t> nonzeroShape = {resultSizes[axis]};
+    auto dtype =
+        dyn_cast<Torch::ValueTensorType>(conditionTensor.getType()).getDtype();
+    auto nonzeroType =
+        rewriter.getType<Torch::ValueTensorType>(nonzeroShape, dtype);
+    Value indexVal = rewriter.create<Torch::AtenNonzeroOp>(
+        binder.getLoc(), nonzeroType, conditionTensor);
+    Value dimVal = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(axis));
+    rewriter.replaceOpWithNewOp<Torch::AtenIndexSelectOp>(
+        binder.op, resultType, operand, dimVal, indexVal);
+    return success();
+  });
+  patterns.onOp("Concat", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    SmallVector<Value> tensors;
+    int64_t dim;
+    if (binder.tensorOperands(tensors, binder.op->getNumOperands()) ||
+        binder.s64IntegerAttr(dim, "axis", 0) ||
+        binder.tensorResultType(resultType))
+      return failure();
+    Type listElemType =
+        cast<Torch::BaseTensorType>(tensors[0].getType())
+            .getWithSizesAndDtype(/*optionalSizes=*/std::nullopt,
+                                  /*optionalDtype=*/nullptr);
+    Type listType = Torch::ListType::get(listElemType);
+    Value tensorList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.op->getLoc(), listType, tensors);
+    Value cstDim = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(dim));
+    rewriter.replaceOpWithNewOp<Torch::AtenCatOp>(binder.op, resultType,
+                                                  tensorList, cstDim);
+    return success();
+  });
+  patterns.onOp("Constant", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    if (binder.tensorResultType(resultType))
+      return failure();
+    auto dtype = resultType.getDtype();
 
-        // Since we know that the padding on the lower end and the higher
-        // end on each axis is the same, we can reduce the size of the
-        // padding list, and filter out the duplicate elements.
-        // (Also, Torch::AtenCol2imOp requires len(padding) to be 2).
-        SmallVector<int64_t> padOnEachAxis = {pads[0], pads[1]};
-        Value dilationsList =
-            createConstantIntList(binder, rewriter, dilations);
-        Value stridesList = createConstantIntList(binder, rewriter, strides);
-        Value paddingList =
-            createConstantIntList(binder, rewriter, padOnEachAxis);
+    float floatValue;
+    if (binder.op->hasAttr("torch.onnx.value_float") &&
+        !binder.f32FloatAttr(floatValue, "value_float", 0.0)) {
+      auto splatAttr =
+          SplatElementsAttr::get(resultType.toBuiltinTensor(),
+                                 rewriter.getFloatAttr(dtype, floatValue));
+      rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
+          binder.op, resultType, splatAttr);
+      return success();
+    }
 
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(0));
+    int64_t intValue;
+    if (binder.op->hasAttr("torch.onnx.value_int") &&
+        !binder.s64IntegerAttr(intValue, "value_int", 0)) {
+      auto splatAttr =
+          SplatElementsAttr::get(resultType.toBuiltinTensor(),
+                                 rewriter.getIntegerAttr(dtype, intValue));
+      rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
+          binder.op, resultType, splatAttr);
+      return success();
+    }
 
-        // Index the imageShape and blockShape tensors, as AtenCol2imOp expects
-        // them to be int lists.
-        auto select = [&](Value v, Value k,
-                          Torch::ValueTensorType ty) -> Value {
-          Value kTensor = rewriter.create<Torch::PrimNumToTensorScalarOp>(
-              binder.getLoc(),
-              Torch::ValueTensorType::get(
-                  binder.op->getContext(), ArrayRef<int64_t>{1},
-                  rewriter.getIntegerType(64, /*signed*/ 1)),
-              k);
+    if (DenseResourceElementsAttr attr =
+            dyn_cast_or_null<DenseResourceElementsAttr>(
+                binder.op->getAttr("torch.onnx.value"))) {
+      // Bytes are stored in little endian order. Big endian support will
+      // require swizzling.
+      if (!Endian::little) {
+        binder.op->emitError("unimplemented: importing on big endian systems");
+        return failure();
+      }
 
-          auto sel = rewriter.create<Torch::AtenIndexSelectOp>(
-              binder.getLoc(),
-              Torch::ValueTensorType::get(ty.getContext(), ArrayRef<int64_t>{1},
-                                          ty.getOptionalDtype()),
-              v, zero, kTensor);
-          Value item = rewriter.create<Torch::AtenItemOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(), sel);
-          return item;
-        };
-
-        SmallVector<Value> imageShapeContainer, blockShapeContainer;
-        for (int64_t i = 0; i < imageShapeSizes[0]; ++i) {
-          Value k = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(i));
-
-          // Passing in the shapeType of each of these tensors avoids
-          // repeated casts, as these have already been calculated.
-          imageShapeContainer.push_back(select(imageShape, k, imageShapeTy));
-          blockShapeContainer.push_back(select(blockShape, k, blockShapeTy));
-        }
-
-        Value imageShapeAsList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
-            imageShapeContainer);
-        Value blockShapeAsList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
-            blockShapeContainer);
-
-        rewriter.replaceOpWithNewOp<Torch::AtenCol2imOp>(
-            binder.op, resultType, input, imageShapeAsList, blockShapeAsList,
-            dilationsList, paddingList, stridesList);
+      auto ty = cast<ShapedType>(attr.getType());
+      ElementsAttr denseAttr;
+      auto ptr = attr.getRawHandle().getBlob();
+      if (!ptr) {
+        denseAttr = DenseResourceElementsAttr::get(
+            ty, "__onnx_constant_not_found_possibly_due_to_being_elided__",
+            AsmResourceBlob());
+        rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
+            binder.op, resultType, denseAttr);
         return success();
-      });
-  patterns.onOp(
-      "Conv", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        std::string autoPad;
-        if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
-          return failure();
-        if (autoPad != "NOTSET") {
-          // TODO: Add support for `auto_pad` != "NOTSET"
-          return rewriter.notifyMatchFailure(
-              binder.op, "unsupported conversion: auto_pad != NOTSET");
+      }
+      auto data = ptr->getData();
+      if (cast<ShapedType>(attr.getType()).getElementType().isInteger(1)) {
+        llvm::SmallVector<APInt> newContents;
+        for (auto val : data) {
+          APInt apval(1, val);
+          newContents.push_back(apval);
         }
-        Torch::ValueTensorType resultType;
-        Value input, weight;
-        int64_t group;
-        if (binder.tensorOperandAtIndex(input, 0) ||
-            binder.tensorOperandAtIndex(weight, 1) ||
-            binder.s64IntegerAttr(group, "group", 1) ||
-            binder.tensorResultType(resultType))
-          return failure();
+        denseAttr = DenseElementsAttr::get(ty, newContents);
+      } else {
+        denseAttr = DenseElementsAttr::getFromRawBuffer(ty, data);
+      }
 
-        auto weightTensorType = cast<Torch::ValueTensorType>(weight.getType());
-        if (!weightTensorType || !weightTensorType.hasSizes()) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "Expected weight type having sizes");
-        }
-        ArrayRef<int64_t> weightShape = weightTensorType.getSizes();
-        SmallVector<int64_t> kernelShape;
-        if (binder.s64IntegerArrayAttr(kernelShape, "kernel_shape", {}))
-          return failure();
-        if (kernelShape.size()) {
-          if (kernelShape.size() != weightShape.size() - 2) {
+      rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
+          binder.op, resultType, denseAttr);
+      return success();
+    }
+
+    if (ElementsAttr attr = dyn_cast_or_null<ElementsAttr>(
+            binder.op->getAttr("torch.onnx.value"))) {
+      rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
+          binder.op, resultType, attr);
+      return success();
+    }
+
+    llvm::SmallVector<int64_t> intValues;
+    if (!binder.s64IntegerArrayAttr(intValues, "value_ints", {}) &&
+        !intValues.empty()) {
+      llvm::SmallVector<APInt> apValues;
+      for (auto intVal : intValues) {
+        apValues.push_back(APInt(dtype.getIntOrFloatBitWidth(), intVal));
+      }
+      auto attr =
+          DenseElementsAttr::get(resultType.toBuiltinTensor(), apValues);
+      rewriter.replaceOpWithNewOp<Torch::ValueTensorLiteralOp>(
+          binder.op, resultType, attr);
+      return success();
+    }
+
+    return failure();
+  });
+  patterns.onOp("Col2Im", 18, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value input, blockShape, imageShape;
+    SmallVector<int64_t> dilations, strides, pads;
+
+    // TODO: The length of dilations should be len(imageShape), and the same
+    // goes for strides. The length of pads should be 2 * len(imageShape).
+    // But, as at the moment we are only supporting 3D or 4D input,
+    // len(imageShape) must necessarily be 2, hence the lengths of the
+    // default values.
+    if (binder.tensorOperandAtIndex(input, 0) ||
+        binder.tensorOperandAtIndex(imageShape, 1) ||
+        binder.tensorOperandAtIndex(blockShape, 2) ||
+        binder.tensorResultType(resultType) ||
+        binder.s64IntegerArrayAttr(dilations, "dilations",
+                                   SmallVector<int64_t>{1, 1}) ||
+        binder.s64IntegerArrayAttr(strides, "strides",
+                                   SmallVector<int64_t>{1, 1}) ||
+        binder.s64IntegerArrayAttr(pads, "pads",
+                                   SmallVector<int64_t>{0, 0, 0, 0}))
+      return failure();
+
+    auto imageShapeTy = cast<Torch::ValueTensorType>(imageShape.getType());
+    auto imageShapeSizes = imageShapeTy.getSizes();
+
+    auto blockShapeTy = cast<Torch::ValueTensorType>(blockShape.getType());
+    auto blockShapeSizes = blockShapeTy.getSizes();
+
+    // Check that neither imageShape nor blockShape have dynamic shapes.
+    if (imageShapeSizes[0] == Torch::kUnknownSize ||
+        blockShapeSizes[0] == Torch::kUnknownSize) {
+      return rewriter.notifyMatchFailure(
+          binder.op,
+          "Dynamic shapes are not allowed for imageShape and blockShape");
+    }
+
+    // TODO: Add support for 5D input tensors.
+    if (imageShapeSizes[0] != 2) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "Expected length of imageShape to be equal to 2");
+    }
+    if (blockShapeSizes[0] != 2) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "Expected length of blockShape to be equal to 2");
+    }
+    if (dilations.size() != 2) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "Expected length of dilations to be equal to 2");
+    }
+    if (strides.size() != 2) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "Expected length of strides to be equal to 2");
+    }
+
+    // TODO: Disable this check and add support for different
+    // paddings on lower and higher ends of each axis.
+    // Because we have already checked that imageShape has 2 elements,
+    // we can safely assume that len(padding) will be 4.
+    if (pads[0] != pads[2] || pads[1] != pads[3])
+      return rewriter.notifyMatchFailure(
+          binder.op, "padding on the lower end and the higher end "
+                     "on each axis should be the same");
+
+    // Since we know that the padding on the lower end and the higher
+    // end on each axis is the same, we can reduce the size of the
+    // padding list, and filter out the duplicate elements.
+    // (Also, Torch::AtenCol2imOp requires len(padding) to be 2).
+    SmallVector<int64_t> padOnEachAxis = {pads[0], pads[1]};
+    Value dilationsList = createConstantIntList(binder, rewriter, dilations);
+    Value stridesList = createConstantIntList(binder, rewriter, strides);
+    Value paddingList = createConstantIntList(binder, rewriter, padOnEachAxis);
+
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(0));
+
+    // Index the imageShape and blockShape tensors, as AtenCol2imOp expects
+    // them to be int lists.
+    auto select = [&](Value v, Value k, Torch::ValueTensorType ty) -> Value {
+      Value kTensor = rewriter.create<Torch::PrimNumToTensorScalarOp>(
+          binder.getLoc(),
+          Torch::ValueTensorType::get(
+              binder.op->getContext(), ArrayRef<int64_t>{1},
+              rewriter.getIntegerType(64, /*signed*/ 1)),
+          k);
+
+      auto sel = rewriter.create<Torch::AtenIndexSelectOp>(
+          binder.getLoc(),
+          Torch::ValueTensorType::get(ty.getContext(), ArrayRef<int64_t>{1},
+                                      ty.getOptionalDtype()),
+          v, zero, kTensor);
+      Value item = rewriter.create<Torch::AtenItemOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(), sel);
+      return item;
+    };
+
+    SmallVector<Value> imageShapeContainer, blockShapeContainer;
+    for (int64_t i = 0; i < imageShapeSizes[0]; ++i) {
+      Value k = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(i));
+
+      // Passing in the shapeType of each of these tensors avoids
+      // repeated casts, as these have already been calculated.
+      imageShapeContainer.push_back(select(imageShape, k, imageShapeTy));
+      blockShapeContainer.push_back(select(blockShape, k, blockShapeTy));
+    }
+
+    Value imageShapeAsList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+        imageShapeContainer);
+    Value blockShapeAsList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+        blockShapeContainer);
+
+    rewriter.replaceOpWithNewOp<Torch::AtenCol2imOp>(
+        binder.op, resultType, input, imageShapeAsList, blockShapeAsList,
+        dilationsList, paddingList, stridesList);
+    return success();
+  });
+  patterns.onOp("Conv", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    std::string autoPad;
+    if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
+      return failure();
+    if (autoPad != "NOTSET") {
+      // TODO: Add support for `auto_pad` != "NOTSET"
+      return rewriter.notifyMatchFailure(
+          binder.op, "unsupported conversion: auto_pad != NOTSET");
+    }
+    Torch::ValueTensorType resultType;
+    Value input, weight;
+    int64_t group;
+    if (binder.tensorOperandAtIndex(input, 0) ||
+        binder.tensorOperandAtIndex(weight, 1) ||
+        binder.s64IntegerAttr(group, "group", 1) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    auto weightTensorType = cast<Torch::ValueTensorType>(weight.getType());
+    if (!weightTensorType || !weightTensorType.hasSizes()) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Expected weight type having sizes");
+    }
+    ArrayRef<int64_t> weightShape = weightTensorType.getSizes();
+    SmallVector<int64_t> kernelShape;
+    if (binder.s64IntegerArrayAttr(kernelShape, "kernel_shape", {}))
+      return failure();
+    if (kernelShape.size()) {
+      if (kernelShape.size() != weightShape.size() - 2) {
+        return rewriter.notifyMatchFailure(
+            binder.op,
+            "unsupported conversion: kernel_shape list size should have "
+            "number of values equal to weight_rank - 2");
+      } else {
+        for (unsigned i = 0; i < kernelShape.size(); i++) {
+          if (weightShape[i + 2] != kernelShape[i]) {
             return rewriter.notifyMatchFailure(
-                binder.op,
-                "unsupported conversion: kernel_shape list size should have "
-                "number of values equal to weight_rank - 2");
-          } else {
-            for (unsigned i = 0; i < kernelShape.size(); i++) {
-              if (weightShape[i + 2] != kernelShape[i]) {
-                return rewriter.notifyMatchFailure(
-                    binder.op, "unsupported conversion: kernel_shape value "
-                               "should be equal to the weight tensor shape");
-              }
-            }
+                binder.op, "unsupported conversion: kernel_shape value "
+                           "should be equal to the weight tensor shape");
           }
         }
+      }
+    }
 
-        // Determine the rank of input tensor.
-        std::optional<unsigned> maybeRank = Torch::getTensorRank(input);
-        if (!maybeRank)
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Unimplemented: unranked tensor");
-        unsigned rank = *maybeRank;
+    // Determine the rank of input tensor.
+    std::optional<unsigned> maybeRank = Torch::getTensorRank(input);
+    if (!maybeRank)
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Unimplemented: unranked tensor");
+    unsigned rank = *maybeRank;
 
-        SmallVector<int64_t> padding, strides, dilations;
-        SmallVector<int64_t> defaultPadding, defaultStrides, defaultDilations;
-        for (unsigned i = 0; i < rank - 2; i++) {
-          defaultPadding.push_back(0);
-          defaultStrides.push_back(1);
-          defaultDilations.push_back(1);
-        }
-        // Padding for the beginning and ending along each spatial axis, it can
-        // take any value greater than or equal to 0. The value represent the
-        // number of pixels added to the beginning and end part of the
-        // corresponding axis. pads format should be as follow [x1_begin,
-        // x2_begin…x1_end, x2_end,…], where xi_begin the number of pixels added
-        // at the beginning of axis i and xi_end, the number of pixels added at
-        // the end of axis i.
-        if (binder.s64IntegerArrayAttr(padding, "pads", defaultPadding)) {
-          return failure();
-        }
-        if (padding.size() != rank - 2 && padding.size() != 2 * (rank - 2)) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "padding list size does not match the number of axes");
-        }
-        if (binder.s64IntegerArrayAttr(dilations, "dilations",
-                                       defaultDilations)) {
-          return failure();
-        }
-        if (dilations.size() != rank - 2) {
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "dilations list size does not match the number of axes");
-        }
-        if (binder.s64IntegerArrayAttr(strides, "strides", defaultStrides)) {
-          return failure();
-        }
-        if (strides.size() != rank - 2) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "strides list size does not match the number of axes");
-        }
+    SmallVector<int64_t> padding, strides, dilations;
+    SmallVector<int64_t> defaultPadding, defaultStrides, defaultDilations;
+    for (unsigned i = 0; i < rank - 2; i++) {
+      defaultPadding.push_back(0);
+      defaultStrides.push_back(1);
+      defaultDilations.push_back(1);
+    }
+    // Padding for the beginning and ending along each spatial axis, it can
+    // take any value greater than or equal to 0. The value represent the
+    // number of pixels added to the beginning and end part of the
+    // corresponding axis. pads format should be as follow [x1_begin,
+    // x2_begin…x1_end, x2_end,…], where xi_begin the number of pixels added
+    // at the beginning of axis i and xi_end, the number of pixels added at
+    // the end of axis i.
+    if (binder.s64IntegerArrayAttr(padding, "pads", defaultPadding)) {
+      return failure();
+    }
+    if (padding.size() != rank - 2 && padding.size() != 2 * (rank - 2)) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "padding list size does not match the number of axes");
+    }
+    if (binder.s64IntegerArrayAttr(dilations, "dilations", defaultDilations)) {
+      return failure();
+    }
+    if (dilations.size() != rank - 2) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "dilations list size does not match the number of axes");
+    }
+    if (binder.s64IntegerArrayAttr(strides, "strides", defaultStrides)) {
+      return failure();
+    }
+    if (strides.size() != rank - 2) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "strides list size does not match the number of axes");
+    }
 
-        SmallVector<Value> cstPadding, cstStrides, cstDilations,
-            cstOutputPadding;
-        Value paddedInput = input;
-        Value paddingList;
-        if (padding.size() != 2 * (rank - 2)) {
-          for (int64_t i : padding) {
-            cstPadding.push_back(rewriter.create<Torch::ConstantIntOp>(
-                binder.getLoc(), rewriter.getI64IntegerAttr(i)));
-          }
-          paddingList = rewriter.create<Torch::PrimListConstructOp>(
+    SmallVector<Value> cstPadding, cstStrides, cstDilations, cstOutputPadding;
+    Value paddedInput = input;
+    Value paddingList;
+    if (padding.size() != 2 * (rank - 2)) {
+      for (int64_t i : padding) {
+        cstPadding.push_back(rewriter.create<Torch::ConstantIntOp>(
+            binder.getLoc(), rewriter.getI64IntegerAttr(i)));
+      }
+      paddingList = rewriter.create<Torch::PrimListConstructOp>(
+          binder.getLoc(),
+          Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+          cstPadding);
+    } else {
+      // ONNX offers pads in the format listing all starting dims, then all
+      // ending dims, e.g. {t, l, b, r} for conv2d. Torch by default accepts
+      // only starting dims, e.g. {t, l}. However, we can support padding at
+      // the beginning and end of each dimension by first performing
+      // torch.nn.functional.pad on the input. But this requires the pad
+      // values to be rearranged since torch pad() takes pads in the order
+      // rightmost dim start and end, then next to last, and so on, e.g. {l,
+      // r, t, b}.
+      bool matchedPads = true;
+      for (unsigned i = 0; i < padding.size() / 2; i++) {
+        if (padding[i] != padding[i + (padding.size() / 2)]) {
+          matchedPads = false;
+          break;
+        }
+      }
+      if (matchedPads) {
+        for (unsigned i = 0; i < padding.size() / 2; i++) {
+          cstPadding.push_back(rewriter.create<Torch::ConstantIntOp>(
+              binder.getLoc(), rewriter.getI64IntegerAttr(padding[i])));
+        }
+        paddingList = rewriter.create<Torch::PrimListConstructOp>(
+            binder.getLoc(),
+            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+            cstPadding);
+      } else {
+        SmallVector<Value> padsRearrange;
+        SmallVector<Value> inputPaddingList;
+        for (uint32_t i = 0; i < padding.size() / 2; i++) {
+          padsRearrange.emplace_back(rewriter.create<Torch::ConstantIntOp>(
               binder.getLoc(),
-              Torch::ListType::get(
-                  Torch::IntType::get(binder.op->getContext())),
-              cstPadding);
-        } else {
-          // ONNX offers pads in the format listing all starting dims, then all
-          // ending dims, e.g. {t, l, b, r} for conv2d. Torch by default accepts
-          // only starting dims, e.g. {t, l}. However, we can support padding at
-          // the beginning and end of each dimension by first performing
-          // torch.nn.functional.pad on the input. But this requires the pad
-          // values to be rearranged since torch pad() takes pads in the order
-          // rightmost dim start and end, then next to last, and so on, e.g. {l,
-          // r, t, b}.
-          bool matchedPads = true;
-          for (unsigned i = 0; i < padding.size() / 2; i++) {
-            if (padding[i] != padding[i + (padding.size() / 2)]) {
-              matchedPads = false;
-              break;
-            }
-          }
-          if (matchedPads) {
-            for (unsigned i = 0; i < padding.size() / 2; i++) {
-              cstPadding.push_back(rewriter.create<Torch::ConstantIntOp>(
-                  binder.getLoc(), rewriter.getI64IntegerAttr(padding[i])));
-            }
-            paddingList = rewriter.create<Torch::PrimListConstructOp>(
-                binder.getLoc(),
-                Torch::ListType::get(
-                    Torch::IntType::get(binder.op->getContext())),
-                cstPadding);
-          } else {
-            SmallVector<Value> padsRearrange;
-            SmallVector<Value> inputPaddingList;
-            for (uint32_t i = 0; i < padding.size() / 2; i++) {
-              padsRearrange.emplace_back(rewriter.create<Torch::ConstantIntOp>(
-                  binder.getLoc(), rewriter.getI64IntegerAttr(
-                                       padding[padding.size() / 2 - i - 1])));
-              padsRearrange.emplace_back(rewriter.create<Torch::ConstantIntOp>(
-                  binder.getLoc(),
-                  rewriter.getI64IntegerAttr(padding[padding.size() - i - 1])));
-              inputPaddingList.emplace_back(
-                  rewriter.create<Torch::ConstantIntOp>(
-                      binder.getLoc(), rewriter.getI64IntegerAttr(0)));
-            }
-            // The conv op itself will have no padding since the actual padding
-            // is performed using the torch.pad preceding it.
-            paddingList = rewriter.create<Torch::PrimListConstructOp>(
-                binder.getLoc(),
-                Torch::ListType::get(
-                    Torch::IntType::get(binder.op->getContext())),
-                inputPaddingList);
-            Value padsSizeList =
-                rewriter
-                    .create<Torch::PrimListConstructOp>(
-                        binder.getLoc(),
-                        Torch::ListType::get(
-                            rewriter.getType<Torch::IntType>()),
-                        padsRearrange)
-                    .getResult();
-            Value modeVal = rewriter.create<Torch::ConstantStrOp>(
-                binder.getLoc(), rewriter.getStringAttr("constant"));
-            Value constantValue;
-            auto inputTensorType =
-                cast<Torch::ValueTensorType>(input.getType());
-            if (isa<IntegerType>(inputTensorType.getDtype()))
-              constantValue = rewriter.create<Torch::ConstantIntOp>(
-                  binder.getLoc(), rewriter.getI64IntegerAttr(0));
-            if (isa<FloatType>(inputTensorType.getDtype()))
-              constantValue = rewriter.create<Torch::ConstantFloatOp>(
-                  binder.getLoc(), rewriter.getF64FloatAttr(0.0f));
-            // Pad output shape must be computed explicitly from the pad values
-            SmallVector<int64_t> newInputShape(inputTensorType.getSizes());
-            for (uint32_t i = 0; i < padding.size() / 2; i++) {
-              newInputShape[2 + i] +=
-                  padding[i] + padding[(padding.size() / 2) + i];
-            }
-            auto padTy = rewriter.getType<Torch::ValueTensorType>(
-                newInputShape, inputTensorType.getDtype());
-            paddedInput = rewriter.create<Torch::AtenPadOp>(
-                binder.getLoc(), padTy, input, padsSizeList, modeVal,
-                constantValue);
-          }
+              rewriter.getI64IntegerAttr(padding[padding.size() / 2 - i - 1])));
+          padsRearrange.emplace_back(rewriter.create<Torch::ConstantIntOp>(
+              binder.getLoc(),
+              rewriter.getI64IntegerAttr(padding[padding.size() - i - 1])));
+          inputPaddingList.emplace_back(rewriter.create<Torch::ConstantIntOp>(
+              binder.getLoc(), rewriter.getI64IntegerAttr(0)));
         }
-        for (int64_t i : dilations) {
-          cstDilations.push_back(rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(i)));
+        // The conv op itself will have no padding since the actual padding
+        // is performed using the torch.pad preceding it.
+        paddingList = rewriter.create<Torch::PrimListConstructOp>(
+            binder.getLoc(),
+            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+            inputPaddingList);
+        Value padsSizeList =
+            rewriter
+                .create<Torch::PrimListConstructOp>(
+                    binder.getLoc(),
+                    Torch::ListType::get(rewriter.getType<Torch::IntType>()),
+                    padsRearrange)
+                .getResult();
+        Value modeVal = rewriter.create<Torch::ConstantStrOp>(
+            binder.getLoc(), rewriter.getStringAttr("constant"));
+        Value constantValue;
+        auto inputTensorType = cast<Torch::ValueTensorType>(input.getType());
+        if (isa<IntegerType>(inputTensorType.getDtype()))
+          constantValue = rewriter.create<Torch::ConstantIntOp>(
+              binder.getLoc(), rewriter.getI64IntegerAttr(0));
+        if (isa<FloatType>(inputTensorType.getDtype()))
+          constantValue = rewriter.create<Torch::ConstantFloatOp>(
+              binder.getLoc(), rewriter.getF64FloatAttr(0.0f));
+        // Pad output shape must be computed explicitly from the pad values
+        SmallVector<int64_t> newInputShape(inputTensorType.getSizes());
+        for (uint32_t i = 0; i < padding.size() / 2; i++) {
+          newInputShape[2 + i] +=
+              padding[i] + padding[(padding.size() / 2) + i];
         }
-        for (int64_t i : strides) {
-          cstStrides.push_back(rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(i)));
-        }
-        Value cstZero = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(0));
-        cstOutputPadding = {cstZero, cstZero};
+        auto padTy = rewriter.getType<Torch::ValueTensorType>(
+            newInputShape, inputTensorType.getDtype());
+        paddedInput = rewriter.create<Torch::AtenPadOp>(binder.getLoc(), padTy,
+                                                        input, padsSizeList,
+                                                        modeVal, constantValue);
+      }
+    }
+    for (int64_t i : dilations) {
+      cstDilations.push_back(rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(i)));
+    }
+    for (int64_t i : strides) {
+      cstStrides.push_back(rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(i)));
+    }
+    Value cstZero = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(0));
+    cstOutputPadding = {cstZero, cstZero};
 
-        Value dilationsList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
-            cstDilations);
-        Value stridesList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
-            cstStrides);
-        Value outputPaddingList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
-            cstOutputPadding);
-        Value transposed =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
-        Value bias;
-        if (binder.op->getNumOperands() == 3) {
-          if (binder.tensorOperandAtIndex(bias, 2)) {
-            return failure();
-          }
-        } else {
-          bias = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        }
-        Value cstGroup = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(group));
+    Value dilationsList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+        cstDilations);
+    Value stridesList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+        cstStrides);
+    Value outputPaddingList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+        cstOutputPadding);
+    Value transposed =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
+    Value bias;
+    if (binder.op->getNumOperands() == 3) {
+      if (binder.tensorOperandAtIndex(bias, 2)) {
+        return failure();
+      }
+    } else {
+      bias = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    }
+    Value cstGroup = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(group));
 
-        rewriter.replaceOpWithNewOp<Torch::AtenConvolutionOp>(
-            binder.op, resultType, paddedInput, weight, bias, stridesList,
-            paddingList, dilationsList, transposed, outputPaddingList,
-            cstGroup);
-        return success();
-      });
+    rewriter.replaceOpWithNewOp<Torch::AtenConvolutionOp>(
+        binder.op, resultType, paddedInput, weight, bias, stridesList,
+        paddingList, dilationsList, transposed, outputPaddingList, cstGroup);
+    return success();
+  });
   patterns.onOp(
-      "ConvInteger", 10,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ConvInteger", 10, [](OpBinder binder, PatternRewriter &rewriter) {
         std::string autoPad;
         if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
           return failure();
@@ -1668,8 +1606,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         return success();
       });
   patterns.onOp(
-      "ConvTranspose", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ConvTranspose", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         std::string autoPad;
         if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
           return failure();
@@ -1847,96 +1784,89 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
             cstGroup);
         return success();
       });
-  patterns.onOp("Cos", 7,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenCosOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("Cosh", 9,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenCoshOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
+  patterns.onOp("Cos", 7, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenCosOp>(binder.op, resultType,
+                                                  operand);
+    return success();
+  });
+  patterns.onOp("Cosh", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenCoshOp>(binder.op, resultType,
+                                                   operand);
+    return success();
+  });
+  patterns.onOp("CumSum", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand, axisTensor;
+    int64_t exclusive, reverse;
+    if (binder.tensorOperands(operand, axisTensor) ||
+        binder.s64IntegerAttr(exclusive, "exclusive", 0) ||
+        binder.s64IntegerAttr(reverse, "reverse", 0) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    Torch::BaseTensorType resultTensorType =
+        cast<Torch::BaseTensorType>(resultType);
+    if (!resultTensorType.hasDtype()) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "expected result type to have a dtype");
+    }
+
+    // deal with neg axis: if (axis < 0) axis += rank
+    int64_t rank =
+        cast<Torch::ValueTensorType>(operand.getType()).getSizes().size();
+    Value rankVal = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), rank));
+    Value cstZero = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(0));
+    Value cstOne = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(1));
+
+    Value axisScalar = rewriter.create<Torch::AtenItemOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(), axisTensor);
+    Value isNegative = rewriter.create<Torch::AtenLtIntOp>(binder.getLoc(),
+                                                           axisScalar, cstZero);
+    isNegative =
+        rewriter.create<Torch::AtenIntBoolOp>(binder.getLoc(), isNegative);
+    Value finalOffset = rewriter.create<Torch::AtenMulIntOp>(
+        binder.getLoc(), isNegative, rankVal);
+    Value axis = rewriter.create<Torch::AtenAddIntOp>(binder.getLoc(),
+                                                      axisScalar, finalOffset);
+    Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+
+    Value res;
+    if (reverse) {
+      Value dims = rewriter.create<Torch::PrimListConstructOp>(
+          binder.getLoc(),
+          rewriter.getType<Torch::ListType>(rewriter.getType<Torch::IntType>()),
+          SmallVector<Value>{axis});
+      Value flip = rewriter.create<Torch::AtenFlipOp>(
+          binder.getLoc(), resultType, operand, dims);
+      Value cumsum = rewriter.create<Torch::AtenCumsumOp>(
+          binder.getLoc(), resultType, flip, axis, none);
+      res = rewriter.create<Torch::AtenFlipOp>(binder.getLoc(), resultType,
+                                               cumsum, dims);
+    } else {
+      res = rewriter.create<Torch::AtenCumsumOp>(binder.getLoc(), resultType,
+                                                 operand, axis, none);
+    }
+
+    if (exclusive)
+      res = rewriter.create<Torch::AtenSubTensorOp>(binder.getLoc(), resultType,
+                                                    res, operand, cstOne);
+    rewriter.replaceOp(binder.op, res);
+    return success();
+  });
   patterns.onOp(
-      "CumSum", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand, axisTensor;
-        int64_t exclusive, reverse;
-        if (binder.tensorOperands(operand, axisTensor) ||
-            binder.s64IntegerAttr(exclusive, "exclusive", 0) ||
-            binder.s64IntegerAttr(reverse, "reverse", 0) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        Torch::BaseTensorType resultTensorType =
-            cast<Torch::BaseTensorType>(resultType);
-        if (!resultTensorType.hasDtype()) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "expected result type to have a dtype");
-        }
-
-        // deal with neg axis: if (axis < 0) axis += rank
-        int64_t rank =
-            cast<Torch::ValueTensorType>(operand.getType()).getSizes().size();
-        Value rankVal = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), rank));
-        Value cstZero = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(0));
-        Value cstOne = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(1));
-
-        Value axisScalar = rewriter.create<Torch::AtenItemOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(), axisTensor);
-        Value isNegative = rewriter.create<Torch::AtenLtIntOp>(
-            binder.getLoc(), axisScalar, cstZero);
-        isNegative =
-            rewriter.create<Torch::AtenIntBoolOp>(binder.getLoc(), isNegative);
-        Value finalOffset = rewriter.create<Torch::AtenMulIntOp>(
-            binder.getLoc(), isNegative, rankVal);
-        Value axis = rewriter.create<Torch::AtenAddIntOp>(
-            binder.getLoc(), axisScalar, finalOffset);
-        Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-
-        Value res;
-        if (reverse) {
-          Value dims = rewriter.create<Torch::PrimListConstructOp>(
-              binder.getLoc(),
-              rewriter.getType<Torch::ListType>(
-                  rewriter.getType<Torch::IntType>()),
-              SmallVector<Value>{axis});
-          Value flip = rewriter.create<Torch::AtenFlipOp>(
-              binder.getLoc(), resultType, operand, dims);
-          Value cumsum = rewriter.create<Torch::AtenCumsumOp>(
-              binder.getLoc(), resultType, flip, axis, none);
-          res = rewriter.create<Torch::AtenFlipOp>(binder.getLoc(), resultType,
-                                                   cumsum, dims);
-        } else {
-          res = rewriter.create<Torch::AtenCumsumOp>(
-              binder.getLoc(), resultType, operand, axis, none);
-        }
-
-        if (exclusive)
-          res = rewriter.create<Torch::AtenSubTensorOp>(
-              binder.getLoc(), resultType, res, operand, cstOne);
-        rewriter.replaceOp(binder.op, res);
-        return success();
-      });
-  patterns.onOp(
-      "DepthToSpace", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "DepthToSpace", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value input;
         int64_t blockSize;
@@ -2043,8 +1973,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         return success();
       });
   patterns.onOp(
-      "DeformConv", 19,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "DeformConv", 19, [](OpBinder binder, PatternRewriter &rewriter) {
         auto loc = binder.getLoc();
 
         // get operands
@@ -2177,19 +2106,17 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
             useMaskValue);
         return success();
       });
+  patterns.onOp("Det", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value input;
+    if (binder.tensorOperand(input) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenLinalgDetOp>(binder.op, resultType,
+                                                        input);
+    return success();
+  });
   patterns.onOp(
-      "Det", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value input;
-        if (binder.tensorOperand(input) || binder.tensorResultType(resultType))
-          return failure();
-        rewriter.replaceOpWithNewOp<Torch::AtenLinalgDetOp>(binder.op,
-                                                            resultType, input);
-        return success();
-      });
-  patterns.onOp(
-      "DequantizeLinear", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "DequantizeLinear", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         llvm::SmallVector<Value> operands;
         if (binder.tensorOperands(operands, 3) ||
@@ -2264,101 +2191,97 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
             binder.op, resultType, quantize);
         return success();
       });
-  patterns.onOp("Div", 7,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value lhs, rhs;
-                  if (binder.tensorOperands(lhs, rhs) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenDivTensorOp>(
-                      binder.op, resultType, lhs, rhs);
-                  return success();
-                });
-  patterns.onOp(
-      "Dropout", 12, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Location loc = binder.getLoc();
-        Torch::ValueTensorType resultType;
-        int64_t numOperands = binder.op->getNumOperands();
-        SmallVector<Value> operands;
-        int64_t seed;
-        if (binder.tensorOperands(operands, numOperands) ||
-            binder.s64IntegerAttr(seed, "seed", 0) ||
-            binder.tensorResultTypeAtIndex(resultType, 0))
-          return failure();
+  patterns.onOp("Div", 7, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    if (binder.tensorOperands(lhs, rhs) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenDivTensorOp>(binder.op, resultType,
+                                                        lhs, rhs);
+    return success();
+  });
+  patterns.onOp("Dropout", 12, [](OpBinder binder, PatternRewriter &rewriter) {
+    Location loc = binder.getLoc();
+    Torch::ValueTensorType resultType;
+    int64_t numOperands = binder.op->getNumOperands();
+    SmallVector<Value> operands;
+    int64_t seed;
+    if (binder.tensorOperands(operands, numOperands) ||
+        binder.s64IntegerAttr(seed, "seed", 0) ||
+        binder.tensorResultTypeAtIndex(resultType, 0))
+      return failure();
 
-        // Global Seed value is 0.
-        if (seed != 0) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "expected seed value to be 0");
-        }
+    // Global Seed value is 0.
+    if (seed != 0) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "expected seed value to be 0");
+    }
 
-        Value ratio, trainingMode;
-        if (numOperands == 3) {
-          ratio = rewriter.create<Torch::AtenFloatImplicitOp>(loc, operands[1]);
-          Value trainVal = operands[2];
-          auto trainTensorType =
-              dyn_cast<Torch::BaseTensorType>(trainVal.getType());
-          if (!trainTensorType)
-            return rewriter.notifyMatchFailure(binder.op,
-                                               "train tensor must have a type");
+    Value ratio, trainingMode;
+    if (numOperands == 3) {
+      ratio = rewriter.create<Torch::AtenFloatImplicitOp>(loc, operands[1]);
+      Value trainVal = operands[2];
+      auto trainTensorType =
+          dyn_cast<Torch::BaseTensorType>(trainVal.getType());
+      if (!trainTensorType)
+        return rewriter.notifyMatchFailure(binder.op,
+                                           "train tensor must have a type");
 
-          Type inputDtype = trainTensorType.getOptionalDtype();
-          if (!inputDtype || !inputDtype.isInteger(1))
-            return rewriter.notifyMatchFailure(
-                binder.op,
-                "train tensor must have an integer dtype of width 1");
+      Type inputDtype = trainTensorType.getOptionalDtype();
+      if (!inputDtype || !inputDtype.isInteger(1))
+        return rewriter.notifyMatchFailure(
+            binder.op, "train tensor must have an integer dtype of width 1");
 
-          std::optional<unsigned> inputRank = Torch::getTensorRank(trainVal);
-          if (!inputRank || *inputRank != 0)
-            return rewriter.notifyMatchFailure(binder.op,
-                                               "train tensor must have rank 0");
+      std::optional<unsigned> inputRank = Torch::getTensorRank(trainVal);
+      if (!inputRank || *inputRank != 0)
+        return rewriter.notifyMatchFailure(binder.op,
+                                           "train tensor must have rank 0");
 
-          if (auto valueTensorLiteralOp =
-                  trainVal.getDefiningOp<Torch::ValueTensorLiteralOp>()) {
-            auto val = cast<DenseElementsAttr>(valueTensorLiteralOp.getValue())
-                           .getSplatValue<bool>();
-            trainingMode = rewriter.create<Torch::ConstantBoolOp>(loc, val);
-          } else {
-            Value trainingModeScalar =
-                rewriter.create<Torch::AtenIntImplicitOp>(loc, operands[2]);
-            Value cstOne = rewriter.create<Torch::ConstantIntOp>(
-                loc, rewriter.getI64IntegerAttr(1));
-            trainingMode = rewriter.create<Torch::AtenEqIntOp>(
-                loc, trainingModeScalar, cstOne);
-          }
-        } else if (numOperands == 2) {
-          ratio = rewriter.create<Torch::AtenFloatImplicitOp>(loc, operands[1]);
-          trainingMode = rewriter.create<Torch::ConstantBoolOp>(loc, false);
-        } else {
-          ratio = rewriter.create<Torch::ConstantFloatOp>(
-              loc, rewriter.getF64FloatAttr(0.5));
-          trainingMode = rewriter.create<Torch::ConstantBoolOp>(loc, false);
-        }
+      if (auto valueTensorLiteralOp =
+              trainVal.getDefiningOp<Torch::ValueTensorLiteralOp>()) {
+        auto val = cast<DenseElementsAttr>(valueTensorLiteralOp.getValue())
+                       .getSplatValue<bool>();
+        trainingMode = rewriter.create<Torch::ConstantBoolOp>(loc, val);
+      } else {
+        Value trainingModeScalar =
+            rewriter.create<Torch::AtenIntImplicitOp>(loc, operands[2]);
+        Value cstOne = rewriter.create<Torch::ConstantIntOp>(
+            loc, rewriter.getI64IntegerAttr(1));
+        trainingMode = rewriter.create<Torch::AtenEqIntOp>(
+            loc, trainingModeScalar, cstOne);
+      }
+    } else if (numOperands == 2) {
+      ratio = rewriter.create<Torch::AtenFloatImplicitOp>(loc, operands[1]);
+      trainingMode = rewriter.create<Torch::ConstantBoolOp>(loc, false);
+    } else {
+      ratio = rewriter.create<Torch::ConstantFloatOp>(
+          loc, rewriter.getF64FloatAttr(0.5));
+      trainingMode = rewriter.create<Torch::ConstantBoolOp>(loc, false);
+    }
 
-        Value dropout = rewriter.create<Torch::AtenDropoutOp>(
-            loc, resultType, /*input=*/operands[0], ratio, trainingMode);
+    Value dropout = rewriter.create<Torch::AtenDropoutOp>(
+        loc, resultType, /*input=*/operands[0], ratio, trainingMode);
 
-        if (binder.op->getNumResults() == 1) {
-          rewriter.replaceOp(binder.op, dropout);
-          return success();
-        }
-        Torch::ValueTensorType maskType;
-        if (binder.tensorResultTypeAtIndex(maskType, 1))
-          return failure();
-        Value dtype = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(
-                     (int64_t)torch_upstream::ScalarType::Bool));
-        Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
-        Value mask = rewriter.create<Torch::AtenOnesLikeOp>(
-            loc, maskType, operands[0], dtype, /*layout=*/none,
-            /*device=*/none, /*pin_memory=*/none, /*memory_format=*/none);
-        rewriter.replaceOp(binder.op, {dropout, mask});
-        return success();
-      });
+    if (binder.op->getNumResults() == 1) {
+      rewriter.replaceOp(binder.op, dropout);
+      return success();
+    }
+    Torch::ValueTensorType maskType;
+    if (binder.tensorResultTypeAtIndex(maskType, 1))
+      return failure();
+    Value dtype = rewriter.create<Torch::ConstantIntOp>(
+        loc,
+        rewriter.getI64IntegerAttr((int64_t)torch_upstream::ScalarType::Bool));
+    Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
+    Value mask = rewriter.create<Torch::AtenOnesLikeOp>(
+        loc, maskType, operands[0], dtype, /*layout=*/none,
+        /*device=*/none, /*pin_memory=*/none, /*memory_format=*/none);
+    rewriter.replaceOp(binder.op, {dropout, mask});
+    return success();
+  });
   patterns.onOp(
       "DynamicQuantizeLinear", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      [](OpBinder binder, PatternRewriter &rewriter) {
         Location loc = binder.getLoc();
         Value input;
         Torch::ValueTensorType resultType, scaleType, zeroPointType;
@@ -2434,320 +2357,304 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         rewriter.replaceOp(binder.op, {output, scaleTensor, zeroPointTensor});
         return success();
       });
-  patterns.onOp("Equal", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value lhs, rhs;
-                  std::string direction;
-                  if (binder.tensorOperands(lhs, rhs) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenEqTensorOp>(
-                      binder.op, resultType, lhs, rhs);
-                  return success();
-                });
-  patterns.onOp("Elu", 6,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Location loc = binder.getLoc();
-                  Torch::ValueTensorType resultType;
-                  Value input;
-                  float alpha;
-                  if (binder.tensorOperand(input) ||
-                      binder.f32FloatAttr(alpha, "alpha", 1.0) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  Value cstAlpha = rewriter.create<Torch::ConstantFloatOp>(
-                      loc, rewriter.getF64FloatAttr(alpha));
-                  Value cstOne = rewriter.create<Torch::ConstantFloatOp>(
-                      loc, rewriter.getF64FloatAttr(1.0));
-                  rewriter.replaceOpWithNewOp<Torch::AtenEluOp>(
-                      binder.op, resultType, input, cstAlpha, /*scale=*/cstOne,
-                      /*input_scale=*/cstOne);
-                  return success();
-                });
-  patterns.onOp("Erf", 13,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  std::string direction;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenErfOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("Exp", 6,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenExpOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
+  patterns.onOp("Equal", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    std::string direction;
+    if (binder.tensorOperands(lhs, rhs) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenEqTensorOp>(binder.op, resultType,
+                                                       lhs, rhs);
+    return success();
+  });
+  patterns.onOp("Elu", 6, [](OpBinder binder, PatternRewriter &rewriter) {
+    Location loc = binder.getLoc();
+    Torch::ValueTensorType resultType;
+    Value input;
+    float alpha;
+    if (binder.tensorOperand(input) ||
+        binder.f32FloatAttr(alpha, "alpha", 1.0) ||
+        binder.tensorResultType(resultType))
+      return failure();
+    Value cstAlpha = rewriter.create<Torch::ConstantFloatOp>(
+        loc, rewriter.getF64FloatAttr(alpha));
+    Value cstOne = rewriter.create<Torch::ConstantFloatOp>(
+        loc, rewriter.getF64FloatAttr(1.0));
+    rewriter.replaceOpWithNewOp<Torch::AtenEluOp>(binder.op, resultType, input,
+                                                  cstAlpha, /*scale=*/cstOne,
+                                                  /*input_scale=*/cstOne);
+    return success();
+  });
+  patterns.onOp("Erf", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    std::string direction;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenErfOp>(binder.op, resultType,
+                                                  operand);
+    return success();
+  });
+  patterns.onOp("Exp", 6, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenExpOp>(binder.op, resultType,
+                                                  operand);
+    return success();
+  });
+  patterns.onOp("Expand", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    // uses ideas and code from onnx.Reshape
+    auto loc = binder.getLoc();
+    Torch::ValueTensorType resultType;
+    Value data, shape;
+    if (binder.tensorOperands(data, shape) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    auto dataType = cast<Torch::BaseTensorType>(data.getType());
+    auto shapeType = cast<Torch::BaseTensorType>(shape.getType());
+    if (!dataType.hasSizes() || !shapeType.hasSizes())
+      return failure();
+
+    auto shapeSizes = shapeType.getSizes();
+    int64_t dataRank = dataType.getSizes().size();
+    int64_t shapeRank = shapeSizes.size();
+    if (shapeRank != 1 || shapeSizes[0] == Torch::kUnknownSize)
+      return failure();
+
+    auto rankDifference = dataRank - shapeSizes[0];
+
+    SmallVector<int64_t> selectSizes;
+    Type selectResultType = shapeType.getWithSizesAndDtype(
+        llvm::ArrayRef(selectSizes), shapeType.getOptionalDtype());
+    // Variable to store 1-D onnx shape tensor, shapeSizes[0] has the
+    // dimension size
+    // A constant zero value
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(0));
+    // Variable to store pytorch int list of shape (dimension)
+    SmallVector<Value> dimList;
+
+    // Convert the shape tensor from vector of int64_t to torch int list as
+    // we are using torch implementation Torch::AtenBroadcastToOp which
+    // takes list of int
+    for (int i = 0; i < shapeSizes[0]; i++) {
+      Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
+      Value extract = rewriter.create<Torch::AtenSelectIntOp>(
+          loc, selectResultType, shape, zero, selectIndex);
+      Value dim = rewriter.create<Torch::AtenItemOp>(
+          loc, rewriter.getType<Torch::IntType>(), extract);
+
+      if (i + rankDifference >= 0) {
+        Value iv =
+            rewriter.create<Torch::ConstantIntOp>(loc, i + rankDifference);
+        auto sz = rewriter.create<Torch::AtenSizeIntOp>(
+            loc, rewriter.getType<Torch::IntType>(), data, iv);
+        dim = rewriter.create<Torch::PrimMaxIntOp>(loc, dim, sz);
+      }
+
+      dimList.push_back(dim);
+    }
+    Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+        dimList);
+    rewriter.replaceOpWithNewOp<Torch::AtenBroadcastToOp>(binder.op, resultType,
+                                                          data, dimValueList);
+    return success();
+  });
+  patterns.onOp("EyeLike", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    int64_t dtypeIntOnnx, diagonalIndex;
+    if (binder.tensorOperand(operand) ||
+        binder.s64IntegerAttr(dtypeIntOnnx, "dtype", 1) ||
+        binder.s64IntegerAttr(diagonalIndex, "k", 0) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    auto operandTy = cast<Torch::ValueTensorType>(operand.getType());
+    SmallVector<int64_t> shape(operandTy.getSizes());
+    for (unsigned i = 0; i < shape.size(); i++) {
+      if (shape[i] == ShapedType::kDynamic)
+        shape[i] = Torch::kUnknownSize;
+    }
+
+    Value cst0 = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(0));
+    Value cst1 = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(1));
+    Value nVal =
+        rewriter.create<Torch::AtenSizeIntOp>(binder.getLoc(), operand, cst0);
+    Value mVal =
+        rewriter.create<Torch::AtenSizeIntOp>(binder.getLoc(), operand, cst1);
+    Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    std::optional<int64_t> dtypeIntTorch =
+        onnxDtypeIntToTorchDtypeInt(dtypeIntOnnx);
+    if (!dtypeIntTorch.has_value()) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented support for the given dtype conversion");
+    }
+    Value dtypeVal = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(dtypeIntTorch.value()));
+
+    // diagonalIndex = 0 populates the main diagonal
+    // diagonalIndex > 0 populates an upper diagonal
+    // diagonalIndex < 0 populates a lower diagonal
+    if (diagonalIndex == 0) {
+      rewriter.replaceOpWithNewOp<Torch::AtenEyeMOp>(binder.op, resultType,
+                                                     nVal, mVal, dtypeVal,
+                                                     noneVal, noneVal, noneVal);
+      return success();
+    }
+
+    Value diagVal = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(std::abs(diagonalIndex)));
+    Value newN, newM, dimVal, startVal;
+    // get shapes of main diag eye op and zeros op
+    if (diagonalIndex > 0) {
+      newN = nVal;
+      newM =
+          rewriter.create<Torch::AtenSubIntOp>(binder.getLoc(), mVal, diagVal);
+      if (shape[1] != Torch::kUnknownSize) {
+        shape[1] -= diagonalIndex;
+      }
+      dimVal = cst1;
+      startVal = mVal;
+    } else {
+      newN =
+          rewriter.create<Torch::AtenSubIntOp>(binder.getLoc(), nVal, diagVal);
+      newM = mVal;
+      if (shape[0] != Torch::kUnknownSize) {
+        shape[0] += diagonalIndex;
+      }
+      dimVal = cst0;
+      startVal = nVal;
+    }
+
+    // create main diag eye op
+    auto eyeResultType = rewriter.getType<Torch::ValueTensorType>(
+        shape, resultType.getOptionalDtype());
+    Value eyeOp = rewriter.create<Torch::AtenEyeMOp>(
+        binder.getLoc(), eyeResultType, newN, newM, dtypeVal, noneVal, noneVal,
+        noneVal);
+    // create zeros op
+    SmallVector<Value> zerosShapeValues = {nVal, mVal};
+    Value zerosShapeList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        rewriter.getType<Torch::ListType>(rewriter.getType<Torch::IntType>()),
+        zerosShapeValues);
+    Value zerosOp = rewriter.create<Torch::AtenZerosOp>(
+        binder.getLoc(), resultType, zerosShapeList, dtypeVal, noneVal, noneVal,
+        noneVal);
+
+    // embeds the values of the eye matrix into zeros
+    rewriter.replaceOpWithNewOp<Torch::AtenSliceScatterOp>(
+        binder.op, resultType, zerosOp, eyeOp, dimVal,
+        /*start=*/diagVal, /*end=*/startVal, /*step=*/cst1);
+    return success();
+  });
+  patterns.onOp("Flatten", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    // Flatten means to partition the input tensor's dimensions
+    // into a "left range" spanning 0 to axis - 1 and a "right range"
+    // spanning axis to rank - 1.  Each range is then collapsed
+    // into a single dimension, resulting in a 2-D tensor.
+    // If either range is empty, it is replaced with a single
+    // dimension of size 1.
+    //
+    // For example, for a 4-D input tensor of shape (a, b, c, d)
+    // and axis==2, flatten produces a 2-D tensor of shape
+    // (a*b, c*d).
+    //
+    // If instead axis==0, the left range is empty, and the result
+    // is (1, a*b*c*d).
+
+    Torch::ValueTensorType resultType;
+    Value operand;
+    int64_t axis;
+    if (binder.tensorOperand(operand) ||
+        binder.s64IntegerAttr(axis, "axis", 1) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    auto operandTy = cast<Torch::ValueTensorType>(operand.getType());
+    llvm::SmallVector<int64_t> shape(operandTy.getSizes());
+    int64_t rank = shape.size();
+
+    // If axis is negative, count from the right instead of left
+    if (axis < 0)
+      axis = rank + axis;
+
+    // We collapse in the dimensions to the right of the axis.
+    for (int i = axis + 1; i < rank; ++i) {
+      bool dynamic =
+          shape[axis] == Torch::kUnknownSize || shape[i] == Torch::kUnknownSize;
+      if (dynamic) {
+        shape[axis] = Torch::kUnknownSize;
+      } else {
+        shape[axis] = shape[axis] * shape[i];
+      }
+    }
+
+    shape.resize(axis + 1, 1);
+
+    auto baseType =
+        rewriter.getType<Torch::ValueTensorType>(shape, operandTy.getDtype());
+    Value collapsedRight;
+    if (axis >= rank) {
+      // If the right range is empty, add a dim of size 1 to the
+      // right side of the shape:
+      // cr = torch.unsqueeze(x, x.ndim)
+      Value rankConst = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(rank));
+      collapsedRight = rewriter.create<Torch::AtenUnsqueezeOp>(
+          binder.getLoc(), baseType, operand, rankConst);
+    } else {
+      // Otherwise, collapse the right range into a single dimension:
+      // cr = torch._prims.collapse(x, axis, x.ndim - 1)
+      Value axisConst = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(axis));
+      Value rankLess1Const = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(rank - 1));
+      collapsedRight = rewriter.create<Torch::PrimsCollapseOp>(
+          binder.getLoc(), baseType, operand, axisConst, rankLess1Const);
+    }
+
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(0));
+
+    if (axis <= 0) {
+      // If the left range is empty, add a dim of size 1 to the
+      // left side of the shape:
+      // torch.unsqueeze(cr, 0)
+      rewriter.replaceOpWithNewOp<Torch::AtenUnsqueezeOp>(binder.op, resultType,
+                                                          collapsedRight, zero);
+      return success();
+    }
+
+    // Otherwise, collapse the left range into a single dimension:
+    // torch._prims.collapse(cr, 0, axis - 1)
+    Value axisLess1Const = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(axis - 1));
+    rewriter.replaceOpWithNewOp<Torch::PrimsCollapseOp>(
+        binder.op, resultType, collapsedRight, zero, axisLess1Const);
+    return success();
+  });
+  patterns.onOp("Floor", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenFloorOp>(binder.op, resultType,
+                                                    operand);
+    return success();
+  });
   patterns.onOp(
-      "Expand", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // uses ideas and code from onnx.Reshape
-        auto loc = binder.getLoc();
-        Torch::ValueTensorType resultType;
-        Value data, shape;
-        if (binder.tensorOperands(data, shape) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        auto dataType = cast<Torch::BaseTensorType>(data.getType());
-        auto shapeType = cast<Torch::BaseTensorType>(shape.getType());
-        if (!dataType.hasSizes() || !shapeType.hasSizes())
-          return failure();
-
-        auto shapeSizes = shapeType.getSizes();
-        int64_t dataRank = dataType.getSizes().size();
-        int64_t shapeRank = shapeSizes.size();
-        if (shapeRank != 1 || shapeSizes[0] == Torch::kUnknownSize)
-          return failure();
-
-        auto rankDifference = dataRank - shapeSizes[0];
-
-        SmallVector<int64_t> selectSizes;
-        Type selectResultType = shapeType.getWithSizesAndDtype(
-            llvm::ArrayRef(selectSizes), shapeType.getOptionalDtype());
-        // Variable to store 1-D onnx shape tensor, shapeSizes[0] has the
-        // dimension size
-        // A constant zero value
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(0));
-        // Variable to store pytorch int list of shape (dimension)
-        SmallVector<Value> dimList;
-
-        // Convert the shape tensor from vector of int64_t to torch int list as
-        // we are using torch implementation Torch::AtenBroadcastToOp which
-        // takes list of int
-        for (int i = 0; i < shapeSizes[0]; i++) {
-          Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
-              loc, rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
-          Value extract = rewriter.create<Torch::AtenSelectIntOp>(
-              loc, selectResultType, shape, zero, selectIndex);
-          Value dim = rewriter.create<Torch::AtenItemOp>(
-              loc, rewriter.getType<Torch::IntType>(), extract);
-
-          if (i + rankDifference >= 0) {
-            Value iv =
-                rewriter.create<Torch::ConstantIntOp>(loc, i + rankDifference);
-            auto sz = rewriter.create<Torch::AtenSizeIntOp>(
-                loc, rewriter.getType<Torch::IntType>(), data, iv);
-            dim = rewriter.create<Torch::PrimMaxIntOp>(loc, dim, sz);
-          }
-
-          dimList.push_back(dim);
-        }
-        Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
-            dimList);
-        rewriter.replaceOpWithNewOp<Torch::AtenBroadcastToOp>(
-            binder.op, resultType, data, dimValueList);
-        return success();
-      });
-  patterns.onOp(
-      "EyeLike", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        int64_t dtypeIntOnnx, diagonalIndex;
-        if (binder.tensorOperand(operand) ||
-            binder.s64IntegerAttr(dtypeIntOnnx, "dtype", 1) ||
-            binder.s64IntegerAttr(diagonalIndex, "k", 0) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        auto operandTy = cast<Torch::ValueTensorType>(operand.getType());
-        SmallVector<int64_t> shape(operandTy.getSizes());
-        for (unsigned i = 0; i < shape.size(); i++) {
-          if (shape[i] == ShapedType::kDynamic)
-            shape[i] = Torch::kUnknownSize;
-        }
-
-        Value cst0 = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(0));
-        Value cst1 = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(1));
-        Value nVal = rewriter.create<Torch::AtenSizeIntOp>(binder.getLoc(),
-                                                           operand, cst0);
-        Value mVal = rewriter.create<Torch::AtenSizeIntOp>(binder.getLoc(),
-                                                           operand, cst1);
-        Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        std::optional<int64_t> dtypeIntTorch =
-            onnxDtypeIntToTorchDtypeInt(dtypeIntOnnx);
-        if (!dtypeIntTorch.has_value()) {
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "unimplemented support for the given dtype conversion");
-        }
-        Value dtypeVal = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(dtypeIntTorch.value()));
-
-        // diagonalIndex = 0 populates the main diagonal
-        // diagonalIndex > 0 populates an upper diagonal
-        // diagonalIndex < 0 populates a lower diagonal
-        if (diagonalIndex == 0) {
-          rewriter.replaceOpWithNewOp<Torch::AtenEyeMOp>(
-              binder.op, resultType, nVal, mVal, dtypeVal, noneVal, noneVal,
-              noneVal);
-          return success();
-        }
-
-        Value diagVal = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(),
-            rewriter.getI64IntegerAttr(std::abs(diagonalIndex)));
-        Value newN, newM, dimVal, startVal;
-        // get shapes of main diag eye op and zeros op
-        if (diagonalIndex > 0) {
-          newN = nVal;
-          newM = rewriter.create<Torch::AtenSubIntOp>(binder.getLoc(), mVal,
-                                                      diagVal);
-          if (shape[1] != Torch::kUnknownSize) {
-            shape[1] -= diagonalIndex;
-          }
-          dimVal = cst1;
-          startVal = mVal;
-        } else {
-          newN = rewriter.create<Torch::AtenSubIntOp>(binder.getLoc(), nVal,
-                                                      diagVal);
-          newM = mVal;
-          if (shape[0] != Torch::kUnknownSize) {
-            shape[0] += diagonalIndex;
-          }
-          dimVal = cst0;
-          startVal = nVal;
-        }
-
-        // create main diag eye op
-        auto eyeResultType = rewriter.getType<Torch::ValueTensorType>(
-            shape, resultType.getOptionalDtype());
-        Value eyeOp = rewriter.create<Torch::AtenEyeMOp>(
-            binder.getLoc(), eyeResultType, newN, newM, dtypeVal, noneVal,
-            noneVal, noneVal);
-        // create zeros op
-        SmallVector<Value> zerosShapeValues = {nVal, mVal};
-        Value zerosShapeList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            rewriter.getType<Torch::ListType>(
-                rewriter.getType<Torch::IntType>()),
-            zerosShapeValues);
-        Value zerosOp = rewriter.create<Torch::AtenZerosOp>(
-            binder.getLoc(), resultType, zerosShapeList, dtypeVal, noneVal,
-            noneVal, noneVal);
-
-        // embeds the values of the eye matrix into zeros
-        rewriter.replaceOpWithNewOp<Torch::AtenSliceScatterOp>(
-            binder.op, resultType, zerosOp, eyeOp, dimVal,
-            /*start=*/diagVal, /*end=*/startVal, /*step=*/cst1);
-        return success();
-      });
-  patterns.onOp(
-      "Flatten", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // Flatten means to partition the input tensor's dimensions
-        // into a "left range" spanning 0 to axis - 1 and a "right range"
-        // spanning axis to rank - 1.  Each range is then collapsed
-        // into a single dimension, resulting in a 2-D tensor.
-        // If either range is empty, it is replaced with a single
-        // dimension of size 1.
-        //
-        // For example, for a 4-D input tensor of shape (a, b, c, d)
-        // and axis==2, flatten produces a 2-D tensor of shape
-        // (a*b, c*d).
-        //
-        // If instead axis==0, the left range is empty, and the result
-        // is (1, a*b*c*d).
-
-        Torch::ValueTensorType resultType;
-        Value operand;
-        int64_t axis;
-        if (binder.tensorOperand(operand) ||
-            binder.s64IntegerAttr(axis, "axis", 1) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        auto operandTy = cast<Torch::ValueTensorType>(operand.getType());
-        llvm::SmallVector<int64_t> shape(operandTy.getSizes());
-        int64_t rank = shape.size();
-
-        // If axis is negative, count from the right instead of left
-        if (axis < 0)
-          axis = rank + axis;
-
-        // We collapse in the dimensions to the right of the axis.
-        for (int i = axis + 1; i < rank; ++i) {
-          bool dynamic = shape[axis] == Torch::kUnknownSize ||
-                         shape[i] == Torch::kUnknownSize;
-          if (dynamic) {
-            shape[axis] = Torch::kUnknownSize;
-          } else {
-            shape[axis] = shape[axis] * shape[i];
-          }
-        }
-
-        shape.resize(axis + 1, 1);
-
-        auto baseType = rewriter.getType<Torch::ValueTensorType>(
-            shape, operandTy.getDtype());
-        Value collapsedRight;
-        if (axis >= rank) {
-          // If the right range is empty, add a dim of size 1 to the
-          // right side of the shape:
-          // cr = torch.unsqueeze(x, x.ndim)
-          Value rankConst = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(rank));
-          collapsedRight = rewriter.create<Torch::AtenUnsqueezeOp>(
-              binder.getLoc(), baseType, operand, rankConst);
-        } else {
-          // Otherwise, collapse the right range into a single dimension:
-          // cr = torch._prims.collapse(x, axis, x.ndim - 1)
-          Value axisConst = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(axis));
-          Value rankLess1Const = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(rank - 1));
-          collapsedRight = rewriter.create<Torch::PrimsCollapseOp>(
-              binder.getLoc(), baseType, operand, axisConst, rankLess1Const);
-        }
-
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(0));
-
-        if (axis <= 0) {
-          // If the left range is empty, add a dim of size 1 to the
-          // left side of the shape:
-          // torch.unsqueeze(cr, 0)
-          rewriter.replaceOpWithNewOp<Torch::AtenUnsqueezeOp>(
-              binder.op, resultType, collapsedRight, zero);
-          return success();
-        }
-
-        // Otherwise, collapse the left range into a single dimension:
-        // torch._prims.collapse(cr, 0, axis - 1)
-        Value axisLess1Const = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(axis - 1));
-        rewriter.replaceOpWithNewOp<Torch::PrimsCollapseOp>(
-            binder.op, resultType, collapsedRight, zero, axisLess1Const);
-        return success();
-      });
-  patterns.onOp("Floor", 13,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenFloorOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp(
-      "ConstantOfShape", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ConstantOfShape", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value shape;
         if (binder.tensorOperand(shape) || binder.tensorResultType(resultType))
@@ -2849,33 +2756,31 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
             /*layout=*/noneVal, /*device=*/noneVal, /*pin_memory=*/noneVal);
         return success();
       });
+  patterns.onOp("Einsum", 12, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    SmallVector<Value> tensors;
+    std::string equation;
+    if (binder.tensorOperands(tensors, binder.op->getNumOperands()) ||
+        binder.customOpNameStringAttr(equation, "equation") ||
+        binder.tensorResultType(resultType))
+      return failure();
+    Type listElemType =
+        cast<Torch::BaseTensorType>(tensors[0].getType())
+            .getWithSizesAndDtype(/*optionalSizes=*/std::nullopt,
+                                  /*optionalDtype=*/nullptr);
+    Type listType = Torch::ListType::get(listElemType);
+    Value tensorList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.op->getLoc(), listType, tensors);
+    Value cstEquation = rewriter.create<Torch::ConstantStrOp>(
+        binder.getLoc(), rewriter.getType<Torch::StringType>(),
+        rewriter.getStringAttr(equation));
+    Value cstNone = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    rewriter.replaceOpWithNewOp<Torch::AtenEinsumOp>(
+        binder.op, resultType, cstEquation, tensorList, /*path=*/cstNone);
+    return success();
+  });
   patterns.onOp(
-      "Einsum", 12, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        SmallVector<Value> tensors;
-        std::string equation;
-        if (binder.tensorOperands(tensors, binder.op->getNumOperands()) ||
-            binder.customOpNameStringAttr(equation, "equation") ||
-            binder.tensorResultType(resultType))
-          return failure();
-        Type listElemType =
-            cast<Torch::BaseTensorType>(tensors[0].getType())
-                .getWithSizesAndDtype(/*optionalSizes=*/std::nullopt,
-                                      /*optionalDtype=*/nullptr);
-        Type listType = Torch::ListType::get(listElemType);
-        Value tensorList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.op->getLoc(), listType, tensors);
-        Value cstEquation = rewriter.create<Torch::ConstantStrOp>(
-            binder.getLoc(), rewriter.getType<Torch::StringType>(),
-            rewriter.getStringAttr(equation));
-        Value cstNone = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        rewriter.replaceOpWithNewOp<Torch::AtenEinsumOp>(
-            binder.op, resultType, cstEquation, tensorList, /*path=*/cstNone);
-        return success();
-      });
-  patterns.onOp(
-      "BlackmanWindow", 17,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "BlackmanWindow", 17, [](OpBinder binder, PatternRewriter &rewriter) {
         Value size;
         Torch::ValueTensorType resultType;
         int64_t periodic, output_datatype;
@@ -2905,8 +2810,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
       });
 
   patterns.onOp(
-      "HannWindow", 17,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "HannWindow", 17, [](OpBinder binder, PatternRewriter &rewriter) {
         Value size;
         Torch::ValueTensorType resultType;
         int64_t periodic, output_datatype;
@@ -2936,8 +2840,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
       });
 
   patterns.onOp(
-      "HammingWindow", 17,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "HammingWindow", 17, [](OpBinder binder, PatternRewriter &rewriter) {
         Value size;
         Torch::ValueTensorType resultType;
         int64_t periodic, output_datatype;
@@ -2966,94 +2869,92 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         return success();
       });
 
-  patterns.onOp(
-      "DFT", 20, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Value inTensor, dftLength, axis;
-        Torch::ValueTensorType resultType;
-        int64_t inverse, onesided;
-        if (binder.tensorOperandAtIndex(inTensor, 0) ||
-            binder.s64IntegerAttr(inverse, "inverse", 0) ||
-            binder.s64IntegerAttr(onesided, "onesided", 0) ||
-            binder.tensorResultType(resultType))
-          return rewriter.notifyMatchFailure(
-              binder.op, "Input Tensor / attrs / resultType bind failed");
-        if (!binder.tensorOperandAtIndex(dftLength, 1)) {
-          // Convert to int and pass as n
-          dftLength = rewriter.create<Torch::AtenItemOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(), dftLength);
-        } else {
-          // Default for torch is None
-          dftLength = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        }
-        // Default is same for onnx and torch
-        if (!binder.tensorOperandAtIndex(axis, 2)) {
-          // convert to int and pass to dims
-          axis = rewriter.create<Torch::AtenItemOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(), axis);
-        } else {
-          // Default in torch is -1 and onnx is -2 (since -1 is for real / img)
-          axis = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(-2));
-        }
+  patterns.onOp("DFT", 20, [](OpBinder binder, PatternRewriter &rewriter) {
+    Value inTensor, dftLength, axis;
+    Torch::ValueTensorType resultType;
+    int64_t inverse, onesided;
+    if (binder.tensorOperandAtIndex(inTensor, 0) ||
+        binder.s64IntegerAttr(inverse, "inverse", 0) ||
+        binder.s64IntegerAttr(onesided, "onesided", 0) ||
+        binder.tensorResultType(resultType))
+      return rewriter.notifyMatchFailure(
+          binder.op, "Input Tensor / attrs / resultType bind failed");
+    if (!binder.tensorOperandAtIndex(dftLength, 1)) {
+      // Convert to int and pass as n
+      dftLength = rewriter.create<Torch::AtenItemOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(), dftLength);
+    } else {
+      // Default for torch is None
+      dftLength = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    }
+    // Default is same for onnx and torch
+    if (!binder.tensorOperandAtIndex(axis, 2)) {
+      // convert to int and pass to dims
+      axis = rewriter.create<Torch::AtenItemOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(), axis);
+    } else {
+      // Default in torch is -1 and onnx is -2 (since -1 is for real / img)
+      axis = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(-2));
+    }
 
-        if (onesided == 1)
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Unsupported option : onesided");
-        // norm default string attr
-        Value norm = rewriter.create<Torch::ConstantStrOp>(
-            binder.getLoc(), rewriter.getStringAttr(Twine("backward")));
-        // Convert from [....., 2] complex number repr for fft consumption.
-        Torch::ValueTensorType inType =
-            binder.toValidTensorType(inTensor.getType());
-        int64_t lastIndex = inType.getSizes().back();
-        if (lastIndex != 1 && lastIndex != 2)
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "Expected input tensor to have dims [..., 1] or [..., 2]");
+    if (onesided == 1)
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Unsupported option : onesided");
+    // norm default string attr
+    Value norm = rewriter.create<Torch::ConstantStrOp>(
+        binder.getLoc(), rewriter.getStringAttr(Twine("backward")));
+    // Convert from [....., 2] complex number repr for fft consumption.
+    Torch::ValueTensorType inType =
+        binder.toValidTensorType(inTensor.getType());
+    int64_t lastIndex = inType.getSizes().back();
+    if (lastIndex != 1 && lastIndex != 2)
+      return rewriter.notifyMatchFailure(
+          binder.op, "Expected input tensor to have dims [..., 1] or [..., 2]");
 
-        // concat with zeros to make it [..., 2]
-        Value inForComplexVal = inTensor;
-        ArrayRef<int64_t> inForComplexSizes = inType.getSizes().drop_back();
-        if (lastIndex == 1) {
-          Value constZeroVal = rewriter.create<Torch::ConstantFloatOp>(
-              binder.getLoc(), rewriter.getF64FloatAttr(0));
-          Value constOne = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(1));
-          Value constZero = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(0));
-          Value padSizeList =
-              rewriter
-                  .create<Torch::PrimListConstructOp>(
-                      binder.getLoc(),
-                      Torch::ListType::get(rewriter.getType<Torch::IntType>()),
-                      SmallVector<Value>({constZero, constOne}))
-                  .getResult();
-          Value modeVal = rewriter.create<Torch::ConstantStrOp>(
-              binder.getLoc(), rewriter.getStringAttr("constant"));
-          SmallVector<int64_t> resSize(inForComplexSizes);
-          resSize.push_back(2);
-          inForComplexVal = rewriter.create<Torch::AtenPadOp>(
-              binder.getLoc(),
-              inType.getWithSizesAndDtype(resSize, inType.getOptionalDtype()),
-              inTensor, padSizeList, modeVal, constZeroVal);
-        }
-        Type inComplexTensorType = Torch::ValueTensorType::get(
-            binder.op->getContext(), inForComplexSizes,
-            mlir::ComplexType::get(inType.getDtype()));
-        Value inComplexTensor = rewriter.create<Torch::AtenViewAsComplexOp>(
-            binder.getLoc(), inComplexTensorType, inForComplexVal);
-        Value ftOp;
-        if (inverse == 0) {
-          ftOp = rewriter.create<Torch::AtenFftFftOp>(
-              binder.getLoc(), inComplexTensorType, inComplexTensor,
-              /*n = */ dftLength, /*dim = */ axis, /*norm = */ norm);
-        } else {
-          ftOp = rewriter.create<Torch::AtenFftIfftOp>(
-              binder.getLoc(), inComplexTensorType, inComplexTensor,
-              /*n = */ dftLength, /*dim = */ axis, /*norm = */ norm);
-        }
-        rewriter.replaceOpWithNewOp<Torch::AtenViewAsRealOp>(binder.op,
-                                                             resultType, ftOp);
-        return success();
-      });
+    // concat with zeros to make it [..., 2]
+    Value inForComplexVal = inTensor;
+    ArrayRef<int64_t> inForComplexSizes = inType.getSizes().drop_back();
+    if (lastIndex == 1) {
+      Value constZeroVal = rewriter.create<Torch::ConstantFloatOp>(
+          binder.getLoc(), rewriter.getF64FloatAttr(0));
+      Value constOne = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(1));
+      Value constZero = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(0));
+      Value padSizeList =
+          rewriter
+              .create<Torch::PrimListConstructOp>(
+                  binder.getLoc(),
+                  Torch::ListType::get(rewriter.getType<Torch::IntType>()),
+                  SmallVector<Value>({constZero, constOne}))
+              .getResult();
+      Value modeVal = rewriter.create<Torch::ConstantStrOp>(
+          binder.getLoc(), rewriter.getStringAttr("constant"));
+      SmallVector<int64_t> resSize(inForComplexSizes);
+      resSize.push_back(2);
+      inForComplexVal = rewriter.create<Torch::AtenPadOp>(
+          binder.getLoc(),
+          inType.getWithSizesAndDtype(resSize, inType.getOptionalDtype()),
+          inTensor, padSizeList, modeVal, constZeroVal);
+    }
+    Type inComplexTensorType =
+        Torch::ValueTensorType::get(binder.op->getContext(), inForComplexSizes,
+                                    mlir::ComplexType::get(inType.getDtype()));
+    Value inComplexTensor = rewriter.create<Torch::AtenViewAsComplexOp>(
+        binder.getLoc(), inComplexTensorType, inForComplexVal);
+    Value ftOp;
+    if (inverse == 0) {
+      ftOp = rewriter.create<Torch::AtenFftFftOp>(
+          binder.getLoc(), inComplexTensorType, inComplexTensor,
+          /*n = */ dftLength, /*dim = */ axis, /*norm = */ norm);
+    } else {
+      ftOp = rewriter.create<Torch::AtenFftIfftOp>(
+          binder.getLoc(), inComplexTensorType, inComplexTensor,
+          /*n = */ dftLength, /*dim = */ axis, /*norm = */ norm);
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenViewAsRealOp>(binder.op, resultType,
+                                                         ftOp);
+    return success();
+  });
 }

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -30,8 +30,7 @@ using namespace mlir::torch::onnx_c;
 void mlir::torch::onnx_c::populateDefaultDomainGtoP(
     OnnxCustomOpConversionPattern &patterns) {
   patterns.onOp(
-      "HardSigmoid", 6,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "HardSigmoid", 6, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value tensorOperand;
         float alpha, beta;
@@ -75,28 +74,25 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             binder.op, resultType, zeroTensor, minExpression);
         return success();
       });
+  patterns.onOp("Gelu", 20, [](OpBinder binder, PatternRewriter &rewriter) {
+    Value operand;
+    Torch::ValueTensorType resultType;
+    std::string approximate;
+
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType) ||
+        binder.customOpNameStringAttr(approximate, "approximate", "none"))
+      return failure();
+
+    Value vApproximate = rewriter.create<Torch::ConstantStrOp>(
+        binder.getLoc(), rewriter.getType<Torch::StringType>(),
+        rewriter.getStringAttr(approximate));
+
+    rewriter.replaceOpWithNewOp<Torch::AtenGeluOp>(binder.op, resultType,
+                                                   operand, vApproximate);
+    return success();
+  });
   patterns.onOp(
-      "Gelu", 20, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Value operand;
-        Torch::ValueTensorType resultType;
-        std::string approximate;
-
-        if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType) ||
-            binder.customOpNameStringAttr(approximate, "approximate", "none"))
-          return failure();
-
-        Value vApproximate = rewriter.create<Torch::ConstantStrOp>(
-            binder.getLoc(), rewriter.getType<Torch::StringType>(),
-            rewriter.getStringAttr(approximate));
-
-        rewriter.replaceOpWithNewOp<Torch::AtenGeluOp>(binder.op, resultType,
-                                                       operand, vApproximate);
-        return success();
-      });
-  patterns.onOp(
-      "GridSample", 17,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "GridSample", 17, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value input;
         Value grid;
@@ -170,74 +166,69 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         return success();
       });
   patterns.onOp("GRU", 1, onnx_c::OnnxGruExpander);
-  patterns.onOp(
-      "If", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Value conditionTensor;
-        if (binder.tensorOperand(conditionTensor)) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "condition bind failure");
-        }
+  patterns.onOp("If", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Value conditionTensor;
+    if (binder.tensorOperand(conditionTensor)) {
+      return rewriter.notifyMatchFailure(binder.op, "condition bind failure");
+    }
 
-        auto conditionType =
-            cast<Torch::ValueTensorType>(conditionTensor.getType());
-        if (!conditionType || conditionType.getSizes().size() != 1)
-          return rewriter.notifyMatchFailure(
-              binder.op, "condition must have one single element per "
-                         "https://onnx.ai/onnx/operators/onnx__If.html");
-        auto conditionInt = rewriter.create<Torch::AtenItemOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            conditionTensor);
-        auto conditionBool = rewriter.create<Torch::AtenBoolIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::BoolType>(), conditionInt);
+    auto conditionType =
+        cast<Torch::ValueTensorType>(conditionTensor.getType());
+    if (!conditionType || conditionType.getSizes().size() != 1)
+      return rewriter.notifyMatchFailure(
+          binder.op, "condition must have one single element per "
+                     "https://onnx.ai/onnx/operators/onnx__If.html");
+    auto conditionInt = rewriter.create<Torch::AtenItemOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(), conditionTensor);
+    auto conditionBool = rewriter.create<Torch::AtenBoolIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::BoolType>(), conditionInt);
 
-        llvm::SmallVector<mlir::Type> resultTypes;
-        if (binder.tensorResultTypes(resultTypes)) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "result type bind failure");
-        }
+    llvm::SmallVector<mlir::Type> resultTypes;
+    if (binder.tensorResultTypes(resultTypes)) {
+      return rewriter.notifyMatchFailure(binder.op, "result type bind failure");
+    }
 
-        Region *thenRegion, *elseRegion;
-        if (binder.getRegionAtIndex(elseRegion, 0) ||
-            binder.getRegionAtIndex(thenRegion, 1)) {
-          return rewriter.notifyMatchFailure(binder.op, "region bind failure");
-        }
+    Region *thenRegion, *elseRegion;
+    if (binder.getRegionAtIndex(elseRegion, 0) ||
+        binder.getRegionAtIndex(thenRegion, 1)) {
+      return rewriter.notifyMatchFailure(binder.op, "region bind failure");
+    }
 
-        auto primIfOp = rewriter.create<Torch::PrimIfOp>(
-            binder.getLoc(), TypeRange(resultTypes), conditionBool);
+    auto primIfOp = rewriter.create<Torch::PrimIfOp>(
+        binder.getLoc(), TypeRange(resultTypes), conditionBool);
 
-        auto inlineIfCase = [&](Region &srcRegion, Region &dstRegion) {
-          rewriter.inlineRegionBefore(srcRegion, dstRegion, dstRegion.begin());
-        };
-        inlineIfCase(*thenRegion, primIfOp.getThenRegion());
-        inlineIfCase(*elseRegion, primIfOp.getElseRegion());
+    auto inlineIfCase = [&](Region &srcRegion, Region &dstRegion) {
+      rewriter.inlineRegionBefore(srcRegion, dstRegion, dstRegion.begin());
+    };
+    inlineIfCase(*thenRegion, primIfOp.getThenRegion());
+    inlineIfCase(*elseRegion, primIfOp.getElseRegion());
 
-        auto replaceTerminator = [&](Region &region) {
-          PatternRewriter::InsertionGuard guard(rewriter);
-          Operation *terminator = region.front().getTerminator();
-          rewriter.setInsertionPoint(terminator);
-          rewriter.replaceOpWithNewOp<Torch::PrimIfYieldOp>(
-              terminator, terminator->getOperands());
-        };
-        replaceTerminator(primIfOp.getThenRegion());
-        replaceTerminator(primIfOp.getElseRegion());
+    auto replaceTerminator = [&](Region &region) {
+      PatternRewriter::InsertionGuard guard(rewriter);
+      Operation *terminator = region.front().getTerminator();
+      rewriter.setInsertionPoint(terminator);
+      rewriter.replaceOpWithNewOp<Torch::PrimIfYieldOp>(
+          terminator, terminator->getOperands());
+    };
+    replaceTerminator(primIfOp.getThenRegion());
+    replaceTerminator(primIfOp.getElseRegion());
 
-        rewriter.replaceOp(binder.op, primIfOp.getResults());
-        return success();
-      });
-  patterns.onOp("Less", 13,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value lhs, rhs;
-                  if (binder.tensorOperands(lhs, rhs) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
-                  rewriter.replaceOpWithNewOp<Torch::AtenLtTensorOp>(
-                      binder.op, resultType, lhs, rhs);
-                  return success();
-                });
+    rewriter.replaceOp(binder.op, primIfOp.getResults());
+    return success();
+  });
+  patterns.onOp("Less", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    if (binder.tensorOperands(lhs, rhs) ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenLtTensorOp>(binder.op, resultType,
+                                                       lhs, rhs);
+    return success();
+  });
   patterns.onOp("LessOrEqual", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;
                   Value lhs, rhs;
                   if (binder.tensorOperands(lhs, rhs) ||
@@ -248,175 +239,167 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
                       binder.op, resultType, lhs, rhs);
                   return success();
                 });
-  patterns.onOp("Log", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
-                  rewriter.replaceOpWithNewOp<Torch::AtenLogOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp(
-      "Loop", 13, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // Get all operands (maxTripCount, cond, ....inits....)
-        llvm::SmallVector<Value> operands;
-        if (binder.tensorOperandsList(operands) || operands.size() == 0 ||
-            binder.getNumOperands() < 2) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Failed to get required operands");
-        }
+  patterns.onOp("Log", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenLogOp>(binder.op, resultType,
+                                                  operand);
+    return success();
+  });
+  patterns.onOp("Loop", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    // Get all operands (maxTripCount, cond, ....inits....)
+    llvm::SmallVector<Value> operands;
+    if (binder.tensorOperandsList(operands) || operands.size() == 0 ||
+        binder.getNumOperands() < 2) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed to get required operands");
+    }
 
-        llvm::SmallVector<mlir::Type> operandTypeVec;
-        if (binder.tensorOperandTypes(operandTypeVec) ||
-            operandTypeVec.size() == 0) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Failed to get operandTypes");
-        }
+    llvm::SmallVector<mlir::Type> operandTypeVec;
+    if (binder.tensorOperandTypes(operandTypeVec) ||
+        operandTypeVec.size() == 0) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed to get operandTypes");
+    }
 
-        Region *loopBodyIn;
-        if (binder.getRegionAtIndex(loopBodyIn, 0)) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Failed getting LoopBody Region");
-        }
+    Region *loopBodyIn;
+    if (binder.getRegionAtIndex(loopBodyIn, 0)) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed getting LoopBody Region");
+    }
 
-        // MaxTripCount - tensor int64 scalar (or empty)
-        Value maxTripCountTensor = operands[0];
-        auto maxTripCountInt = rewriter.create<Torch::AtenItemOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            maxTripCountTensor);
+    // MaxTripCount - tensor int64 scalar (or empty)
+    Value maxTripCountTensor = operands[0];
+    auto maxTripCountInt = rewriter.create<Torch::AtenItemOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        maxTripCountTensor);
 
-        // Condition - tensor bool scalar (or empty)
-        Value conditionTensor = operands[1];
-        auto conditionInt = rewriter.create<Torch::AtenItemOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            conditionTensor);
-        auto conditionBool = rewriter.create<Torch::AtenBoolIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::BoolType>(), conditionInt);
-        // To be used for "for like" loop case
-        auto constBoolTrue = rewriter.create<Torch::ConstantBoolOp>(
-            binder.getLoc(), rewriter.getBoolAttr(true));
+    // Condition - tensor bool scalar (or empty)
+    Value conditionTensor = operands[1];
+    auto conditionInt = rewriter.create<Torch::AtenItemOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(), conditionTensor);
+    auto conditionBool = rewriter.create<Torch::AtenBoolIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::BoolType>(), conditionInt);
+    // To be used for "for like" loop case
+    auto constBoolTrue = rewriter.create<Torch::ConstantBoolOp>(
+        binder.getLoc(), rewriter.getBoolAttr(true));
 
-        // Others (if present) - variadic (can be tensors and scalar values)
-        if (binder.getNumOperands() > 2) {
-          operandTypeVec.erase(operandTypeVec.begin(),
-                               operandTypeVec.begin() + 2);
-          operands.erase(operands.begin(), operands.begin() + 2);
-        }
+    // Others (if present) - variadic (can be tensors and scalar values)
+    if (binder.getNumOperands() > 2) {
+      operandTypeVec.erase(operandTypeVec.begin(), operandTypeVec.begin() + 2);
+      operands.erase(operands.begin(), operands.begin() + 2);
+    }
 
-        auto getOpName = [](Operation *op) -> std::string {
-          std::string name = op->getName().getStringRef().str();
-          if (name != "torch.operator")
-            return name;
-          // for unconverted onnx ops
-          return mlir::dyn_cast<StringAttr>(op->getAttr("name"))
-              .getValue()
-              .str();
-        };
+    auto getOpName = [](Operation *op) -> std::string {
+      std::string name = op->getName().getStringRef().str();
+      if (name != "torch.operator")
+        return name;
+      // for unconverted onnx ops
+      return mlir::dyn_cast<StringAttr>(op->getAttr("name")).getValue().str();
+    };
 
-        // PrimLoop Op expectes inputCondition to be boolConstantTrue
-        // to decide if the loopOp is `forlike`. Use loopIsForLike to
-        // ensure appropriate inputCondition is set
-        // Case 1 : loopCondInp -> identity -> terminator(loopCondOut)
-        bool loopIsForLike = false;
-        auto case1ForLike = [&getOpName](Region *loopBody) -> bool {
-          Value onnxLoopBodyCondIn = loopBody->front().getArgument(1);
-          if (!onnxLoopBodyCondIn.hasOneUse())
-            return false;
-          Operation *inpCondUser = *onnxLoopBodyCondIn.getUsers().begin();
-          if (getOpName(inpCondUser) != "onnx.Identity") {
-            return false;
-          }
-          if (!inpCondUser->hasOneUse() ||
-              getOpName(*(inpCondUser->getUsers().begin())) !=
-                  "torch.operator_terminator")
-            return false;
-          return true;
-        };
-        loopIsForLike = case1ForLike(loopBodyIn);
+    // PrimLoop Op expectes inputCondition to be boolConstantTrue
+    // to decide if the loopOp is `forlike`. Use loopIsForLike to
+    // ensure appropriate inputCondition is set
+    // Case 1 : loopCondInp -> identity -> terminator(loopCondOut)
+    bool loopIsForLike = false;
+    auto case1ForLike = [&getOpName](Region *loopBody) -> bool {
+      Value onnxLoopBodyCondIn = loopBody->front().getArgument(1);
+      if (!onnxLoopBodyCondIn.hasOneUse())
+        return false;
+      Operation *inpCondUser = *onnxLoopBodyCondIn.getUsers().begin();
+      if (getOpName(inpCondUser) != "onnx.Identity") {
+        return false;
+      }
+      if (!inpCondUser->hasOneUse() ||
+          getOpName(*(inpCondUser->getUsers().begin())) !=
+              "torch.operator_terminator")
+        return false;
+      return true;
+    };
+    loopIsForLike = case1ForLike(loopBodyIn);
 
-        Value loopInitCondition =
-            loopIsForLike ? constBoolTrue : conditionBool.getResult();
-        auto loc = binder.getLoc();
-        mlir::ImplicitLocOpBuilder b(loc, rewriter);
-        auto loop = b.create<Torch::PrimLoopOp>(
-            TypeRange(operandTypeVec), maxTripCountInt, loopInitCondition,
-            ValueRange(operands));
+    Value loopInitCondition =
+        loopIsForLike ? constBoolTrue : conditionBool.getResult();
+    auto loc = binder.getLoc();
+    mlir::ImplicitLocOpBuilder b(loc, rewriter);
+    auto loop =
+        b.create<Torch::PrimLoopOp>(TypeRange(operandTypeVec), maxTripCountInt,
+                                    loopInitCondition, ValueRange(operands));
 
-        rewriter.cloneRegionBefore(*loopBodyIn, loop.getRegion(),
-                                   loop.getRegion().begin());
+    rewriter.cloneRegionBefore(*loopBodyIn, loop.getRegion(),
+                               loop.getRegion().begin());
 
-        // primLoopOp loopBody expects torch.int as first arg
-        // insert torch.int arg in loop body, convert to tensor,
-        // replace all uses of old arg, delete old arg.
-        auto loopVarArg = loop.getRegion().front().getArgument(0);
-        // insert new Arg
-        loop.getRegion().front().insertArgument(
-            0U, rewriter.getType<Torch::IntType>(), binder.getLoc());
-        auto newLoopVarArg = loop.getRegion().front().getArgument(0);
+    // primLoopOp loopBody expects torch.int as first arg
+    // insert torch.int arg in loop body, convert to tensor,
+    // replace all uses of old arg, delete old arg.
+    auto loopVarArg = loop.getRegion().front().getArgument(0);
+    // insert new Arg
+    loop.getRegion().front().insertArgument(
+        0U, rewriter.getType<Torch::IntType>(), binder.getLoc());
+    auto newLoopVarArg = loop.getRegion().front().getArgument(0);
 
-        // convert int arg to tensor of original Type
-        rewriter.setInsertionPointToStart(&loop.getRegion().front());
-        Value loopVarVal = BlockArgument::Value(loopVarArg);
-        auto newTensor = rewriter.create<Torch::PrimNumToTensorScalarOp>(
-            loop.getRegion().op_begin()->getLoc(), loopVarVal.getType(),
-            newLoopVarArg);
+    // convert int arg to tensor of original Type
+    rewriter.setInsertionPointToStart(&loop.getRegion().front());
+    Value loopVarVal = BlockArgument::Value(loopVarArg);
+    auto newTensor = rewriter.create<Torch::PrimNumToTensorScalarOp>(
+        loop.getRegion().op_begin()->getLoc(), loopVarVal.getType(),
+        newLoopVarArg);
 
-        loopVarArg.replaceAllUsesWith(newTensor);
-        loop.getRegion().eraseArgument(1);
+    loopVarArg.replaceAllUsesWith(newTensor);
+    loop.getRegion().eraseArgument(1);
 
-        // primLoopOp loopBody has no condition arg
-        auto condArg = loop.getRegion().front().getArgument(1);
-        if (!condArg.use_empty())
-          condArg.replaceAllUsesWith(conditionTensor);
+    // primLoopOp loopBody has no condition arg
+    auto condArg = loop.getRegion().front().getArgument(1);
+    if (!condArg.use_empty())
+      condArg.replaceAllUsesWith(conditionTensor);
 
-        // replace terminator
-        PatternRewriter::InsertionGuard guard(rewriter);
-        Operation *terminator = loop.getRegion().front().getTerminator();
-        rewriter.setInsertionPoint(terminator);
+    // replace terminator
+    PatternRewriter::InsertionGuard guard(rewriter);
+    Operation *terminator = loop.getRegion().front().getTerminator();
+    rewriter.setInsertionPoint(terminator);
 
-        // results - n loop carried dependencies and k scan outputs
-        // Fail when there are scanOutputs in onnxLoop (K>0);
-        // unsupported for now
-        if (terminator->getNumOperands() !=
-            loop.getRegion().getNumArguments() - 1) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "scanOutputs in loop body unsupported");
-        }
+    // results - n loop carried dependencies and k scan outputs
+    // Fail when there are scanOutputs in onnxLoop (K>0);
+    // unsupported for now
+    if (terminator->getNumOperands() !=
+        loop.getRegion().getNumArguments() - 1) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "scanOutputs in loop body unsupported");
+    }
 
-        // Get remaining operands from onnxLoopBody's terminator Op
-        // these are all the loop carried dependencies in the loop body
-        auto terminatorOperands = terminator->getOperands();
-        llvm::SmallVector<Value> remTerminatorOperands(
-            terminatorOperands.begin() + 1, terminatorOperands.end());
-        Value terminatorCond;
-        if (loopIsForLike) {
-          terminatorCond = constBoolTrue;
-        } else {
-          // Only use when loop is not forlike
-          Value terminatorCondTensor = terminatorOperands[0];
-          auto terminatorCondInt = rewriter.create<Torch::AtenItemOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              terminatorCondTensor);
-          auto terminatorCondBool = rewriter.create<Torch::AtenBoolIntOp>(
-              binder.getLoc(), rewriter.getType<Torch::BoolType>(),
-              terminatorCondInt);
-          terminatorCond = terminatorCondBool.getResult();
-        }
-        rewriter.replaceOpWithNewOp<Torch::PrimLoopConditionOp>(
-            terminator, terminatorCond, remTerminatorOperands);
+    // Get remaining operands from onnxLoopBody's terminator Op
+    // these are all the loop carried dependencies in the loop body
+    auto terminatorOperands = terminator->getOperands();
+    llvm::SmallVector<Value> remTerminatorOperands(
+        terminatorOperands.begin() + 1, terminatorOperands.end());
+    Value terminatorCond;
+    if (loopIsForLike) {
+      terminatorCond = constBoolTrue;
+    } else {
+      // Only use when loop is not forlike
+      Value terminatorCondTensor = terminatorOperands[0];
+      auto terminatorCondInt = rewriter.create<Torch::AtenItemOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(),
+          terminatorCondTensor);
+      auto terminatorCondBool = rewriter.create<Torch::AtenBoolIntOp>(
+          binder.getLoc(), rewriter.getType<Torch::BoolType>(),
+          terminatorCondInt);
+      terminatorCond = terminatorCondBool.getResult();
+    }
+    rewriter.replaceOpWithNewOp<Torch::PrimLoopConditionOp>(
+        terminator, terminatorCond, remTerminatorOperands);
 
-        loop.getRegion().eraseArgument(1);
-        rewriter.replaceOp(binder.op, loop);
-        return success();
-      });
+    loop.getRegion().eraseArgument(1);
+    rewriter.replaceOp(binder.op, loop);
+    return success();
+  });
   patterns.onOp("LSTM", 1, onnx_c::OnnxLstmExpander);
   patterns.onOp(
-      "LogSoftmax", 13,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "LogSoftmax", 13, [](OpBinder binder, PatternRewriter &rewriter) {
         Value input;
         Torch::ValueTensorType resultType;
         if (binder.tensorOperand(input) || binder.tensorResultType(resultType))
@@ -432,8 +415,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         return success();
       });
   patterns.onOp(
-      "LogSoftmax", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "LogSoftmax", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Value input;
         Torch::ValueTensorType resultType;
         if (binder.tensorOperand(input) || binder.tensorResultType(resultType))
@@ -508,20 +490,17 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             rightDimsPrimList);
         return success();
       });
-  patterns.onOp("MatMul", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value lhs, rhs;
-                  if (binder.tensorOperands(lhs, rhs) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenMatmulOp>(
-                      binder.op, resultType, lhs, rhs);
-                  return success();
-                });
+  patterns.onOp("MatMul", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    if (binder.tensorOperands(lhs, rhs) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenMatmulOp>(binder.op, resultType, lhs,
+                                                     rhs);
+    return success();
+  });
   patterns.onOp(
-      "MatMulInteger", 10,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "MatMulInteger", 10, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value lhs, rhs, lhsZp, rhsZp;
         if (binder.tensorOperandAtIndex(lhs, 0) ||
@@ -579,22 +558,20 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
                                                          lhs, rhs);
         return success();
       });
-  patterns.onOp("Mul", 7,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value lhs, rhs;
-                  if (binder.tensorOperands(lhs, rhs) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
-                  rewriter.replaceOpWithNewOp<Torch::AtenMulTensorOp>(
-                      binder.op, resultType, lhs, rhs);
-                  return success();
-                });
+  patterns.onOp("Mul", 7, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    if (binder.tensorOperands(lhs, rhs) ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenMulTensorOp>(binder.op, resultType,
+                                                        lhs, rhs);
+    return success();
+  });
 
   patterns.onOp(
-      "MelWeightMatrix", 17,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "MelWeightMatrix", 17, [](OpBinder binder, PatternRewriter &rewriter) {
         llvm::SmallVector<Value> operands;
         Torch::ValueTensorType resultType;
         int64_t output_dtype_attr;
@@ -959,8 +936,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
       });
 
   patterns.onOp(
-      "Multinomial", 7,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "Multinomial", 7, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value self;
         int64_t onnxDtype, sampleSize;
@@ -1026,7 +1002,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
       });
   patterns.onOp(
       "NegativeLogLikelihoodLoss", 13,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value self, target, weight, reduction, ignore_index;
         int64_t ignore_index_int;
@@ -1063,183 +1039,172 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         rewriter.replaceOp(binder.op, nllLoss);
         return success();
       });
-  patterns.onOp("NonZero", 13,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
-                  rewriter.replaceOpWithNewOp<Torch::AtenNonzeroOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
+  patterns.onOp("NonZero", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenNonzeroOp>(binder.op, resultType,
+                                                      operand);
+    return success();
+  });
+  patterns.onOp("MaxPool", 12, [](OpBinder binder, PatternRewriter &rewriter) {
+    std::string autoPad;
+    if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
+      return rewriter.notifyMatchFailure(binder.op, "auto_pad bind failure");
+    if (autoPad != "NOTSET")
+      return rewriter.notifyMatchFailure(
+          binder.op, "unsupported conversion: auto_pad != NOTSET");
+
+    Torch::ValueTensorType resultTypeOut;
+    Value operand;
+    int64_t ceilMode, storageOrder;
+    // TODO: Add support for indices output and storage_order
+    if (binder.tensorOperand(operand) ||
+        binder.s64IntegerAttr(ceilMode, "ceil_mode", 0) ||
+        binder.s64IntegerAttr(storageOrder, "storage_order", 0) ||
+        binder.tensorResultTypeAtIndex(resultTypeOut, 0))
+      return rewriter.notifyMatchFailure(
+          binder.op, "operand/ceil_mode/storage_order/resultType bind failure");
+    if (storageOrder != 0)
+      return rewriter.notifyMatchFailure(
+          binder.op, "storage_order setting is not supported.");
+    // Determine the rank of input tensor.
+    std::optional<unsigned> maybeRank = Torch::getTensorRank(operand);
+    if (!maybeRank)
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Unimplemented: unranked tensor");
+    int64_t rank = *maybeRank;
+    int64_t spatial = rank - 2;
+
+    SmallVector<int64_t> kernel, padding, strides, dilations;
+    if (binder.s64IntegerArrayAttr(kernel, "kernel_shape", {}))
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "kernel_shape bind failure");
+    if (kernel.size() != static_cast<size_t>(spatial))
+      return rewriter.notifyMatchFailure(
+          binder.op, "kernel list size does not match the number of axes");
+    if (binder.s64IntegerArrayAttr(padding, "pads", {}))
+      return rewriter.notifyMatchFailure(binder.op, "pads bind failure");
+    if (!padding.empty() && padding.size() != static_cast<size_t>(2 * spatial))
+      return rewriter.notifyMatchFailure(
+          binder.op, "padding list must contain (begin,end) pair for each "
+                     "spatial axis");
+    if (binder.s64IntegerArrayAttr(strides, "strides", {}))
+      return rewriter.notifyMatchFailure(binder.op, "strides bind failure");
+    if (!strides.empty() && strides.size() != static_cast<size_t>(spatial))
+      return rewriter.notifyMatchFailure(
+          binder.op, "strides list size does not match the number of axes");
+    if (binder.s64IntegerArrayAttr(dilations, "dilations", {}))
+      return rewriter.notifyMatchFailure(binder.op, "dilations bind failure");
+
+    if (padding.empty())
+      padding.resize(spatial, 0);
+    if (strides.empty())
+      strides.resize(spatial, 1);
+    if (dilations.empty())
+      dilations.resize(spatial, 1);
+
+    // If the padding is symmetric we can push the padding operation to the
+    // torch operator.
+    if (padding.size() == static_cast<size_t>(2 * spatial)) {
+      bool equal = true;
+      for (int i = 0; i < spatial; ++i) {
+        equal = equal && (padding[i] == padding[i + spatial]);
+      }
+      if (equal)
+        padding.resize(spatial);
+    }
+
+    // Torch pool operators require equal padding on each size of each
+    // dimension so we materialize the padding behavior explicitly and set
+    // the padding to 0.
+    if (padding.size() == static_cast<size_t>(2 * spatial)) {
+      auto operandTy = cast<Torch::ValueTensorType>(operand.getType());
+      llvm::SmallVector<int64_t> shuffledPadding(spatial * 2);
+      llvm::SmallVector<int64_t> paddedShape(operandTy.getSizes());
+      for (int i = 0; i < spatial; ++i) {
+        paddedShape[i + 2] += padding[i] + padding[i + spatial];
+        shuffledPadding[2 * i] = padding[spatial - i - 1];
+        shuffledPadding[2 * i + 1] = padding[2 * spatial - i - 1];
+      }
+
+      Value shuffledPaddingList =
+          createConstantIntList(binder, rewriter, shuffledPadding);
+      Value zero;
+      if (isa<FloatType>(resultTypeOut.getDtype())) {
+        zero = rewriter.create<Torch::ConstantFloatOp>(
+            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+            rewriter.getF64FloatAttr(std::numeric_limits<double>::lowest()));
+      } else if (isa<IntegerType>(resultTypeOut.getDtype())) {
+        zero = rewriter.create<Torch::ConstantIntOp>(
+            binder.getLoc(),
+            rewriter.getI64IntegerAttr(std::numeric_limits<int64_t>::lowest()));
+      }
+
+      auto paddedInputTy = rewriter.getType<Torch::ValueTensorType>(
+          paddedShape, operandTy.getDtype());
+      operand = rewriter.create<Torch::AtenConstantPadNdOp>(
+          binder.getLoc(), paddedInputTy, operand, shuffledPaddingList, zero);
+      padding.clear();
+      padding.resize(spatial, 0);
+    }
+
+    Value kernelSizeList = createConstantIntList(binder, rewriter, kernel);
+    Value paddingList = createConstantIntList(binder, rewriter, padding);
+    Value stridesList = createConstantIntList(binder, rewriter, strides);
+    Value dilationsList = createConstantIntList(binder, rewriter, dilations);
+    Value cstCeilMode =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), ceilMode);
+
+    if (binder.op->getNumResults() == 2) {
+      Torch::ValueTensorType resultTypeIndices;
+      if (binder.tensorResultTypeAtIndex(resultTypeIndices, 1))
+        return failure();
+
+      if (rank == 3)
+        return rewriter.notifyMatchFailure(
+            binder.op, "Unimplemented: AtenMaxPool1dWithIndicesOp");
+
+      if (rank == 4) {
+        rewriter.replaceOpWithNewOp<Torch::AtenMaxPool2dWithIndicesOp>(
+            binder.op, resultTypeOut, resultTypeIndices, operand,
+            kernelSizeList, stridesList, paddingList, dilationsList,
+            cstCeilMode);
+        return success();
+      }
+      if (rank == 5) {
+        rewriter.replaceOpWithNewOp<Torch::AtenMaxPool3dWithIndicesOp>(
+            binder.op, resultTypeOut, resultTypeIndices, operand,
+            kernelSizeList, stridesList, paddingList, dilationsList,
+            cstCeilMode);
+        return success();
+      }
+    } else {
+      if (rank == 3) {
+        rewriter.replaceOpWithNewOp<Torch::AtenMaxPool1dOp>(
+            binder.op, resultTypeOut, operand, kernelSizeList, stridesList,
+            paddingList, dilationsList, cstCeilMode);
+        return success();
+      }
+      if (rank == 4) {
+        rewriter.replaceOpWithNewOp<Torch::AtenMaxPool2dOp>(
+            binder.op, resultTypeOut, operand, kernelSizeList, stridesList,
+            paddingList, dilationsList, cstCeilMode);
+        return success();
+      }
+      if (rank == 5) {
+        rewriter.replaceOpWithNewOp<Torch::AtenMaxPool3dOp>(
+            binder.op, resultTypeOut, operand, kernelSizeList, stridesList,
+            paddingList, dilationsList, cstCeilMode);
+        return success();
+      }
+    }
+    return rewriter.notifyMatchFailure(binder.op, "No rank is matched.");
+  });
   patterns.onOp(
-      "MaxPool", 12, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        std::string autoPad;
-        if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "auto_pad bind failure");
-        if (autoPad != "NOTSET")
-          return rewriter.notifyMatchFailure(
-              binder.op, "unsupported conversion: auto_pad != NOTSET");
-
-        Torch::ValueTensorType resultTypeOut;
-        Value operand;
-        int64_t ceilMode, storageOrder;
-        // TODO: Add support for indices output and storage_order
-        if (binder.tensorOperand(operand) ||
-            binder.s64IntegerAttr(ceilMode, "ceil_mode", 0) ||
-            binder.s64IntegerAttr(storageOrder, "storage_order", 0) ||
-            binder.tensorResultTypeAtIndex(resultTypeOut, 0))
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "operand/ceil_mode/storage_order/resultType bind failure");
-        if (storageOrder != 0)
-          return rewriter.notifyMatchFailure(
-              binder.op, "storage_order setting is not supported.");
-        // Determine the rank of input tensor.
-        std::optional<unsigned> maybeRank = Torch::getTensorRank(operand);
-        if (!maybeRank)
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Unimplemented: unranked tensor");
-        int64_t rank = *maybeRank;
-        int64_t spatial = rank - 2;
-
-        SmallVector<int64_t> kernel, padding, strides, dilations;
-        if (binder.s64IntegerArrayAttr(kernel, "kernel_shape", {}))
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "kernel_shape bind failure");
-        if (kernel.size() != static_cast<size_t>(spatial))
-          return rewriter.notifyMatchFailure(
-              binder.op, "kernel list size does not match the number of axes");
-        if (binder.s64IntegerArrayAttr(padding, "pads", {}))
-          return rewriter.notifyMatchFailure(binder.op, "pads bind failure");
-        if (!padding.empty() &&
-            padding.size() != static_cast<size_t>(2 * spatial))
-          return rewriter.notifyMatchFailure(
-              binder.op, "padding list must contain (begin,end) pair for each "
-                         "spatial axis");
-        if (binder.s64IntegerArrayAttr(strides, "strides", {}))
-          return rewriter.notifyMatchFailure(binder.op, "strides bind failure");
-        if (!strides.empty() && strides.size() != static_cast<size_t>(spatial))
-          return rewriter.notifyMatchFailure(
-              binder.op, "strides list size does not match the number of axes");
-        if (binder.s64IntegerArrayAttr(dilations, "dilations", {}))
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "dilations bind failure");
-
-        if (padding.empty())
-          padding.resize(spatial, 0);
-        if (strides.empty())
-          strides.resize(spatial, 1);
-        if (dilations.empty())
-          dilations.resize(spatial, 1);
-
-        // If the padding is symmetric we can push the padding operation to the
-        // torch operator.
-        if (padding.size() == static_cast<size_t>(2 * spatial)) {
-          bool equal = true;
-          for (int i = 0; i < spatial; ++i) {
-            equal = equal && (padding[i] == padding[i + spatial]);
-          }
-          if (equal)
-            padding.resize(spatial);
-        }
-
-        // Torch pool operators require equal padding on each size of each
-        // dimension so we materialize the padding behavior explicitly and set
-        // the padding to 0.
-        if (padding.size() == static_cast<size_t>(2 * spatial)) {
-          auto operandTy = cast<Torch::ValueTensorType>(operand.getType());
-          llvm::SmallVector<int64_t> shuffledPadding(spatial * 2);
-          llvm::SmallVector<int64_t> paddedShape(operandTy.getSizes());
-          for (int i = 0; i < spatial; ++i) {
-            paddedShape[i + 2] += padding[i] + padding[i + spatial];
-            shuffledPadding[2 * i] = padding[spatial - i - 1];
-            shuffledPadding[2 * i + 1] = padding[2 * spatial - i - 1];
-          }
-
-          Value shuffledPaddingList =
-              createConstantIntList(binder, rewriter, shuffledPadding);
-          Value zero;
-          if (isa<FloatType>(resultTypeOut.getDtype())) {
-            zero = rewriter.create<Torch::ConstantFloatOp>(
-                binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-                rewriter.getF64FloatAttr(
-                    std::numeric_limits<double>::lowest()));
-          } else if (isa<IntegerType>(resultTypeOut.getDtype())) {
-            zero = rewriter.create<Torch::ConstantIntOp>(
-                binder.getLoc(), rewriter.getI64IntegerAttr(
-                                     std::numeric_limits<int64_t>::lowest()));
-          }
-
-          auto paddedInputTy = rewriter.getType<Torch::ValueTensorType>(
-              paddedShape, operandTy.getDtype());
-          operand = rewriter.create<Torch::AtenConstantPadNdOp>(
-              binder.getLoc(), paddedInputTy, operand, shuffledPaddingList,
-              zero);
-          padding.clear();
-          padding.resize(spatial, 0);
-        }
-
-        Value kernelSizeList = createConstantIntList(binder, rewriter, kernel);
-        Value paddingList = createConstantIntList(binder, rewriter, padding);
-        Value stridesList = createConstantIntList(binder, rewriter, strides);
-        Value dilationsList =
-            createConstantIntList(binder, rewriter, dilations);
-        Value cstCeilMode =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), ceilMode);
-
-        if (binder.op->getNumResults() == 2) {
-          Torch::ValueTensorType resultTypeIndices;
-          if (binder.tensorResultTypeAtIndex(resultTypeIndices, 1))
-            return failure();
-
-          if (rank == 3)
-            return rewriter.notifyMatchFailure(
-                binder.op, "Unimplemented: AtenMaxPool1dWithIndicesOp");
-
-          if (rank == 4) {
-            rewriter.replaceOpWithNewOp<Torch::AtenMaxPool2dWithIndicesOp>(
-                binder.op, resultTypeOut, resultTypeIndices, operand,
-                kernelSizeList, stridesList, paddingList, dilationsList,
-                cstCeilMode);
-            return success();
-          }
-          if (rank == 5) {
-            rewriter.replaceOpWithNewOp<Torch::AtenMaxPool3dWithIndicesOp>(
-                binder.op, resultTypeOut, resultTypeIndices, operand,
-                kernelSizeList, stridesList, paddingList, dilationsList,
-                cstCeilMode);
-            return success();
-          }
-        } else {
-          if (rank == 3) {
-            rewriter.replaceOpWithNewOp<Torch::AtenMaxPool1dOp>(
-                binder.op, resultTypeOut, operand, kernelSizeList, stridesList,
-                paddingList, dilationsList, cstCeilMode);
-            return success();
-          }
-          if (rank == 4) {
-            rewriter.replaceOpWithNewOp<Torch::AtenMaxPool2dOp>(
-                binder.op, resultTypeOut, operand, kernelSizeList, stridesList,
-                paddingList, dilationsList, cstCeilMode);
-            return success();
-          }
-          if (rank == 5) {
-            rewriter.replaceOpWithNewOp<Torch::AtenMaxPool3dOp>(
-                binder.op, resultTypeOut, operand, kernelSizeList, stridesList,
-                paddingList, dilationsList, cstCeilMode);
-            return success();
-          }
-        }
-        return rewriter.notifyMatchFailure(binder.op, "No rank is matched.");
-      });
-  patterns.onOp(
-      "MaxRoiPool", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "MaxRoiPool", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         SmallVector<int64_t> pooledShape;
         float spatialScale;
         if (binder.s64IntegerArrayAttr(pooledShape, "pooled_shape", {}) ||
@@ -1468,20 +1433,18 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
 
         return success();
       });
-  patterns.onOp("Greater", 16,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value lhs, rhs;
-                  std::string direction;
-                  if (binder.tensorOperands(lhs, rhs) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenGtTensorOp>(
-                      binder.op, resultType, lhs, rhs);
-                  return success();
-                });
+  patterns.onOp("Greater", 16, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    std::string direction;
+    if (binder.tensorOperands(lhs, rhs) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenGtTensorOp>(binder.op, resultType,
+                                                       lhs, rhs);
+    return success();
+  });
   patterns.onOp("GreaterOrEqual", 16,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;
                   Value lhs, rhs;
                   std::string direction;
@@ -1494,7 +1457,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
                 });
   patterns.onOp(
       "InstanceNormalization", 6,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         llvm::SmallVector<Value> operands;
         float eps;
@@ -1523,460 +1486,443 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             /* cudnn enabled */ boolFalse);
         return success();
       });
-  patterns.onOp(
-      "Max", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        llvm::SmallVector<Value> operands;
-        if (binder.tensorOperandsList(operands) ||
-            binder.tensorResultType(resultType) || operands.size() == 0) {
-          return failure();
-        }
-        Value result = operands[0];
-        for (uint64_t i = 1; i < operands.size(); i++) {
-          result = rewriter.create<Torch::AtenMaximumOp>(
-              binder.getLoc(), resultType, result, operands[i]);
-        }
-        rewriter.replaceOp(binder.op, result);
-        return success();
-      });
-  patterns.onOp(
-      "Min", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        llvm::SmallVector<Value> operands;
-        if (binder.tensorOperandsList(operands) ||
-            binder.tensorResultType(resultType) || operands.size() == 0) {
-          return failure();
-        }
-        Value result = operands[0];
-        for (uint64_t i = 1; i < operands.size(); i++) {
-          result = rewriter.create<Torch::AtenMinimumOp>(
-              binder.getLoc(), resultType, result, operands[i]);
-        }
-        rewriter.replaceOp(binder.op, result);
-        return success();
-      });
-  patterns.onOp("Neg", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
-                  rewriter.replaceOpWithNewOp<Torch::AtenNegOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp(
-      "Not", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType)) {
-          return failure();
-        }
+  patterns.onOp("Max", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    llvm::SmallVector<Value> operands;
+    if (binder.tensorOperandsList(operands) ||
+        binder.tensorResultType(resultType) || operands.size() == 0) {
+      return failure();
+    }
+    Value result = operands[0];
+    for (uint64_t i = 1; i < operands.size(); i++) {
+      result = rewriter.create<Torch::AtenMaximumOp>(
+          binder.getLoc(), resultType, result, operands[i]);
+    }
+    rewriter.replaceOp(binder.op, result);
+    return success();
+  });
+  patterns.onOp("Min", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    llvm::SmallVector<Value> operands;
+    if (binder.tensorOperandsList(operands) ||
+        binder.tensorResultType(resultType) || operands.size() == 0) {
+      return failure();
+    }
+    Value result = operands[0];
+    for (uint64_t i = 1; i < operands.size(); i++) {
+      result = rewriter.create<Torch::AtenMinimumOp>(
+          binder.getLoc(), resultType, result, operands[i]);
+    }
+    rewriter.replaceOp(binder.op, result);
+    return success();
+  });
+  patterns.onOp("Neg", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenNegOp>(binder.op, resultType,
+                                                  operand);
+    return success();
+  });
+  patterns.onOp("Not", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType)) {
+      return failure();
+    }
 
-        auto loc = binder.getLoc();
-        auto operandTy = cast<Torch::ValueTensorType>(operand.getType());
-        auto eTy = operandTy.getDtype();
+    auto loc = binder.getLoc();
+    auto operandTy = cast<Torch::ValueTensorType>(operand.getType());
+    auto eTy = operandTy.getDtype();
 
-        if (!eTy.isInteger(1)) {
-          auto i1ty = rewriter.getI1Type();
-          auto ty = rewriter.getType<Torch::ValueTensorType>(
-              operandTy.getSizes(), i1ty);
-          auto torchqTy = Torch::getScalarTypeForType(i1ty);
-          Value tyConst = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64),
-                                      static_cast<int64_t>(torchqTy)));
-          Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
-          Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(loc, false);
-          operand = rewriter.create<Torch::AtenToDtypeOp>(
-              loc, ty, operand, tyConst,
-              /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
-              /*memory_format=*/none);
-        }
-        rewriter.replaceOpWithNewOp<Torch::AtenBitwiseNotOp>(
-            binder.op, resultType, operand);
-        return success();
-      });
-  patterns.onOp("Or", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value lhs, rhs;
-                  if (binder.tensorOperands(lhs, rhs) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
-                  rewriter.replaceOpWithNewOp<Torch::AtenBitwiseOrTensorOp>(
-                      binder.op, resultType, lhs, rhs);
-                  return success();
-                });
-  patterns.onOp(
-      "GatherND", 13, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value data, indices;
-        int64_t batchDimCount;
-        if (binder.tensorOperandAtIndex(data, 0) ||
-            binder.tensorOperandAtIndex(indices, 1) ||
-            binder.tensorResultType(resultType) ||
-            binder.s64IntegerAttr(batchDimCount, "batch_dims", 0))
-          return failure();
+    if (!eTy.isInteger(1)) {
+      auto i1ty = rewriter.getI1Type();
+      auto ty =
+          rewriter.getType<Torch::ValueTensorType>(operandTy.getSizes(), i1ty);
+      auto torchqTy = Torch::getScalarTypeForType(i1ty);
+      Value tyConst = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64),
+                                  static_cast<int64_t>(torchqTy)));
+      Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
+      Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(loc, false);
+      operand = rewriter.create<Torch::AtenToDtypeOp>(loc, ty, operand, tyConst,
+                                                      /*non_blocking=*/cstFalse,
+                                                      /*copy=*/cstFalse,
+                                                      /*memory_format=*/none);
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenBitwiseNotOp>(binder.op, resultType,
+                                                         operand);
+    return success();
+  });
+  patterns.onOp("Or", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    if (binder.tensorOperands(lhs, rhs) ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenBitwiseOrTensorOp>(
+        binder.op, resultType, lhs, rhs);
+    return success();
+  });
+  patterns.onOp("GatherND", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value data, indices;
+    int64_t batchDimCount;
+    if (binder.tensorOperandAtIndex(data, 0) ||
+        binder.tensorOperandAtIndex(indices, 1) ||
+        binder.tensorResultType(resultType) ||
+        binder.s64IntegerAttr(batchDimCount, "batch_dims", 0))
+      return failure();
 
-        Location loc = binder.getLoc();
-        auto dataTy = cast<Torch::ValueTensorType>(data.getType());
-        auto indicesTy = cast<Torch::ValueTensorType>(indices.getType());
-        if (!dataTy || !dataTy.hasSizes())
-          return failure();
-        if (!indicesTy || !indicesTy.hasSizes())
-          return failure();
+    Location loc = binder.getLoc();
+    auto dataTy = cast<Torch::ValueTensorType>(data.getType());
+    auto indicesTy = cast<Torch::ValueTensorType>(indices.getType());
+    if (!dataTy || !dataTy.hasSizes())
+      return failure();
+    if (!indicesTy || !indicesTy.hasSizes())
+      return failure();
 
-        // step 1. Get shapes and ranks of data and indices. The last dimension
-        // of indices is expected to be static.
-        ArrayRef<int64_t> dataShape = dataTy.getSizes();
-        int64_t dataRank = dataShape.size();
-        ArrayRef<int64_t> indicesShape = indicesTy.getSizes();
-        int64_t indicesRank = indicesShape.size();
-        int64_t indicesLastDim = indicesShape.back();
-        // Given data tensor of rank r >= 1, indices tensor of rank q >= 1, and
-        // batch_dims integer b, onnx.gather_nd gathers slices of data into an
-        // output tensor of rank q + r - indices_shape[-1] - 1 - b.
-        // indices_shape[-1] must be static to have deterministic output rank.
-        if (dataRank < 1 || indicesRank < 1)
-          return rewriter.notifyMatchFailure(
-              binder.op, "expected data and indices rank to be >= 1");
-        if (batchDimCount >= std::min(dataRank, indicesRank))
-          return rewriter.notifyMatchFailure(
-              binder.op, "batch_dims should be strictly less than "
-                         "min(rank(data), rank(indices))");
-        if (indicesLastDim == Torch::kUnknownSize)
-          return rewriter.notifyMatchFailure(
-              binder.op, "expected last dimension of indices to be static");
+    // step 1. Get shapes and ranks of data and indices. The last dimension
+    // of indices is expected to be static.
+    ArrayRef<int64_t> dataShape = dataTy.getSizes();
+    int64_t dataRank = dataShape.size();
+    ArrayRef<int64_t> indicesShape = indicesTy.getSizes();
+    int64_t indicesRank = indicesShape.size();
+    int64_t indicesLastDim = indicesShape.back();
+    // Given data tensor of rank r >= 1, indices tensor of rank q >= 1, and
+    // batch_dims integer b, onnx.gather_nd gathers slices of data into an
+    // output tensor of rank q + r - indices_shape[-1] - 1 - b.
+    // indices_shape[-1] must be static to have deterministic output rank.
+    if (dataRank < 1 || indicesRank < 1)
+      return rewriter.notifyMatchFailure(
+          binder.op, "expected data and indices rank to be >= 1");
+    if (batchDimCount >= std::min(dataRank, indicesRank))
+      return rewriter.notifyMatchFailure(
+          binder.op, "batch_dims should be strictly less than "
+                     "min(rank(data), rank(indices))");
+    if (indicesLastDim == Torch::kUnknownSize)
+      return rewriter.notifyMatchFailure(
+          binder.op, "expected last dimension of indices to be static");
 
-        // step 2. Get dimension list of data.
-        SmallVector<int64_t> batchShape;
-        SmallVector<Value> batchDims;
-        SmallVector<Value> dataDims;
-        for (int64_t i = 0; i < dataRank; ++i) {
-          Value k = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), i);
-          Value dataDim = rewriter.create<Torch::AtenSizeIntOp>(loc, data, k);
-          dataDims.push_back(dataDim);
-          if (i < batchDimCount) {
-            batchShape.push_back(dataShape[i]);
-            batchDims.push_back(dataDim);
-          }
-        }
+    // step 2. Get dimension list of data.
+    SmallVector<int64_t> batchShape;
+    SmallVector<Value> batchDims;
+    SmallVector<Value> dataDims;
+    for (int64_t i = 0; i < dataRank; ++i) {
+      Value k = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), i);
+      Value dataDim = rewriter.create<Torch::AtenSizeIntOp>(loc, data, k);
+      dataDims.push_back(dataDim);
+      if (i < batchDimCount) {
+        batchShape.push_back(dataShape[i]);
+        batchDims.push_back(dataDim);
+      }
+    }
 
-        // step 3. Get dimension list of indices.
-        Value constZero = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(0));
-        Value constOne = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(1));
-        SmallVector<Value> indicesDimsMinusOne;
-        SmallVector<Value> unflattenIndicesDims;
-        Value indicesFlattenDim = constOne;
-        for (int64_t i = 0; i < indicesRank - 1; ++i) {
-          Value k = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), i);
-          Value indicesDim =
-              rewriter.create<Torch::AtenSizeIntOp>(loc, indices, k);
-          indicesDimsMinusOne.push_back(indicesDim);
-          if (i >= batchDimCount) {
-            unflattenIndicesDims.push_back(indicesDim);
-            indicesFlattenDim = rewriter.create<Torch::AtenMulIntOp>(
-                loc, indicesFlattenDim, indicesDim);
-          }
-        }
-        ArrayRef<int64_t> indicesShapeMinusOne = indicesShape.drop_back();
+    // step 3. Get dimension list of indices.
+    Value constZero = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(0));
+    Value constOne = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(1));
+    SmallVector<Value> indicesDimsMinusOne;
+    SmallVector<Value> unflattenIndicesDims;
+    Value indicesFlattenDim = constOne;
+    for (int64_t i = 0; i < indicesRank - 1; ++i) {
+      Value k = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), i);
+      Value indicesDim = rewriter.create<Torch::AtenSizeIntOp>(loc, indices, k);
+      indicesDimsMinusOne.push_back(indicesDim);
+      if (i >= batchDimCount) {
+        unflattenIndicesDims.push_back(indicesDim);
+        indicesFlattenDim = rewriter.create<Torch::AtenMulIntOp>(
+            loc, indicesFlattenDim, indicesDim);
+      }
+    }
+    ArrayRef<int64_t> indicesShapeMinusOne = indicesShape.drop_back();
 
-        // Algorithm: We can not directly perform torch.gather as it requires
-        // the ranks of data(`r`) and indices(`q`) to be same. So we will
-        // perform collapse and reshape operations to match the ranks of data
-        // and indices(making sure the semantics of the onnx.gather_nd are
-        // preserved), perform torch.gather operation, later unflatten the
-        // gather result to match onnx.gather_nd output. For example, assuming
-        // indices is of shape (4, 5, 3, 2), data is (4, 10, 11, 7, 4) and
-        // batch_dims(`b`)=1. Firstly, modify indices to 1-D indexing as the
-        // torch.gather op supports only single dimensional indexing. (this
-        // algorithm would have been simpler if we can get a torch op that
-        // supports indexing at multiple dimensions simultaneously). 1-D indexed
-        // indices will be of shape (4, 5, 3, 1), now materialize it to
-        // `r-b-indices_shape[-1]` dimension of data i.e. reshaping it to the
-        // shape (4, 5, 3, 1, 1). Next step is to flatten+expand the indices and
-        // flatten the data to (4, 15, 7, 4) and (4, 110, 7, 4) shapes
-        // respectively and then perform the torch.gather operation. Post the
-        // gather operation, unflatten the indices dimensions of result to (4,
-        // 5, 3, 7, 4) which is our required result.
+    // Algorithm: We can not directly perform torch.gather as it requires
+    // the ranks of data(`r`) and indices(`q`) to be same. So we will
+    // perform collapse and reshape operations to match the ranks of data
+    // and indices(making sure the semantics of the onnx.gather_nd are
+    // preserved), perform torch.gather operation, later unflatten the
+    // gather result to match onnx.gather_nd output. For example, assuming
+    // indices is of shape (4, 5, 3, 2), data is (4, 10, 11, 7, 4) and
+    // batch_dims(`b`)=1. Firstly, modify indices to 1-D indexing as the
+    // torch.gather op supports only single dimensional indexing. (this
+    // algorithm would have been simpler if we can get a torch op that
+    // supports indexing at multiple dimensions simultaneously). 1-D indexed
+    // indices will be of shape (4, 5, 3, 1), now materialize it to
+    // `r-b-indices_shape[-1]` dimension of data i.e. reshaping it to the
+    // shape (4, 5, 3, 1, 1). Next step is to flatten+expand the indices and
+    // flatten the data to (4, 15, 7, 4) and (4, 110, 7, 4) shapes
+    // respectively and then perform the torch.gather operation. Post the
+    // gather operation, unflatten the indices dimensions of result to (4,
+    // 5, 3, 7, 4) which is our required result.
 
-        // step 4. Convert indices_shape[-1] dimensional indexing to 1D
-        // indexing.
-        Value sliceDim = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(indicesRank - 1));
-        SmallVector<int64_t> indicesSliceShape(indicesShapeMinusOne);
-        indicesSliceShape.push_back(1);
-        auto indicesSliceTy = rewriter.getType<Torch::ValueTensorType>(
-            indicesSliceShape, indicesTy.getOptionalDtype());
+    // step 4. Convert indices_shape[-1] dimensional indexing to 1D
+    // indexing.
+    Value sliceDim = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(indicesRank - 1));
+    SmallVector<int64_t> indicesSliceShape(indicesShapeMinusOne);
+    indicesSliceShape.push_back(1);
+    auto indicesSliceTy = rewriter.getType<Torch::ValueTensorType>(
+        indicesSliceShape, indicesTy.getOptionalDtype());
 
-        Value start = constZero;
-        Value updatedIndices;
-        for (int64_t i = 0; i < indicesLastDim; ++i) {
-          Value end = rewriter.create<Torch::ConstantIntOp>(
-              loc, rewriter.getI64IntegerAttr(i + 1));
-          Value indicesSlice = rewriter.create<Torch::AtenSliceTensorOp>(
-              loc, indicesSliceTy, indices, sliceDim, start, end,
-              /*step=*/constOne);
-          start = end;
-          // Apply bounds checking on the indices slice.
-          auto boolTy = rewriter.getType<Torch::ValueTensorType>(
-              indicesSliceShape, rewriter.getI1Type());
-          Value lt = rewriter.create<Torch::AtenLtScalarOp>(
-              loc, boolTy, indicesSlice, constZero);
-          Value add = rewriter.create<Torch::AtenAddScalarOp>(
-              loc, indicesSliceTy, indicesSlice, dataDims[batchDimCount + i],
-              /*alpha=*/constOne);
-          indicesSlice = rewriter.create<Torch::AtenWhereSelfOp>(
-              loc, indicesSliceTy, lt, add, indicesSlice);
-          if (i == 0) {
-            updatedIndices = indicesSlice;
-            continue;
-          }
-          updatedIndices = rewriter.create<Torch::AtenAddTensorOp>(
-              loc, indicesSliceTy, indicesSlice, updatedIndices,
-              dataDims[batchDimCount + i]);
-        }
+    Value start = constZero;
+    Value updatedIndices;
+    for (int64_t i = 0; i < indicesLastDim; ++i) {
+      Value end = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(i + 1));
+      Value indicesSlice = rewriter.create<Torch::AtenSliceTensorOp>(
+          loc, indicesSliceTy, indices, sliceDim, start, end,
+          /*step=*/constOne);
+      start = end;
+      // Apply bounds checking on the indices slice.
+      auto boolTy = rewriter.getType<Torch::ValueTensorType>(
+          indicesSliceShape, rewriter.getI1Type());
+      Value lt = rewriter.create<Torch::AtenLtScalarOp>(
+          loc, boolTy, indicesSlice, constZero);
+      Value add = rewriter.create<Torch::AtenAddScalarOp>(
+          loc, indicesSliceTy, indicesSlice, dataDims[batchDimCount + i],
+          /*alpha=*/constOne);
+      indicesSlice = rewriter.create<Torch::AtenWhereSelfOp>(
+          loc, indicesSliceTy, lt, add, indicesSlice);
+      if (i == 0) {
+        updatedIndices = indicesSlice;
+        continue;
+      }
+      updatedIndices = rewriter.create<Torch::AtenAddTensorOp>(
+          loc, indicesSliceTy, indicesSlice, updatedIndices,
+          dataDims[batchDimCount + i]);
+    }
 
-        // step 5. Compute all the required result types here.
-        SmallVector<int64_t> reshapeIndicesShape(indicesShapeMinusOne);
-        SmallVector<Value> reshapeIndicesDims(indicesDimsMinusOne);
-        // Determine the collapsed dim size of indices(index_shape[-1] is not
-        // part of collapsing as we already removed it by 1-D indexing).
-        SmallVector<int64_t> flattenIndicesShape(batchShape);
-        auto indicesCt = 1;
-        for (int64_t i = batchDimCount; i < indicesRank - 1; ++i) {
-          if (indicesShape[i] == Torch::kUnknownSize) {
-            indicesCt = Torch::kUnknownSize;
-            break;
-          }
-          indicesCt *= indicesShape[i];
-        }
-        flattenIndicesShape.push_back(indicesCt);
-        // Determine the collapsed dim size of data.
-        SmallVector<int64_t> flattenDataShape(batchShape);
-        auto dataCt = 1;
-        for (int64_t i = 0; i < indicesLastDim; ++i) {
-          int64_t sz = dataShape[i + batchDimCount];
-          if (sz == Torch::kUnknownSize) {
-            dataCt = Torch::kUnknownSize;
-            break;
-          }
-          dataCt *= sz;
-        }
-        flattenDataShape.push_back(dataCt);
-        // Compute the shape of expand op.
-        SmallVector<Value> expandIndicesDims(batchDims);
-        expandIndicesDims.push_back(indicesFlattenDim);
-        SmallVector<int64_t> expandIndicesShape(batchShape);
-        expandIndicesShape.push_back(indicesCt);
-        // Append `r-b-indices_shape[-1]` unit or data dims appropriately to all
-        // result types.
-        for (int64_t i = batchDimCount + indicesLastDim; i < dataRank; ++i) {
-          reshapeIndicesShape.push_back(1);
-          flattenIndicesShape.push_back(1);
-          flattenDataShape.push_back(dataShape[i]);
-          expandIndicesShape.push_back(dataShape[i]);
-          reshapeIndicesDims.push_back(constOne);
-          expandIndicesDims.push_back(dataDims[i]);
-        }
+    // step 5. Compute all the required result types here.
+    SmallVector<int64_t> reshapeIndicesShape(indicesShapeMinusOne);
+    SmallVector<Value> reshapeIndicesDims(indicesDimsMinusOne);
+    // Determine the collapsed dim size of indices(index_shape[-1] is not
+    // part of collapsing as we already removed it by 1-D indexing).
+    SmallVector<int64_t> flattenIndicesShape(batchShape);
+    auto indicesCt = 1;
+    for (int64_t i = batchDimCount; i < indicesRank - 1; ++i) {
+      if (indicesShape[i] == Torch::kUnknownSize) {
+        indicesCt = Torch::kUnknownSize;
+        break;
+      }
+      indicesCt *= indicesShape[i];
+    }
+    flattenIndicesShape.push_back(indicesCt);
+    // Determine the collapsed dim size of data.
+    SmallVector<int64_t> flattenDataShape(batchShape);
+    auto dataCt = 1;
+    for (int64_t i = 0; i < indicesLastDim; ++i) {
+      int64_t sz = dataShape[i + batchDimCount];
+      if (sz == Torch::kUnknownSize) {
+        dataCt = Torch::kUnknownSize;
+        break;
+      }
+      dataCt *= sz;
+    }
+    flattenDataShape.push_back(dataCt);
+    // Compute the shape of expand op.
+    SmallVector<Value> expandIndicesDims(batchDims);
+    expandIndicesDims.push_back(indicesFlattenDim);
+    SmallVector<int64_t> expandIndicesShape(batchShape);
+    expandIndicesShape.push_back(indicesCt);
+    // Append `r-b-indices_shape[-1]` unit or data dims appropriately to all
+    // result types.
+    for (int64_t i = batchDimCount + indicesLastDim; i < dataRank; ++i) {
+      reshapeIndicesShape.push_back(1);
+      flattenIndicesShape.push_back(1);
+      flattenDataShape.push_back(dataShape[i]);
+      expandIndicesShape.push_back(dataShape[i]);
+      reshapeIndicesDims.push_back(constOne);
+      expandIndicesDims.push_back(dataDims[i]);
+    }
 
-        // step 6. Reshape 1-D indexed indices to match the rank of flattened
-        // data by inserting unit dimensions.
-        auto intListTy = rewriter.getType<Torch::ListType>(
-            rewriter.getType<Torch::IntType>());
-        Value reshapeIndicesSizeList =
-            rewriter.create<Torch::PrimListConstructOp>(loc, intListTy,
-                                                        reshapeIndicesDims);
-        auto reshapeIndicesTy = rewriter.getType<Torch::ValueTensorType>(
-            reshapeIndicesShape, indicesTy.getOptionalDtype());
-        Value reshapedIndices = rewriter.create<Torch::AtenViewOp>(
-            loc, reshapeIndicesTy, updatedIndices, reshapeIndicesSizeList);
+    // step 6. Reshape 1-D indexed indices to match the rank of flattened
+    // data by inserting unit dimensions.
+    auto intListTy =
+        rewriter.getType<Torch::ListType>(rewriter.getType<Torch::IntType>());
+    Value reshapeIndicesSizeList = rewriter.create<Torch::PrimListConstructOp>(
+        loc, intListTy, reshapeIndicesDims);
+    auto reshapeIndicesTy = rewriter.getType<Torch::ValueTensorType>(
+        reshapeIndicesShape, indicesTy.getOptionalDtype());
+    Value reshapedIndices = rewriter.create<Torch::AtenViewOp>(
+        loc, reshapeIndicesTy, updatedIndices, reshapeIndicesSizeList);
 
-        // step 7. Flatten `q-b-1` dimensions of the indices.
-        auto flattenIndicesTy = rewriter.getType<Torch::ValueTensorType>(
-            flattenIndicesShape, indicesTy.getOptionalDtype());
-        Value batchDimCountVal = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(batchDimCount));
-        Value flattenedIndices = reshapedIndices;
-        if (indicesRank == 1) {
-          flattenedIndices = rewriter.create<Torch::AtenUnsqueezeOp>(
-              loc, flattenIndicesTy, reshapedIndices, constZero);
-        } else if (indicesRank > 1) {
-          if (batchDimCount > indicesRank - 2) {
-            flattenedIndices = rewriter.create<Torch::AtenUnsqueezeOp>(
-                loc, flattenIndicesTy, reshapedIndices, batchDimCountVal);
-          } else {
-            Value endDim = rewriter.create<Torch::ConstantIntOp>(
-                loc, rewriter.getI64IntegerAttr(indicesRank - 2));
-            flattenedIndices = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
-                loc, flattenIndicesTy, reshapedIndices, batchDimCountVal,
-                endDim);
-          }
-        }
-
-        // step 8. Expand `r-b-indices_shape[-1]` dims of flattened indices.
-        auto expandIndicesTy = rewriter.getType<Torch::ValueTensorType>(
-            expandIndicesShape, indicesTy.getOptionalDtype());
-        Value expandIndicesSizeList =
-            rewriter.create<Torch::PrimListConstructOp>(loc, intListTy,
-                                                        expandIndicesDims);
-        Value constFalse = rewriter.create<Torch::ConstantBoolOp>(
-            loc, rewriter.getType<Torch::BoolType>(),
-            rewriter.getBoolAttr(false));
-        Value expandedIndices = rewriter.create<Torch::AtenExpandOp>(
-            loc, expandIndicesTy, flattenedIndices, expandIndicesSizeList,
-            /*implicit=*/constFalse);
-
-        // step 9. Flatten indices_shape[-1] dimensions of data.
-        auto flattenDataTy = rewriter.getType<Torch::ValueTensorType>(
-            flattenDataShape, dataTy.getOptionalDtype());
+    // step 7. Flatten `q-b-1` dimensions of the indices.
+    auto flattenIndicesTy = rewriter.getType<Torch::ValueTensorType>(
+        flattenIndicesShape, indicesTy.getOptionalDtype());
+    Value batchDimCountVal = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(batchDimCount));
+    Value flattenedIndices = reshapedIndices;
+    if (indicesRank == 1) {
+      flattenedIndices = rewriter.create<Torch::AtenUnsqueezeOp>(
+          loc, flattenIndicesTy, reshapedIndices, constZero);
+    } else if (indicesRank > 1) {
+      if (batchDimCount > indicesRank - 2) {
+        flattenedIndices = rewriter.create<Torch::AtenUnsqueezeOp>(
+            loc, flattenIndicesTy, reshapedIndices, batchDimCountVal);
+      } else {
         Value endDim = rewriter.create<Torch::ConstantIntOp>(
-            loc,
-            rewriter.getI64IntegerAttr(batchDimCount + indicesLastDim - 1));
-        Value flattenedData = data;
+            loc, rewriter.getI64IntegerAttr(indicesRank - 2));
+        flattenedIndices = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
+            loc, flattenIndicesTy, reshapedIndices, batchDimCountVal, endDim);
+      }
+    }
 
-        if (indicesLastDim != 1) {
-          flattenedData = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
-              loc, flattenDataTy, data, batchDimCountVal, endDim);
-        }
+    // step 8. Expand `r-b-indices_shape[-1]` dims of flattened indices.
+    auto expandIndicesTy = rewriter.getType<Torch::ValueTensorType>(
+        expandIndicesShape, indicesTy.getOptionalDtype());
+    Value expandIndicesSizeList = rewriter.create<Torch::PrimListConstructOp>(
+        loc, intListTy, expandIndicesDims);
+    Value constFalse = rewriter.create<Torch::ConstantBoolOp>(
+        loc, rewriter.getType<Torch::BoolType>(), rewriter.getBoolAttr(false));
+    Value expandedIndices = rewriter.create<Torch::AtenExpandOp>(
+        loc, expandIndicesTy, flattenedIndices, expandIndicesSizeList,
+        /*implicit=*/constFalse);
 
-        // step 10. Now we have flattenedData and expandedIndices of same rank
-        // to perform gather operation.
-        auto gatherTy = rewriter.getType<Torch::ValueTensorType>(
-            expandIndicesShape, dataTy.getOptionalDtype());
-        Value gather = rewriter.create<Torch::AtenGatherOp>(
-            loc, gatherTy, flattenedData, batchDimCountVal, expandedIndices,
-            /*sparseGrad=*/constFalse);
+    // step 9. Flatten indices_shape[-1] dimensions of data.
+    auto flattenDataTy = rewriter.getType<Torch::ValueTensorType>(
+        flattenDataShape, dataTy.getOptionalDtype());
+    Value endDim = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(batchDimCount + indicesLastDim - 1));
+    Value flattenedData = data;
 
-        // step 11. Unflatten the collapsed indices dims of gather result.
-        if (indicesRank == 1) {
-          rewriter.replaceOpWithNewOp<Torch::AtenSqueezeDimOp>(
-              binder.op, resultType, gather, /*dim=*/constZero);
-          return success();
-        }
+    if (indicesLastDim != 1) {
+      flattenedData = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
+          loc, flattenDataTy, data, batchDimCountVal, endDim);
+    }
 
-        if (unflattenIndicesDims.empty()) {
-          rewriter.replaceOpWithNewOp<Torch::AtenSqueezeDimOp>(
-              binder.op, resultType, gather, /*dim=*/batchDimCountVal);
-          return success();
-        }
+    // step 10. Now we have flattenedData and expandedIndices of same rank
+    // to perform gather operation.
+    auto gatherTy = rewriter.getType<Torch::ValueTensorType>(
+        expandIndicesShape, dataTy.getOptionalDtype());
+    Value gather = rewriter.create<Torch::AtenGatherOp>(
+        loc, gatherTy, flattenedData, batchDimCountVal, expandedIndices,
+        /*sparseGrad=*/constFalse);
 
-        Value unflattenSizeList = rewriter.create<Torch::PrimListConstructOp>(
-            loc, intListTy, unflattenIndicesDims);
-        rewriter.replaceOpWithNewOp<Torch::AtenUnflattenIntOp>(
-            binder.op, resultType, gather, batchDimCountVal, unflattenSizeList);
-        return success();
-      });
+    // step 11. Unflatten the collapsed indices dims of gather result.
+    if (indicesRank == 1) {
+      rewriter.replaceOpWithNewOp<Torch::AtenSqueezeDimOp>(
+          binder.op, resultType, gather, /*dim=*/constZero);
+      return success();
+    }
+
+    if (unflattenIndicesDims.empty()) {
+      rewriter.replaceOpWithNewOp<Torch::AtenSqueezeDimOp>(
+          binder.op, resultType, gather, /*dim=*/batchDimCountVal);
+      return success();
+    }
+
+    Value unflattenSizeList = rewriter.create<Torch::PrimListConstructOp>(
+        loc, intListTy, unflattenIndicesDims);
+    rewriter.replaceOpWithNewOp<Torch::AtenUnflattenIntOp>(
+        binder.op, resultType, gather, batchDimCountVal, unflattenSizeList);
+    return success();
+  });
+  patterns.onOp("Gather", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value data, indices;
+    int64_t axis;
+    if (binder.tensorOperandAtIndex(data, 0) ||
+        binder.tensorOperandAtIndex(indices, 1) ||
+        binder.tensorResultType(resultType) ||
+        binder.s64IntegerAttr(axis, "axis", 0))
+      return failure();
+    Location loc = binder.getLoc();
+    auto ctx = binder.op->getContext();
+    auto indicesTy = cast<Torch::ValueTensorType>(indices.getType());
+    auto dataTy = cast<Torch::ValueTensorType>(data.getType());
+    if (!dataTy || !dataTy.hasSizes() || !indicesTy.hasSizes())
+      return failure();
+
+    int64_t dataRank = dataTy.getSizes().size();
+    int64_t indicesRank = indicesTy.getSizes().size();
+    axis = axis < 0 ? axis + dataRank : axis;
+
+    Value index = rewriter.create<Torch::ConstantIntOp>(
+        loc, Torch::IntType::get(ctx), rewriter.getI64IntegerAttr(axis));
+
+    // Apply bounds checking on the input:
+    auto intTy = rewriter.getType<Torch::IntType>();
+    auto boolTy = rewriter.getType<Torch::ValueTensorType>(
+        indicesTy.getSizes(), rewriter.getI1Type());
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        loc, intTy, rewriter.getI64IntegerAttr(0));
+    Value one = rewriter.create<Torch::ConstantIntOp>(
+        loc, intTy, rewriter.getI64IntegerAttr(1));
+    Value lt =
+        rewriter.create<Torch::AtenLtScalarOp>(loc, boolTy, indices, zero);
+    Value dim = rewriter.create<Torch::AtenSizeIntOp>(loc, intTy, data, index);
+    Value add = rewriter.create<Torch::AtenAddScalarOp>(loc, indicesTy, indices,
+                                                        dim, one);
+    indices = rewriter.create<Torch::AtenWhereSelfOp>(loc, indicesTy, lt, add,
+                                                      indices);
+
+    auto intListTy =
+        rewriter.getType<Torch::ListType>(rewriter.getType<Torch::IntType>());
+
+    llvm::SmallVector<Value> indicesDims;
+    for (int i = 0, s = indicesTy.getSizes().size(); i < s; ++i) {
+      Value k = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), i);
+      indicesDims.push_back(
+          rewriter.create<Torch::AtenSizeIntOp>(binder.getLoc(), indices, k));
+    }
+
+    Value indicesSizeList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(), intListTy, indicesDims);
+
+    // Determine the collapsed dim size:
+    auto indicesCt = 1;
+    for (auto sz : indicesTy.getSizes()) {
+      if (sz == Torch::kUnknownSize) {
+        indicesCt = Torch::kUnknownSize;
+        break;
+      }
+
+      indicesCt *= sz;
+    }
+
+    auto flattenTy = rewriter.getType<Torch::ValueTensorType>(
+        SmallVector<int64_t>{indicesCt}, indicesTy.getOptionalDtype());
+
+    if (indicesRank == 0) {
+      indices = rewriter.create<Torch::AtenUnsqueezeOp>(
+          binder.getLoc(), flattenTy, indices, zero);
+    } else if (indicesRank > 1) {
+      Value rank = rewriter.create<Torch::AtenDimOp>(loc, intTy, indices);
+      Value end = rewriter.create<Torch::AtenSubIntOp>(loc, rank, one);
+      indices = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
+          loc, flattenTy, indices, zero, end);
+    }
+
+    llvm::SmallVector<int64_t> gatherShape(dataTy.getSizes());
+    gatherShape[axis] = indicesCt;
+    auto gatherTy = rewriter.getType<Torch::ValueTensorType>(
+        gatherShape, dataTy.getOptionalDtype());
+    Value gather = rewriter.create<Torch::AtenIndexSelectOp>(
+        loc, gatherTy, data, index, indices);
+
+    if (indicesRank == 1) {
+      rewriter.replaceOp(binder.op, gather);
+      return success();
+    }
+
+    if (indicesRank > 1) {
+      gather = rewriter.replaceOpWithNewOp<Torch::AtenUnflattenIntOp>(
+          binder.op, resultType, gather, index, indicesSizeList);
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<Torch::AtenSqueezeOp>(binder.op, resultType,
+                                                      gather);
+    return success();
+  });
   patterns.onOp(
-      "Gather", 13, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value data, indices;
-        int64_t axis;
-        if (binder.tensorOperandAtIndex(data, 0) ||
-            binder.tensorOperandAtIndex(indices, 1) ||
-            binder.tensorResultType(resultType) ||
-            binder.s64IntegerAttr(axis, "axis", 0))
-          return failure();
-        Location loc = binder.getLoc();
-        auto ctx = binder.op->getContext();
-        auto indicesTy = cast<Torch::ValueTensorType>(indices.getType());
-        auto dataTy = cast<Torch::ValueTensorType>(data.getType());
-        if (!dataTy || !dataTy.hasSizes() || !indicesTy.hasSizes())
-          return failure();
-
-        int64_t dataRank = dataTy.getSizes().size();
-        int64_t indicesRank = indicesTy.getSizes().size();
-        axis = axis < 0 ? axis + dataRank : axis;
-
-        Value index = rewriter.create<Torch::ConstantIntOp>(
-            loc, Torch::IntType::get(ctx), rewriter.getI64IntegerAttr(axis));
-
-        // Apply bounds checking on the input:
-        auto intTy = rewriter.getType<Torch::IntType>();
-        auto boolTy = rewriter.getType<Torch::ValueTensorType>(
-            indicesTy.getSizes(), rewriter.getI1Type());
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
-            loc, intTy, rewriter.getI64IntegerAttr(0));
-        Value one = rewriter.create<Torch::ConstantIntOp>(
-            loc, intTy, rewriter.getI64IntegerAttr(1));
-        Value lt =
-            rewriter.create<Torch::AtenLtScalarOp>(loc, boolTy, indices, zero);
-        Value dim =
-            rewriter.create<Torch::AtenSizeIntOp>(loc, intTy, data, index);
-        Value add = rewriter.create<Torch::AtenAddScalarOp>(loc, indicesTy,
-                                                            indices, dim, one);
-        indices = rewriter.create<Torch::AtenWhereSelfOp>(loc, indicesTy, lt,
-                                                          add, indices);
-
-        auto intListTy = rewriter.getType<Torch::ListType>(
-            rewriter.getType<Torch::IntType>());
-
-        llvm::SmallVector<Value> indicesDims;
-        for (int i = 0, s = indicesTy.getSizes().size(); i < s; ++i) {
-          Value k = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), i);
-          indicesDims.push_back(rewriter.create<Torch::AtenSizeIntOp>(
-              binder.getLoc(), indices, k));
-        }
-
-        Value indicesSizeList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(), intListTy, indicesDims);
-
-        // Determine the collapsed dim size:
-        auto indicesCt = 1;
-        for (auto sz : indicesTy.getSizes()) {
-          if (sz == Torch::kUnknownSize) {
-            indicesCt = Torch::kUnknownSize;
-            break;
-          }
-
-          indicesCt *= sz;
-        }
-
-        auto flattenTy = rewriter.getType<Torch::ValueTensorType>(
-            SmallVector<int64_t>{indicesCt}, indicesTy.getOptionalDtype());
-
-        if (indicesRank == 0) {
-          indices = rewriter.create<Torch::AtenUnsqueezeOp>(
-              binder.getLoc(), flattenTy, indices, zero);
-        } else if (indicesRank > 1) {
-          Value rank = rewriter.create<Torch::AtenDimOp>(loc, intTy, indices);
-          Value end = rewriter.create<Torch::AtenSubIntOp>(loc, rank, one);
-          indices = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
-              loc, flattenTy, indices, zero, end);
-        }
-
-        llvm::SmallVector<int64_t> gatherShape(dataTy.getSizes());
-        gatherShape[axis] = indicesCt;
-        auto gatherTy = rewriter.getType<Torch::ValueTensorType>(
-            gatherShape, dataTy.getOptionalDtype());
-        Value gather = rewriter.create<Torch::AtenIndexSelectOp>(
-            loc, gatherTy, data, index, indices);
-
-        if (indicesRank == 1) {
-          rewriter.replaceOp(binder.op, gather);
-          return success();
-        }
-
-        if (indicesRank > 1) {
-          gather = rewriter.replaceOpWithNewOp<Torch::AtenUnflattenIntOp>(
-              binder.op, resultType, gather, index, indicesSizeList);
-          return success();
-        }
-
-        rewriter.replaceOpWithNewOp<Torch::AtenSqueezeOp>(binder.op, resultType,
-                                                          gather);
-        return success();
-      });
-  patterns.onOp(
-      "GatherElements", 13,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "GatherElements", 13, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value data, indices;
         int64_t axis;
@@ -2013,93 +1959,90 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             binder.op, resultType, data, constAxis, indices, sparseGrad);
         return success();
       });
+  patterns.onOp("Gemm", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value a, b, c;
+    float alpha, beta;
+    int64_t transA, transB;
+    if (binder.tensorOperandAtIndex(a, 0) ||
+        binder.tensorOperandAtIndex(b, 1) ||
+        binder.s64IntegerAttr(transA, "transA", 0) ||
+        binder.s64IntegerAttr(transB, "transB", 0) ||
+        binder.f32FloatAttr(alpha, "alpha", 1.0f) ||
+        binder.f32FloatAttr(beta, "beta", 1.0f) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+    Value one = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
+
+    auto transpose = [&](Value m) -> Value {
+      auto tty = cast<Torch::ValueTensorType>(m.getType());
+      std::optional<ArrayRef<int64_t>> shape = tty.getOptionalSizes();
+      llvm::SmallVector<int64_t> newShape;
+      if (shape.has_value()) {
+        newShape.append(shape.value().begin(), shape.value().end());
+        std::reverse(newShape.begin(), newShape.end());
+        shape = newShape;
+      }
+      auto oty = Torch::ValueTensorType::get(tty.getContext(), shape,
+                                             tty.getOptionalDtype());
+      return rewriter.create<Torch::AtenTransposeIntOp>(binder.getLoc(), oty, m,
+                                                        zero, one);
+    };
+
+    if (transA) {
+      a = transpose(a);
+    }
+
+    if (transB) {
+      b = transpose(b);
+    }
+
+    if (binder.getNumOperands() == 2) {
+      rewriter.replaceOpWithNewOp<Torch::AtenMmOp>(binder.op, resultType, a, b);
+      return success();
+    }
+
+    if (binder.tensorOperandAtIndex(c, 2))
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Expected either 2 or 3 inputs");
+
+    Value mm =
+        rewriter.create<Torch::AtenMmOp>(binder.getLoc(), resultType, a, b);
+    if (alpha == 1.0 && beta == 1.0) {
+      rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(binder.op, resultType,
+                                                          mm, c, one);
+      return success();
+    }
+
+    if (alpha != 1.0 && beta != 1.0) {
+      Value constAlpha = rewriter.create<Torch::ConstantFloatOp>(
+          binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+          rewriter.getF64FloatAttr(alpha));
+      mm = rewriter.create<Torch::AtenMulScalarOp>(binder.getLoc(), resultType,
+                                                   mm, constAlpha);
+      alpha = 1.0;
+    }
+
+    if (alpha != 1.0) {
+      std::swap(alpha, beta);
+      std::swap(mm, c);
+    }
+
+    Value constBeta = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getF64FloatAttr(beta));
+    rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(binder.op, resultType,
+                                                        mm, c, constBeta);
+    return success();
+  });
   patterns.onOp(
-      "Gemm", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value a, b, c;
-        float alpha, beta;
-        int64_t transA, transB;
-        if (binder.tensorOperandAtIndex(a, 0) ||
-            binder.tensorOperandAtIndex(b, 1) ||
-            binder.s64IntegerAttr(transA, "transA", 0) ||
-            binder.s64IntegerAttr(transB, "transB", 0) ||
-            binder.f32FloatAttr(alpha, "alpha", 1.0f) ||
-            binder.f32FloatAttr(beta, "beta", 1.0f) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
-        Value one = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
-
-        auto transpose = [&](Value m) -> Value {
-          auto tty = cast<Torch::ValueTensorType>(m.getType());
-          std::optional<ArrayRef<int64_t>> shape = tty.getOptionalSizes();
-          llvm::SmallVector<int64_t> newShape;
-          if (shape.has_value()) {
-            newShape.append(shape.value().begin(), shape.value().end());
-            std::reverse(newShape.begin(), newShape.end());
-            shape = newShape;
-          }
-          auto oty = Torch::ValueTensorType::get(tty.getContext(), shape,
-                                                 tty.getOptionalDtype());
-          return rewriter.create<Torch::AtenTransposeIntOp>(binder.getLoc(),
-                                                            oty, m, zero, one);
-        };
-
-        if (transA) {
-          a = transpose(a);
-        }
-
-        if (transB) {
-          b = transpose(b);
-        }
-
-        if (binder.getNumOperands() == 2) {
-          rewriter.replaceOpWithNewOp<Torch::AtenMmOp>(binder.op, resultType, a,
-                                                       b);
-          return success();
-        }
-
-        if (binder.tensorOperandAtIndex(c, 2))
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Expected either 2 or 3 inputs");
-
-        Value mm =
-            rewriter.create<Torch::AtenMmOp>(binder.getLoc(), resultType, a, b);
-        if (alpha == 1.0 && beta == 1.0) {
-          rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
-              binder.op, resultType, mm, c, one);
-          return success();
-        }
-
-        if (alpha != 1.0 && beta != 1.0) {
-          Value constAlpha = rewriter.create<Torch::ConstantFloatOp>(
-              binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-              rewriter.getF64FloatAttr(alpha));
-          mm = rewriter.create<Torch::AtenMulScalarOp>(
-              binder.getLoc(), resultType, mm, constAlpha);
-          alpha = 1.0;
-        }
-
-        if (alpha != 1.0) {
-          std::swap(alpha, beta);
-          std::swap(mm, c);
-        }
-
-        Value constBeta = rewriter.create<Torch::ConstantFloatOp>(
-            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-            rewriter.getF64FloatAttr(beta));
-        rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
-            binder.op, resultType, mm, c, constBeta);
-        return success();
-      });
-  patterns.onOp(
-      "GlobalAveragePool", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "GlobalAveragePool", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value operand;
         if (binder.tensorOperand(operand) ||
@@ -2178,8 +2121,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         return failure();
       });
   patterns.onOp(
-      "GlobalMaxPool", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "GlobalMaxPool", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value operand;
         if (binder.tensorOperand(operand) ||
@@ -2255,8 +2197,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         return failure();
       });
   patterns.onOp(
-      "GlobalLpPool", 2,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "GlobalLpPool", 2, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value operand;
         int64_t p;
@@ -2354,125 +2295,122 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         return success();
       });
 
-  patterns.onOp(
-      "LpPool", 18, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        std::string autoPad;
-        if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
-          return failure();
-        if (autoPad != "NOTSET") {
-          // TODO: Add support for `auto_pad` != "NOTSET"
-          return rewriter.notifyMatchFailure(
-              binder.op, "unsupported conversion: auto_pad != NOTSET");
-        }
+  patterns.onOp("LpPool", 18, [](OpBinder binder, PatternRewriter &rewriter) {
+    std::string autoPad;
+    if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
+      return failure();
+    if (autoPad != "NOTSET") {
+      // TODO: Add support for `auto_pad` != "NOTSET"
+      return rewriter.notifyMatchFailure(
+          binder.op, "unsupported conversion: auto_pad != NOTSET");
+    }
 
-        Torch::ValueTensorType resultType;
-        Value operand;
-        int64_t ceilMode, p;
-        if (binder.tensorOperand(operand) ||
-            binder.s64IntegerAttr(ceilMode, "ceil_mode", 0) ||
-            binder.s64IntegerAttr(p, "p", 2) ||
-            binder.tensorResultType(resultType))
-          return failure();
-        // Determine the rank of input tensor.
-        std::optional<unsigned> maybeRank = Torch::getTensorRank(operand);
-        if (!maybeRank)
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Unimplemented: unranked tensor");
-        unsigned rank = *maybeRank;
-        // only 1D, 2D and 3D LpPool is supported.
-        if (rank > 5 or rank < 3) {
-          return failure();
-        }
+    Torch::ValueTensorType resultType;
+    Value operand;
+    int64_t ceilMode, p;
+    if (binder.tensorOperand(operand) ||
+        binder.s64IntegerAttr(ceilMode, "ceil_mode", 0) ||
+        binder.s64IntegerAttr(p, "p", 2) || binder.tensorResultType(resultType))
+      return failure();
+    // Determine the rank of input tensor.
+    std::optional<unsigned> maybeRank = Torch::getTensorRank(operand);
+    if (!maybeRank)
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Unimplemented: unranked tensor");
+    unsigned rank = *maybeRank;
+    // only 1D, 2D and 3D LpPool is supported.
+    if (rank > 5 or rank < 3) {
+      return failure();
+    }
 
-        SmallVector<int64_t> kernel, padding, strides, dilations;
-        SmallVector<int64_t> defaultPadding(2 * (rank - 2), 0);
-        if (binder.s64IntegerArrayAttr(kernel, "kernel_shape", {}) ||
-            binder.s64IntegerArrayAttr(padding, "pads", defaultPadding) ||
-            binder.s64IntegerArrayAttr(
-                strides, "strides", llvm::SmallVector<int64_t>(rank - 2, 1)) ||
-            binder.s64IntegerArrayAttr(dilations, "dilations", {})) {
-          return failure();
-        }
-        if (kernel.size() != rank - 2) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "kernel list size does not match the number of axes");
-        }
-        if (padding.size() != 2 * (rank - 2)) {
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "padding list size does not match twice the number of axes");
-        }
-        if (strides.size() != rank - 2) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "strides list size does not match the number of axes");
-        }
-        if (dilations.size() > 0) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "dilation is not supported by torch.aten.avgpool op "
-                         "and therefore it is not supported for LpPool.");
-        }
+    SmallVector<int64_t> kernel, padding, strides, dilations;
+    SmallVector<int64_t> defaultPadding(2 * (rank - 2), 0);
+    if (binder.s64IntegerArrayAttr(kernel, "kernel_shape", {}) ||
+        binder.s64IntegerArrayAttr(padding, "pads", defaultPadding) ||
+        binder.s64IntegerArrayAttr(strides, "strides",
+                                   llvm::SmallVector<int64_t>(rank - 2, 1)) ||
+        binder.s64IntegerArrayAttr(dilations, "dilations", {})) {
+      return failure();
+    }
+    if (kernel.size() != rank - 2) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "kernel list size does not match the number of axes");
+    }
+    if (padding.size() != 2 * (rank - 2)) {
+      return rewriter.notifyMatchFailure(
+          binder.op,
+          "padding list size does not match twice the number of axes");
+    }
+    if (strides.size() != rank - 2) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "strides list size does not match the number of axes");
+    }
+    if (dilations.size() > 0) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "dilation is not supported by torch.aten.avgpool op "
+                     "and therefore it is not supported for LpPool.");
+    }
 
-        SmallVector<Value> cstKernel, cstPadding, cstStrides;
-        Value cstOne = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(1));
-        Value numElements = cstOne;
-        for (int64_t i : kernel) {
-          cstKernel.push_back(rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(i)));
-          numElements = rewriter.create<Torch::AtenMulOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              cstKernel.back(), numElements);
-        }
-        Value kernelSizeList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
-            cstKernel);
-        Value paddingList = createConstantIntList(binder, rewriter, padding);
-        Value stridesList = createConstantIntList(binder, rewriter, strides);
-        Value cstCeilMode =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), ceilMode);
-        // onnx lp pool doesn't have countIncludePad attribute but set it to
-        // true so that in 1D case numElements is correctly undoes divison. For
-        // 2D/3D case, division is avoided by divison_override.
-        Value cstCountIncludePad =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
-        Value pv = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), p));
-        auto inputTensorType = cast<Torch::ValueTensorType>(operand.getType());
-        Value abs = rewriter.create<Torch::AtenAbsOp>(binder.getLoc(),
-                                                      inputTensorType, operand);
-        Value pow = rewriter.create<Torch::AtenPowTensorScalarOp>(
-            binder.getLoc(), inputTensorType, abs, pv);
-        Value avgPool;
-        if (rank == 3) {
-          avgPool = rewriter.create<Torch::AtenAvgPool1dOp>(
-              binder.getLoc(), resultType, pow, kernelSizeList, stridesList,
-              paddingList, cstCeilMode, cstCountIncludePad);
-          avgPool = rewriter.create<Torch::AtenMulScalarOp>(
-              binder.getLoc(), resultType, avgPool, numElements);
-        } else if (rank == 4) {
-          avgPool = rewriter.create<Torch::AtenAvgPool2dOp>(
-              binder.getLoc(), resultType, pow, kernelSizeList, stridesList,
-              paddingList, cstCeilMode, cstCountIncludePad,
-              /*divisor_override=*/cstOne);
-        } else { // rank == 5
-          avgPool = rewriter.create<Torch::AtenAvgPool3dOp>(
-              binder.getLoc(), resultType, pow, kernelSizeList, stridesList,
-              paddingList, cstCeilMode, cstCountIncludePad,
-              /*divisor_override=*/cstOne);
-        }
-        Value invP = rewriter.create<Torch::ConstantFloatOp>(
-            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-            rewriter.getF64FloatAttr(double{1.0 / p}));
-        rewriter.replaceOpWithNewOp<Torch::AtenPowTensorScalarOp>(
-            binder.op, resultType, avgPool, invP);
-        return success();
-      });
+    SmallVector<Value> cstKernel, cstPadding, cstStrides;
+    Value cstOne = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(1));
+    Value numElements = cstOne;
+    for (int64_t i : kernel) {
+      cstKernel.push_back(rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(i)));
+      numElements = rewriter.create<Torch::AtenMulOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(), cstKernel.back(),
+          numElements);
+    }
+    Value kernelSizeList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+        cstKernel);
+    Value paddingList = createConstantIntList(binder, rewriter, padding);
+    Value stridesList = createConstantIntList(binder, rewriter, strides);
+    Value cstCeilMode =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), ceilMode);
+    // onnx lp pool doesn't have countIncludePad attribute but set it to
+    // true so that in 1D case numElements is correctly undoes divison. For
+    // 2D/3D case, division is avoided by divison_override.
+    Value cstCountIncludePad =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
+    Value pv = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), p));
+    auto inputTensorType = cast<Torch::ValueTensorType>(operand.getType());
+    Value abs = rewriter.create<Torch::AtenAbsOp>(binder.getLoc(),
+                                                  inputTensorType, operand);
+    Value pow = rewriter.create<Torch::AtenPowTensorScalarOp>(
+        binder.getLoc(), inputTensorType, abs, pv);
+    Value avgPool;
+    if (rank == 3) {
+      avgPool = rewriter.create<Torch::AtenAvgPool1dOp>(
+          binder.getLoc(), resultType, pow, kernelSizeList, stridesList,
+          paddingList, cstCeilMode, cstCountIncludePad);
+      avgPool = rewriter.create<Torch::AtenMulScalarOp>(
+          binder.getLoc(), resultType, avgPool, numElements);
+    } else if (rank == 4) {
+      avgPool = rewriter.create<Torch::AtenAvgPool2dOp>(
+          binder.getLoc(), resultType, pow, kernelSizeList, stridesList,
+          paddingList, cstCeilMode, cstCountIncludePad,
+          /*divisor_override=*/cstOne);
+    } else { // rank == 5
+      avgPool = rewriter.create<Torch::AtenAvgPool3dOp>(
+          binder.getLoc(), resultType, pow, kernelSizeList, stridesList,
+          paddingList, cstCeilMode, cstCountIncludePad,
+          /*divisor_override=*/cstOne);
+    }
+    Value invP = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getF64FloatAttr(double{1.0 / p}));
+    rewriter.replaceOpWithNewOp<Torch::AtenPowTensorScalarOp>(
+        binder.op, resultType, avgPool, invP);
+    return success();
+  });
 
   patterns.onOp(
-      "LayerNormalization", 17,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "LayerNormalization", 17, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType yType, meanType, invStdDevType;
         Value x, scale, b;
         int64_t axis, stashType;
@@ -2557,624 +2495,597 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         return rewriter.notifyMatchFailure(
             binder.op, "Unimplemented: expected either 1 or 3 results");
       });
-  patterns.onOp("LeakyRelu", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  float alpha;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType) ||
-                      binder.f32FloatAttr(alpha, "alpha", 0.01f))
-                    return failure();
-                  Value constAlpha = rewriter.create<Torch::ConstantFloatOp>(
-                      binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-                      rewriter.getF64FloatAttr(alpha));
-                  rewriter.replaceOpWithNewOp<Torch::AtenLeakyReluOp>(
-                      binder.op, resultType, operand, constAlpha);
-                  return success();
-                });
-  patterns.onOp(
-      "LRN", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        int64_t size;
-        float alpha, beta, bias;
-        if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType) ||
-            binder.s64IntegerAttr(size, "size", 2) ||
-            binder.f32FloatAttr(alpha, "alpha", 0.0001f) ||
-            binder.f32FloatAttr(beta, "beta", 0.75f) ||
-            binder.f32FloatAttr(bias, "bias", 1.0f))
-          return failure();
-        Type dtype = resultType.getOptionalDtype();
-        Value constAlpha = rewriter.create<Torch::ConstantFloatOp>(
-            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-            rewriter.getF64FloatAttr(alpha));
-        Value constBeta = rewriter.create<Torch::ConstantFloatOp>(
-            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-            rewriter.getF64FloatAttr(beta));
-        Value constBias = rewriter.create<Torch::ConstantFloatOp>(
-            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-            rewriter.getF64FloatAttr(bias));
-        // Please refer to the operator description
-        // for more info on the lowering
-        // https://onnx.ai/onnx/operators/onnx__LRN.html
+  patterns.onOp("LeakyRelu", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    float alpha;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType) ||
+        binder.f32FloatAttr(alpha, "alpha", 0.01f))
+      return failure();
+    Value constAlpha = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getF64FloatAttr(alpha));
+    rewriter.replaceOpWithNewOp<Torch::AtenLeakyReluOp>(binder.op, resultType,
+                                                        operand, constAlpha);
+    return success();
+  });
+  patterns.onOp("LRN", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    int64_t size;
+    float alpha, beta, bias;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType) ||
+        binder.s64IntegerAttr(size, "size", 2) ||
+        binder.f32FloatAttr(alpha, "alpha", 0.0001f) ||
+        binder.f32FloatAttr(beta, "beta", 0.75f) ||
+        binder.f32FloatAttr(bias, "bias", 1.0f))
+      return failure();
+    Type dtype = resultType.getOptionalDtype();
+    Value constAlpha = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getF64FloatAttr(alpha));
+    Value constBeta = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getF64FloatAttr(beta));
+    Value constBias = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getF64FloatAttr(bias));
+    // Please refer to the operator description
+    // for more info on the lowering
+    // https://onnx.ai/onnx/operators/onnx__LRN.html
 
-        // squared = operand^2
-        Location loc = binder.getLoc();
-        Torch::ValueTensorType inTy =
-            cast<Torch::ValueTensorType>(operand.getType());
-        Value sqOperand = rewriter.create<Torch::AtenMulTensorOp>(
-            loc, inTy, operand, operand);
-        // view it as n x 1 x c x d0 x d..
-        if (!inTy.hasSizes()) {
+    // squared = operand^2
+    Location loc = binder.getLoc();
+    Torch::ValueTensorType inTy =
+        cast<Torch::ValueTensorType>(operand.getType());
+    Value sqOperand =
+        rewriter.create<Torch::AtenMulTensorOp>(loc, inTy, operand, operand);
+    // view it as n x 1 x c x d0 x d..
+    if (!inTy.hasSizes()) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Expected input to have sizes");
+    }
+    ArrayRef<int64_t> inTyShape = inTy.getSizes();
+    if (inTyShape.size() < 3) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "Unsupported: the input dimensions should be >= 3");
+    }
+    if (inTyShape[1] == Torch::kUnknownSize) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "Unsupported: the second dimension size must be "
+                     "statically known");
+    }
+    SmallVector<int64_t, 5> viewShapeInt{inTyShape[0], 1, inTyShape[1],
+                                         inTyShape[2], Torch::kUnknownSize};
+    Torch::ValueTensorType reshapeType =
+        rewriter.getType<Torch::ValueTensorType>(viewShapeInt, dtype);
+    Value viewShapeListVal =
+        createConstantIntList(binder, rewriter, viewShapeInt);
+    auto view = rewriter.create<Torch::AtenViewOp>(loc, reshapeType, sqOperand,
+                                                   viewShapeListVal);
+    // padding
+    int64_t highPad = (size - 1) / 2;
+    int64_t lowPad = (size - 1) - highPad;
+    SmallVector<int64_t> paddingInt{0, 0, 0, 0, lowPad, highPad};
+    auto constPadVal = rewriter.create<Torch::ConstantFloatOp>(
+        loc, rewriter.getType<Torch::FloatType>(),
+        rewriter.getF64FloatAttr(0.0));
+    Value paddingListVal = createConstantIntList(binder, rewriter, paddingInt);
+    SmallVector<int64_t, 5> paddedShapeInt = viewShapeInt;
+    paddedShapeInt[2] += size - 1;
+    Torch::ValueTensorType paddedType =
+        rewriter.getType<Torch::ValueTensorType>(paddedShapeInt, dtype);
+    auto padded = rewriter.create<Torch::AtenConstantPadNdOp>(
+        loc, paddedType, view, paddingListVal, constPadVal);
+    // avg_pool3d
+    SmallVector<int64_t, 3> kernelSize{size, 1, 1};
+    Value kernelSizeList = createConstantIntList(binder, rewriter, kernelSize);
+    SmallVector<int64_t, 3> strides{1, 1, 1};
+    Value stridesList = createConstantIntList(binder, rewriter, strides);
+    SmallVector<int64_t, 3> padding{0, 0, 0};
+    Value paddingList = createConstantIntList(binder, rewriter, padding);
+    auto cstCeilMode =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
+    auto cstCountIncludeMode =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
+    Value cstNone = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    // Output of pooling is same reshape(view) type because
+    // of the padding done on the dimensions being pooled.
+    auto pool = rewriter.create<Torch::AtenAvgPool3dOp>(
+        loc, reshapeType, padded, kernelSizeList, stridesList, paddingList,
+        cstCeilMode, cstCountIncludeMode, /*divisor_override=*/cstNone);
+    // squeeze
+    auto one = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(1));
+    SmallVector<int64_t, 5> squeezeShapeInt{viewShapeInt[0], viewShapeInt[2],
+                                            viewShapeInt[3], viewShapeInt[4]};
+    Torch::ValueTensorType squeezeType =
+        rewriter.getType<Torch::ValueTensorType>(squeezeShapeInt, dtype);
+    auto squeeze =
+        rewriter.create<Torch::AtenSqueezeDimOp>(loc, squeezeType, pool, one);
+    // view as input Type
+    Value intTyShapeList = createConstantIntList(binder, rewriter, inTyShape);
+    auto viewAsInput =
+        rewriter.create<Torch::AtenViewOp>(loc, inTy, squeeze, intTyShapeList);
+    // mul + add + pow + div
+    auto mul = rewriter.create<Torch::AtenMulScalarOp>(loc, resultType,
+                                                       viewAsInput, constAlpha);
+    auto add = rewriter.create<Torch::AtenAddScalarOp>(loc, resultType, mul,
+                                                       constBias, one);
+    auto pow = rewriter.create<Torch::AtenPowTensorScalarOp>(loc, resultType,
+                                                             add, constBeta);
+
+    rewriter.replaceOpWithNewOp<Torch::AtenDivTensorOp>(binder.op, resultType,
+                                                        operand, pow);
+    return success();
+  });
+  patterns.onOp("Pad", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value data, pads, axes;
+    std::string mode;
+
+    // TODO: The `axes` parameter is not supported yet.
+    if (!binder.tensorOperandAtIndex(axes, 3)) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "The axes parameter is not supported yet");
+    }
+    if (binder.tensorOperandAtIndex(data, 0) ||
+        binder.tensorResultType(resultType) ||
+        binder.customOpNameStringAttr(mode, "mode", "constant"))
+      return failure();
+    bool cstMode = (mode == "constant");
+
+    // get input rank
+    auto dataOpTy = cast<Torch::ValueTensorType>(data.getType());
+    TensorType dataTensor = dataOpTy.toBuiltinTensor();
+    if (!dataTensor || !dataTensor.hasRank())
+      return rewriter.notifyMatchFailure(
+          binder.op, "pad length unknown and data operand unranked");
+    int64_t dataRank = dataTensor.getRank();
+    int64_t padsSize = 2 * dataRank;
+
+    Location loc = binder.getLoc();
+
+    // get pads (earlier versions use an attribute, newer versions use a
+    // tensor input)
+    SmallVector<Value> padsTensorValue;
+    if (binder.tensorOperandAtIndex(pads, 1)) {
+      SmallVector<int64_t> defaultPads(2 * dataRank, 0);
+      SmallVector<int64_t> padInts;
+      if (binder.s64IntegerArrayAttr(padInts, "pads", defaultPads))
+        return rewriter.notifyMatchFailure(binder.op, "pads binder failure");
+      // opset_version 1 uses the attribute name "paddings"
+      if (padInts == defaultPads) {
+        SmallVector<int64_t> paddingsInts;
+        if (binder.s64IntegerArrayAttr(paddingsInts, "paddings", defaultPads))
           return rewriter.notifyMatchFailure(binder.op,
-                                             "Expected input to have sizes");
-        }
-        ArrayRef<int64_t> inTyShape = inTy.getSizes();
-        if (inTyShape.size() < 3) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "Unsupported: the input dimensions should be >= 3");
-        }
-        if (inTyShape[1] == Torch::kUnknownSize) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "Unsupported: the second dimension size must be "
-                         "statically known");
-        }
-        SmallVector<int64_t, 5> viewShapeInt{inTyShape[0], 1, inTyShape[1],
-                                             inTyShape[2], Torch::kUnknownSize};
-        Torch::ValueTensorType reshapeType =
-            rewriter.getType<Torch::ValueTensorType>(viewShapeInt, dtype);
-        Value viewShapeListVal =
-            createConstantIntList(binder, rewriter, viewShapeInt);
-        auto view = rewriter.create<Torch::AtenViewOp>(
-            loc, reshapeType, sqOperand, viewShapeListVal);
-        // padding
-        int64_t highPad = (size - 1) / 2;
-        int64_t lowPad = (size - 1) - highPad;
-        SmallVector<int64_t> paddingInt{0, 0, 0, 0, lowPad, highPad};
-        auto constPadVal = rewriter.create<Torch::ConstantFloatOp>(
-            loc, rewriter.getType<Torch::FloatType>(),
-            rewriter.getF64FloatAttr(0.0));
-        Value paddingListVal =
-            createConstantIntList(binder, rewriter, paddingInt);
-        SmallVector<int64_t, 5> paddedShapeInt = viewShapeInt;
-        paddedShapeInt[2] += size - 1;
-        Torch::ValueTensorType paddedType =
-            rewriter.getType<Torch::ValueTensorType>(paddedShapeInt, dtype);
-        auto padded = rewriter.create<Torch::AtenConstantPadNdOp>(
-            loc, paddedType, view, paddingListVal, constPadVal);
-        // avg_pool3d
-        SmallVector<int64_t, 3> kernelSize{size, 1, 1};
-        Value kernelSizeList =
-            createConstantIntList(binder, rewriter, kernelSize);
-        SmallVector<int64_t, 3> strides{1, 1, 1};
-        Value stridesList = createConstantIntList(binder, rewriter, strides);
-        SmallVector<int64_t, 3> padding{0, 0, 0};
-        Value paddingList = createConstantIntList(binder, rewriter, padding);
-        auto cstCeilMode =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
-        auto cstCountIncludeMode =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
-        Value cstNone = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        // Output of pooling is same reshape(view) type because
-        // of the padding done on the dimensions being pooled.
-        auto pool = rewriter.create<Torch::AtenAvgPool3dOp>(
-            loc, reshapeType, padded, kernelSizeList, stridesList, paddingList,
-            cstCeilMode, cstCountIncludeMode, /*divisor_override=*/cstNone);
-        // squeeze
-        auto one = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(1));
-        SmallVector<int64_t, 5> squeezeShapeInt{
-            viewShapeInt[0], viewShapeInt[2], viewShapeInt[3], viewShapeInt[4]};
-        Torch::ValueTensorType squeezeType =
-            rewriter.getType<Torch::ValueTensorType>(squeezeShapeInt, dtype);
-        auto squeeze = rewriter.create<Torch::AtenSqueezeDimOp>(
-            loc, squeezeType, pool, one);
-        // view as input Type
-        Value intTyShapeList =
-            createConstantIntList(binder, rewriter, inTyShape);
-        auto viewAsInput = rewriter.create<Torch::AtenViewOp>(
-            loc, inTy, squeeze, intTyShapeList);
-        // mul + add + pow + div
-        auto mul = rewriter.create<Torch::AtenMulScalarOp>(
-            loc, resultType, viewAsInput, constAlpha);
-        auto add = rewriter.create<Torch::AtenAddScalarOp>(loc, resultType, mul,
-                                                           constBias, one);
-        auto pow = rewriter.create<Torch::AtenPowTensorScalarOp>(
-            loc, resultType, add, constBeta);
+                                             "paddings binder failure");
+        padInts = paddingsInts;
+      }
+      for (auto p : padInts)
+        padsTensorValue.push_back(rewriter.create<Torch::ConstantIntOp>(
+            loc, rewriter.getI64IntegerAttr(p)));
+    } else {
+      // Get pads shape and rank. The pads tensor is expected to be 1-D
+      // tensor.
+      auto padsTensorType = cast<Torch::ValueTensorType>(pads.getType());
+      if (!padsTensorType || !padsTensorType.hasSizes()) {
+        return rewriter.notifyMatchFailure(binder.op,
+                                           "Expect non empty pad tensor");
+      }
+      ArrayRef<int64_t> padsShape = padsTensorType.getSizes();
+      int64_t padsRank = padsShape.size();
+      if (padsRank != 1)
+        return rewriter.notifyMatchFailure(binder.op, "expect 1-d pad tensor");
+      if (padsShape[0] != Torch::kUnknownSize) {
+        // As per onnx.Pad documentation, padSize = 2*num_data_axes
+        // (if axes param not passed). Need to be updated when adding
+        // support for `axes` param.
+        padsSize = padsShape[0];
+      }
 
-        rewriter.replaceOpWithNewOp<Torch::AtenDivTensorOp>(
-            binder.op, resultType, operand, pow);
-        return success();
-      });
-  patterns.onOp(
-      "Pad", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value data, pads, axes;
-        std::string mode;
+      // Extract all the values of 1-D pad tensor and create a list of all
+      // these values as torch.pad op expects pad list.
+      Value constZero = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(0));
+      SmallVector<int64_t> emptyShape;
+      Type padsElemType =
+          Torch::ValueTensorType::get(padsTensorType.getContext(), emptyShape,
+                                      padsTensorType.getOptionalDtype());
+      for (uint32_t i = 0; i < padsSize; ++i) {
+        Value index = rewriter.create<Torch::ConstantIntOp>(
+            loc, rewriter.getI64IntegerAttr(i));
+        auto select = rewriter.create<Torch::AtenSelectIntOp>(
+            loc, padsElemType, pads, constZero, index);
+        Value selectInt = rewriter.create<Torch::AtenItemOp>(
+            loc, rewriter.getType<Torch::IntType>(), select);
+        padsTensorValue.push_back(selectInt);
+      }
+    }
 
-        // TODO: The `axes` parameter is not supported yet.
-        if (!binder.tensorOperandAtIndex(axes, 3)) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "The axes parameter is not supported yet");
-        }
-        if (binder.tensorOperandAtIndex(data, 0) ||
-            binder.tensorResultType(resultType) ||
-            binder.customOpNameStringAttr(mode, "mode", "constant"))
-          return failure();
-        bool cstMode = (mode == "constant");
-
-        // get input rank
-        auto dataOpTy = cast<Torch::ValueTensorType>(data.getType());
-        TensorType dataTensor = dataOpTy.toBuiltinTensor();
-        if (!dataTensor || !dataTensor.hasRank())
-          return rewriter.notifyMatchFailure(
-              binder.op, "pad length unknown and data operand unranked");
-        int64_t dataRank = dataTensor.getRank();
-        int64_t padsSize = 2 * dataRank;
-
-        Location loc = binder.getLoc();
-
-        // get pads (earlier versions use an attribute, newer versions use a
-        // tensor input)
-        SmallVector<Value> padsTensorValue;
-        if (binder.tensorOperandAtIndex(pads, 1)) {
-          SmallVector<int64_t> defaultPads(2 * dataRank, 0);
-          SmallVector<int64_t> padInts;
-          if (binder.s64IntegerArrayAttr(padInts, "pads", defaultPads))
-            return rewriter.notifyMatchFailure(binder.op,
-                                               "pads binder failure");
-          // opset_version 1 uses the attribute name "paddings"
-          if (padInts == defaultPads) {
-            SmallVector<int64_t> paddingsInts;
-            if (binder.s64IntegerArrayAttr(paddingsInts, "paddings",
-                                           defaultPads))
-              return rewriter.notifyMatchFailure(binder.op,
-                                                 "paddings binder failure");
-            padInts = paddingsInts;
-          }
-          for (auto p : padInts)
-            padsTensorValue.push_back(rewriter.create<Torch::ConstantIntOp>(
-                loc, rewriter.getI64IntegerAttr(p)));
-        } else {
-          // Get pads shape and rank. The pads tensor is expected to be 1-D
-          // tensor.
-          auto padsTensorType = cast<Torch::ValueTensorType>(pads.getType());
-          if (!padsTensorType || !padsTensorType.hasSizes()) {
-            return rewriter.notifyMatchFailure(binder.op,
-                                               "Expect non empty pad tensor");
-          }
-          ArrayRef<int64_t> padsShape = padsTensorType.getSizes();
-          int64_t padsRank = padsShape.size();
-          if (padsRank != 1)
-            return rewriter.notifyMatchFailure(binder.op,
-                                               "expect 1-d pad tensor");
-          if (padsShape[0] != Torch::kUnknownSize) {
-            // As per onnx.Pad documentation, padSize = 2*num_data_axes
-            // (if axes param not passed). Need to be updated when adding
-            // support for `axes` param.
-            padsSize = padsShape[0];
-          }
-
-          // Extract all the values of 1-D pad tensor and create a list of all
-          // these values as torch.pad op expects pad list.
-          Value constZero = rewriter.create<Torch::ConstantIntOp>(
-              loc, rewriter.getI64IntegerAttr(0));
-          SmallVector<int64_t> emptyShape;
-          Type padsElemType = Torch::ValueTensorType::get(
-              padsTensorType.getContext(), emptyShape,
-              padsTensorType.getOptionalDtype());
-          for (uint32_t i = 0; i < padsSize; ++i) {
-            Value index = rewriter.create<Torch::ConstantIntOp>(
-                loc, rewriter.getI64IntegerAttr(i));
-            auto select = rewriter.create<Torch::AtenSelectIntOp>(
-                loc, padsElemType, pads, constZero, index);
-            Value selectInt = rewriter.create<Torch::AtenItemOp>(
-                loc, rewriter.getType<Torch::IntType>(), select);
-            padsTensorValue.push_back(selectInt);
-          }
-        }
-
-        Value constantValue;
-        if (binder.getNumOperands() >= 3 && cstMode) {
-          if (!binder.tensorOperandAtIndex(constantValue, 2)) {
-            auto constTy =
-                dyn_cast<Torch::BaseTensorType>(constantValue.getType());
-            if (!constTy || !constTy.hasDtype())
-              return rewriter.notifyMatchFailure(
-                  binder.op, "constant ty is unsupport type");
-
-            Type scalarTy = rewriter.getType<Torch::IntType>();
-            if (isa<FloatType>(constTy.getDtype()))
-              scalarTy = rewriter.getType<Torch::FloatType>();
-            constantValue = rewriter.create<Torch::AtenItemOp>(loc, scalarTy,
-                                                               constantValue);
-          }
-        }
-
-        if (!constantValue && cstMode) {
-          auto dataTensorType = cast<Torch::ValueTensorType>(data.getType());
-          if (isa<IntegerType>(dataTensorType.getDtype()))
-            constantValue = rewriter.create<Torch::ConstantIntOp>(
-                loc, rewriter.getI64IntegerAttr(0));
-          // Earlier versions used a FLOAT attribute to store the constant
-          // value. The following will pick up on any non-default value attr if
-          // provided.
-          float constantFloat;
-          if (isa<FloatType>(dataTensorType.getDtype()) &&
-              !binder.f32FloatAttr(constantFloat, "value", 0.0f))
-            constantValue = rewriter.create<Torch::ConstantFloatOp>(
-                loc, rewriter.getF64FloatAttr(constantFloat));
-
-          if (!constantValue)
-            return rewriter.notifyMatchFailure(
-                binder.op, "expected integer or float data tensor");
-        }
-
-        // for modes other than "constant" a value is not required
-        if (!cstMode)
-          constantValue = rewriter.create<Torch::ConstantNoneOp>(loc);
-
-        // The torch.pad op expects a different arrangement of padding pairs for
-        // each dimension as compared to the onnx.pad op. Rearrange the pad
-        // tensor as shown below:
-        //
-        // [x1_begin, x2_begin, ..., x1_end, x2_end,...] ->
-        // [xn_begin, xn_end, ...., x2_begin, x2_end, x1_begin, x1_end]
-        SmallVector<Value> padsRearrange;
-        for (uint32_t i = padsSize - 1; i >= padsSize / 2; i--) {
-          padsRearrange.emplace_back(padsTensorValue[i - padsSize / 2]);
-          padsRearrange.emplace_back(padsTensorValue[i]);
-        }
-
-        Value padsSizeList =
-            rewriter
-                .create<Torch::PrimListConstructOp>(
-                    loc,
-                    Torch::ListType::get(rewriter.getType<Torch::IntType>()),
-                    padsRearrange)
-                .getResult();
-
-        // lowering to AtenConstantPadNdOp directly allows passing any torch
-        // scalar type for the value, whereas AtenPadOp takes an optional float
-        // type.
-        if (cstMode && !isa<Torch::NoneType>(constantValue.getType())) {
-          rewriter.replaceOpWithNewOp<Torch::AtenConstantPadNdOp>(
-              binder.op, resultType, data, padsSizeList, constantValue);
-          return success();
-        }
-
-        // translate a few mismatching mode names ONNX -> Torch
-        mode = (mode == "edge") ? "replicate" : mode;
-        mode = (mode == "wrap") ? "circular" : mode;
-
-        Value modeVal = rewriter.create<Torch::ConstantStrOp>(
-            loc, rewriter.getStringAttr(mode));
-
-        rewriter.replaceOpWithNewOp<Torch::AtenPadOp>(
-            binder.op, resultType, data, padsSizeList, modeVal, constantValue);
-        return success();
-      });
-  patterns.onOp(
-      "Pow", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value lhs, rhs;
-        if (binder.tensorOperands(lhs, rhs) ||
-            binder.tensorResultType(resultType)) {
-          return failure();
-        }
-
-        auto loc = binder.getLoc();
-        auto lhsTy = cast<Torch::ValueTensorType>(lhs.getType());
-        auto rhsTy = cast<Torch::ValueTensorType>(rhs.getType());
-        Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(
-            loc, rewriter.getBoolAttr(false));
-        Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
-        auto torchDtype = Torch::getScalarTypeForType(rewriter.getF32Type());
-        Value tyConst = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64),
-                                    static_cast<int64_t>(torchDtype)));
-
-        if (isa<IntegerType>(lhsTy.getDtype())) {
-          lhsTy = rewriter.getType<Torch::ValueTensorType>(
-              lhsTy.getSizes(), rewriter.getF32Type());
-          lhs = rewriter.create<Torch::AtenToDtypeOp>(loc, lhsTy, lhs, tyConst,
-                                                      cstFalse, cstFalse, none);
-        }
-
-        if (isa<IntegerType>(rhsTy.getDtype())) {
-          rhsTy = rewriter.getType<Torch::ValueTensorType>(
-              rhsTy.getSizes(), rewriter.getF32Type());
-          rhs = rewriter.create<Torch::AtenToDtypeOp>(loc, rhsTy, rhs, tyConst,
-                                                      cstFalse, cstFalse, none);
-        }
-
-        auto powType = resultType;
-        if (isa<IntegerType>(resultType.getDtype())) {
-          powType = rewriter.getType<Torch::ValueTensorType>(
-              resultType.getSizes(), rewriter.getF32Type());
-        }
-
-        Value pow = rewriter.create<Torch::AtenPowTensorTensorOp>(loc, powType,
-                                                                  lhs, rhs);
-
-        if (!isa<IntegerType>(resultType.getDtype())) {
-          rewriter.replaceOp(binder.op, pow);
-          return success();
-        }
-
-        auto outDtype = Torch::getScalarTypeForType(resultType.getDtype());
-        auto outTyConst = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64),
-                                    static_cast<int64_t>(outDtype)));
-
-        rewriter.replaceOpWithNewOp<Torch::AtenToDtypeOp>(
-            binder.op, resultType, pow, outTyConst, cstFalse, cstFalse, none);
-
-        return success();
-      });
-  patterns.onOp(
-      "Identity", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value tensor;
-        if (binder.tensorOperand(tensor) ||
-            binder.tensorResultType(resultType)) {
-          return failure();
-        }
-        Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        rewriter.replaceOpWithNewOp<Torch::AtenCloneOp>(
-            binder.op, resultType, tensor, /*memory_format=*/noneVal);
-        return success();
-      });
-  patterns.onOp(
-      "Mean", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        if (binder.op->getNumOperands() == 1) {
-          Torch::ValueTensorType resultType;
-          Value x;
-          if (binder.tensorOperand(x) || binder.tensorResultType(resultType))
-            return failure();
-          rewriter.replaceOp(binder.op, x);
-          return success();
-        }
-        Torch::ValueTensorType resultType;
-        SmallVector<Value> valList;
-        int64_t numOperands = binder.op->getNumOperands();
-        Value numOperandsConstant = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), numOperands));
-        if (binder.tensorOperands(valList, numOperands) ||
-            binder.tensorResultType(resultType))
-          return failure();
-        Value constOne = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
-        // Short circuit to binary add
-        Value curr = rewriter.create<Torch::AtenAddTensorOp>(
-            binder.getLoc(), resultType, valList[0], valList[1], constOne);
-        if (numOperands == 2) {
-          rewriter.replaceOpWithNewOp<Torch::AtenDivScalarOp>(
-              binder.op, resultType, curr, numOperandsConstant);
-          return success();
-        }
-        // When binder.op->getNumOperands() > 2
-        auto baseType = Torch::ValueTensorType::getWithLeastStaticInformation(
-            binder.op->getContext());
-        for (int i = 2; i < numOperands; i++) {
-          if (i == numOperands - 1) {
-            curr = rewriter.create<Torch::AtenAddTensorOp>(
-                binder.getLoc(), resultType, curr, valList[i], constOne);
-          } else {
-            curr = rewriter.create<Torch::AtenAddTensorOp>(
-                binder.getLoc(), baseType, curr, valList[i], constOne);
-          }
-        }
-        rewriter.replaceOpWithNewOp<Torch::AtenDivScalarOp>(
-            binder.op, resultType, curr, numOperandsConstant);
-        return success();
-      });
-  patterns.onOp(
-      "IsInf", 10, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value tensor;
-        int64_t neg;
-        int64_t pos;
-        if (binder.tensorOperand(tensor) ||
-            binder.s64IntegerAttr(neg, "detect_negative", 1) ||
-            binder.s64IntegerAttr(pos, "detect_positive", 1) ||
-            binder.tensorResultType(resultType)) {
-          return failure();
-        }
-        if (neg == 0) {
-          // replace all negative infs with 0
-          tensor = rewriter.create<Torch::AtenReluOp>(
-              binder.getLoc(),
-              dyn_cast<Torch::ValueTensorType>(tensor.getType()), tensor);
-        }
-        if (pos == 0) {
-          // first use neg op to flip positive inf to negative inf. Then relu to
-          // replace all positive infs with 0.
-          Value flip = rewriter.create<Torch::AtenNegOp>(
-              binder.getLoc(),
-              dyn_cast<Torch::ValueTensorType>(tensor.getType()), tensor);
-          tensor = rewriter.create<Torch::AtenReluOp>(
-              binder.getLoc(), dyn_cast<Torch::ValueTensorType>(flip.getType()),
-              flip);
-        }
-        rewriter.replaceOpWithNewOp<Torch::AtenIsinfOp>(binder.op, resultType,
-                                                        tensor);
-        return success();
-      });
-  patterns.onOp("IsNaN", 9,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value tensor;
-                  if (binder.tensorOperand(tensor) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
-                  rewriter.replaceOpWithNewOp<Torch::AtenIsnanOp>(
-                      binder.op, resultType, tensor);
-                  return success();
-                });
-  patterns.onOp("PRelu", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value tensor;
-                  Value slope;
-                  if (binder.tensorOperands(tensor, slope) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
-                  rewriter.replaceOpWithNewOp<Torch::AtenPreluOp>(
-                      binder.op, resultType, tensor, slope);
-                  return success();
-                });
-  patterns.onOp("Mod", 13,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value self, other;
-                  int64_t fmod;
-                  if (binder.tensorOperands(self, other) ||
-                      binder.tensorResultType(resultType) ||
-                      binder.s64IntegerAttr(fmod, "fmod", 0)) {
-                    return failure();
-                  }
-
-                  if (fmod) {
-                    rewriter.replaceOpWithNewOp<Torch::AtenFmodTensorOp>(
-                        binder.op, resultType, self, other);
-                    return success();
-                  }
-
-                  rewriter.replaceOpWithNewOp<Torch::AtenRemainderTensorOp>(
-                      binder.op, resultType, self, other);
-                  return success();
-                });
-  patterns.onOp("Mish", 18,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value input;
-                  if (binder.tensorOperand(input) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
-                  rewriter.replaceOpWithNewOp<Torch::AtenMishOp>(
-                      binder.op, resultType, input);
-                  return success();
-                });
-  patterns.onOp(
-      "OneHot", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        llvm::SmallVector<Value> inputs;
-        Torch::ValueTensorType resultType;
-        if (binder.tensorOperandsList(inputs) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        if (inputs.size() != 3)
-          return rewriter.notifyMatchFailure(binder.op, "expected 3 operands");
-
-        int64_t axis;
-        if (binder.s64IntegerAttr(axis, "axis", -1))
+    Value constantValue;
+    if (binder.getNumOperands() >= 3 && cstMode) {
+      if (!binder.tensorOperandAtIndex(constantValue, 2)) {
+        auto constTy = dyn_cast<Torch::BaseTensorType>(constantValue.getType());
+        if (!constTy || !constTy.hasDtype())
           return rewriter.notifyMatchFailure(binder.op,
-                                             "`axis` attr not found");
+                                             "constant ty is unsupport type");
 
-        auto loc = binder.getLoc();
-        Value indices = inputs[0];
-        Value depth = inputs[1];
-        Value values = inputs[2];
+        Type scalarTy = rewriter.getType<Torch::IntType>();
+        if (isa<FloatType>(constTy.getDtype()))
+          scalarTy = rewriter.getType<Torch::FloatType>();
+        constantValue =
+            rewriter.create<Torch::AtenItemOp>(loc, scalarTy, constantValue);
+      }
+    }
 
-        auto indicesTy = cast<Torch::ValueTensorType>(indices.getType());
-        auto valuesTy = cast<Torch::ValueTensorType>(values.getType());
-        auto depthTy = cast<Torch::ValueTensorType>(depth.getType());
-
-        axis = axis < 0 ? axis + indicesTy.getSizes().size() + 1 : axis;
-
-        bool depthIsInt = isa<IntegerType>(depthTy.getDtype());
-        Type intTy = rewriter.getType<Torch::IntType>();
-        Type floatTy = rewriter.getType<Torch::FloatType>();
-        Type depthETy = depthIsInt ? intTy : floatTy;
-        depth = rewriter.create<Torch::AtenItemOp>(loc, depthETy, depth);
-
-        if (!depthIsInt)
-          depth = rewriter.create<Torch::AtenIntScalarOp>(
-              loc, rewriter.getType<Torch::IntType>(), depth);
-
-        Type boolTy = rewriter.getType<Torch::ValueTensorType>(
-            indicesTy.getSizes(), rewriter.getI1Type());
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
+    if (!constantValue && cstMode) {
+      auto dataTensorType = cast<Torch::ValueTensorType>(data.getType());
+      if (isa<IntegerType>(dataTensorType.getDtype()))
+        constantValue = rewriter.create<Torch::ConstantIntOp>(
             loc, rewriter.getI64IntegerAttr(0));
-        Value one = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(1));
-        Value lt =
-            rewriter.create<Torch::AtenLtScalarOp>(loc, boolTy, indices, zero);
-        Value add = rewriter.create<Torch::AtenAddScalarOp>(
-            loc, indicesTy, indices, depth, one);
-        indices = rewriter.create<Torch::AtenWhereSelfOp>(loc, indicesTy, lt,
-                                                          add, indices);
+      // Earlier versions used a FLOAT attribute to store the constant
+      // value. The following will pick up on any non-default value attr if
+      // provided.
+      float constantFloat;
+      if (isa<FloatType>(dataTensorType.getDtype()) &&
+          !binder.f32FloatAttr(constantFloat, "value", 0.0f))
+        constantValue = rewriter.create<Torch::ConstantFloatOp>(
+            loc, rewriter.getF64FloatAttr(constantFloat));
 
-        auto selectTy = rewriter.getType<Torch::ValueTensorType>(
-            llvm::SmallVector<int64_t>{1}, valuesTy.getDtype());
+      if (!constantValue)
+        return rewriter.notifyMatchFailure(
+            binder.op, "expected integer or float data tensor");
+    }
 
-        bool valuesAreInt = isa<IntegerType>(valuesTy.getDtype());
-        Type valuesETy = valuesAreInt ? intTy : floatTy;
+    // for modes other than "constant" a value is not required
+    if (!cstMode)
+      constantValue = rewriter.create<Torch::ConstantNoneOp>(loc);
 
-        Value off = rewriter.create<Torch::AtenSelectIntOp>(loc, selectTy,
-                                                            values, zero, zero);
-        off = rewriter.create<Torch::AtenItemOp>(loc, valuesETy, off);
+    // The torch.pad op expects a different arrangement of padding pairs for
+    // each dimension as compared to the onnx.pad op. Rearrange the pad
+    // tensor as shown below:
+    //
+    // [x1_begin, x2_begin, ..., x1_end, x2_end,...] ->
+    // [xn_begin, xn_end, ...., x2_begin, x2_end, x1_begin, x1_end]
+    SmallVector<Value> padsRearrange;
+    for (uint32_t i = padsSize - 1; i >= padsSize / 2; i--) {
+      padsRearrange.emplace_back(padsTensorValue[i - padsSize / 2]);
+      padsRearrange.emplace_back(padsTensorValue[i]);
+    }
 
-        Value on = rewriter.create<Torch::AtenSelectIntOp>(loc, selectTy,
-                                                           values, zero, one);
-        on = rewriter.create<Torch::AtenItemOp>(loc, valuesETy, on);
+    Value padsSizeList =
+        rewriter
+            .create<Torch::PrimListConstructOp>(
+                loc, Torch::ListType::get(rewriter.getType<Torch::IntType>()),
+                padsRearrange)
+            .getResult();
 
-        auto i32Ty = rewriter.getIntegerType(32, true);
-        llvm::SmallVector<int64_t> onehotShape(indicesTy.getSizes());
-        onehotShape.push_back(Torch::kUnknownSize);
-        auto onehotTy =
-            rewriter.getType<Torch::ValueTensorType>(onehotShape, i32Ty);
+    // lowering to AtenConstantPadNdOp directly allows passing any torch
+    // scalar type for the value, whereas AtenPadOp takes an optional float
+    // type.
+    if (cstMode && !isa<Torch::NoneType>(constantValue.getType())) {
+      rewriter.replaceOpWithNewOp<Torch::AtenConstantPadNdOp>(
+          binder.op, resultType, data, padsSizeList, constantValue);
+      return success();
+    }
 
-        Value onehot = rewriter.create<Torch::AtenOneHotOp>(
-            binder.getLoc(), onehotTy, indices, depth);
+    // translate a few mismatching mode names ONNX -> Torch
+    mode = (mode == "edge") ? "replicate" : mode;
+    mode = (mode == "wrap") ? "circular" : mode;
 
-        for (int i = indicesTy.getSizes().size(); i > axis; --i) {
-          std::swap(onehotShape[i - 1], onehotShape[i]);
-          Value iv0 = rewriter.create<Torch::ConstantIntOp>(
-              loc, rewriter.getI64IntegerAttr(i));
-          Value iv1 = rewriter.create<Torch::ConstantIntOp>(
-              loc, rewriter.getI64IntegerAttr(i - 1));
+    Value modeVal = rewriter.create<Torch::ConstantStrOp>(
+        loc, rewriter.getStringAttr(mode));
 
-          onehotTy =
-              rewriter.getType<Torch::ValueTensorType>(onehotShape, i32Ty);
-          onehot = rewriter.create<Torch::AtenTransposeIntOp>(loc, onehotTy,
-                                                              onehot, iv1, iv0);
-        }
+    rewriter.replaceOpWithNewOp<Torch::AtenPadOp>(
+        binder.op, resultType, data, padsSizeList, modeVal, constantValue);
+    return success();
+  });
+  patterns.onOp("Pow", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value lhs, rhs;
+    if (binder.tensorOperands(lhs, rhs) ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
 
-        // Change one hot to an array of booleans to select value:
-        auto i1Ty = rewriter.getI1Type();
-        auto torchqTy = Torch::getScalarTypeForType(i1Ty);
-        Value tyConst = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64),
-                                    static_cast<int64_t>(torchqTy)));
+    auto loc = binder.getLoc();
+    auto lhsTy = cast<Torch::ValueTensorType>(lhs.getType());
+    auto rhsTy = cast<Torch::ValueTensorType>(rhs.getType());
+    Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(
+        loc, rewriter.getBoolAttr(false));
+    Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
+    auto torchDtype = Torch::getScalarTypeForType(rewriter.getF32Type());
+    Value tyConst = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64),
+                                static_cast<int64_t>(torchDtype)));
 
-        onehotTy = rewriter.getType<Torch::ValueTensorType>(onehotShape, i1Ty);
-        Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
-        Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(loc, false);
-        onehot = rewriter.create<Torch::AtenToDtypeOp>(
-            loc, onehotTy, onehot, tyConst,
-            /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
-            /*memory_format=*/none);
+    if (isa<IntegerType>(lhsTy.getDtype())) {
+      lhsTy = rewriter.getType<Torch::ValueTensorType>(lhsTy.getSizes(),
+                                                       rewriter.getF32Type());
+      lhs = rewriter.create<Torch::AtenToDtypeOp>(loc, lhsTy, lhs, tyConst,
+                                                  cstFalse, cstFalse, none);
+    }
 
-        onehot = rewriter.create<Torch::AtenWhereScalarOp>(loc, resultType,
-                                                           onehot, on, off);
+    if (isa<IntegerType>(rhsTy.getDtype())) {
+      rhsTy = rewriter.getType<Torch::ValueTensorType>(rhsTy.getSizes(),
+                                                       rewriter.getF32Type());
+      rhs = rewriter.create<Torch::AtenToDtypeOp>(loc, rhsTy, rhs, tyConst,
+                                                  cstFalse, cstFalse, none);
+    }
 
-        rewriter.replaceOp(binder.op, onehot);
-        return success();
-      });
+    auto powType = resultType;
+    if (isa<IntegerType>(resultType.getDtype())) {
+      powType = rewriter.getType<Torch::ValueTensorType>(resultType.getSizes(),
+                                                         rewriter.getF32Type());
+    }
+
+    Value pow =
+        rewriter.create<Torch::AtenPowTensorTensorOp>(loc, powType, lhs, rhs);
+
+    if (!isa<IntegerType>(resultType.getDtype())) {
+      rewriter.replaceOp(binder.op, pow);
+      return success();
+    }
+
+    auto outDtype = Torch::getScalarTypeForType(resultType.getDtype());
+    auto outTyConst = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64),
+                                static_cast<int64_t>(outDtype)));
+
+    rewriter.replaceOpWithNewOp<Torch::AtenToDtypeOp>(
+        binder.op, resultType, pow, outTyConst, cstFalse, cstFalse, none);
+
+    return success();
+  });
+  patterns.onOp("Identity", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value tensor;
+    if (binder.tensorOperand(tensor) || binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    rewriter.replaceOpWithNewOp<Torch::AtenCloneOp>(
+        binder.op, resultType, tensor, /*memory_format=*/noneVal);
+    return success();
+  });
+  patterns.onOp("Mean", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    if (binder.op->getNumOperands() == 1) {
+      Torch::ValueTensorType resultType;
+      Value x;
+      if (binder.tensorOperand(x) || binder.tensorResultType(resultType))
+        return failure();
+      rewriter.replaceOp(binder.op, x);
+      return success();
+    }
+    Torch::ValueTensorType resultType;
+    SmallVector<Value> valList;
+    int64_t numOperands = binder.op->getNumOperands();
+    Value numOperandsConstant = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), numOperands));
+    if (binder.tensorOperands(valList, numOperands) ||
+        binder.tensorResultType(resultType))
+      return failure();
+    Value constOne = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
+    // Short circuit to binary add
+    Value curr = rewriter.create<Torch::AtenAddTensorOp>(
+        binder.getLoc(), resultType, valList[0], valList[1], constOne);
+    if (numOperands == 2) {
+      rewriter.replaceOpWithNewOp<Torch::AtenDivScalarOp>(
+          binder.op, resultType, curr, numOperandsConstant);
+      return success();
+    }
+    // When binder.op->getNumOperands() > 2
+    auto baseType = Torch::ValueTensorType::getWithLeastStaticInformation(
+        binder.op->getContext());
+    for (int i = 2; i < numOperands; i++) {
+      if (i == numOperands - 1) {
+        curr = rewriter.create<Torch::AtenAddTensorOp>(
+            binder.getLoc(), resultType, curr, valList[i], constOne);
+      } else {
+        curr = rewriter.create<Torch::AtenAddTensorOp>(
+            binder.getLoc(), baseType, curr, valList[i], constOne);
+      }
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenDivScalarOp>(
+        binder.op, resultType, curr, numOperandsConstant);
+    return success();
+  });
+  patterns.onOp("IsInf", 10, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value tensor;
+    int64_t neg;
+    int64_t pos;
+    if (binder.tensorOperand(tensor) ||
+        binder.s64IntegerAttr(neg, "detect_negative", 1) ||
+        binder.s64IntegerAttr(pos, "detect_positive", 1) ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    if (neg == 0) {
+      // replace all negative infs with 0
+      tensor = rewriter.create<Torch::AtenReluOp>(
+          binder.getLoc(), dyn_cast<Torch::ValueTensorType>(tensor.getType()),
+          tensor);
+    }
+    if (pos == 0) {
+      // first use neg op to flip positive inf to negative inf. Then relu to
+      // replace all positive infs with 0.
+      Value flip = rewriter.create<Torch::AtenNegOp>(
+          binder.getLoc(), dyn_cast<Torch::ValueTensorType>(tensor.getType()),
+          tensor);
+      tensor = rewriter.create<Torch::AtenReluOp>(
+          binder.getLoc(), dyn_cast<Torch::ValueTensorType>(flip.getType()),
+          flip);
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenIsinfOp>(binder.op, resultType,
+                                                    tensor);
+    return success();
+  });
+  patterns.onOp("IsNaN", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value tensor;
+    if (binder.tensorOperand(tensor) || binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenIsnanOp>(binder.op, resultType,
+                                                    tensor);
+    return success();
+  });
+  patterns.onOp("PRelu", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value tensor;
+    Value slope;
+    if (binder.tensorOperands(tensor, slope) ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenPreluOp>(binder.op, resultType,
+                                                    tensor, slope);
+    return success();
+  });
+  patterns.onOp("Mod", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value self, other;
+    int64_t fmod;
+    if (binder.tensorOperands(self, other) ||
+        binder.tensorResultType(resultType) ||
+        binder.s64IntegerAttr(fmod, "fmod", 0)) {
+      return failure();
+    }
+
+    if (fmod) {
+      rewriter.replaceOpWithNewOp<Torch::AtenFmodTensorOp>(
+          binder.op, resultType, self, other);
+      return success();
+    }
+
+    rewriter.replaceOpWithNewOp<Torch::AtenRemainderTensorOp>(
+        binder.op, resultType, self, other);
+    return success();
+  });
+  patterns.onOp("Mish", 18, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value input;
+    if (binder.tensorOperand(input) || binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenMishOp>(binder.op, resultType,
+                                                   input);
+    return success();
+  });
+  patterns.onOp("OneHot", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    llvm::SmallVector<Value> inputs;
+    Torch::ValueTensorType resultType;
+    if (binder.tensorOperandsList(inputs) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    if (inputs.size() != 3)
+      return rewriter.notifyMatchFailure(binder.op, "expected 3 operands");
+
+    int64_t axis;
+    if (binder.s64IntegerAttr(axis, "axis", -1))
+      return rewriter.notifyMatchFailure(binder.op, "`axis` attr not found");
+
+    auto loc = binder.getLoc();
+    Value indices = inputs[0];
+    Value depth = inputs[1];
+    Value values = inputs[2];
+
+    auto indicesTy = cast<Torch::ValueTensorType>(indices.getType());
+    auto valuesTy = cast<Torch::ValueTensorType>(values.getType());
+    auto depthTy = cast<Torch::ValueTensorType>(depth.getType());
+
+    axis = axis < 0 ? axis + indicesTy.getSizes().size() + 1 : axis;
+
+    bool depthIsInt = isa<IntegerType>(depthTy.getDtype());
+    Type intTy = rewriter.getType<Torch::IntType>();
+    Type floatTy = rewriter.getType<Torch::FloatType>();
+    Type depthETy = depthIsInt ? intTy : floatTy;
+    depth = rewriter.create<Torch::AtenItemOp>(loc, depthETy, depth);
+
+    if (!depthIsInt)
+      depth = rewriter.create<Torch::AtenIntScalarOp>(
+          loc, rewriter.getType<Torch::IntType>(), depth);
+
+    Type boolTy = rewriter.getType<Torch::ValueTensorType>(
+        indicesTy.getSizes(), rewriter.getI1Type());
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(0));
+    Value one = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(1));
+    Value lt =
+        rewriter.create<Torch::AtenLtScalarOp>(loc, boolTy, indices, zero);
+    Value add = rewriter.create<Torch::AtenAddScalarOp>(loc, indicesTy, indices,
+                                                        depth, one);
+    indices = rewriter.create<Torch::AtenWhereSelfOp>(loc, indicesTy, lt, add,
+                                                      indices);
+
+    auto selectTy = rewriter.getType<Torch::ValueTensorType>(
+        llvm::SmallVector<int64_t>{1}, valuesTy.getDtype());
+
+    bool valuesAreInt = isa<IntegerType>(valuesTy.getDtype());
+    Type valuesETy = valuesAreInt ? intTy : floatTy;
+
+    Value off = rewriter.create<Torch::AtenSelectIntOp>(loc, selectTy, values,
+                                                        zero, zero);
+    off = rewriter.create<Torch::AtenItemOp>(loc, valuesETy, off);
+
+    Value on = rewriter.create<Torch::AtenSelectIntOp>(loc, selectTy, values,
+                                                       zero, one);
+    on = rewriter.create<Torch::AtenItemOp>(loc, valuesETy, on);
+
+    auto i32Ty = rewriter.getIntegerType(32, true);
+    llvm::SmallVector<int64_t> onehotShape(indicesTy.getSizes());
+    onehotShape.push_back(Torch::kUnknownSize);
+    auto onehotTy =
+        rewriter.getType<Torch::ValueTensorType>(onehotShape, i32Ty);
+
+    Value onehot = rewriter.create<Torch::AtenOneHotOp>(
+        binder.getLoc(), onehotTy, indices, depth);
+
+    for (int i = indicesTy.getSizes().size(); i > axis; --i) {
+      std::swap(onehotShape[i - 1], onehotShape[i]);
+      Value iv0 = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(i));
+      Value iv1 = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(i - 1));
+
+      onehotTy = rewriter.getType<Torch::ValueTensorType>(onehotShape, i32Ty);
+      onehot = rewriter.create<Torch::AtenTransposeIntOp>(loc, onehotTy, onehot,
+                                                          iv1, iv0);
+    }
+
+    // Change one hot to an array of booleans to select value:
+    auto i1Ty = rewriter.getI1Type();
+    auto torchqTy = Torch::getScalarTypeForType(i1Ty);
+    Value tyConst = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64),
+                                static_cast<int64_t>(torchqTy)));
+
+    onehotTy = rewriter.getType<Torch::ValueTensorType>(onehotShape, i1Ty);
+    Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
+    Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(loc, false);
+    onehot = rewriter.create<Torch::AtenToDtypeOp>(
+        loc, onehotTy, onehot, tyConst,
+        /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
+        /*memory_format=*/none);
+
+    onehot = rewriter.create<Torch::AtenWhereScalarOp>(loc, resultType, onehot,
+                                                       on, off);
+
+    rewriter.replaceOp(binder.op, onehot);
+    return success();
+  });
   patterns.onOp("HardSwish", 14,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;
                   Value input;
                   if (binder.tensorOperand(input) ||
@@ -3186,208 +3097,202 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
                   return success();
                 });
 
-  patterns.onOp(
-      "Hardmax", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // onnx.Hardmax can be expanded into the following python code:
-        //
-        // import torch.nn.functional as F
-        // def hardmax(tensor, dim=-1):
-        //   maximums = torch.argmax(tensor, dim=dim, keepdim=False)
-        //   return F.one_hot(maximums)
-        //
-        // Given an example input:
-        // tensor([[1, 2, 3],
-        //         [4, 6, 5],
-        //         [9, 8, 7]])
-        // Above code yields the following:
-        // tensor([[0, 0, 1],
-        //         [0, 1, 0],
-        //         [1, 0, 0]])
+  patterns.onOp("Hardmax", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    // onnx.Hardmax can be expanded into the following python code:
+    //
+    // import torch.nn.functional as F
+    // def hardmax(tensor, dim=-1):
+    //   maximums = torch.argmax(tensor, dim=dim, keepdim=False)
+    //   return F.one_hot(maximums)
+    //
+    // Given an example input:
+    // tensor([[1, 2, 3],
+    //         [4, 6, 5],
+    //         [9, 8, 7]])
+    // Above code yields the following:
+    // tensor([[0, 0, 1],
+    //         [0, 1, 0],
+    //         [1, 0, 0]])
 
+    Torch::ValueTensorType resultType;
+    int64_t axisValue;
+    Value input, axis;
+    if (binder.tensorOperand(input) ||
+        binder.s64IntegerAttr(axisValue, "axis", -1) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    auto loc = binder.getLoc();
+    auto inputTy = cast<Torch::ValueTensorType>(input.getType());
+
+    if (axisValue < 0)
+      axisValue += inputTy.getSizes().size();
+
+    axis = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(axisValue));
+
+    // torch.argmax
+    Value constKeepDims = rewriter.create<Torch::ConstantBoolOp>(
+        loc, rewriter.getType<Torch::BoolType>(), rewriter.getBoolAttr(false));
+
+    SmallVector<int64_t> argmaxShape;
+    for (int i = 0, s = inputTy.getSizes().size(); i < s; ++i) {
+      if (i == axisValue)
+        continue;
+      argmaxShape.push_back(inputTy.getSizes()[i]);
+    }
+
+    auto argmaxTy = rewriter.getType<Torch::ValueTensorType>(
+        argmaxShape, rewriter.getIntegerType(32, IntegerType::Signed));
+    Value argmax = rewriter.create<Torch::AtenArgmaxOp>(loc, argmaxTy, input,
+                                                        axis, constKeepDims);
+
+    // one_hot
+    SmallVector<int64_t> onehotShape(argmaxShape);
+    onehotShape.push_back(inputTy.getSizes()[axisValue]);
+    auto onehotTy = rewriter.getType<Torch::ValueTensorType>(
+        onehotShape, resultType.getDtype());
+    Value numClasses =
+        rewriter.create<Torch::AtenSizeIntOp>(binder.getLoc(), input, axis);
+    Value onehot = rewriter.create<Torch::AtenOneHotOp>(
+        binder.getLoc(), onehotTy, argmax, numClasses);
+
+    SmallVector<int64_t> permutation;
+    for (int i = 0; i < axisValue; ++i)
+      permutation.push_back(i);
+    permutation.push_back(onehotShape.size() - 1);
+    for (int i = axisValue, s = onehotShape.size(); i < s - 1; ++i)
+      permutation.push_back(i);
+
+    SmallVector<Value> permValues;
+    for (auto d : permutation) {
+      permValues.push_back(rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(d)));
+    }
+
+    Value permuteDims = rewriter.create<Torch::PrimListConstructOp>(
+        loc, Torch::ListType::get(rewriter.getType<Torch::IntType>()),
+        permValues);
+    rewriter.replaceOpWithNewOp<Torch::AtenPermuteOp>(binder.op, resultType,
+                                                      onehot, permuteDims);
+    return success();
+  });
+  patterns.onOp(
+      "LpNormalization", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
-        int64_t axisValue;
-        Value input, axis;
+        int64_t axis, p;
+        Value input;
         if (binder.tensorOperand(input) ||
-            binder.s64IntegerAttr(axisValue, "axis", -1) ||
+            binder.s64IntegerAttr(axis, "axis", -1) ||
+            binder.s64IntegerAttr(p, "p", 2) ||
             binder.tensorResultType(resultType))
           return failure();
 
         auto loc = binder.getLoc();
-        auto inputTy = cast<Torch::ValueTensorType>(input.getType());
+        Value cstAxis = rewriter.create<Torch::ConstantIntOp>(
+            loc, rewriter.getI64IntegerAttr(axis));
+        Value cstP = rewriter.create<Torch::ConstantIntOp>(
+            loc, rewriter.getI64IntegerAttr(p));
+        Value cstKeepDim = rewriter.create<Torch::ConstantBoolOp>(
+            loc, rewriter.getBoolAttr(true));
+        Value axisPrimList = rewriter.create<Torch::PrimListConstructOp>(
+            binder.getLoc(),
+            rewriter.getType<Torch::ListType>(
+                rewriter.getType<Torch::IntType>()),
+            llvm::ArrayRef<Value>{cstAxis});
 
-        if (axisValue < 0)
-          axisValue += inputTy.getSizes().size();
+        SmallVector<int64_t> normSizes(resultType.getSizes());
+        int64_t rank = normSizes.size();
+        axis = axis % rank;
+        axis = (axis < 0) ? axis + rank : axis;
+        normSizes[axis] = 1;
+        auto normType = rewriter.getType<Torch::ValueTensorType>(
+            normSizes, resultType.getDtype());
+        Value norm = rewriter.create<Torch::AtenNormScalarOptDimOp>(
+            loc, normType, input, cstP, axisPrimList, cstKeepDim);
 
-        axis = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(axisValue));
-
-        // torch.argmax
-        Value constKeepDims = rewriter.create<Torch::ConstantBoolOp>(
-            loc, rewriter.getType<Torch::BoolType>(),
-            rewriter.getBoolAttr(false));
-
-        SmallVector<int64_t> argmaxShape;
-        for (int i = 0, s = inputTy.getSizes().size(); i < s; ++i) {
-          if (i == axisValue)
-            continue;
-          argmaxShape.push_back(inputTy.getSizes()[i]);
-        }
-
-        auto argmaxTy = rewriter.getType<Torch::ValueTensorType>(
-            argmaxShape, rewriter.getIntegerType(32, IntegerType::Signed));
-        Value argmax = rewriter.create<Torch::AtenArgmaxOp>(
-            loc, argmaxTy, input, axis, constKeepDims);
-
-        // one_hot
-        SmallVector<int64_t> onehotShape(argmaxShape);
-        onehotShape.push_back(inputTy.getSizes()[axisValue]);
-        auto onehotTy = rewriter.getType<Torch::ValueTensorType>(
-            onehotShape, resultType.getDtype());
-        Value numClasses =
-            rewriter.create<Torch::AtenSizeIntOp>(binder.getLoc(), input, axis);
-        Value onehot = rewriter.create<Torch::AtenOneHotOp>(
-            binder.getLoc(), onehotTy, argmax, numClasses);
-
-        SmallVector<int64_t> permutation;
-        for (int i = 0; i < axisValue; ++i)
-          permutation.push_back(i);
-        permutation.push_back(onehotShape.size() - 1);
-        for (int i = axisValue, s = onehotShape.size(); i < s - 1; ++i)
-          permutation.push_back(i);
-
-        SmallVector<Value> permValues;
-        for (auto d : permutation) {
-          permValues.push_back(rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(d)));
-        }
-
-        Value permuteDims = rewriter.create<Torch::PrimListConstructOp>(
-            loc, Torch::ListType::get(rewriter.getType<Torch::IntType>()),
-            permValues);
-        rewriter.replaceOpWithNewOp<Torch::AtenPermuteOp>(binder.op, resultType,
-                                                          onehot, permuteDims);
+        rewriter.replaceOpWithNewOp<Torch::AtenDivTensorOp>(
+            binder.op, resultType, input, norm);
         return success();
       });
-  patterns.onOp("LpNormalization", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  int64_t axis, p;
-                  Value input;
-                  if (binder.tensorOperand(input) ||
-                      binder.s64IntegerAttr(axis, "axis", -1) ||
-                      binder.s64IntegerAttr(p, "p", 2) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
+  patterns.onOp("MaxUnpool", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    // TODO: Add support for `output_shape` arg.
+    if (binder.op->getNumOperands() == 3)
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: output_shape arg is not supported");
 
-                  auto loc = binder.getLoc();
-                  Value cstAxis = rewriter.create<Torch::ConstantIntOp>(
-                      loc, rewriter.getI64IntegerAttr(axis));
-                  Value cstP = rewriter.create<Torch::ConstantIntOp>(
-                      loc, rewriter.getI64IntegerAttr(p));
-                  Value cstKeepDim = rewriter.create<Torch::ConstantBoolOp>(
-                      loc, rewriter.getBoolAttr(true));
-                  Value axisPrimList =
-                      rewriter.create<Torch::PrimListConstructOp>(
-                          binder.getLoc(),
-                          rewriter.getType<Torch::ListType>(
-                              rewriter.getType<Torch::IntType>()),
-                          llvm::ArrayRef<Value>{cstAxis});
+    Torch::ValueTensorType resultType;
+    Value data, indices;
+    if (binder.tensorOperandAtIndex(data, 0) ||
+        binder.tensorOperandAtIndex(indices, 1) ||
+        binder.tensorResultType(resultType))
+      return rewriter.notifyMatchFailure(
+          binder.op, "data/indices/resultType bind failure");
+    std::optional<unsigned> maybeRank = Torch::getTensorRank(data);
+    if (!maybeRank)
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Unimplemented: unranked tensor");
+    int64_t rank = *maybeRank;
+    int64_t spatial = rank - 2;
 
-                  SmallVector<int64_t> normSizes(resultType.getSizes());
-                  int64_t rank = normSizes.size();
-                  axis = axis % rank;
-                  axis = (axis < 0) ? axis + rank : axis;
-                  normSizes[axis] = 1;
-                  auto normType = rewriter.getType<Torch::ValueTensorType>(
-                      normSizes, resultType.getDtype());
-                  Value norm = rewriter.create<Torch::AtenNormScalarOptDimOp>(
-                      loc, normType, input, cstP, axisPrimList, cstKeepDim);
+    if (rank <= 3 || rank > 5)
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Unimplemented: MaxUnpool support "
+                                         "only present for rank 4/5 input");
 
-                  rewriter.replaceOpWithNewOp<Torch::AtenDivTensorOp>(
-                      binder.op, resultType, input, norm);
-                  return success();
-                });
+    if (!(resultType.hasSizes() && resultType.areAllSizesKnown()))
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: expected result to have all shapes "
+                     "statically known");
+
+    SmallVector<int64_t> resultShape(resultType.getSizes());
+    Value resultShapeList =
+        createConstantIntList(binder, rewriter, resultShape);
+    if (rank == 4) {
+      rewriter.replaceOpWithNewOp<Torch::AtenMaxUnpool2dOp>(
+          binder.op, resultType, data, indices, resultShapeList);
+      return success();
+    }
+
+    SmallVector<int64_t> padding, strides;
+    if (binder.s64IntegerArrayAttr(padding, "pads", {}))
+      return rewriter.notifyMatchFailure(binder.op, "pads bind failure");
+    if (!padding.empty() && padding.size() != static_cast<size_t>(2 * spatial))
+      return rewriter.notifyMatchFailure(
+          binder.op, "padding list must contain (begin,end) pair for each "
+                     "spatial axis");
+    if (binder.s64IntegerArrayAttr(strides, "strides", {}))
+      return rewriter.notifyMatchFailure(binder.op, "strides bind failure");
+    if (!strides.empty() && strides.size() != static_cast<size_t>(spatial))
+      return rewriter.notifyMatchFailure(
+          binder.op, "strides list size does not match the number of axes");
+
+    if (padding.empty())
+      padding.resize(spatial, 0);
+    if (strides.empty())
+      strides.resize(spatial, 1);
+
+    // If the padding is symmetric we can push the padding
+    // operation to the torch operator.
+    if (padding.size() == static_cast<size_t>(2 * spatial)) {
+      bool equal = true;
+      for (int i = 0; i < spatial; ++i) {
+        equal = equal && (padding[i] == padding[i + spatial]);
+      }
+      if (equal)
+        padding.resize(spatial);
+    }
+
+    Value paddingList = createConstantIntList(binder, rewriter, padding);
+    Value stridesList = createConstantIntList(binder, rewriter, strides);
+
+    rewriter.replaceOpWithNewOp<Torch::AtenMaxUnpool3dOp>(
+        binder.op, resultType, data, indices, resultShapeList, stridesList,
+        paddingList);
+    return success();
+  });
   patterns.onOp(
-      "MaxUnpool", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // TODO: Add support for `output_shape` arg.
-        if (binder.op->getNumOperands() == 3)
-          return rewriter.notifyMatchFailure(
-              binder.op, "unimplemented: output_shape arg is not supported");
-
-        Torch::ValueTensorType resultType;
-        Value data, indices;
-        if (binder.tensorOperandAtIndex(data, 0) ||
-            binder.tensorOperandAtIndex(indices, 1) ||
-            binder.tensorResultType(resultType))
-          return rewriter.notifyMatchFailure(
-              binder.op, "data/indices/resultType bind failure");
-        std::optional<unsigned> maybeRank = Torch::getTensorRank(data);
-        if (!maybeRank)
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Unimplemented: unranked tensor");
-        int64_t rank = *maybeRank;
-        int64_t spatial = rank - 2;
-
-        if (rank <= 3 || rank > 5)
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Unimplemented: MaxUnpool support "
-                                             "only present for rank 4/5 input");
-
-        if (!(resultType.hasSizes() && resultType.areAllSizesKnown()))
-          return rewriter.notifyMatchFailure(
-              binder.op, "unimplemented: expected result to have all shapes "
-                         "statically known");
-
-        SmallVector<int64_t> resultShape(resultType.getSizes());
-        Value resultShapeList =
-            createConstantIntList(binder, rewriter, resultShape);
-        if (rank == 4) {
-          rewriter.replaceOpWithNewOp<Torch::AtenMaxUnpool2dOp>(
-              binder.op, resultType, data, indices, resultShapeList);
-          return success();
-        }
-
-        SmallVector<int64_t> padding, strides;
-        if (binder.s64IntegerArrayAttr(padding, "pads", {}))
-          return rewriter.notifyMatchFailure(binder.op, "pads bind failure");
-        if (!padding.empty() &&
-            padding.size() != static_cast<size_t>(2 * spatial))
-          return rewriter.notifyMatchFailure(
-              binder.op, "padding list must contain (begin,end) pair for each "
-                         "spatial axis");
-        if (binder.s64IntegerArrayAttr(strides, "strides", {}))
-          return rewriter.notifyMatchFailure(binder.op, "strides bind failure");
-        if (!strides.empty() && strides.size() != static_cast<size_t>(spatial))
-          return rewriter.notifyMatchFailure(
-              binder.op, "strides list size does not match the number of axes");
-
-        if (padding.empty())
-          padding.resize(spatial, 0);
-        if (strides.empty())
-          strides.resize(spatial, 1);
-
-        // If the padding is symmetric we can push the padding
-        // operation to the torch operator.
-        if (padding.size() == static_cast<size_t>(2 * spatial)) {
-          bool equal = true;
-          for (int i = 0; i < spatial; ++i) {
-            equal = equal && (padding[i] == padding[i + spatial]);
-          }
-          if (equal)
-            padding.resize(spatial);
-        }
-
-        Value paddingList = createConstantIntList(binder, rewriter, padding);
-        Value stridesList = createConstantIntList(binder, rewriter, strides);
-
-        rewriter.replaceOpWithNewOp<Torch::AtenMaxUnpool3dOp>(
-            binder.op, resultType, data, indices, resultShapeList, stridesList,
-            paddingList);
-        return success();
-      });
-  patterns.onOp(
-      "GroupNormalization", 18,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "GroupNormalization", 18, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value input, scale, bias;
         int64_t numGroups, stashType;
@@ -3434,28 +3339,27 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             /*cudnn_enabled=*/cstFalse);
         return success();
       });
-  patterns.onOp(
-      "Optional", 15, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::OptionalType resultType;
-        Value input;
+  patterns.onOp("Optional", 15, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::OptionalType resultType;
+    Value input;
 
-        if (binder.getNumOperands() == 0)
-          return rewriter.notifyMatchFailure(
-              binder.op, "unimplemented support for missing input element");
+    if (binder.getNumOperands() == 0)
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented support for missing input element");
 
-        if (binder.tensorListOperand(input))
-          if (binder.tensorOperand(input))
-            return failure();
+    if (binder.tensorListOperand(input))
+      if (binder.tensorOperand(input))
+        return failure();
 
-        if (binder.optionalResultType(resultType))
-          return failure();
+    if (binder.optionalResultType(resultType))
+      return failure();
 
-        rewriter.replaceOpWithNewOp<Torch::DerefineOp>(binder.op, resultType,
-                                                       input);
-        return success();
-      });
+    rewriter.replaceOpWithNewOp<Torch::DerefineOp>(binder.op, resultType,
+                                                   input);
+    return success();
+  });
   patterns.onOp("OptionalGetElement", 15,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ListType tensorListResultType;
                   Torch::ValueTensorType tensorResultType;
                   Value input;
@@ -3494,8 +3398,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
                   return success();
                 });
   patterns.onOp(
-      "OptionalHasElement", 15,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "OptionalHasElement", 15, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         if (binder.tensorResultType(resultType))
           return rewriter.notifyMatchFailure(binder.op,
@@ -3531,8 +3434,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         return success();
       });
   patterns.onOp(
-      "NonMaxSuppression", 10,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "NonMaxSuppression", 10, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         SmallVector<Value> operands;
         int64_t centerPointBox;

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -36,9 +36,8 @@ namespace {
 // we provide the original operand through storeResult, which will be modified
 // if the result will be passed onto another operation, and will be used for
 // noop_with_empty_axes handling before that.
-LogicalResult reducedSumImpl(OpBinder binder,
-                             ConversionPatternRewriter &rewriter, Value data,
-                             Torch::ValueTensorType resultType,
+LogicalResult reducedSumImpl(OpBinder binder, PatternRewriter &rewriter,
+                             Value data, Torch::ValueTensorType resultType,
                              Value &storeResult, int64_t keepDims,
                              int64_t noop_with_empty_axes,
                              bool isIntermediateOp) {
@@ -153,8 +152,7 @@ LogicalResult reducedSumImpl(OpBinder binder,
   return success();
 }
 
-Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
-                   Value operand) {
+Value getValueList(OpBinder binder, PatternRewriter &rewriter, Value operand) {
   SmallVector<Value> itemList;
   auto sizes = dyn_cast<Torch::ValueTensorType>(operand.getType()).getSizes();
   Torch::BaseTensorType operandType =
@@ -206,8 +204,7 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
 void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
     OnnxCustomOpConversionPattern &patterns) {
   patterns.onOp(
-      "QuantizeLinear", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "QuantizeLinear", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         llvm::SmallVector<Value> operands;
         if (binder.tensorOperands(operands, 3) ||
@@ -283,8 +280,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "QLinearConv", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "QLinearConv", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         llvm::SmallVector<Value> operands;
         if ((binder.tensorOperands(operands, 8) &&
@@ -394,8 +390,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "QLinearMatMul", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "QLinearMatMul", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         llvm::SmallVector<Value> operands;
         if (binder.tensorOperands(operands, 8) ||
@@ -505,7 +500,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp("Reciprocal", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;
                   Value operand;
                   if (binder.tensorOperand(operand) ||
@@ -515,69 +510,62 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
                       binder.op, resultType, operand);
                   return success();
                 });
+  patterns.onOp("Relu", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value x;
+    if (binder.tensorOperand(x) || binder.tensorResultType(resultType))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<Torch::AtenReluOp>(binder.op, resultType, x);
+    return success();
+  });
+  patterns.onOp("Round", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenRoundOp>(binder.op, resultType,
+                                                    operand);
+    return success();
+  });
+  patterns.onOp("RNN", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    return OnnxRnnExpander(binder, rewriter);
+  });
+  patterns.onOp("Scatter", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    int64_t axis;
+    if (binder.s64IntegerAttr(axis, "axis", {}))
+      return rewriter.notifyMatchFailure(binder.op, "axis bind failure");
+
+    Torch::ValueTensorType resultTy;
+    Value data, indices, updates;
+    if (binder.tensorOperandAtIndex(data, 0) ||
+        binder.tensorOperandAtIndex(indices, 1) ||
+        binder.tensorOperandAtIndex(updates, 2) ||
+        binder.tensorResultType(resultTy))
+      return failure();
+
+    auto dataTy = cast<Torch::ValueTensorType>(data.getType()),
+         indicesTy = cast<Torch::ValueTensorType>(indices.getType()),
+         updatesTy = cast<Torch::ValueTensorType>(updates.getType());
+
+    int64_t dataRank = dataTy.getSizes().size(),
+            indicesRank = indicesTy.getSizes().size(),
+            updatesRank = updatesTy.getSizes().size();
+
+    if ((dataRank < 1) || (indicesRank < 1) || (updatesRank < 1) ||
+        (axis < -dataRank) || (axis >= dataRank))
+      return failure();
+
+    Value axisValue = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(axis));
+
+    rewriter.replaceOpWithNewOp<Torch::AtenScatterSrcOp>(
+        binder.op, resultTy, data, axisValue, indices, updates);
+
+    return success();
+  });
   patterns.onOp(
-      "Relu", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value x;
-        if (binder.tensorOperand(x) || binder.tensorResultType(resultType))
-          return failure();
-
-        rewriter.replaceOpWithNewOp<Torch::AtenReluOp>(binder.op, resultType,
-                                                       x);
-        return success();
-      });
-  patterns.onOp("Round", 11,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenRoundOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("RNN", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  return OnnxRnnExpander(binder, rewriter);
-                });
-  patterns.onOp(
-      "Scatter", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        int64_t axis;
-        if (binder.s64IntegerAttr(axis, "axis", {}))
-          return rewriter.notifyMatchFailure(binder.op, "axis bind failure");
-
-        Torch::ValueTensorType resultTy;
-        Value data, indices, updates;
-        if (binder.tensorOperandAtIndex(data, 0) ||
-            binder.tensorOperandAtIndex(indices, 1) ||
-            binder.tensorOperandAtIndex(updates, 2) ||
-            binder.tensorResultType(resultTy))
-          return failure();
-
-        auto dataTy = cast<Torch::ValueTensorType>(data.getType()),
-             indicesTy = cast<Torch::ValueTensorType>(indices.getType()),
-             updatesTy = cast<Torch::ValueTensorType>(updates.getType());
-
-        int64_t dataRank = dataTy.getSizes().size(),
-                indicesRank = indicesTy.getSizes().size(),
-                updatesRank = updatesTy.getSizes().size();
-
-        if ((dataRank < 1) || (indicesRank < 1) || (updatesRank < 1) ||
-            (axis < -dataRank) || (axis >= dataRank))
-          return failure();
-
-        Value axisValue = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(axis));
-
-        rewriter.replaceOpWithNewOp<Torch::AtenScatterSrcOp>(
-            binder.op, resultTy, data, axisValue, indices, updates);
-
-        return success();
-      });
-  patterns.onOp(
-      "ScatterElements", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ScatterElements", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         SmallVector<Value> valList;
         int64_t axis;
@@ -650,8 +638,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "SequenceConstruct", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "SequenceConstruct", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         SmallVector<Value> operands;
         Torch::ListType resultType;
 
@@ -664,8 +651,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "SequenceLength", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "SequenceLength", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         // onnx.SequenceLength takes a sequence(list) of tensors, and returns
         // a zero rank tensor with the length.
         Torch::ValueTensorType resultType;
@@ -687,229 +673,213 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
 
         return success();
       });
-  patterns.onOp(
-      "Sigmoid", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value x;
-        if (binder.tensorOperand(x) || binder.tensorResultType(resultType))
-          return failure();
+  patterns.onOp("Sigmoid", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value x;
+    if (binder.tensorOperand(x) || binder.tensorResultType(resultType))
+      return failure();
 
-        rewriter.replaceOpWithNewOp<Torch::AtenSigmoidOp>(binder.op, resultType,
-                                                          x);
-        return success();
-      });
-  patterns.onOp("Sin", 7,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenSinOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("Tanh", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenTanhOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp("Sqrt", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenSqrtOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp(
-      "Sub", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value x;
-        Value y;
-        if (binder.tensorOperands(x, y) || binder.tensorResultType(resultType))
-          return failure();
-        Value const1 = rewriter.create<Torch::ConstantIntOp>(
+    rewriter.replaceOpWithNewOp<Torch::AtenSigmoidOp>(binder.op, resultType, x);
+    return success();
+  });
+  patterns.onOp("Sin", 7, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenSinOp>(binder.op, resultType,
+                                                  operand);
+    return success();
+  });
+  patterns.onOp("Tanh", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenTanhOp>(binder.op, resultType,
+                                                   operand);
+    return success();
+  });
+  patterns.onOp("Sqrt", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenSqrtOp>(binder.op, resultType,
+                                                   operand);
+    return success();
+  });
+  patterns.onOp("Sub", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value x;
+    Value y;
+    if (binder.tensorOperands(x, y) || binder.tensorResultType(resultType))
+      return failure();
+    Value const1 = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
+    rewriter.replaceOpWithNewOp<Torch::AtenSubTensorOp>(binder.op, resultType,
+                                                        x, y, const1);
+    return success();
+  });
+  patterns.onOp("Sum", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    if (binder.op->getNumOperands() == 1) {
+      Torch::ValueTensorType resultType;
+      Value x;
+      if (binder.tensorOperand(x) || binder.tensorResultType(resultType))
+        return failure();
+      rewriter.replaceOp(binder.op, x);
+      return success();
+    }
+    Torch::ValueTensorType resultType;
+    SmallVector<Value> valList;
+    int64_t numOperands = binder.op->getNumOperands();
+    if (binder.tensorOperands(valList, numOperands) ||
+        binder.tensorResultType(resultType))
+      return failure();
+    Value const1 = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
+    // Short circuit to binary add
+    if (numOperands == 2) {
+      rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
+          binder.op, resultType, valList[0], valList[1], const1);
+      return success();
+    }
+    // When binder.op->getNumOperands() > 2
+    Value curr = rewriter.create<Torch::AtenAddTensorOp>(
+        binder.getLoc(), resultType, valList[0], valList[1], const1);
+    for (int i = 2; i < numOperands; i++) {
+      if (i == numOperands - 1) {
+        curr = rewriter.create<Torch::AtenAddTensorOp>(
+            binder.getLoc(), resultType, curr, valList[i], const1);
+      } else {
+        SmallVector<int64_t> resultBroadcastShapeInt;
+        SmallVector<Value> resultBroadcastShapeValue;
+        Torch::computeBroadcastShape(rewriter, binder.getLoc(), curr,
+                                     valList[i], resultBroadcastShapeInt,
+                                     resultBroadcastShapeValue);
+        auto baseType = Torch::ValueTensorType::get(
+            binder.op->getContext(), resultBroadcastShapeInt,
+            resultType.getOptionalDtype());
+        curr = rewriter.create<Torch::AtenAddTensorOp>(
+            binder.getLoc(), baseType, curr, valList[i], const1);
+      }
+    }
+    rewriter.replaceOp(binder.op, curr);
+    return success();
+  });
+  patterns.onOp("Where", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    SmallVector<Value> valList;
+    int64_t numOperands = binder.op->getNumOperands();
+    if (binder.tensorOperands(valList, numOperands) ||
+        binder.tensorResultType(resultType))
+      return failure();
+    Value condition = valList[0];
+    Value x = valList[1];
+    Value y = valList[2];
+    rewriter.replaceOpWithNewOp<Torch::AtenWhereSelfOp>(binder.op, resultType,
+                                                        condition, x, y);
+    return success();
+  });
+  patterns.onOp("Xor", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value x;
+    Value y;
+    if (binder.tensorOperands(x, y) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenLogicalXorOp>(binder.op, resultType,
+                                                         x, y);
+    return success();
+  });
+  patterns.onOp("Squeeze", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    SmallVector<Value> inputOperands;
+    if (binder.tensorOperands(inputOperands, binder.op->getNumOperands()) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    Value data = inputOperands[0];
+    auto inputType = dyn_cast<Torch::ValueTensorType>(data.getType());
+    if (!inputType.hasSizes() || !resultType.hasSizes())
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: expected input and result to have shapes");
+
+    int64_t inputRank = inputType.getSizes().size();
+    int64_t resultRank = resultType.getSizes().size();
+    int64_t rankDiff = inputRank - resultRank;
+    if (rankDiff == 0) {
+      // In this case, no dimension is squeezed. Hence just replace the op
+      // with input.
+      rewriter.replaceOp(binder.op, data);
+      return success();
+    }
+
+    if (inputOperands.size() == 1) {
+      // Case: `axes` value is not present which means squeeze all the
+      // dimensions with shape value 1.
+      rewriter.replaceOpWithNewOp<Torch::AtenSqueezeOp>(binder.op, resultType,
+                                                        data);
+      return success();
+    }
+
+    SmallVector<Value> dimList;
+    if (inputType.areAllSizesKnown() && resultType.areAllSizesKnown()) {
+      // If the input shape and result shape is statically known then the
+      // list of dims to be squeezed can be derived from those shapes. As a
+      // result, we don't have to wait for the dim values to be known at
+      // runtime which is also expected by the downstream pipeline.
+      SmallVector<int64_t> inputShape(inputType.getSizes());
+      SmallVector<int64_t> resultShape(resultType.getSizes());
+      SmallVector<int64_t> squeezeDims;
+      unsigned resultShapeCounter = 0;
+      for (unsigned i = 0; i < inputRank; i++) {
+        if (resultShapeCounter < resultRank &&
+            inputShape[i] == resultShape[resultShapeCounter]) {
+          resultShapeCounter++;
+        } else {
+          squeezeDims.push_back(i);
+        }
+      }
+      for (auto i : squeezeDims) {
+        dimList.push_back(rewriter.create<Torch::ConstantIntOp>(
+            binder.getLoc(), rewriter.getI64IntegerAttr(i)));
+      }
+    }
+
+    if (dimList.empty()) {
+      Value axes = inputOperands[1];
+      Torch::BaseTensorType axesType =
+          cast<Torch::BaseTensorType>(axes.getType());
+      SmallVector<int64_t> selectSizes{1};
+      Type selectResultType = axesType.getWithSizesAndDtype(
+          selectSizes, axesType.getOptionalDtype());
+      Value zero = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+      for (int i = 0; i < rankDiff; i++) {
+        // Go through the axes list and get each dim in the list
+        Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
             binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
-        rewriter.replaceOpWithNewOp<Torch::AtenSubTensorOp>(
-            binder.op, resultType, x, y, const1);
-        return success();
-      });
+            rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
+        Value extract = rewriter.create<Torch::AtenSelectIntOp>(
+            binder.getLoc(), selectResultType, axes, zero, selectIndex);
+        Value dim = rewriter.create<Torch::AtenItemOp>(
+            binder.getLoc(), rewriter.getType<Torch::IntType>(), extract);
+        dimList.push_back(dim);
+      }
+    }
+    Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        rewriter.getType<Torch::ListType>(rewriter.getType<Torch::IntType>()),
+        dimList);
+    rewriter.replaceOpWithNewOp<Torch::PrimsSqueezeOp>(binder.op, resultType,
+                                                       data, dimValueList);
+    return success();
+  });
   patterns.onOp(
-      "Sum", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        if (binder.op->getNumOperands() == 1) {
-          Torch::ValueTensorType resultType;
-          Value x;
-          if (binder.tensorOperand(x) || binder.tensorResultType(resultType))
-            return failure();
-          rewriter.replaceOp(binder.op, x);
-          return success();
-        }
-        Torch::ValueTensorType resultType;
-        SmallVector<Value> valList;
-        int64_t numOperands = binder.op->getNumOperands();
-        if (binder.tensorOperands(valList, numOperands) ||
-            binder.tensorResultType(resultType))
-          return failure();
-        Value const1 = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
-        // Short circuit to binary add
-        if (numOperands == 2) {
-          rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
-              binder.op, resultType, valList[0], valList[1], const1);
-          return success();
-        }
-        // When binder.op->getNumOperands() > 2
-        Value curr = rewriter.create<Torch::AtenAddTensorOp>(
-            binder.getLoc(), resultType, valList[0], valList[1], const1);
-        for (int i = 2; i < numOperands; i++) {
-          if (i == numOperands - 1) {
-            curr = rewriter.create<Torch::AtenAddTensorOp>(
-                binder.getLoc(), resultType, curr, valList[i], const1);
-          } else {
-            SmallVector<int64_t> resultBroadcastShapeInt;
-            SmallVector<Value> resultBroadcastShapeValue;
-            Torch::computeBroadcastShape(rewriter, binder.getLoc(), curr,
-                                         valList[i], resultBroadcastShapeInt,
-                                         resultBroadcastShapeValue);
-            auto baseType = Torch::ValueTensorType::get(
-                binder.op->getContext(), resultBroadcastShapeInt,
-                resultType.getOptionalDtype());
-            curr = rewriter.create<Torch::AtenAddTensorOp>(
-                binder.getLoc(), baseType, curr, valList[i], const1);
-          }
-        }
-        rewriter.replaceOp(binder.op, curr);
-        return success();
-      });
-  patterns.onOp("Where", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  SmallVector<Value> valList;
-                  int64_t numOperands = binder.op->getNumOperands();
-                  if (binder.tensorOperands(valList, numOperands) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  Value condition = valList[0];
-                  Value x = valList[1];
-                  Value y = valList[2];
-                  rewriter.replaceOpWithNewOp<Torch::AtenWhereSelfOp>(
-                      binder.op, resultType, condition, x, y);
-                  return success();
-                });
-  patterns.onOp(
-      "Xor", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value x;
-        Value y;
-        if (binder.tensorOperands(x, y) || binder.tensorResultType(resultType))
-          return failure();
-        rewriter.replaceOpWithNewOp<Torch::AtenLogicalXorOp>(binder.op,
-                                                             resultType, x, y);
-        return success();
-      });
-  patterns.onOp(
-      "Squeeze", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        SmallVector<Value> inputOperands;
-        if (binder.tensorOperands(inputOperands, binder.op->getNumOperands()) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        Value data = inputOperands[0];
-        auto inputType = dyn_cast<Torch::ValueTensorType>(data.getType());
-        if (!inputType.hasSizes() || !resultType.hasSizes())
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "unimplemented: expected input and result to have shapes");
-
-        int64_t inputRank = inputType.getSizes().size();
-        int64_t resultRank = resultType.getSizes().size();
-        int64_t rankDiff = inputRank - resultRank;
-        if (rankDiff == 0) {
-          // In this case, no dimension is squeezed. Hence just replace the op
-          // with input.
-          rewriter.replaceOp(binder.op, data);
-          return success();
-        }
-
-        if (inputOperands.size() == 1) {
-          // Case: `axes` value is not present which means squeeze all the
-          // dimensions with shape value 1.
-          rewriter.replaceOpWithNewOp<Torch::AtenSqueezeOp>(binder.op,
-                                                            resultType, data);
-          return success();
-        }
-
-        SmallVector<Value> dimList;
-        if (inputType.areAllSizesKnown() && resultType.areAllSizesKnown()) {
-          // If the input shape and result shape is statically known then the
-          // list of dims to be squeezed can be derived from those shapes. As a
-          // result, we don't have to wait for the dim values to be known at
-          // runtime which is also expected by the downstream pipeline.
-          SmallVector<int64_t> inputShape(inputType.getSizes());
-          SmallVector<int64_t> resultShape(resultType.getSizes());
-          SmallVector<int64_t> squeezeDims;
-          unsigned resultShapeCounter = 0;
-          for (unsigned i = 0; i < inputRank; i++) {
-            if (resultShapeCounter < resultRank &&
-                inputShape[i] == resultShape[resultShapeCounter]) {
-              resultShapeCounter++;
-            } else {
-              squeezeDims.push_back(i);
-            }
-          }
-          for (auto i : squeezeDims) {
-            dimList.push_back(rewriter.create<Torch::ConstantIntOp>(
-                binder.getLoc(), rewriter.getI64IntegerAttr(i)));
-          }
-        }
-
-        if (dimList.empty()) {
-          Value axes = inputOperands[1];
-          Torch::BaseTensorType axesType =
-              cast<Torch::BaseTensorType>(axes.getType());
-          SmallVector<int64_t> selectSizes{1};
-          Type selectResultType = axesType.getWithSizesAndDtype(
-              selectSizes, axesType.getOptionalDtype());
-          Value zero = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
-          for (int i = 0; i < rankDiff; i++) {
-            // Go through the axes list and get each dim in the list
-            Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
-                binder.getLoc(), rewriter.getType<Torch::IntType>(),
-                rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
-            Value extract = rewriter.create<Torch::AtenSelectIntOp>(
-                binder.getLoc(), selectResultType, axes, zero, selectIndex);
-            Value dim = rewriter.create<Torch::AtenItemOp>(
-                binder.getLoc(), rewriter.getType<Torch::IntType>(), extract);
-            dimList.push_back(dim);
-          }
-        }
-        Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            rewriter.getType<Torch::ListType>(
-                rewriter.getType<Torch::IntType>()),
-            dimList);
-        rewriter.replaceOpWithNewOp<Torch::PrimsSqueezeOp>(
-            binder.op, resultType, data, dimValueList);
-        return success();
-      });
-  patterns.onOp(
-      "Unsqueeze", 13,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "Unsqueeze", 13, [](OpBinder binder, PatternRewriter &rewriter) {
         // Unlike squeeze where we are able to lower to Torch::PrimsSqueezeOp,
         // pytorch does not support torch.unsqueeze to insert multiple new dims.
         // discussion can be found here:
@@ -980,164 +950,154 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         rewriter.replaceOp(binder.op, result);
         return success();
       });
+  patterns.onOp("Softmax", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value input;
+    int64_t axis;
+    if (binder.tensorOperand(input) ||
+        binder.s64IntegerAttr(axis, "axis", -1) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    // ONNX allows negative axis.
+    if (axis < 0)
+      axis += cast<Torch::ValueTensorType>(input.getType()).getSizes().size();
+
+    Value constAxis = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), axis));
+
+    Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+
+    rewriter.replaceOpWithNewOp<Torch::AtenSoftmaxIntOp>(
+        binder.op, resultType, input, constAxis, /*dtype=*/noneVal);
+    return success();
+  });
+
+  patterns.onOp("Selu", 6, [](OpBinder binder, PatternRewriter &rewriter) {
+    // y = gamma * (alpha * e^x - alpha) for x <= 0, y = gamma * x for x > 0
+    Torch::ValueTensorType resultType;
+    float alpha, gamma;
+    Value operand;
+    // Refer https://onnx.ai/onnx/operators/onnx__Selu.html for the default
+    // alpha and gamma values.
+    if (binder.tensorOperand(operand) ||
+        binder.f32FloatAttr(alpha, "alpha", 1.67326) ||
+        binder.f32FloatAttr(gamma, "gamma", 1.0507) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    Value vAlpha = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getFloatAttr(rewriter.getF64Type(), alpha));
+
+    Value vScale = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getFloatAttr(rewriter.getF64Type(), gamma));
+
+    Value vInputScale = rewriter.create<Torch::ConstantFloatOp>(
+        binder.getLoc(), rewriter.getType<Torch::FloatType>(),
+        rewriter.getFloatAttr(rewriter.getF64Type(), 1.0));
+
+    rewriter.replaceOpWithNewOp<Torch::AtenEluOp>(
+        binder.op, resultType, operand, vAlpha, vScale, vInputScale);
+    return success();
+  });
+  patterns.onOp("ReduceL1", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    int64_t keepDims, noop_with_empty_axes;
+    Value operand;
+    if (binder.tensorOperandAtIndex(operand, 0) ||
+        binder.tensorResultType(resultType) ||
+        binder.s64IntegerAttr(keepDims, "keepdims", 1) ||
+        binder.s64IntegerAttr(noop_with_empty_axes, "noop_with_empty_axes", 0))
+      return failure();
+
+    Value data = rewriter.create<Torch::AtenAbsOp>(binder.getLoc(),
+                                                   operand.getType(), operand);
+
+    return reducedSumImpl(binder, rewriter, data, resultType,
+                          /*storeValue=*/operand, keepDims,
+                          noop_with_empty_axes, false);
+  });
+  patterns.onOp("ReduceL2", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    int64_t keepDims, noop_with_empty_axes;
+    if (binder.tensorOperandAtIndex(operand, 0) ||
+        binder.tensorResultType(resultType) ||
+        binder.s64IntegerAttr(keepDims, "keepdims", 1) ||
+        binder.s64IntegerAttr(noop_with_empty_axes, "noop_with_empty_axes", 0))
+      return failure();
+
+    // A ReduceL2 op is equivalent to the following sequence of operations:
+    // Mul(x, x) -> ReduceSum -> CastF32 -> Sqrt -> CastLike(resultType)
+    Value squareOfOperand = rewriter.create<Torch::AtenMulTensorOp>(
+        binder.getLoc(), operand.getType(), operand, operand);
+
+    auto reducedSum =
+        reducedSumImpl(binder, rewriter, squareOfOperand, resultType, operand,
+                       keepDims, noop_with_empty_axes, true);
+    if (failed(reducedSum))
+      return rewriter.notifyMatchFailure(
+          binder.op, "Failed to perform sum operation on square of operand");
+
+    Value castDType = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(/*Float32Type*/ 6));
+
+    Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    Value constFalse =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
+
+    // Perform an AtenToDtype op on the squared sum of the operand, stored
+    // now in operand itself.
+    auto size =
+        dyn_cast<Torch::ValueTensorType>(operand.getType()).getOptionalSizes();
+    auto f32ResultType =
+        rewriter.getType<Torch::ValueTensorType>(size, rewriter.getF32Type());
+    Value operandCast = rewriter.create<Torch::AtenToDtypeOp>(
+        binder.getLoc(), f32ResultType, operand, castDType,
+        /*non_blocking=*/constFalse, /*copy=*/constFalse,
+        /*memory_format=*/noneVal);
+
+    Value operandSqrt = rewriter.create<Torch::AtenSqrtOp>(
+        binder.getLoc(), f32ResultType, operandCast);
+
+    Value resultDtype = Torch::getDtypeIntValueForType(
+        rewriter, binder.getLoc(), resultType.getDtype());
+    rewriter.replaceOpWithNewOp<Torch::AtenToDtypeOp>(
+        binder.op, resultType, operandSqrt, resultDtype,
+        /*non_blocking=*/constFalse, /*copy=*/constFalse,
+        /*memory_format=*/noneVal);
+    return success();
+  });
   patterns.onOp(
-      "Softmax", 13, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ReduceLogSum", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
-        Value input;
-        int64_t axis;
-        if (binder.tensorOperand(input) ||
-            binder.s64IntegerAttr(axis, "axis", -1) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        // ONNX allows negative axis.
-        if (axis < 0)
-          axis +=
-              cast<Torch::ValueTensorType>(input.getType()).getSizes().size();
-
-        Value constAxis = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), axis));
-
-        Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-
-        rewriter.replaceOpWithNewOp<Torch::AtenSoftmaxIntOp>(
-            binder.op, resultType, input, constAxis, /*dtype=*/noneVal);
-        return success();
-      });
-
-  patterns.onOp(
-      "Selu", 6, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // y = gamma * (alpha * e^x - alpha) for x <= 0, y = gamma * x for x > 0
-        Torch::ValueTensorType resultType;
-        float alpha, gamma;
-        Value operand;
-        // Refer https://onnx.ai/onnx/operators/onnx__Selu.html for the default
-        // alpha and gamma values.
-        if (binder.tensorOperand(operand) ||
-            binder.f32FloatAttr(alpha, "alpha", 1.67326) ||
-            binder.f32FloatAttr(gamma, "gamma", 1.0507) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        Value vAlpha = rewriter.create<Torch::ConstantFloatOp>(
-            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-            rewriter.getFloatAttr(rewriter.getF64Type(), alpha));
-
-        Value vScale = rewriter.create<Torch::ConstantFloatOp>(
-            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-            rewriter.getFloatAttr(rewriter.getF64Type(), gamma));
-
-        Value vInputScale = rewriter.create<Torch::ConstantFloatOp>(
-            binder.getLoc(), rewriter.getType<Torch::FloatType>(),
-            rewriter.getFloatAttr(rewriter.getF64Type(), 1.0));
-
-        rewriter.replaceOpWithNewOp<Torch::AtenEluOp>(
-            binder.op, resultType, operand, vAlpha, vScale, vInputScale);
-        return success();
-      });
-  patterns.onOp("ReduceL1", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  int64_t keepDims, noop_with_empty_axes;
-                  Value operand;
-                  if (binder.tensorOperandAtIndex(operand, 0) ||
-                      binder.tensorResultType(resultType) ||
-                      binder.s64IntegerAttr(keepDims, "keepdims", 1) ||
-                      binder.s64IntegerAttr(noop_with_empty_axes,
-                                            "noop_with_empty_axes", 0))
-                    return failure();
-
-                  Value data = rewriter.create<Torch::AtenAbsOp>(
-                      binder.getLoc(), operand.getType(), operand);
-
-                  return reducedSumImpl(binder, rewriter, data, resultType,
-                                        /*storeValue=*/operand, keepDims,
-                                        noop_with_empty_axes, false);
-                });
-  patterns.onOp(
-      "ReduceL2", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
+        Value data;
         int64_t keepDims, noop_with_empty_axes;
-        if (binder.tensorOperandAtIndex(operand, 0) ||
+        if (binder.tensorOperandAtIndex(data, 0) ||
             binder.tensorResultType(resultType) ||
             binder.s64IntegerAttr(keepDims, "keepdims", 1) ||
             binder.s64IntegerAttr(noop_with_empty_axes, "noop_with_empty_axes",
                                   0))
           return failure();
 
-        // A ReduceL2 op is equivalent to the following sequence of operations:
-        // Mul(x, x) -> ReduceSum -> CastF32 -> Sqrt -> CastLike(resultType)
-        Value squareOfOperand = rewriter.create<Torch::AtenMulTensorOp>(
-            binder.getLoc(), operand.getType(), operand, operand);
+        auto reducedSumBool = reducedSumImpl(binder, rewriter, data, resultType,
+                                             /*storeValue=*/data, keepDims,
+                                             noop_with_empty_axes, true);
 
-        auto reducedSum =
-            reducedSumImpl(binder, rewriter, squareOfOperand, resultType,
-                           operand, keepDims, noop_with_empty_axes, true);
-        if (failed(reducedSum))
+        if (failed(reducedSumBool))
           return rewriter.notifyMatchFailure(
               binder.op,
               "Failed to perform sum operation on square of operand");
 
-        Value castDType = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(/*Float32Type*/ 6));
-
-        Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        Value constFalse =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
-
-        // Perform an AtenToDtype op on the squared sum of the operand, stored
-        // now in operand itself.
-        auto size = dyn_cast<Torch::ValueTensorType>(operand.getType())
-                        .getOptionalSizes();
-        auto f32ResultType = rewriter.getType<Torch::ValueTensorType>(
-            size, rewriter.getF32Type());
-        Value operandCast = rewriter.create<Torch::AtenToDtypeOp>(
-            binder.getLoc(), f32ResultType, operand, castDType,
-            /*non_blocking=*/constFalse, /*copy=*/constFalse,
-            /*memory_format=*/noneVal);
-
-        Value operandSqrt = rewriter.create<Torch::AtenSqrtOp>(
-            binder.getLoc(), f32ResultType, operandCast);
-
-        Value resultDtype = Torch::getDtypeIntValueForType(
-            rewriter, binder.getLoc(), resultType.getDtype());
-        rewriter.replaceOpWithNewOp<Torch::AtenToDtypeOp>(
-            binder.op, resultType, operandSqrt, resultDtype,
-            /*non_blocking=*/constFalse, /*copy=*/constFalse,
-            /*memory_format=*/noneVal);
+        rewriter.replaceOpWithNewOp<Torch::AtenLogOp>(binder.op, resultType,
+                                                      data);
         return success();
       });
-  patterns.onOp("ReduceLogSum", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value data;
-                  int64_t keepDims, noop_with_empty_axes;
-                  if (binder.tensorOperandAtIndex(data, 0) ||
-                      binder.tensorResultType(resultType) ||
-                      binder.s64IntegerAttr(keepDims, "keepdims", 1) ||
-                      binder.s64IntegerAttr(noop_with_empty_axes,
-                                            "noop_with_empty_axes", 0))
-                    return failure();
-
-                  auto reducedSumBool =
-                      reducedSumImpl(binder, rewriter, data, resultType,
-                                     /*storeValue=*/data, keepDims,
-                                     noop_with_empty_axes, true);
-
-                  if (failed(reducedSumBool))
-                    return rewriter.notifyMatchFailure(
-                        binder.op,
-                        "Failed to perform sum operation on square of operand");
-
-                  rewriter.replaceOpWithNewOp<Torch::AtenLogOp>(
-                      binder.op, resultType, data);
-                  return success();
-                });
   patterns.onOp(
-      "ReduceLogSumExp", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ReduceLogSumExp", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value data;
         int64_t keepDims, noop_with_empty_axes;
@@ -1183,45 +1143,41 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
             /*memory_format=*/noneVal);
         return success();
       });
-  patterns.onOp("ReduceSum", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value data;
-                  int64_t keepDims, noop_with_empty_axes;
-                  if (binder.tensorOperandAtIndex(data, 0) ||
-                      binder.tensorResultType(resultType) ||
-                      binder.s64IntegerAttr(keepDims, "keepdims", 1) ||
-                      binder.s64IntegerAttr(noop_with_empty_axes,
-                                            "noop_with_empty_axes", 0))
-                    return failure();
+  patterns.onOp("ReduceSum", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value data;
+    int64_t keepDims, noop_with_empty_axes;
+    if (binder.tensorOperandAtIndex(data, 0) ||
+        binder.tensorResultType(resultType) ||
+        binder.s64IntegerAttr(keepDims, "keepdims", 1) ||
+        binder.s64IntegerAttr(noop_with_empty_axes, "noop_with_empty_axes", 0))
+      return failure();
 
-                  return reducedSumImpl(binder, rewriter, data, resultType,
-                                        /*storeValue=*/data, keepDims,
-                                        noop_with_empty_axes, false);
-                });
-  patterns.onOp("ReduceSumSquare", 1,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value data;
-                  int64_t keepDims, noop_with_empty_axes;
-                  if (binder.tensorOperandAtIndex(data, 0) ||
-                      binder.tensorResultType(resultType) ||
-                      binder.s64IntegerAttr(keepDims, "keepdims", 1) ||
-                      binder.s64IntegerAttr(noop_with_empty_axes,
-                                            "noop_with_empty_axes", 0))
-                    return failure();
-
-                  Value dataSquare = rewriter.create<Torch::AtenMulTensorOp>(
-                      binder.getLoc(), data.getType(), data, data);
-
-                  return reducedSumImpl(binder, rewriter, dataSquare,
-                                        resultType,
-                                        /*storeValue=*/data, keepDims,
-                                        noop_with_empty_axes, false);
-                });
+    return reducedSumImpl(binder, rewriter, data, resultType,
+                          /*storeValue=*/data, keepDims, noop_with_empty_axes,
+                          false);
+  });
   patterns.onOp(
-      "ReduceMean", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ReduceSumSquare", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+        Torch::ValueTensorType resultType;
+        Value data;
+        int64_t keepDims, noop_with_empty_axes;
+        if (binder.tensorOperandAtIndex(data, 0) ||
+            binder.tensorResultType(resultType) ||
+            binder.s64IntegerAttr(keepDims, "keepdims", 1) ||
+            binder.s64IntegerAttr(noop_with_empty_axes, "noop_with_empty_axes",
+                                  0))
+          return failure();
+
+        Value dataSquare = rewriter.create<Torch::AtenMulTensorOp>(
+            binder.getLoc(), data.getType(), data, data);
+
+        return reducedSumImpl(binder, rewriter, dataSquare, resultType,
+                              /*storeValue=*/data, keepDims,
+                              noop_with_empty_axes, false);
+      });
+  patterns.onOp(
+      "ReduceMean", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value data;
         int64_t keepDims, noop_with_empty_axes;
@@ -1339,8 +1295,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "ReduceMax", 13,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ReduceMax", 13, [](OpBinder binder, PatternRewriter &rewriter) {
         // AtenAmaxOp allows us to pass a list of dims
         Torch::ValueTensorType resultType;
         Value data;
@@ -1493,8 +1448,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
       });
 
   patterns.onOp(
-      "ReduceMin", 13,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ReduceMin", 13, [](OpBinder binder, PatternRewriter &rewriter) {
         // AtenAminOp allows us to pass a list of dims
         Torch::ValueTensorType resultType;
         Value data;
@@ -1645,61 +1599,57 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
 
-  patterns.onOp(
-      "Shape", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        int64_t start, end;
-        if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType) ||
-            binder.s64IntegerAttr(start, "start", 0) ||
-            binder.s64IntegerAttr(end, "end", -1))
-          return failure();
+  patterns.onOp("Shape", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    int64_t start, end;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType) ||
+        binder.s64IntegerAttr(start, "start", 0) ||
+        binder.s64IntegerAttr(end, "end", -1))
+      return failure();
 
-        auto inputType = dyn_cast<Torch::ValueTensorType>(operand.getType());
-        int64_t inputRank = inputType.getSizes().size();
+    auto inputType = dyn_cast<Torch::ValueTensorType>(operand.getType());
+    int64_t inputRank = inputType.getSizes().size();
 
-        auto shapeType = Torch::ValueTensorType::get(
-            binder.op->getContext(), SmallVector<int64_t>{inputRank},
-            resultType.getOptionalDtype());
+    auto shapeType = Torch::ValueTensorType::get(
+        binder.op->getContext(), SmallVector<int64_t>{inputRank},
+        resultType.getOptionalDtype());
 
-        Value shape = rewriter.create<Torch::Aten_ShapeAsTensorOp>(
-            binder.getLoc(), shapeType, operand);
+    Value shape = rewriter.create<Torch::Aten_ShapeAsTensorOp>(
+        binder.getLoc(), shapeType, operand);
 
-        if (start == 0 && end == -1) {
-          rewriter.replaceOp(binder.op, shape);
-          return success();
-        }
+    if (start == 0 && end == -1) {
+      rewriter.replaceOp(binder.op, shape);
+      return success();
+    }
 
-        Value sv = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(start));
+    Value sv = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(start));
 
-        Value ev = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(end));
+    Value ev = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(end));
 
-        Value step = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), 1);
+    Value step = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), 1);
 
-        Value dim = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), 0);
+    Value dim = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), 0);
 
-        shape = rewriter.create<Torch::AtenSliceTensorOp>(
-            binder.getLoc(), resultType, shape, dim, sv, ev, step);
+    shape = rewriter.create<Torch::AtenSliceTensorOp>(
+        binder.getLoc(), resultType, shape, dim, sv, ev, step);
 
-        rewriter.replaceOp(binder.op, shape);
-        return success();
-      });
+    rewriter.replaceOp(binder.op, shape);
+    return success();
+  });
 
-  patterns.onOp("Sinh", 9,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
+  patterns.onOp("Sinh", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
 
-                  rewriter.replaceOpWithNewOp<Torch::AtenSinhOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
+    rewriter.replaceOpWithNewOp<Torch::AtenSinhOp>(binder.op, resultType,
+                                                   operand);
+    return success();
+  });
 
   // split with fixed-size parts
   // Arguments:
@@ -1712,80 +1662,78 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
   // Note: torch.aten gives a list of tensors, but ONNX gives a variadic list of
   // tensors
   //       so we need to unpack the list
-  patterns.onOp(
-      "Split", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Value self;
-        int64_t axis;
-        int64_t numOutputs;
-        if (binder.tensorOperand(self))
-          return rewriter.notifyMatchFailure(
-              binder.op, "Not converting to AtenSplitTensorOp due to input "
-                         "tensor mismatch");
-        if (binder.s64IntegerAttr(axis, "axis", 0))
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Failed to get axis attribute");
+  patterns.onOp("Split", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Value self;
+    int64_t axis;
+    int64_t numOutputs;
+    if (binder.tensorOperand(self))
+      return rewriter.notifyMatchFailure(
+          binder.op, "Not converting to AtenSplitTensorOp due to input "
+                     "tensor mismatch");
+    if (binder.s64IntegerAttr(axis, "axis", 0))
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed to get axis attribute");
 
-        numOutputs = binder.op->getNumResults();
-        if (binder.s64IntegerAttr(numOutputs, "num_outputs", numOutputs))
-          return rewriter.notifyMatchFailure(
-              binder.op, "Failed to get num_outputs attribute");
+    numOutputs = binder.op->getNumResults();
+    if (binder.s64IntegerAttr(numOutputs, "num_outputs", numOutputs))
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed to get num_outputs attribute");
 
-        auto loc = binder.getLoc();
-        auto result0Ty =
-            cast<Torch::ValueTensorType>(binder.op->getResult(0).getType());
-        auto resultNTy = cast<Torch::ValueTensorType>(
-            binder.op->getResults().back().getType());
-        auto selfTy = cast<Torch::ValueTensorType>(self.getType());
+    auto loc = binder.getLoc();
+    auto result0Ty =
+        cast<Torch::ValueTensorType>(binder.op->getResult(0).getType());
+    auto resultNTy =
+        cast<Torch::ValueTensorType>(binder.op->getResults().back().getType());
+    auto selfTy = cast<Torch::ValueTensorType>(self.getType());
 
-        int64_t dim = axis;
-        if (dim < 0)
-          dim += selfTy.getSizes().size();
+    int64_t dim = axis;
+    if (dim < 0)
+      dim += selfTy.getSizes().size();
 
-        Value dimValue = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getType<Torch::IntType>(),
-            rewriter.getI64IntegerAttr(dim));
+    Value dimValue = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getType<Torch::IntType>(),
+        rewriter.getI64IntegerAttr(dim));
 
-        Value vNumOutputs = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getType<Torch::IntType>(),
-            rewriter.getI64IntegerAttr(numOutputs));
+    Value vNumOutputs = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getType<Torch::IntType>(),
+        rewriter.getI64IntegerAttr(numOutputs));
 
-        Value one = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(1));
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(0));
+    Value one = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(1));
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(0));
 
-        Value vDimSize = rewriter.create<Torch::AtenSizeIntOp>(
-            loc, rewriter.getType<Torch::IntType>(), self, dimValue);
+    Value vDimSize = rewriter.create<Torch::AtenSizeIntOp>(
+        loc, rewriter.getType<Torch::IntType>(), self, dimValue);
 
-        Value addNumOutputs =
-            rewriter.create<Torch::AtenAddIntOp>(loc, vDimSize, vNumOutputs);
-        Value subOne =
-            rewriter.create<Torch::AtenSubIntOp>(loc, addNumOutputs, one);
-        Value splitSize =
-            rewriter.create<Torch::AtenFloordivIntOp>(loc, subOne, vNumOutputs);
+    Value addNumOutputs =
+        rewriter.create<Torch::AtenAddIntOp>(loc, vDimSize, vNumOutputs);
+    Value subOne =
+        rewriter.create<Torch::AtenSubIntOp>(loc, addNumOutputs, one);
+    Value splitSize =
+        rewriter.create<Torch::AtenFloordivIntOp>(loc, subOne, vNumOutputs);
 
-        llvm::SmallVector<Value> outputs;
-        Value step = one;
-        Value start = zero;
+    llvm::SmallVector<Value> outputs;
+    Value step = one;
+    Value start = zero;
 
-        for (int i = 0; i < numOutputs - 1; ++i) {
-          Value end =
-              rewriter.create<Torch::AtenAddIntOp>(loc, start, splitSize);
-          Value slice = rewriter.create<Torch::AtenSliceTensorOp>(
-              loc, result0Ty, self, dimValue, start, end, step);
-          start = end;
-          outputs.push_back(slice);
-        }
+    for (int i = 0; i < numOutputs - 1; ++i) {
+      Value end = rewriter.create<Torch::AtenAddIntOp>(loc, start, splitSize);
+      Value slice = rewriter.create<Torch::AtenSliceTensorOp>(
+          loc, result0Ty, self, dimValue, start, end, step);
+      start = end;
+      outputs.push_back(slice);
+    }
 
-        Value end = vDimSize;
-        Value lastSlice = rewriter.create<Torch::AtenSliceTensorOp>(
-            loc, resultNTy, self, dimValue, start, end, step);
-        outputs.push_back(lastSlice);
+    Value end = vDimSize;
+    Value lastSlice = rewriter.create<Torch::AtenSliceTensorOp>(
+        loc, resultNTy, self, dimValue, start, end, step);
+    outputs.push_back(lastSlice);
 
-        rewriter.replaceOp(binder.op, outputs);
+    rewriter.replaceOp(binder.op, outputs);
 
-        return success();
-      });
+    return success();
+  });
 
   // split with variable parts
   // Arguments:
@@ -1799,428 +1747,413 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
   // Note: torch.aten gives a list of tensors, but ONNX gives a variadic list of
   // tensors
   //       so we need to unpack the list
-  patterns.onOp(
-      "Split", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Value self;
-        Value split;
-        int64_t axis;
-        int64_t num_outputs;
-        if (binder.tensorOperandAtIndex(self, 0) ||
-            binder.tensorOperandAtIndex(split, 1))
-          return rewriter.notifyMatchFailure(
-              binder.op, "Not converting to AtenSplitWithSizesOp due to input "
-                         "tensor mismatch");
-        if (binder.s64IntegerAttr(axis, "axis", 0))
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Failed to get axis attribute");
-        if (binder.s64IntegerAttr(num_outputs, "num_outputs", 0))
-          return rewriter.notifyMatchFailure(
-              binder.op, "Failed to get num_outputs attribute");
+  patterns.onOp("Split", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Value self;
+    Value split;
+    int64_t axis;
+    int64_t num_outputs;
+    if (binder.tensorOperandAtIndex(self, 0) ||
+        binder.tensorOperandAtIndex(split, 1))
+      return rewriter.notifyMatchFailure(
+          binder.op, "Not converting to AtenSplitWithSizesOp due to input "
+                     "tensor mismatch");
+    if (binder.s64IntegerAttr(axis, "axis", 0))
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed to get axis attribute");
+    if (binder.s64IntegerAttr(num_outputs, "num_outputs", 0))
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed to get num_outputs attribute");
 
-        auto result0Ty =
-            cast<Torch::ValueTensorType>(binder.op->getResult(0).getType());
-        auto selfTy =
-            cast<Torch::ValueTensorType>(binder.op->getOperand(0).getType());
+    auto result0Ty =
+        cast<Torch::ValueTensorType>(binder.op->getResult(0).getType());
+    auto selfTy =
+        cast<Torch::ValueTensorType>(binder.op->getOperand(0).getType());
 
-        int64_t dim = axis;
-        if (dim < 0)
-          dim += selfTy.getSizes().size();
+    int64_t dim = axis;
+    if (dim < 0)
+      dim += selfTy.getSizes().size();
 
-        llvm::SmallVector<int64_t> intermediateShape(result0Ty.getSizes());
-        for (auto result : binder.op->getResultTypes()) {
-          int64_t d = cast<Torch::ValueTensorType>(result).getSizes()[dim];
-          intermediateShape[dim] = d == intermediateShape[dim] ? d : -1;
+    llvm::SmallVector<int64_t> intermediateShape(result0Ty.getSizes());
+    for (auto result : binder.op->getResultTypes()) {
+      int64_t d = cast<Torch::ValueTensorType>(result).getSizes()[dim];
+      intermediateShape[dim] = d == intermediateShape[dim] ? d : -1;
+    }
+
+    Torch::PrimTolistOp splitToList = rewriter.create<Torch::PrimTolistOp>(
+        binder.getLoc(),
+        Torch::ListType::get(rewriter.getType<Torch::IntType>()), split);
+
+    Value dimValue = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), dim));
+
+    // TODO: Attempting to use the shape expected by the ONNX mlir as ground
+    // truth. For now just use dynamic shapes.
+    auto resultOuterType =
+        Torch::ListType::get(rewriter.getType<Torch::ValueTensorType>(
+            /*std::optional<llvm::ArrayRef<int64_t>>=*/intermediateShape,
+            result0Ty.getOptionalDtype()));
+    Torch::AtenSplitWithSizesOp new_op =
+        rewriter.create<Torch::AtenSplitWithSizesOp>(
+            binder.getLoc(), resultOuterType, self, splitToList.getResult(0),
+            dimValue);
+
+    // the onnx op is variadic with multiple results, but AtenSplitWithSizes
+    // outputs a list so we need to unpack the list
+    rewriter.replaceOpWithNewOp<Torch::PrimListUnpackOp>(
+        binder.op, binder.op->getResults().getType(), new_op.getResult());
+
+    return success();
+  });
+
+  patterns.onOp("Tan", 7, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenTanOp>(binder.op, resultType,
+                                                  operand);
+    return success();
+  });
+
+  patterns.onOp("Transpose", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    auto loc = binder.getLoc();
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
+    auto operandType = cast<Torch::ValueTensorType>(operand.getType());
+    TensorType tensorType = operandType.toBuiltinTensor();
+    if (!tensorType || !tensorType.hasRank())
+      return failure();
+
+    // Default permutation is to reverse orders:
+    int64_t rank = tensorType.getRank();
+    llvm::SmallVector<int64_t> reverse(rank);
+    for (int64_t i = 0; i < rank; ++i) {
+      reverse[i] = rank - i - 1;
+    }
+
+    llvm::SmallVector<int64_t> permutations;
+    if (failed(binder.s64IntegerArrayAttr(permutations, "perm", reverse)))
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed to obtain permutations");
+
+    if (static_cast<int64_t>(permutations.size()) != rank)
+      return rewriter.notifyMatchFailure(
+          binder.op, "Permutation length does not match operand rank");
+
+    llvm::SmallVector<int64_t> shape(tensorType.getShape());
+    llvm::SmallVector<int64_t> current(rank);
+    for (int64_t i = 0; i < rank; ++i) {
+      current[i] = i;
+    }
+
+    for (auto &dim : permutations)
+      dim = dim < 0 ? dim + rank : dim;
+
+    // We need to override to the destination if known:
+    if (resultType.hasSizes()) {
+      for (int i = 0; i < rank; ++i) {
+        shape[permutations[i]] = resultType.getSizes()[i];
+      }
+    }
+
+    // Convert dynamic shape dimension:
+    for (unsigned i = 0; i < shape.size(); i++) {
+      if (shape[i] == ShapedType::kDynamic)
+        shape[i] = Torch::kUnknownSize;
+    }
+
+    for (int64_t i = 0; i < rank; ++i) {
+      if (current[i] == permutations[i])
+        continue;
+
+      int64_t target = i + 1;
+      for (; target < rank; ++target) {
+        if (current[target] == permutations[i])
+          break;
+      }
+
+      std::swap(shape[i], shape[target]);
+      std::swap(current[i], current[target]);
+
+      Value dim0 = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
+
+      Value dim1 = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64), target));
+
+      operand = rewriter.create<Torch::AtenTransposeIntOp>(
+          loc,
+          Torch::ValueTensorType::get(tensorType.getContext(), shape,
+                                      operandType.getOptionalDtype()),
+          operand, dim0, dim1);
+    }
+
+    rewriter.replaceOp(binder.op, operand);
+    return success();
+  });
+  patterns.onOp("Slice", 13, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultTorchType;
+    Value operand, starts, ends;
+    // Handle if axes are not provided
+
+    if (binder.tensorOperandAtIndex(operand, 0) ||
+        binder.tensorOperandAtIndex(starts, 1) ||
+        binder.tensorOperandAtIndex(ends, 2) ||
+        binder.tensorResultType(resultTorchType)) {
+      return failure();
+    }
+
+    auto context = rewriter.getContext();
+    auto operandTorchTy = cast<Torch::ValueTensorType>(operand.getType());
+    auto operandTy =
+        dyn_cast<RankedTensorType>(operandTorchTy.toBuiltinTensor());
+
+    if (!operandTy)
+      return rewriter.notifyMatchFailure(
+          binder.op,
+          "Expected tensor operator argument to be a ranked tensor type");
+
+    auto startsTorchTy = cast<Torch::ValueTensorType>(starts.getType());
+    auto startsTy = dyn_cast<RankedTensorType>(startsTorchTy.toBuiltinTensor());
+    int startSize = startsTy.getDimSize(0);
+
+    auto endsTorchTy = cast<Torch::ValueTensorType>(ends.getType());
+    auto endsTy = dyn_cast<RankedTensorType>(endsTorchTy.toBuiltinTensor());
+    int endSize = endsTy.getDimSize(0);
+    auto resultTy =
+        dyn_cast<RankedTensorType>(resultTorchType.toBuiltinTensor());
+    if (!resultTy)
+      return rewriter.notifyMatchFailure(
+          binder.op, "Expected result type to be a ranked tensor type");
+
+    Location loc = binder.getLoc();
+
+    // Binding `axes` from its arguments or through a default value
+    Value axes;
+    if (binder.getNumOperands() >= 4) {
+      if (binder.tensorOperandAtIndex(axes, 3)) {
+        return failure();
+      }
+    }
+
+    // Binding `steps` from its arguments or through a default value
+    Value steps;
+    if (binder.getNumOperands() >= 5) {
+      if (binder.tensorOperandAtIndex(steps, 4)) {
+        return failure();
+      }
+    } else {
+      // The default `steps` value is a 1d tensor filled with ones with a
+      // size equal to the size of `starts` and `ends`.
+      Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
+      Value sizeStepInput = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64), startSize));
+      Value sizeStepsInput = rewriter.create<Torch::PrimListConstructOp>(
+          loc,
+          Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+          sizeStepInput);
+      steps = rewriter.create<Torch::AtenOnesOp>(
+          loc, startsTorchTy, sizeStepsInput, none, none, none, none);
+    }
+
+    if (!(endsTy.getRank() == 1 && startsTy.getRank() == 1 &&
+          startSize == endSize))
+      return rewriter.notifyMatchFailure(
+          binder.op, "Expected the rank of starts and ends tensors to be 1 "
+                     "and their dimensions to match");
+
+    if (axes) {
+      auto axesTorchTy = cast<Torch::ValueTensorType>(axes.getType());
+      auto axesTy = dyn_cast<RankedTensorType>(axesTorchTy.toBuiltinTensor());
+      int64_t numAxes = axesTy.getDimSize(0);
+
+      if (!(axesTy && numAxes == endSize))
+        return rewriter.notifyMatchFailure(
+            binder.op, "Axes should be the same size of starts and ends");
+    }
+
+    auto stepsTy = dyn_cast<RankedTensorType>(
+        cast<Torch::ValueTensorType>(steps.getType()).toBuiltinTensor());
+
+    if (!(stepsTy && stepsTy.getDimSize(0) == endsTy.getDimSize(0)))
+      return rewriter.notifyMatchFailure(
+          binder.op, "Steps should be the same size of starts and ends");
+
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+
+    auto select = [&](Value v, Value k) -> Value {
+      auto ty = cast<Torch::ValueTensorType>(v.getType());
+      auto sel = rewriter.create<Torch::AtenIndexSelectOp>(
+          loc,
+          Torch::ValueTensorType::get(ty.getContext(), ArrayRef<int64_t>{1},
+                                      ty.getOptionalDtype()),
+          v, zero, k);
+      Value item = rewriter.create<Torch::AtenItemOp>(
+          loc, rewriter.getType<Torch::IntType>(), sel);
+      return item;
+    };
+
+    llvm::SmallVector<int64_t> intermediateShape(operandTy.getShape());
+    for (int i = 0, s = operandTy.getRank(); i < s; ++i) {
+      if (operandTy.getDimSize(i) != resultTy.getDimSize(i))
+        intermediateShape[i] = -1;
+      if (intermediateShape[i] == ShapedType::kDynamic)
+        intermediateShape[i] = Torch::kUnknownSize;
+    }
+    auto intermediateType = Torch::ValueTensorType::get(
+        context, intermediateShape, resultTorchType.getOptionalDtype());
+    for (int i = 0; i < endSize; ++i) {
+
+      Value k = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
+      Value kTensor = rewriter.create<Torch::PrimNumToTensorScalarOp>(
+          loc,
+          Torch::ValueTensorType::get(
+              context, ArrayRef<int64_t>{1},
+              rewriter.getIntegerType(64, /*signed*/ 1)),
+          k);
+
+      Value start = select(starts, kTensor);
+      Value end = select(ends, kTensor);
+      Value axis = axes ? select(axes, kTensor) : k;
+      Value step = select(steps, kTensor);
+
+      auto sliceType = intermediateType;
+      sliceType = i == (endSize - 1) ? resultTorchType : sliceType;
+      operand = rewriter.create<Torch::AtenSliceTensorOp>(
+          loc, sliceType, operand, axis, start, end, step);
+    }
+
+    rewriter.replaceOp(binder.op, operand);
+    return success();
+  });
+  patterns.onOp("Reshape", 5, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value data;
+    Value shape;
+    int64_t allowzero;
+    if (binder.tensorOperands(data, shape) ||
+        binder.tensorResultType(resultType) ||
+        binder.s64IntegerAttr(allowzero, "allowzero", 0))
+      return failure();
+
+    // If the result shape is static then we can create a result shape list
+    // directly using the result shape values (integers).
+    if (resultType.hasSizes()) {
+      bool hasStaticShape = resultType.areAllSizesKnown();
+      ArrayRef<int64_t> resultShapeInt = resultType.getSizes();
+      if (hasStaticShape) {
+        SmallVector<Value> resultShape;
+        for (int64_t dim : resultShapeInt) {
+          resultShape.push_back(rewriter.create<Torch::ConstantIntOp>(
+              binder.getLoc(), rewriter.getI64IntegerAttr(dim)));
         }
-
-        Torch::PrimTolistOp splitToList = rewriter.create<Torch::PrimTolistOp>(
-            binder.getLoc(),
-            Torch::ListType::get(rewriter.getType<Torch::IntType>()), split);
-
-        Value dimValue = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), dim));
-
-        // TODO: Attempting to use the shape expected by the ONNX mlir as ground
-        // truth. For now just use dynamic shapes.
-        auto resultOuterType =
-            Torch::ListType::get(rewriter.getType<Torch::ValueTensorType>(
-                /*std::optional<llvm::ArrayRef<int64_t>>=*/intermediateShape,
-                result0Ty.getOptionalDtype()));
-        Torch::AtenSplitWithSizesOp new_op =
-            rewriter.create<Torch::AtenSplitWithSizesOp>(
-                binder.getLoc(), resultOuterType, self,
-                splitToList.getResult(0), dimValue);
-
-        // the onnx op is variadic with multiple results, but AtenSplitWithSizes
-        // outputs a list so we need to unpack the list
-        rewriter.replaceOpWithNewOp<Torch::PrimListUnpackOp>(
-            binder.op, binder.op->getResults().getType(), new_op.getResult());
-
-        return success();
-      });
-
-  patterns.onOp("Tan", 7,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-                  rewriter.replaceOpWithNewOp<Torch::AtenTanOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-
-  patterns.onOp(
-      "Transpose", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        auto loc = binder.getLoc();
-        Torch::ValueTensorType resultType;
-        Value operand;
-        if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType))
-          return failure();
-        auto operandType = cast<Torch::ValueTensorType>(operand.getType());
-        TensorType tensorType = operandType.toBuiltinTensor();
-        if (!tensorType || !tensorType.hasRank())
-          return failure();
-
-        // Default permutation is to reverse orders:
-        int64_t rank = tensorType.getRank();
-        llvm::SmallVector<int64_t> reverse(rank);
-        for (int64_t i = 0; i < rank; ++i) {
-          reverse[i] = rank - i - 1;
-        }
-
-        llvm::SmallVector<int64_t> permutations;
-        if (failed(binder.s64IntegerArrayAttr(permutations, "perm", reverse)))
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Failed to obtain permutations");
-
-        if (static_cast<int64_t>(permutations.size()) != rank)
-          return rewriter.notifyMatchFailure(
-              binder.op, "Permutation length does not match operand rank");
-
-        llvm::SmallVector<int64_t> shape(tensorType.getShape());
-        llvm::SmallVector<int64_t> current(rank);
-        for (int64_t i = 0; i < rank; ++i) {
-          current[i] = i;
-        }
-
-        for (auto &dim : permutations)
-          dim = dim < 0 ? dim + rank : dim;
-
-        // We need to override to the destination if known:
-        if (resultType.hasSizes()) {
-          for (int i = 0; i < rank; ++i) {
-            shape[permutations[i]] = resultType.getSizes()[i];
-          }
-        }
-
-        // Convert dynamic shape dimension:
-        for (unsigned i = 0; i < shape.size(); i++) {
-          if (shape[i] == ShapedType::kDynamic)
-            shape[i] = Torch::kUnknownSize;
-        }
-
-        for (int64_t i = 0; i < rank; ++i) {
-          if (current[i] == permutations[i])
-            continue;
-
-          int64_t target = i + 1;
-          for (; target < rank; ++target) {
-            if (current[target] == permutations[i])
-              break;
-          }
-
-          std::swap(shape[i], shape[target]);
-          std::swap(current[i], current[target]);
-
-          Value dim0 = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
-
-          Value dim1 = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), target));
-
-          operand = rewriter.create<Torch::AtenTransposeIntOp>(
-              loc,
-              Torch::ValueTensorType::get(tensorType.getContext(), shape,
-                                          operandType.getOptionalDtype()),
-              operand, dim0, dim1);
-        }
-
-        rewriter.replaceOp(binder.op, operand);
-        return success();
-      });
-  patterns.onOp(
-      "Slice", 13, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultTorchType;
-        Value operand, starts, ends;
-        // Handle if axes are not provided
-
-        if (binder.tensorOperandAtIndex(operand, 0) ||
-            binder.tensorOperandAtIndex(starts, 1) ||
-            binder.tensorOperandAtIndex(ends, 2) ||
-            binder.tensorResultType(resultTorchType)) {
-          return failure();
-        }
-
-        auto context = rewriter.getContext();
-        auto operandTorchTy = cast<Torch::ValueTensorType>(operand.getType());
-        auto operandTy =
-            dyn_cast<RankedTensorType>(operandTorchTy.toBuiltinTensor());
-
-        if (!operandTy)
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "Expected tensor operator argument to be a ranked tensor type");
-
-        auto startsTorchTy = cast<Torch::ValueTensorType>(starts.getType());
-        auto startsTy =
-            dyn_cast<RankedTensorType>(startsTorchTy.toBuiltinTensor());
-        int startSize = startsTy.getDimSize(0);
-
-        auto endsTorchTy = cast<Torch::ValueTensorType>(ends.getType());
-        auto endsTy = dyn_cast<RankedTensorType>(endsTorchTy.toBuiltinTensor());
-        int endSize = endsTy.getDimSize(0);
-        auto resultTy =
-            dyn_cast<RankedTensorType>(resultTorchType.toBuiltinTensor());
-        if (!resultTy)
-          return rewriter.notifyMatchFailure(
-              binder.op, "Expected result type to be a ranked tensor type");
-
-        Location loc = binder.getLoc();
-
-        // Binding `axes` from its arguments or through a default value
-        Value axes;
-        if (binder.getNumOperands() >= 4) {
-          if (binder.tensorOperandAtIndex(axes, 3)) {
-            return failure();
-          }
-        }
-
-        // Binding `steps` from its arguments or through a default value
-        Value steps;
-        if (binder.getNumOperands() >= 5) {
-          if (binder.tensorOperandAtIndex(steps, 4)) {
-            return failure();
-          }
-        } else {
-          // The default `steps` value is a 1d tensor filled with ones with a
-          // size equal to the size of `starts` and `ends`.
-          Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
-          Value sizeStepInput = rewriter.create<Torch::ConstantIntOp>(
-              loc, rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), startSize));
-          Value sizeStepsInput = rewriter.create<Torch::PrimListConstructOp>(
-              loc,
-              Torch::ListType::get(
-                  Torch::IntType::get(binder.op->getContext())),
-              sizeStepInput);
-          steps = rewriter.create<Torch::AtenOnesOp>(
-              loc, startsTorchTy, sizeStepsInput, none, none, none, none);
-        }
-
-        if (!(endsTy.getRank() == 1 && startsTy.getRank() == 1 &&
-              startSize == endSize))
-          return rewriter.notifyMatchFailure(
-              binder.op, "Expected the rank of starts and ends tensors to be 1 "
-                         "and their dimensions to match");
-
-        if (axes) {
-          auto axesTorchTy = cast<Torch::ValueTensorType>(axes.getType());
-          auto axesTy =
-              dyn_cast<RankedTensorType>(axesTorchTy.toBuiltinTensor());
-          int64_t numAxes = axesTy.getDimSize(0);
-
-          if (!(axesTy && numAxes == endSize))
-            return rewriter.notifyMatchFailure(
-                binder.op, "Axes should be the same size of starts and ends");
-        }
-
-        auto stepsTy = dyn_cast<RankedTensorType>(
-            cast<Torch::ValueTensorType>(steps.getType()).toBuiltinTensor());
-
-        if (!(stepsTy && stepsTy.getDimSize(0) == endsTy.getDimSize(0)))
-          return rewriter.notifyMatchFailure(
-              binder.op, "Steps should be the same size of starts and ends");
-
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
-
-        auto select = [&](Value v, Value k) -> Value {
-          auto ty = cast<Torch::ValueTensorType>(v.getType());
-          auto sel = rewriter.create<Torch::AtenIndexSelectOp>(
-              loc,
-              Torch::ValueTensorType::get(ty.getContext(), ArrayRef<int64_t>{1},
-                                          ty.getOptionalDtype()),
-              v, zero, k);
-          Value item = rewriter.create<Torch::AtenItemOp>(
-              loc, rewriter.getType<Torch::IntType>(), sel);
-          return item;
-        };
-
-        llvm::SmallVector<int64_t> intermediateShape(operandTy.getShape());
-        for (int i = 0, s = operandTy.getRank(); i < s; ++i) {
-          if (operandTy.getDimSize(i) != resultTy.getDimSize(i))
-            intermediateShape[i] = -1;
-          if (intermediateShape[i] == ShapedType::kDynamic)
-            intermediateShape[i] = Torch::kUnknownSize;
-        }
-        auto intermediateType = Torch::ValueTensorType::get(
-            context, intermediateShape, resultTorchType.getOptionalDtype());
-        for (int i = 0; i < endSize; ++i) {
-
-          Value k = rewriter.create<Torch::ConstantIntOp>(
-              loc, rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
-          Value kTensor = rewriter.create<Torch::PrimNumToTensorScalarOp>(
-              loc,
-              Torch::ValueTensorType::get(
-                  context, ArrayRef<int64_t>{1},
-                  rewriter.getIntegerType(64, /*signed*/ 1)),
-              k);
-
-          Value start = select(starts, kTensor);
-          Value end = select(ends, kTensor);
-          Value axis = axes ? select(axes, kTensor) : k;
-          Value step = select(steps, kTensor);
-
-          auto sliceType = intermediateType;
-          sliceType = i == (endSize - 1) ? resultTorchType : sliceType;
-          operand = rewriter.create<Torch::AtenSliceTensorOp>(
-              loc, sliceType, operand, axis, start, end, step);
-        }
-
-        rewriter.replaceOp(binder.op, operand);
-        return success();
-      });
-  patterns.onOp(
-      "Reshape", 5, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value data;
-        Value shape;
-        int64_t allowzero;
-        if (binder.tensorOperands(data, shape) ||
-            binder.tensorResultType(resultType) ||
-            binder.s64IntegerAttr(allowzero, "allowzero", 0))
-          return failure();
-
-        // If the result shape is static then we can create a result shape list
-        // directly using the result shape values (integers).
-        if (resultType.hasSizes()) {
-          bool hasStaticShape = resultType.areAllSizesKnown();
-          ArrayRef<int64_t> resultShapeInt = resultType.getSizes();
-          if (hasStaticShape) {
-            SmallVector<Value> resultShape;
-            for (int64_t dim : resultShapeInt) {
-              resultShape.push_back(rewriter.create<Torch::ConstantIntOp>(
-                  binder.getLoc(), rewriter.getI64IntegerAttr(dim)));
-            }
-            Value resultShapeList = rewriter.create<Torch::PrimListConstructOp>(
-                binder.getLoc(),
-                Torch::ListType::get(
-                    Torch::IntType::get(binder.op->getContext())),
-                resultShape);
-            rewriter.replaceOpWithNewOp<Torch::AtenReshapeOp>(
-                binder.op, resultType, data, resultShapeList);
-            return success();
-          }
-        }
-
-        Torch::BaseTensorType shapeType =
-            cast<Torch::BaseTensorType>(shape.getType());
-        SmallVector<Value> dimList;
-        SmallVector<int64_t> selectSizes;
-        selectSizes.push_back(1);
-        Type selectResultType = shapeType.getWithSizesAndDtype(
-            llvm::ArrayRef(selectSizes), shapeType.getOptionalDtype());
-        auto shapeSizes =
-            dyn_cast<Torch::ValueTensorType>(shape.getType()).getSizes();
-        auto dataSizes =
-            dyn_cast<Torch::ValueTensorType>(data.getType()).getSizes();
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
-        if (allowzero == 0) {
-          // convert shape (tensor) into torch int list while dealing with zero
-          // vals
-          for (int i = 0; i < shapeSizes[0]; i++) {
-            // Go through the shape list and get each dim in the list
-            Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
-                binder.getLoc(), rewriter.getType<Torch::IntType>(),
-                rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
-            Value extract = rewriter.create<Torch::AtenSelectIntOp>(
-                binder.getLoc(), selectResultType, shape, zero, selectIndex);
-            Value dim = rewriter.create<Torch::AtenItemOp>(
-                binder.getLoc(), rewriter.getType<Torch::IntType>(), extract);
-            // deal with zero axis values: replace with original dim value in
-            // input
-            Value isZero =
-                rewriter.create<Torch::AtenEqIntOp>(binder.getLoc(), dim, zero);
-            isZero =
-                rewriter.create<Torch::AtenIntBoolOp>(binder.getLoc(), isZero);
-
-            int64_t dataRank = dataSizes.size();
-            if (i < dataRank) {
-              auto torchIntTy = rewriter.getType<Torch::IntType>();
-              auto int64Ty = rewriter.getIntegerType(64, true);
-              auto dimTy = rewriter.getType<Torch::ValueTensorType>(
-                  ArrayRef<int64_t>(), int64Ty);
-              auto boolTy = rewriter.getType<Torch::ValueTensorType>(
-                  ArrayRef<int64_t>(), rewriter.getI1Type());
-              Value iv = rewriter.create<Torch::ConstantIntOp>(
-                  binder.getLoc(), rewriter.getI64IntegerAttr(i));
-              Value inDim = rewriter.create<Torch::AtenSizeIntOp>(
-                  binder.getLoc(), torchIntTy, data, iv);
-              isZero = rewriter.create<Torch::PrimNumToTensorScalarOp>(
-                  binder.getLoc(), boolTy, isZero);
-              inDim = rewriter.create<Torch::PrimNumToTensorScalarOp>(
-                  binder.getLoc(), dimTy, inDim);
-              dim = rewriter.create<Torch::PrimNumToTensorScalarOp>(
-                  binder.getLoc(), dimTy, dim);
-              Value finalDim = rewriter.create<Torch::AtenWhereSelfOp>(
-                  binder.getLoc(), dimTy, isZero, inDim, dim);
-              dim = rewriter.create<Torch::AtenItemOp>(
-                  binder.getLoc(), rewriter.getType<Torch::IntType>(),
-                  finalDim);
-            }
-            dimList.push_back(dim);
-          }
-          Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
-              binder.getLoc(),
-              Torch::ListType::get(
-                  Torch::IntType::get(binder.op->getContext())),
-              dimList);
-          rewriter.replaceOpWithNewOp<Torch::AtenReshapeOp>(
-              binder.op, resultType, data, dimValueList);
-          return success();
-        }
-        // convert axes (tensor) into torch int list
-        for (int i = 0; i < shapeSizes[0]; i++) {
-          // Go through the axes list and get each dim in the list
-          Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
-          Value extract = rewriter.create<Torch::AtenSelectIntOp>(
-              binder.getLoc(), selectResultType, shape, zero, selectIndex);
-          Value dim = rewriter.create<Torch::AtenItemOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(), extract);
-          dimList.push_back(dim);
-        }
-        Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
+        Value resultShapeList = rewriter.create<Torch::PrimListConstructOp>(
             binder.getLoc(),
             Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
-            dimList);
-        rewriter.replaceOpWithNewOp<Torch::AtenReshapeOp>(binder.op, resultType,
-                                                          data, dimValueList);
+            resultShape);
+        rewriter.replaceOpWithNewOp<Torch::AtenReshapeOp>(
+            binder.op, resultType, data, resultShapeList);
         return success();
-      });
+      }
+    }
+
+    Torch::BaseTensorType shapeType =
+        cast<Torch::BaseTensorType>(shape.getType());
+    SmallVector<Value> dimList;
+    SmallVector<int64_t> selectSizes;
+    selectSizes.push_back(1);
+    Type selectResultType = shapeType.getWithSizesAndDtype(
+        llvm::ArrayRef(selectSizes), shapeType.getOptionalDtype());
+    auto shapeSizes =
+        dyn_cast<Torch::ValueTensorType>(shape.getType()).getSizes();
+    auto dataSizes =
+        dyn_cast<Torch::ValueTensorType>(data.getType()).getSizes();
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+    if (allowzero == 0) {
+      // convert shape (tensor) into torch int list while dealing with zero
+      // vals
+      for (int i = 0; i < shapeSizes[0]; i++) {
+        // Go through the shape list and get each dim in the list
+        Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
+            binder.getLoc(), rewriter.getType<Torch::IntType>(),
+            rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
+        Value extract = rewriter.create<Torch::AtenSelectIntOp>(
+            binder.getLoc(), selectResultType, shape, zero, selectIndex);
+        Value dim = rewriter.create<Torch::AtenItemOp>(
+            binder.getLoc(), rewriter.getType<Torch::IntType>(), extract);
+        // deal with zero axis values: replace with original dim value in
+        // input
+        Value isZero =
+            rewriter.create<Torch::AtenEqIntOp>(binder.getLoc(), dim, zero);
+        isZero = rewriter.create<Torch::AtenIntBoolOp>(binder.getLoc(), isZero);
+
+        int64_t dataRank = dataSizes.size();
+        if (i < dataRank) {
+          auto torchIntTy = rewriter.getType<Torch::IntType>();
+          auto int64Ty = rewriter.getIntegerType(64, true);
+          auto dimTy = rewriter.getType<Torch::ValueTensorType>(
+              ArrayRef<int64_t>(), int64Ty);
+          auto boolTy = rewriter.getType<Torch::ValueTensorType>(
+              ArrayRef<int64_t>(), rewriter.getI1Type());
+          Value iv = rewriter.create<Torch::ConstantIntOp>(
+              binder.getLoc(), rewriter.getI64IntegerAttr(i));
+          Value inDim = rewriter.create<Torch::AtenSizeIntOp>(
+              binder.getLoc(), torchIntTy, data, iv);
+          isZero = rewriter.create<Torch::PrimNumToTensorScalarOp>(
+              binder.getLoc(), boolTy, isZero);
+          inDim = rewriter.create<Torch::PrimNumToTensorScalarOp>(
+              binder.getLoc(), dimTy, inDim);
+          dim = rewriter.create<Torch::PrimNumToTensorScalarOp>(binder.getLoc(),
+                                                                dimTy, dim);
+          Value finalDim = rewriter.create<Torch::AtenWhereSelfOp>(
+              binder.getLoc(), dimTy, isZero, inDim, dim);
+          dim = rewriter.create<Torch::AtenItemOp>(
+              binder.getLoc(), rewriter.getType<Torch::IntType>(), finalDim);
+        }
+        dimList.push_back(dim);
+      }
+      Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
+          binder.getLoc(),
+          Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+          dimList);
+      rewriter.replaceOpWithNewOp<Torch::AtenReshapeOp>(binder.op, resultType,
+                                                        data, dimValueList);
+      return success();
+    }
+    // convert axes (tensor) into torch int list
+    for (int i = 0; i < shapeSizes[0]; i++) {
+      // Go through the axes list and get each dim in the list
+      Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
+      Value extract = rewriter.create<Torch::AtenSelectIntOp>(
+          binder.getLoc(), selectResultType, shape, zero, selectIndex);
+      Value dim = rewriter.create<Torch::AtenItemOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(), extract);
+      dimList.push_back(dim);
+    }
+    Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+        dimList);
+    rewriter.replaceOpWithNewOp<Torch::AtenReshapeOp>(binder.op, resultType,
+                                                      data, dimValueList);
+    return success();
+  });
   patterns.onOp(
-      "ReduceProd", 13,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ReduceProd", 13, [](OpBinder binder, PatternRewriter &rewriter) {
         // ReduceProd allows us to pass a list of dims but AtenProdDimIn only
         // allow one dim as input.
         Torch::ValueTensorType resultType;
@@ -2375,250 +2308,237 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
             binder.op, resultType, dataReduceProd, dataReduceProdShapeList);
         return success();
       });
-  patterns.onOp(
-      "Range", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // ONNX.Range(start, limit, delta) -- limit is exclusive
+  patterns.onOp("Range", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    // ONNX.Range(start, limit, delta) -- limit is exclusive
 
-        Torch::ValueTensorType resultType;
-        Value start, limit, delta;
-        auto loc = binder.getLoc();
-        Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
-        if (binder.tensorOperandAtIndex(start, 0) ||
-            binder.tensorOperandAtIndex(limit, 1) ||
-            binder.tensorOperandAtIndex(delta, 2) ||
-            binder.tensorResultType(resultType))
-          return failure();
+    Torch::ValueTensorType resultType;
+    Value start, limit, delta;
+    auto loc = binder.getLoc();
+    Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
+    if (binder.tensorOperandAtIndex(start, 0) ||
+        binder.tensorOperandAtIndex(limit, 1) ||
+        binder.tensorOperandAtIndex(delta, 2) ||
+        binder.tensorResultType(resultType))
+      return failure();
 
-        // Convert a 0-dimensional/Scalar Tensor ([]) to Scalar Torch Numeric
-        // Value torch.tensor(1.1) equivalent in ONNX to 1.1 as an example
-        // type of start, limit, delta can be one of: double, float, int16,
-        // int32, int64 Assuming start, limit and delta to be same type (could
-        // they be different?)
-        Torch::BaseTensorType startTensorType =
-            cast<Torch::BaseTensorType>(start.getType());
-        bool isFloatDType = startTensorType.getDtype().isF64() ||
-                            startTensorType.getDtype().isF32();
-        bool isIntDType = startTensorType.getDtype().isInteger(16) ||
-                          startTensorType.getDtype().isInteger(32) ||
-                          startTensorType.getDtype().isInteger(64);
-        if (!isFloatDType && !isIntDType) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "Expected the start, limit, delta to be one of "
-                         "double, float, int16, int32, int64");
-        }
-        Value scalarStart, scalarLimit, scalarDelta;
-        if (isFloatDType) {
-          scalarStart = getItemOp<Torch::FloatType>(binder, rewriter, start);
-          scalarLimit = getItemOp<Torch::FloatType>(binder, rewriter, limit);
-          scalarDelta = getItemOp<Torch::FloatType>(binder, rewriter, delta);
-        } else {
-          scalarStart = getItemOp<Torch::IntType>(binder, rewriter, start);
-          scalarLimit = getItemOp<Torch::IntType>(binder, rewriter, limit);
-          scalarDelta = getItemOp<Torch::IntType>(binder, rewriter, delta);
-        }
-        rewriter.replaceOpWithNewOp<Torch::AtenArangeStartStepOp>(
-            binder.op, resultType, scalarStart, scalarLimit, scalarDelta, none,
-            none, none, none);
-        return success();
-      });
-  patterns.onOp(
-      "Size", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        if (binder.tensorOperand(operand) ||
-            binder.tensorResultType(resultType))
-          return failure();
+    // Convert a 0-dimensional/Scalar Tensor ([]) to Scalar Torch Numeric
+    // Value torch.tensor(1.1) equivalent in ONNX to 1.1 as an example
+    // type of start, limit, delta can be one of: double, float, int16,
+    // int32, int64 Assuming start, limit and delta to be same type (could
+    // they be different?)
+    Torch::BaseTensorType startTensorType =
+        cast<Torch::BaseTensorType>(start.getType());
+    bool isFloatDType = startTensorType.getDtype().isF64() ||
+                        startTensorType.getDtype().isF32();
+    bool isIntDType = startTensorType.getDtype().isInteger(16) ||
+                      startTensorType.getDtype().isInteger(32) ||
+                      startTensorType.getDtype().isInteger(64);
+    if (!isFloatDType && !isIntDType) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "Expected the start, limit, delta to be one of "
+                     "double, float, int16, int32, int64");
+    }
+    Value scalarStart, scalarLimit, scalarDelta;
+    if (isFloatDType) {
+      scalarStart = getItemOp<Torch::FloatType>(binder, rewriter, start);
+      scalarLimit = getItemOp<Torch::FloatType>(binder, rewriter, limit);
+      scalarDelta = getItemOp<Torch::FloatType>(binder, rewriter, delta);
+    } else {
+      scalarStart = getItemOp<Torch::IntType>(binder, rewriter, start);
+      scalarLimit = getItemOp<Torch::IntType>(binder, rewriter, limit);
+      scalarDelta = getItemOp<Torch::IntType>(binder, rewriter, delta);
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenArangeStartStepOp>(
+        binder.op, resultType, scalarStart, scalarLimit, scalarDelta, none,
+        none, none, none);
+    return success();
+  });
+  patterns.onOp("Size", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
 
-        auto loc = binder.getLoc();
-        auto &op = binder.op;
-        auto operandTy = cast<Torch::BaseTensorType>(operand.getType());
+    auto loc = binder.getLoc();
+    auto &op = binder.op;
+    auto operandTy = cast<Torch::BaseTensorType>(operand.getType());
 
-        if (!operandTy.hasSizes())
-          return rewriter.notifyMatchFailure(op, "input rank unknown");
+    if (!operandTy.hasSizes())
+      return rewriter.notifyMatchFailure(op, "input rank unknown");
 
-        llvm::SmallVector<Value> dims;
-        int64_t rank = operandTy.getSizes().size();
-        for (int i = 0; i < rank; ++i) {
-          auto iv = rewriter.create<Torch::ConstantIntOp>(
-              loc, rewriter.getI64IntegerAttr(i));
-          Value dim = rewriter.create<Torch::AtenSizeIntOp>(
-              loc, rewriter.getType<Torch::IntType>(), operand, iv);
-          dims.push_back(dim);
-        }
+    llvm::SmallVector<Value> dims;
+    int64_t rank = operandTy.getSizes().size();
+    for (int i = 0; i < rank; ++i) {
+      auto iv = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(i));
+      Value dim = rewriter.create<Torch::AtenSizeIntOp>(
+          loc, rewriter.getType<Torch::IntType>(), operand, iv);
+      dims.push_back(dim);
+    }
 
-        Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(loc, false);
-        Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
+    Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(loc, false);
+    Value none = rewriter.create<Torch::ConstantNoneOp>(loc);
 
-        if (dims.empty()) {
-          Value one = rewriter.create<Torch::ConstantIntOp>(
-              loc, rewriter.getI64IntegerAttr(1));
-          rewriter.replaceOpWithNewOp<Torch::AtenTensorIntOp>(
-              op, resultType, one, none, none, cstFalse);
-          return success();
-        }
+    if (dims.empty()) {
+      Value one = rewriter.create<Torch::ConstantIntOp>(
+          loc, rewriter.getI64IntegerAttr(1));
+      rewriter.replaceOpWithNewOp<Torch::AtenTensorIntOp>(op, resultType, one,
+                                                          none, none, cstFalse);
+      return success();
+    }
 
-        Value prod = dims[0];
-        for (int i = 1, s = dims.size(); i < s; ++i)
-          prod = rewriter.create<Torch::AtenMulIntOp>(loc, prod, dims[i]);
+    Value prod = dims[0];
+    for (int i = 1, s = dims.size(); i < s; ++i)
+      prod = rewriter.create<Torch::AtenMulIntOp>(loc, prod, dims[i]);
 
-        rewriter.replaceOpWithNewOp<Torch::AtenTensorIntOp>(
-            op, resultType, prod, none, none, cstFalse);
-        return success();
-      });
-  patterns.onOp(
-      "Tile", 6, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value operand;
-        Value repeatDims;
-        if (binder.tensorOperands(operand, repeatDims) ||
-            binder.tensorResultType(resultType))
-          return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenTensorIntOp>(op, resultType, prod,
+                                                        none, none, cstFalse);
+    return success();
+  });
+  patterns.onOp("Tile", 6, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    Value repeatDims;
+    if (binder.tensorOperands(operand, repeatDims) ||
+        binder.tensorResultType(resultType))
+      return failure();
 
-        // convert repeatDims tensor to list of ints
-        auto repeatDimsSizes =
-            dyn_cast<Torch::ValueTensorType>(repeatDims.getType()).getSizes();
-        SmallVector<Value> dimList;
-        SmallVector<int64_t> selectSizes;
-        selectSizes.push_back(1);
-        Torch::BaseTensorType shapeType =
-            cast<Torch::BaseTensorType>(repeatDims.getType());
-        Type selectResultType = shapeType.getWithSizesAndDtype(
-            llvm::ArrayRef(selectSizes), shapeType.getOptionalDtype());
-        Value zero = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
-        for (int i = 0; i < repeatDimsSizes[0]; i++) {
-          Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
-          Value extract = rewriter.create<Torch::AtenSelectIntOp>(
-              binder.getLoc(), selectResultType, repeatDims, zero, selectIndex);
-          Value dim = rewriter.create<Torch::AtenItemOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(), extract);
-          dimList.push_back(dim);
-        }
-        Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.getLoc(),
-            Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
-            dimList);
+    // convert repeatDims tensor to list of ints
+    auto repeatDimsSizes =
+        dyn_cast<Torch::ValueTensorType>(repeatDims.getType()).getSizes();
+    SmallVector<Value> dimList;
+    SmallVector<int64_t> selectSizes;
+    selectSizes.push_back(1);
+    Torch::BaseTensorType shapeType =
+        cast<Torch::BaseTensorType>(repeatDims.getType());
+    Type selectResultType = shapeType.getWithSizesAndDtype(
+        llvm::ArrayRef(selectSizes), shapeType.getOptionalDtype());
+    Value zero = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(),
+        rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+    for (int i = 0; i < repeatDimsSizes[0]; i++) {
+      Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64), i));
+      Value extract = rewriter.create<Torch::AtenSelectIntOp>(
+          binder.getLoc(), selectResultType, repeatDims, zero, selectIndex);
+      Value dim = rewriter.create<Torch::AtenItemOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(), extract);
+      dimList.push_back(dim);
+    }
+    Value dimValueList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.getLoc(),
+        Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+        dimList);
 
-        rewriter.replaceOpWithNewOp<Torch::AtenTileOp>(binder.op, resultType,
-                                                       operand, dimValueList);
-        return success();
-      });
-  patterns.onOp(
-      "TopK", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType Values_type, Indices_type;
-        Value input, kValue;
-        int64_t axis;
-        bool largest, sorted;
-        if (binder.tensorOperandAtIndex(input, 0) ||
-            binder.tensorOperandAtIndex(kValue, 1) ||
-            binder.s64IntegerAttr(axis, "axis", -1) ||
-            binder.s64BoolAttr(largest, "largest", true) ||
-            binder.s64BoolAttr(sorted, "sorted", true) ||
-            binder.tensorResultTypeAtIndex(Values_type, 0) ||
-            binder.tensorResultTypeAtIndex(Indices_type, 1))
-          return failure();
-        std::optional<unsigned> maybeRank = Torch::getTensorRank(input);
-        if (!maybeRank)
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Unimplemented: unranked tensor");
-        unsigned rank = *maybeRank;
-        axis = Torch::toPositiveDim(axis, rank);
-        Value cstAxis = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(axis));
-        Value cstLargest =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), largest);
-        Value cstSorted =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), sorted);
-        Value kValueInt = rewriter.create<Torch::AtenItemOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(), kValue);
-        rewriter.replaceOpWithNewOp<Torch::AtenTopkOp>(
-            binder.op, Values_type, Indices_type, input, kValueInt, cstAxis,
-            cstLargest, cstSorted);
-        return success();
-      });
-  patterns.onOp("Sign", 9,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value operand;
-                  if (binder.tensorOperand(operand) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
+    rewriter.replaceOpWithNewOp<Torch::AtenTileOp>(binder.op, resultType,
+                                                   operand, dimValueList);
+    return success();
+  });
+  patterns.onOp("TopK", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType Values_type, Indices_type;
+    Value input, kValue;
+    int64_t axis;
+    bool largest, sorted;
+    if (binder.tensorOperandAtIndex(input, 0) ||
+        binder.tensorOperandAtIndex(kValue, 1) ||
+        binder.s64IntegerAttr(axis, "axis", -1) ||
+        binder.s64BoolAttr(largest, "largest", true) ||
+        binder.s64BoolAttr(sorted, "sorted", true) ||
+        binder.tensorResultTypeAtIndex(Values_type, 0) ||
+        binder.tensorResultTypeAtIndex(Indices_type, 1))
+      return failure();
+    std::optional<unsigned> maybeRank = Torch::getTensorRank(input);
+    if (!maybeRank)
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Unimplemented: unranked tensor");
+    unsigned rank = *maybeRank;
+    axis = Torch::toPositiveDim(axis, rank);
+    Value cstAxis = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(axis));
+    Value cstLargest =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), largest);
+    Value cstSorted =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), sorted);
+    Value kValueInt = rewriter.create<Torch::AtenItemOp>(
+        binder.getLoc(), rewriter.getType<Torch::IntType>(), kValue);
+    rewriter.replaceOpWithNewOp<Torch::AtenTopkOp>(
+        binder.op, Values_type, Indices_type, input, kValueInt, cstAxis,
+        cstLargest, cstSorted);
+    return success();
+  });
+  patterns.onOp("Sign", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value operand;
+    if (binder.tensorOperand(operand) || binder.tensorResultType(resultType))
+      return failure();
 
-                  rewriter.replaceOpWithNewOp<Torch::AtenSignOp>(
-                      binder.op, resultType, operand);
-                  return success();
-                });
-  patterns.onOp(
-      "Softplus", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value input;
-        if (binder.tensorOperand(input) ||
-            binder.tensorResultType(resultType)) {
-          return failure();
-        }
-        // out = ln(exp(x) + 1)
-        Value exp = rewriter.create<Torch::AtenExpOp>(binder.getLoc(),
-                                                      resultType, input);
-        rewriter.replaceOpWithNewOp<Torch::AtenLog1pOp>(binder.op, resultType,
-                                                        exp);
-        return success();
-      });
-  patterns.onOp("Softsign", 22,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value input;
-                  if (binder.tensorOperand(input) ||
-                      binder.tensorResultType(resultType)) {
-                    return failure();
-                  }
+    rewriter.replaceOpWithNewOp<Torch::AtenSignOp>(binder.op, resultType,
+                                                   operand);
+    return success();
+  });
+  patterns.onOp("Softplus", 1, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value input;
+    if (binder.tensorOperand(input) || binder.tensorResultType(resultType)) {
+      return failure();
+    }
+    // out = ln(exp(x) + 1)
+    Value exp =
+        rewriter.create<Torch::AtenExpOp>(binder.getLoc(), resultType, input);
+    rewriter.replaceOpWithNewOp<Torch::AtenLog1pOp>(binder.op, resultType, exp);
+    return success();
+  });
+  patterns.onOp("Softsign", 22, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value input;
+    if (binder.tensorOperand(input) || binder.tensorResultType(resultType)) {
+      return failure();
+    }
 
-                  Value absX = rewriter.create<Torch::AtenAbsOp>(
-                      binder.getLoc(), resultType, input);
+    Value absX =
+        rewriter.create<Torch::AtenAbsOp>(binder.getLoc(), resultType, input);
 
-                  Value constOne = rewriter.create<Torch::ConstantIntOp>(
-                      binder.getLoc(), rewriter.getI64IntegerAttr(1));
+    Value constOne = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(1));
 
-                  Value absXPlusOne = rewriter.create<Torch::AtenAddScalarOp>(
-                      binder.getLoc(), resultType, absX, constOne, constOne);
+    Value absXPlusOne = rewriter.create<Torch::AtenAddScalarOp>(
+        binder.getLoc(), resultType, absX, constOne, constOne);
 
-                  rewriter.replaceOpWithNewOp<Torch::AtenDivTensorOp>(
-                      binder.op, resultType, input, absXPlusOne);
-                  return success();
-                });
-  patterns.onOp(
-      "Trilu", 14, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value input;
-        int64_t upper;
-        if (binder.tensorOperandAtIndex(input, 0) ||
-            binder.s64IntegerAttr(upper, "upper", 1) ||
-            binder.tensorResultType(resultType)) {
-          return failure();
-        }
+    rewriter.replaceOpWithNewOp<Torch::AtenDivTensorOp>(binder.op, resultType,
+                                                        input, absXPlusOne);
+    return success();
+  });
+  patterns.onOp("Trilu", 14, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    Value input;
+    int64_t upper;
+    if (binder.tensorOperandAtIndex(input, 0) ||
+        binder.s64IntegerAttr(upper, "upper", 1) ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
 
-        Value diagonal;
-        if (binder.tensorOperandAtIndex(diagonal, 1)) {
-          diagonal = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(0));
-        } else {
-          diagonal = rewriter.create<Torch::AtenItemOp>(
-              binder.getLoc(), rewriter.getType<Torch::IntType>(), diagonal);
-        }
+    Value diagonal;
+    if (binder.tensorOperandAtIndex(diagonal, 1)) {
+      diagonal = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(0));
+    } else {
+      diagonal = rewriter.create<Torch::AtenItemOp>(
+          binder.getLoc(), rewriter.getType<Torch::IntType>(), diagonal);
+    }
 
-        if (upper) {
-          rewriter.replaceOpWithNewOp<Torch::AtenTriuOp>(binder.op, resultType,
-                                                         input, diagonal);
-          return success();
-        }
-        rewriter.replaceOpWithNewOp<Torch::AtenTrilOp>(binder.op, resultType,
-                                                       input, diagonal);
-        return success();
-      });
+    if (upper) {
+      rewriter.replaceOpWithNewOp<Torch::AtenTriuOp>(binder.op, resultType,
+                                                     input, diagonal);
+      return success();
+    }
+    rewriter.replaceOpWithNewOp<Torch::AtenTrilOp>(binder.op, resultType, input,
+                                                   diagonal);
+    return success();
+  });
   patterns.onOp("ThresholdedRelu", 10,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                [](OpBinder binder, PatternRewriter &rewriter) {
                   Torch::ValueTensorType resultType;
                   Value input;
                   float alpha;
@@ -2637,8 +2557,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
                   return success();
                 });
   patterns.onOp(
-      "RandomNormal", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "RandomNormal", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         SmallString<64> name("torch.onnx.seed");
         auto seedAttr = binder.op->getAttr(name);
         if (seedAttr)
@@ -2691,8 +2610,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "RandomNormalLike", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "RandomNormalLike", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         SmallString<64> name("torch.onnx.seed");
         auto seedAttr = binder.op->getAttr(name);
         if (seedAttr)
@@ -2744,8 +2662,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "RandomUniform", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "RandomUniform", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         SmallString<64> name("torch.onnx.seed");
         auto seedAttr = binder.op->getAttr(name);
         if (seedAttr)
@@ -2798,8 +2715,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "RandomUniformLike", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "RandomUniformLike", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         SmallString<64> name("torch.onnx.seed");
         auto seedAttr = binder.op->getAttr(name);
         if (seedAttr)
@@ -2852,7 +2768,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
       });
   patterns.onOp(
       "SoftmaxCrossEntropyLoss", 12,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         int64_t ignoreIndex;
         std::string reduction;
@@ -2907,245 +2823,235 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         rewriter.replaceOp(binder.op, {loss, logProb});
         return success();
       });
+  patterns.onOp("Resize", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    llvm::SmallVector<Value> operands;
+    std::string mode, nearest_mode, coordTfMode;
+    int64_t antialias, exclude_outside;
+    float extrapolation_value;
+    Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+
+    if (auto attr = binder.op->getAttr("torch.onnx.axes")) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: support not present for axes attribute");
+    }
+    if (auto attr = binder.op->getAttr("torch.onnx.keep_aspect_ratio_policy")) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: support not present for "
+                     "keep_aspect_ratio_policy attribute");
+    }
+
+    if (binder.tensorOperandsList(operands) ||
+        binder.tensorResultType(resultType) ||
+        binder.customOpNameStringAttr(mode, "mode", "nearest") ||
+        binder.customOpNameStringAttr(
+            coordTfMode, "coordinate_transformation_mode", "half_pixel") ||
+        binder.s64IntegerAttr(antialias, "antialias", 0) ||
+        binder.s64IntegerAttr(exclude_outside, "exclude_outside", 0) ||
+        binder.f32FloatAttr(extrapolation_value, "extrapolation_value", 0.0) ||
+        binder.customOpNameStringAttr(nearest_mode, "nearest_mode",
+                                      "round_prefer_floor"))
+      return failure();
+    if (antialias != 0) {
+      return rewriter.notifyMatchFailure(
+          binder.op,
+          "unimplemented: support not present for antialias attribute");
+    }
+    if (exclude_outside != 0) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: support not present for "
+                     "exclude_outside attribute");
+    }
+    if (extrapolation_value != 0.0) {
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: support not present for "
+                     "extrapolation_value attribute");
+    }
+    if (coordTfMode == "tf_crop_and_resize")
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: coordinate transformation mode: "
+                     "tf_crop_and_resize");
+
+    if (mode == "nearest" && coordTfMode != "asymmetric" &&
+        coordTfMode != "half_pixel") {
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: support not present for coord tf mode "
+                     "except asymmetric and half_pixel");
+    }
+
+    unsigned rank = dyn_cast<Torch::ValueTensorType>(operands[0].getType())
+                        .getSizes()
+                        .size();
+
+    Value cstFalse =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
+    Value cstTrue =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
+    Value modeStrValue;
+
+    Value scalesValueList = noneVal;
+    Value sizesValueList = noneVal;
+    Value alignCorners = coordTfMode == "align_corners" ? cstTrue : cstFalse;
+    if (mode == "cubic") {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "unimplemented: bicubic mode");
+    }
+    // supported modes:
+    // bilinear (half_pixel), bilinear with align_corners,
+    // bilinear_pytorch_half_pixel, bilinear_asymmetric nearest
+    // (asymmetric), nearest with align_corners, nearest_half_pixel,
+    // nearest_pytorch_half_pixel
+    if (mode == "linear") {
+      std::string modeStr;
+      switch (rank) {
+      case 3:
+        modeStr = "linear";
+        break;
+      case 4:
+        modeStr = "bilinear";
+        break;
+      case 5:
+        modeStr = "trilinear";
+        break;
+      default:
+        return failure();
+      }
+      // Confusingly enough, the default coordTfMode for pytorch bilinear
+      // mode is apparently half_pixel, NOT pytorch_half_pixel
+      if (coordTfMode != "half_pixel" && coordTfMode != "align_corners")
+        modeStr = (modeStr + "_") + coordTfMode;
+      modeStrValue =
+          rewriter.create<Torch::ConstantStrOp>(binder.getLoc(), modeStr);
+    }
+    if (mode == "nearest") {
+      std::string modeStr = "nearest";
+      // The default coordTfMode for pytorch with mode = nearest is
+      // apparently asymmetric
+      if (coordTfMode != "asymmetric" && coordTfMode != "align_corners")
+        modeStr = (modeStr + "_") + coordTfMode;
+      if (nearest_mode != "floor" && nearest_mode != "")
+        modeStr = modeStr + "," + nearest_mode;
+      modeStrValue =
+          rewriter.create<Torch::ConstantStrOp>(binder.getLoc(), modeStr);
+    }
+    if (operands.size() < 4) {
+      Value scaleOperand = operands[2];
+      scalesValueList = getValueList(binder, rewriter, scaleOperand);
+      sizesValueList = noneVal;
+    } else {
+      Value sizeOperand = operands[3];
+      scalesValueList = noneVal;
+      sizesValueList = getValueList(binder, rewriter, sizeOperand);
+    }
+    if (isa<Torch::NoneType>(scalesValueList.getType()) &&
+        isa<Torch::NoneType>(sizesValueList.getType())) {
+      return rewriter.notifyMatchFailure(binder.op, "unknown scaling mode");
+    }
+    rewriter.replaceOpWithNewOp<Torch::Aten__InterpolateSizeListScaleListOp>(
+        binder.op, resultType, operands[0], sizesValueList, scalesValueList,
+        modeStrValue,
+        /* AnyTorchOptionalBoolType:$align_corners */ alignCorners,
+        /* AnyTorchOptionalBoolType:$recompute_scale_factor */ noneVal,
+        /*Torch_BoolType:$antialias*/ cstFalse);
+    return success();
+  });
+  patterns.onOp("RoiAlign", 16, [](OpBinder binder, PatternRewriter &rewriter) {
+    // operands = input, rois, batch_indices
+    SmallVector<Value> operands;
+    std::string coordTfMode, mode;
+    int64_t outHInt, outWInt, samplingRatioInt;
+    float spatialScaleFloat;
+    Torch::ValueTensorType resultType;
+    if (binder.tensorOperands(operands, 3) ||
+        binder.customOpNameStringAttr(
+            coordTfMode, "coordinate_transformation_mode", "half_pixel") ||
+        binder.customOpNameStringAttr(mode, "mode", "avg") ||
+        binder.s64IntegerAttr(outHInt, "output_height", 1) ||
+        binder.s64IntegerAttr(outWInt, "output_width", 1) ||
+        binder.s64IntegerAttr(samplingRatioInt, "sampling_ratio", 0) ||
+        binder.f32FloatAttr(spatialScaleFloat, "spatial_scale", 1.0f) ||
+        binder.tensorResultType(resultType))
+      return failure();
+    Value input = operands[0];
+    Value rois = operands[1];
+    Value batchIndices = operands[2];
+
+    // the torchvision roi_pool op does not support these features:
+    if (mode == "max" && (coordTfMode != "half_pixel" || samplingRatioInt != 0))
+      return rewriter.notifyMatchFailure(
+          binder.op, "unsupported: roi max pooling without default "
+                     "coordTfMode and sampling_ratio");
+
+    Location loc = binder.getLoc();
+    // concatenate the batchIndices to the rois to get rois as a num_roisx5
+    // tensor. The batchIndices tensor is an int64 tensor, and needs to be
+    // converted to float before concatenation.
+    auto roisType = dyn_cast<Torch::ValueTensorType>(rois.getType());
+    if (!roisType || !roisType.hasSizes())
+      return failure();
+    Value cstDim = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(1));
+    FailureOr<Value> unsqueezeIndices =
+        Torch::unsqueezeTensor(rewriter, binder.op, batchIndices, cstDim);
+    if (failed(unsqueezeIndices))
+      return failure();
+    batchIndices = unsqueezeIndices.value();
+    auto batchIndicesType =
+        cast<Torch::ValueTensorType>(batchIndices.getType());
+    Value dTypeInt =
+        Torch::getDtypeIntValueForType(rewriter, loc, roisType.getDtype());
+    Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    Value cstFalse =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
+    Value newBatchIndices = rewriter.create<Torch::AtenToDtypeOp>(
+        loc,
+        batchIndicesType.getWithSizesAndDtype(
+            batchIndicesType.getOptionalSizes(), roisType.getOptionalDtype()),
+        batchIndices, dTypeInt, cstFalse, cstFalse, none);
+    SmallVector<int64_t> roiSizes(roisType.getSizes());
+    roiSizes.back() = 5;
+    auto catType =
+        rewriter.getType<Torch::ValueTensorType>(roiSizes, roisType.getDtype());
+    Type listElemType =
+        roisType.getWithSizesAndDtype(/*optionalSizes=*/std::nullopt,
+                                      /*optionalDtype=*/nullptr);
+    Type listType = Torch::ListType::get(listElemType);
+    Value tensorList = rewriter.create<Torch::PrimListConstructOp>(
+        binder.op->getLoc(), listType, ValueRange{newBatchIndices, rois});
+    Value newRois =
+        rewriter.create<Torch::AtenCatOp>(loc, catType, tensorList, cstDim);
+
+    // make constants from attributes
+    Value cstSpatialScale = rewriter.create<Torch::ConstantFloatOp>(
+        loc, rewriter.getF64FloatAttr(spatialScaleFloat));
+    Value pooledHeight = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(outHInt));
+    Value pooledWidth = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(outWInt));
+    // this is for consistency with the default pytorch sampling ratio value
+    samplingRatioInt = (samplingRatioInt == 0) ? -1 : samplingRatioInt;
+    Value samplingRatio = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(samplingRatioInt));
+    bool aligned = coordTfMode == "half_pixel";
+    Value cstAligned = rewriter.create<Torch::ConstantBoolOp>(loc, aligned);
+
+    if (mode == "avg") {
+      rewriter.replaceOpWithNewOp<Torch::TorchvisionRoiAlignOp>(
+          binder.op, resultType, input, newRois, cstSpatialScale, pooledHeight,
+          pooledWidth, samplingRatio, cstAligned);
+      return success();
+    }
+    // mode == "max"
+    auto indicesType = resultType.getWithSizesAndDtype(
+        resultType.getOptionalSizes(), batchIndicesType.getDtype());
+    auto roiPool = rewriter.create<Torch::TorchvisionRoiPoolOp>(
+        loc, TypeRange{resultType, indicesType}, input, newRois,
+        cstSpatialScale, pooledHeight, pooledWidth);
+    rewriter.replaceOp(binder.op, roiPool.getResult(0));
+    return success();
+  });
   patterns.onOp(
-      "Resize", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        llvm::SmallVector<Value> operands;
-        std::string mode, nearest_mode, coordTfMode;
-        int64_t antialias, exclude_outside;
-        float extrapolation_value;
-        Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-
-        if (auto attr = binder.op->getAttr("torch.onnx.axes")) {
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "unimplemented: support not present for axes attribute");
-        }
-        if (auto attr =
-                binder.op->getAttr("torch.onnx.keep_aspect_ratio_policy")) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "unimplemented: support not present for "
-                         "keep_aspect_ratio_policy attribute");
-        }
-
-        if (binder.tensorOperandsList(operands) ||
-            binder.tensorResultType(resultType) ||
-            binder.customOpNameStringAttr(mode, "mode", "nearest") ||
-            binder.customOpNameStringAttr(
-                coordTfMode, "coordinate_transformation_mode", "half_pixel") ||
-            binder.s64IntegerAttr(antialias, "antialias", 0) ||
-            binder.s64IntegerAttr(exclude_outside, "exclude_outside", 0) ||
-            binder.f32FloatAttr(extrapolation_value, "extrapolation_value",
-                                0.0) ||
-            binder.customOpNameStringAttr(nearest_mode, "nearest_mode",
-                                          "round_prefer_floor"))
-          return failure();
-        if (antialias != 0) {
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "unimplemented: support not present for antialias attribute");
-        }
-        if (exclude_outside != 0) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "unimplemented: support not present for "
-                         "exclude_outside attribute");
-        }
-        if (extrapolation_value != 0.0) {
-          return rewriter.notifyMatchFailure(
-              binder.op, "unimplemented: support not present for "
-                         "extrapolation_value attribute");
-        }
-        if (coordTfMode == "tf_crop_and_resize")
-          return rewriter.notifyMatchFailure(
-              binder.op, "unimplemented: coordinate transformation mode: "
-                         "tf_crop_and_resize");
-
-        if (mode == "nearest" && coordTfMode != "asymmetric" &&
-            coordTfMode != "half_pixel") {
-          return rewriter.notifyMatchFailure(
-              binder.op, "unimplemented: support not present for coord tf mode "
-                         "except asymmetric and half_pixel");
-        }
-
-        unsigned rank = dyn_cast<Torch::ValueTensorType>(operands[0].getType())
-                            .getSizes()
-                            .size();
-
-        Value cstFalse =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
-        Value cstTrue =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
-        Value modeStrValue;
-
-        Value scalesValueList = noneVal;
-        Value sizesValueList = noneVal;
-        Value alignCorners =
-            coordTfMode == "align_corners" ? cstTrue : cstFalse;
-        if (mode == "cubic") {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "unimplemented: bicubic mode");
-        }
-        // supported modes:
-        // bilinear (half_pixel), bilinear with align_corners,
-        // bilinear_pytorch_half_pixel, bilinear_asymmetric nearest
-        // (asymmetric), nearest with align_corners, nearest_half_pixel,
-        // nearest_pytorch_half_pixel
-        if (mode == "linear") {
-          std::string modeStr;
-          switch (rank) {
-          case 3:
-            modeStr = "linear";
-            break;
-          case 4:
-            modeStr = "bilinear";
-            break;
-          case 5:
-            modeStr = "trilinear";
-            break;
-          default:
-            return failure();
-          }
-          // Confusingly enough, the default coordTfMode for pytorch bilinear
-          // mode is apparently half_pixel, NOT pytorch_half_pixel
-          if (coordTfMode != "half_pixel" && coordTfMode != "align_corners")
-            modeStr = (modeStr + "_") + coordTfMode;
-          modeStrValue =
-              rewriter.create<Torch::ConstantStrOp>(binder.getLoc(), modeStr);
-        }
-        if (mode == "nearest") {
-          std::string modeStr = "nearest";
-          // The default coordTfMode for pytorch with mode = nearest is
-          // apparently asymmetric
-          if (coordTfMode != "asymmetric" && coordTfMode != "align_corners")
-            modeStr = (modeStr + "_") + coordTfMode;
-          if (nearest_mode != "floor" && nearest_mode != "")
-            modeStr = modeStr + "," + nearest_mode;
-          modeStrValue =
-              rewriter.create<Torch::ConstantStrOp>(binder.getLoc(), modeStr);
-        }
-        if (operands.size() < 4) {
-          Value scaleOperand = operands[2];
-          scalesValueList = getValueList(binder, rewriter, scaleOperand);
-          sizesValueList = noneVal;
-        } else {
-          Value sizeOperand = operands[3];
-          scalesValueList = noneVal;
-          sizesValueList = getValueList(binder, rewriter, sizeOperand);
-        }
-        if (isa<Torch::NoneType>(scalesValueList.getType()) &&
-            isa<Torch::NoneType>(sizesValueList.getType())) {
-          return rewriter.notifyMatchFailure(binder.op, "unknown scaling mode");
-        }
-        rewriter
-            .replaceOpWithNewOp<Torch::Aten__InterpolateSizeListScaleListOp>(
-                binder.op, resultType, operands[0], sizesValueList,
-                scalesValueList, modeStrValue,
-                /* AnyTorchOptionalBoolType:$align_corners */ alignCorners,
-                /* AnyTorchOptionalBoolType:$recompute_scale_factor */ noneVal,
-                /*Torch_BoolType:$antialias*/ cstFalse);
-        return success();
-      });
-  patterns.onOp(
-      "RoiAlign", 16, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // operands = input, rois, batch_indices
-        SmallVector<Value> operands;
-        std::string coordTfMode, mode;
-        int64_t outHInt, outWInt, samplingRatioInt;
-        float spatialScaleFloat;
-        Torch::ValueTensorType resultType;
-        if (binder.tensorOperands(operands, 3) ||
-            binder.customOpNameStringAttr(
-                coordTfMode, "coordinate_transformation_mode", "half_pixel") ||
-            binder.customOpNameStringAttr(mode, "mode", "avg") ||
-            binder.s64IntegerAttr(outHInt, "output_height", 1) ||
-            binder.s64IntegerAttr(outWInt, "output_width", 1) ||
-            binder.s64IntegerAttr(samplingRatioInt, "sampling_ratio", 0) ||
-            binder.f32FloatAttr(spatialScaleFloat, "spatial_scale", 1.0f) ||
-            binder.tensorResultType(resultType))
-          return failure();
-        Value input = operands[0];
-        Value rois = operands[1];
-        Value batchIndices = operands[2];
-
-        // the torchvision roi_pool op does not support these features:
-        if (mode == "max" &&
-            (coordTfMode != "half_pixel" || samplingRatioInt != 0))
-          return rewriter.notifyMatchFailure(
-              binder.op, "unsupported: roi max pooling without default "
-                         "coordTfMode and sampling_ratio");
-
-        Location loc = binder.getLoc();
-        // concatenate the batchIndices to the rois to get rois as a num_roisx5
-        // tensor. The batchIndices tensor is an int64 tensor, and needs to be
-        // converted to float before concatenation.
-        auto roisType = dyn_cast<Torch::ValueTensorType>(rois.getType());
-        if (!roisType || !roisType.hasSizes())
-          return failure();
-        Value cstDim = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(1));
-        FailureOr<Value> unsqueezeIndices =
-            Torch::unsqueezeTensor(rewriter, binder.op, batchIndices, cstDim);
-        if (failed(unsqueezeIndices))
-          return failure();
-        batchIndices = unsqueezeIndices.value();
-        auto batchIndicesType =
-            cast<Torch::ValueTensorType>(batchIndices.getType());
-        Value dTypeInt =
-            Torch::getDtypeIntValueForType(rewriter, loc, roisType.getDtype());
-        Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        Value cstFalse =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
-        Value newBatchIndices = rewriter.create<Torch::AtenToDtypeOp>(
-            loc,
-            batchIndicesType.getWithSizesAndDtype(
-                batchIndicesType.getOptionalSizes(),
-                roisType.getOptionalDtype()),
-            batchIndices, dTypeInt, cstFalse, cstFalse, none);
-        SmallVector<int64_t> roiSizes(roisType.getSizes());
-        roiSizes.back() = 5;
-        auto catType = rewriter.getType<Torch::ValueTensorType>(
-            roiSizes, roisType.getDtype());
-        Type listElemType =
-            roisType.getWithSizesAndDtype(/*optionalSizes=*/std::nullopt,
-                                          /*optionalDtype=*/nullptr);
-        Type listType = Torch::ListType::get(listElemType);
-        Value tensorList = rewriter.create<Torch::PrimListConstructOp>(
-            binder.op->getLoc(), listType, ValueRange{newBatchIndices, rois});
-        Value newRois =
-            rewriter.create<Torch::AtenCatOp>(loc, catType, tensorList, cstDim);
-
-        // make constants from attributes
-        Value cstSpatialScale = rewriter.create<Torch::ConstantFloatOp>(
-            loc, rewriter.getF64FloatAttr(spatialScaleFloat));
-        Value pooledHeight = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(outHInt));
-        Value pooledWidth = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(outWInt));
-        // this is for consistency with the default pytorch sampling ratio value
-        samplingRatioInt = (samplingRatioInt == 0) ? -1 : samplingRatioInt;
-        Value samplingRatio = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(samplingRatioInt));
-        bool aligned = coordTfMode == "half_pixel";
-        Value cstAligned = rewriter.create<Torch::ConstantBoolOp>(loc, aligned);
-
-        if (mode == "avg") {
-          rewriter.replaceOpWithNewOp<Torch::TorchvisionRoiAlignOp>(
-              binder.op, resultType, input, newRois, cstSpatialScale,
-              pooledHeight, pooledWidth, samplingRatio, cstAligned);
-          return success();
-        }
-        // mode == "max"
-        auto indicesType = resultType.getWithSizesAndDtype(
-            resultType.getOptionalSizes(), batchIndicesType.getDtype());
-        auto roiPool = rewriter.create<Torch::TorchvisionRoiPoolOp>(
-            loc, TypeRange{resultType, indicesType}, input, newRois,
-            cstSpatialScale, pooledHeight, pooledWidth);
-        rewriter.replaceOp(binder.op, roiPool.getResult(0));
-        return success();
-      });
-  patterns.onOp(
-      "SpaceToDepth", 1,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "SpaceToDepth", 1, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value input;
         int64_t blockSize;
@@ -3241,96 +3147,91 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
             binder.op, resultType, permutedInput, reshapeSizesList);
         return success();
       });
+  patterns.onOp("Shrink", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Location loc = binder.getLoc();
+    Torch::ValueTensorType resultType;
+    Value input;
+    float bias, lambd;
+    if (binder.tensorOperand(input) || binder.f32FloatAttr(bias, "bias", 0.0) ||
+        binder.f32FloatAttr(lambd, "lambd", 0.5) ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
+
+    Torch::ValueTensorType inputType =
+        cast<Torch::ValueTensorType>(input.getType());
+    if (!isa<mlir::FloatType>(inputType.getDtype()))
+      return rewriter.notifyMatchFailure(
+          binder.op, "unimplemented: non-floating point dtype");
+
+    Torch::ValueTensorType comparisonResultType =
+        rewriter.getType<Torch::ValueTensorType>(
+            ArrayRef<int64_t>(inputType.getSizes()), rewriter.getI1Type());
+
+    // The formula of this operator is: If x < -lambd, y = x + bias; If x >
+    // lambd, y = x - bias; Otherwise, y = 0.
+    // The implementation is based on the following algorithm:
+    // Shrink <bias,lambd>(input) => (output)
+    // {
+    //    Lambd = Constant <value_float: float = @lambd> ()
+    //    LambdCast = CastLike (Lambd, input)
+    //    Bias = Constant <value_float: float = @bias> ()
+    //    BiasCast = CastLike (Bias, input)
+    //    Zero = Constant <value: tensor = float {0}> ()
+    //    ZeroCast = CastLike (Zero, input)
+    //    NegLmbda = Neg (LambdCast)
+    //    InputLessThanNegLambda = Less (input, NegLmbda)
+    //    InputAddBias = Add (input, BiasCast)
+    //    InputSubBias = Sub (input, BiasCast)
+    //    LambdaLessThanInput = Less (LambdCast, input)
+    //    InputSubBiasOrZero = Where (LambdaLessThanInput, InputSubBias,
+    //    ZeroCast) output = Where (InputLessThanNegLambda, InputAddBias,
+    //    InputSubBiasOrZero)
+    // }
+    Value constLambd = rewriter.create<Torch::ConstantFloatOp>(
+        loc, rewriter.getFloatAttr(rewriter.getF64Type(), lambd));
+    Value constBias = rewriter.create<Torch::ConstantFloatOp>(
+        loc, rewriter.getFloatAttr(rewriter.getF64Type(), bias));
+    Value constZero = rewriter.create<Torch::ConstantFloatOp>(
+        loc, rewriter.getFloatAttr(rewriter.getF64Type(), 0.0));
+    Value constOne = rewriter.create<Torch::ConstantFloatOp>(
+        loc, rewriter.getFloatAttr(rewriter.getF64Type(), 1.0));
+    Value constNegLambd = rewriter.create<Torch::ConstantFloatOp>(
+        loc, rewriter.getFloatAttr(rewriter.getF64Type(), -lambd));
+
+    Value inputLTNegLambd = rewriter.create<Torch::AtenLtScalarOp>(
+        loc, comparisonResultType, input, constNegLambd);
+    Value inputPlusBias = rewriter.create<Torch::AtenAddScalarOp>(
+        loc, inputType, input, constBias, /*alpha=*/constOne);
+    Value inputSubBias = rewriter.create<Torch::AtenSubScalarOp>(
+        loc, inputType, input, constBias, /*alpha=*/constOne);
+    Value inputGTLambd = rewriter.create<Torch::AtenGtScalarOp>(
+        loc, comparisonResultType, input, constLambd);
+
+    Value inputSubBiasOrZero = rewriter.create<Torch::AtenWhereScalarOtherOp>(
+        loc, resultType, inputGTLambd, inputSubBias, constZero);
+    rewriter.replaceOpWithNewOp<Torch::AtenWhereSelfOp>(
+        binder.op, resultType, inputLTNegLambd, inputPlusBias,
+        inputSubBiasOrZero);
+    return success();
+  });
   patterns.onOp(
-      "Shrink", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Location loc = binder.getLoc();
+      "SequenceAt", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
-        Value input;
-        float bias, lambd;
-        if (binder.tensorOperand(input) ||
-            binder.f32FloatAttr(bias, "bias", 0.0) ||
-            binder.f32FloatAttr(lambd, "lambd", 0.5) ||
-            binder.tensorResultType(resultType)) {
+        Value inputSequence, position;
+        if (binder.tensorListOperandAtIndex(inputSequence, 0) ||
+            binder.tensorOperandAtIndex(position, 1) ||
+            binder.tensorResultType(resultType))
           return failure();
-        }
 
-        Torch::ValueTensorType inputType =
-            cast<Torch::ValueTensorType>(input.getType());
-        if (!isa<mlir::FloatType>(inputType.getDtype()))
-          return rewriter.notifyMatchFailure(
-              binder.op, "unimplemented: non-floating point dtype");
-
-        Torch::ValueTensorType comparisonResultType =
-            rewriter.getType<Torch::ValueTensorType>(
-                ArrayRef<int64_t>(inputType.getSizes()), rewriter.getI1Type());
-
-        // The formula of this operator is: If x < -lambd, y = x + bias; If x >
-        // lambd, y = x - bias; Otherwise, y = 0.
-        // The implementation is based on the following algorithm:
-        // Shrink <bias,lambd>(input) => (output)
-        // {
-        //    Lambd = Constant <value_float: float = @lambd> ()
-        //    LambdCast = CastLike (Lambd, input)
-        //    Bias = Constant <value_float: float = @bias> ()
-        //    BiasCast = CastLike (Bias, input)
-        //    Zero = Constant <value: tensor = float {0}> ()
-        //    ZeroCast = CastLike (Zero, input)
-        //    NegLmbda = Neg (LambdCast)
-        //    InputLessThanNegLambda = Less (input, NegLmbda)
-        //    InputAddBias = Add (input, BiasCast)
-        //    InputSubBias = Sub (input, BiasCast)
-        //    LambdaLessThanInput = Less (LambdCast, input)
-        //    InputSubBiasOrZero = Where (LambdaLessThanInput, InputSubBias,
-        //    ZeroCast) output = Where (InputLessThanNegLambda, InputAddBias,
-        //    InputSubBiasOrZero)
-        // }
-        Value constLambd = rewriter.create<Torch::ConstantFloatOp>(
-            loc, rewriter.getFloatAttr(rewriter.getF64Type(), lambd));
-        Value constBias = rewriter.create<Torch::ConstantFloatOp>(
-            loc, rewriter.getFloatAttr(rewriter.getF64Type(), bias));
-        Value constZero = rewriter.create<Torch::ConstantFloatOp>(
-            loc, rewriter.getFloatAttr(rewriter.getF64Type(), 0.0));
-        Value constOne = rewriter.create<Torch::ConstantFloatOp>(
-            loc, rewriter.getFloatAttr(rewriter.getF64Type(), 1.0));
-        Value constNegLambd = rewriter.create<Torch::ConstantFloatOp>(
-            loc, rewriter.getFloatAttr(rewriter.getF64Type(), -lambd));
-
-        Value inputLTNegLambd = rewriter.create<Torch::AtenLtScalarOp>(
-            loc, comparisonResultType, input, constNegLambd);
-        Value inputPlusBias = rewriter.create<Torch::AtenAddScalarOp>(
-            loc, inputType, input, constBias, /*alpha=*/constOne);
-        Value inputSubBias = rewriter.create<Torch::AtenSubScalarOp>(
-            loc, inputType, input, constBias, /*alpha=*/constOne);
-        Value inputGTLambd = rewriter.create<Torch::AtenGtScalarOp>(
-            loc, comparisonResultType, input, constLambd);
-
-        Value inputSubBiasOrZero =
-            rewriter.create<Torch::AtenWhereScalarOtherOp>(
-                loc, resultType, inputGTLambd, inputSubBias, constZero);
-        rewriter.replaceOpWithNewOp<Torch::AtenWhereSelfOp>(
-            binder.op, resultType, inputLTNegLambd, inputPlusBias,
-            inputSubBiasOrZero);
+        Value index = rewriter.create<Torch::AtenItemOp>(
+            binder.getLoc(), rewriter.getType<Torch::IntType>(), position);
+        rewriter.replaceOpWithNewOp<Torch::Aten__Getitem__TOp>(
+            binder.op, resultType, inputSequence, index);
         return success();
       });
-  patterns.onOp("SequenceAt", 11,
-                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Torch::ValueTensorType resultType;
-                  Value inputSequence, position;
-                  if (binder.tensorListOperandAtIndex(inputSequence, 0) ||
-                      binder.tensorOperandAtIndex(position, 1) ||
-                      binder.tensorResultType(resultType))
-                    return failure();
-
-                  Value index = rewriter.create<Torch::AtenItemOp>(
-                      binder.getLoc(), rewriter.getType<Torch::IntType>(),
-                      position);
-                  rewriter.replaceOpWithNewOp<Torch::Aten__Getitem__TOp>(
-                      binder.op, resultType, inputSequence, index);
-                  return success();
-                });
   patterns.onOp(
-      "SequenceEmpty", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "SequenceEmpty", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ListType resultType;
         int64_t dtypeIntOnnx;
         if (binder.s64IntegerAttr(dtypeIntOnnx, "dtype", 1) ||
@@ -3362,8 +3263,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "SequenceErase", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "SequenceErase", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ListType resultType;
         Value inputSequence, position;
         if (binder.tensorListOperandAtIndex(inputSequence, 0) ||
@@ -3419,8 +3319,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "SequenceInsert", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "SequenceInsert", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ListType resultType;
         Value inputSequence, position, insertValue;
         if (binder.tensorListOperandAtIndex(inputSequence, 0) ||
@@ -3452,8 +3351,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "SequenceMap", 17,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "SequenceMap", 17, [](OpBinder binder, PatternRewriter &rewriter) {
         llvm::SmallVector<Value> operands;
         Torch::ListType resultType;
         if (binder.tensorOperandsList(operands) || operands.size() == 0 ||
@@ -3532,218 +3430,211 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         rewriter.replaceOp(binder.op, loop);
         return success();
       });
+  patterns.onOp("Upsample", 9, [](OpBinder binder, PatternRewriter &rewriter) {
+    Torch::ValueTensorType resultType;
+    std::string mode;
+    Value input, scales;
+    if (binder.tensorOperands(input, scales) ||
+        binder.customOpNameStringAttr(mode, "mode", "nearest") ||
+        binder.tensorResultType(resultType)) {
+      return failure();
+    }
+
+    if (mode != "nearest" && mode != "linear")
+      return rewriter.notifyMatchFailure(
+          binder.op, "unsupported interpolation mode other than nearest, "
+                     "linear");
+
+    int64_t resultRank = resultType.getSizes().size();
+    if (resultRank > 5)
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "supports upto 3d upsampling only");
+
+    Value scalesValueList = getValueList(binder, rewriter, scales);
+    if (mode == "linear") {
+      if (resultRank == 4)
+        mode = "bilinear";
+      if (resultRank == 5)
+        mode = "trilinear";
+    }
+    Value modeStrValue =
+        rewriter.create<Torch::ConstantStrOp>(binder.getLoc(), mode);
+    Value cstNone = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(
+        binder.getLoc(), rewriter.getBoolAttr(false));
+
+    rewriter.replaceOpWithNewOp<Torch::Aten__InterpolateSizeListScaleListOp>(
+        binder.op, resultType, input, /*size=*/cstNone, scalesValueList,
+        modeStrValue,
+        /* AnyTorchOptionalBoolType:$align_corners */ cstNone,
+        /* AnyTorchOptionalBoolType:$recompute_scale_factor */ cstNone,
+        /*Torch_BoolType:$antialias*/ cstFalse);
+    return success();
+  });
+  patterns.onOp("STFT", 17, [](OpBinder binder, PatternRewriter &rewriter) {
+    // operands in order ->(signal, frameStep, window, frameLength*)
+    SmallVector<Value> operands;
+    int64_t onesided;
+    Torch::ValueTensorType resultType;
+
+    if (binder.tensorOperandsList(operands) ||
+        binder.s64IntegerAttr(onesided, "onesided", 1) ||
+        binder.tensorResultType(resultType))
+      return failure();
+
+    Value signal = operands[0];
+    Value frameStep = operands[1];
+    auto signalTy = cast<Torch::ValueTensorType>(signal.getType());
+    auto signalShape = signalTy.getSizes();
+    auto resultShape = resultType.getSizes();
+
+    // There are two possible cases for optional inputs frameLength and
+    // window, which are that either 4 operands will be passed with window
+    // being !torch.none, or three operands will be passed, with window
+    // present and frameLength absent. In the former case, we simply create
+    // a rectangular window consisting of ones, and in the latter, we set
+    // frameLength equal to the the inputShape[-2] or windowShape[0]
+    // depending upon whether window was present or not. Note that it is
+    // possible that both window and frameLength can be none, which would
+    // mean that either only two operands were passed, or, in case of three
+    // operands, window was passed in as none, and frameLength was absent.
+    Value window = nullptr, frameLength = nullptr;
+    bool windowIsNone = true, frameLengthIsNone = true;
+    if (operands.size() == 3) {
+      window = operands[2];
+      windowIsNone = isa<Torch::NoneType>(window.getType());
+    }
+    if (operands.size() == 4) {
+      window = operands[2];
+      frameLength = operands[3];
+      windowIsNone = isa<Torch::NoneType>(window.getType());
+      frameLengthIsNone = isa<Torch::NoneType>(frameLength.getType());
+    }
+
+    ArrayRef<int64_t> windowShape;
+    if (frameLengthIsNone) {
+      if (windowIsNone) {
+        frameLength = rewriter.create<Torch::ConstantIntOp>(
+            binder.getLoc(),
+            rewriter.getI64IntegerAttr(signalShape[signalShape.size() - 2]));
+      } else {
+        windowShape = cast<Torch::ValueTensorType>(window.getType()).getSizes();
+        frameLength = rewriter.create<Torch::ConstantIntOp>(
+            binder.getLoc(), rewriter.getI64IntegerAttr(windowShape[0]));
+      }
+    }
+
+    Value frameLengthItem;
+    if (!frameLengthIsNone || windowIsNone) {
+      frameLengthItem =
+          getItemOp<Torch::IntType>(binder, rewriter, frameLength);
+    } else {
+      frameLengthItem = frameLength;
+    }
+    Value frameStepItem =
+        getItemOp<Torch::IntType>(binder, rewriter, frameStep);
+
+    if (windowIsNone) {
+      auto onesResultTy = rewriter.getType<Torch::ValueTensorType>(
+          ArrayRef<int64_t>({-1}), signalTy.getDtype());
+
+      Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+      Value sizes = rewriter.create<Torch::PrimListConstructOp>(
+          binder.getLoc(),
+          Torch::ListType::get(Torch::IntType::get(binder.op->getContext())),
+          SmallVector<Value>{frameLengthItem});
+      window = rewriter.create<Torch::AtenOnesOp>(
+          binder.getLoc(), onesResultTy, sizes, none, none, none, none);
+    }
+
+    FailureOr<Type> complexDtype;
+    if (signalTy.getDtype().isBF16()) {
+      return rewriter.notifyMatchFailure(
+          binder.op,
+          "unimplemented: support for bfloat16 type is unimplemented.");
+    }
+    if (signalTy.getDtype().isF16()) {
+      complexDtype = Torch::getTypeForScalarType(
+          binder.op->getContext(),
+          torch::torch_upstream::ScalarType::ComplexHalf);
+    } else if (signalTy.getDtype().isF32()) {
+      complexDtype = Torch::getTypeForScalarType(
+          binder.op->getContext(),
+          torch::torch_upstream::ScalarType::ComplexFloat);
+    } else {
+      complexDtype = Torch::getTypeForScalarType(
+          binder.op->getContext(),
+          torch::torch_upstream::ScalarType::ComplexDouble);
+    }
+
+    auto complexSignalTy = rewriter.getType<Torch::ValueTensorType>(
+        ArrayRef<int64_t>({signalShape[0], signalShape[1]}),
+        complexDtype.value());
+
+    // The onnx STFT op always passes in a float input, and if the input
+    // is intended to be complex, its shape will be [batch][length][2],
+    // where [...][0] is the real component, and [...][1] is the complex
+    // component. This complex input has to be made torch compatible before
+    // being passed into torch.stft, so it is necessary to call
+    // AtenViewAsComplexOp. In case of real input, the shape of the signal
+    // will be [batch][length][1], and therefore it will have to be squeezed
+    // at dim=2, before being passed into torch.stft.
+    if (signalShape[2] == 2) {
+      signal = rewriter.create<Torch::AtenViewAsComplexOp>(
+          binder.getLoc(), complexSignalTy, signal);
+    } else {
+      Value two = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(2));
+      auto newSignalTy = signalTy.getWithSizesAndDtype(
+          ArrayRef<int64_t>({signalShape[0], signalShape[1]}),
+          signalTy.getDtype());
+      signal = rewriter.create<Torch::AtenSqueezeDimOp>(
+          binder.getLoc(), newSignalTy, signal, two);
+    }
+
+    // In case the window is not given, we use frameLength
+    // as the length of the window.
+    Value windowLen;
+    if (!windowIsNone) {
+      windowLen = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(windowShape[0]));
+    } else {
+      windowLen = frameLengthItem;
+    }
+
+    Value falseVal =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
+    Value trueVal =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
+    auto stftTy = complexSignalTy.getWithSizesAndDtype(
+        ArrayRef<int64_t>({resultShape[0], resultShape[2], resultShape[1]}),
+        complexSignalTy.getDtype());
+
+    // After torch.stft is called and the result is stored into the value
+    // stft, there is one thing to note: The resultType for the onnx op
+    // will have shape [batch][num_frames][length][2], while the shape of
+    // stft will be [batch][length][num_frames]. Before the value is
+    // converted to real through torch.view_as_real, we must permute the
+    // shape of stft to match the shape of resultType. Also, it is
+    // immaterial whether torch.view_as_real is called after or before the
+    // permutation; both outputs will be equivalent.
+    Value stft = rewriter.create<Torch::AtenStftOp>(
+        binder.getLoc(), stftTy, signal, frameLengthItem, frameStepItem,
+        windowLen, window, falseVal, onesided ? trueVal : falseVal, trueVal);
+
+    auto permuteStftTy = complexSignalTy.getWithSizesAndDtype(
+        ArrayRef<int64_t>({resultShape[0], resultShape[1], resultShape[2]}),
+        complexSignalTy.getDtype());
+    Value permuteDims = createConstantIntList(binder, rewriter, {0, 2, 1});
+    Value permutedStft = rewriter.create<Torch::AtenPermuteOp>(
+        binder.getLoc(), permuteStftTy, stft, permuteDims);
+
+    rewriter.replaceOpWithNewOp<Torch::AtenViewAsRealOp>(binder.op, resultType,
+                                                         permutedStft);
+    return success();
+  });
   patterns.onOp(
-      "Upsample", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        std::string mode;
-        Value input, scales;
-        if (binder.tensorOperands(input, scales) ||
-            binder.customOpNameStringAttr(mode, "mode", "nearest") ||
-            binder.tensorResultType(resultType)) {
-          return failure();
-        }
-
-        if (mode != "nearest" && mode != "linear")
-          return rewriter.notifyMatchFailure(
-              binder.op, "unsupported interpolation mode other than nearest, "
-                         "linear");
-
-        int64_t resultRank = resultType.getSizes().size();
-        if (resultRank > 5)
-          return rewriter.notifyMatchFailure(
-              binder.op, "supports upto 3d upsampling only");
-
-        Value scalesValueList = getValueList(binder, rewriter, scales);
-        if (mode == "linear") {
-          if (resultRank == 4)
-            mode = "bilinear";
-          if (resultRank == 5)
-            mode = "trilinear";
-        }
-        Value modeStrValue =
-            rewriter.create<Torch::ConstantStrOp>(binder.getLoc(), mode);
-        Value cstNone = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-        Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(
-            binder.getLoc(), rewriter.getBoolAttr(false));
-
-        rewriter
-            .replaceOpWithNewOp<Torch::Aten__InterpolateSizeListScaleListOp>(
-                binder.op, resultType, input, /*size=*/cstNone, scalesValueList,
-                modeStrValue,
-                /* AnyTorchOptionalBoolType:$align_corners */ cstNone,
-                /* AnyTorchOptionalBoolType:$recompute_scale_factor */ cstNone,
-                /*Torch_BoolType:$antialias*/ cstFalse);
-        return success();
-      });
-  patterns.onOp(
-      "STFT", 17, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        // operands in order ->(signal, frameStep, window, frameLength*)
-        SmallVector<Value> operands;
-        int64_t onesided;
-        Torch::ValueTensorType resultType;
-
-        if (binder.tensorOperandsList(operands) ||
-            binder.s64IntegerAttr(onesided, "onesided", 1) ||
-            binder.tensorResultType(resultType))
-          return failure();
-
-        Value signal = operands[0];
-        Value frameStep = operands[1];
-        auto signalTy = cast<Torch::ValueTensorType>(signal.getType());
-        auto signalShape = signalTy.getSizes();
-        auto resultShape = resultType.getSizes();
-
-        // There are two possible cases for optional inputs frameLength and
-        // window, which are that either 4 operands will be passed with window
-        // being !torch.none, or three operands will be passed, with window
-        // present and frameLength absent. In the former case, we simply create
-        // a rectangular window consisting of ones, and in the latter, we set
-        // frameLength equal to the the inputShape[-2] or windowShape[0]
-        // depending upon whether window was present or not. Note that it is
-        // possible that both window and frameLength can be none, which would
-        // mean that either only two operands were passed, or, in case of three
-        // operands, window was passed in as none, and frameLength was absent.
-        Value window = nullptr, frameLength = nullptr;
-        bool windowIsNone = true, frameLengthIsNone = true;
-        if (operands.size() == 3) {
-          window = operands[2];
-          windowIsNone = isa<Torch::NoneType>(window.getType());
-        }
-        if (operands.size() == 4) {
-          window = operands[2];
-          frameLength = operands[3];
-          windowIsNone = isa<Torch::NoneType>(window.getType());
-          frameLengthIsNone = isa<Torch::NoneType>(frameLength.getType());
-        }
-
-        ArrayRef<int64_t> windowShape;
-        if (frameLengthIsNone) {
-          if (windowIsNone) {
-            frameLength = rewriter.create<Torch::ConstantIntOp>(
-                binder.getLoc(), rewriter.getI64IntegerAttr(
-                                     signalShape[signalShape.size() - 2]));
-          } else {
-            windowShape =
-                cast<Torch::ValueTensorType>(window.getType()).getSizes();
-            frameLength = rewriter.create<Torch::ConstantIntOp>(
-                binder.getLoc(), rewriter.getI64IntegerAttr(windowShape[0]));
-          }
-        }
-
-        Value frameLengthItem;
-        if (!frameLengthIsNone || windowIsNone) {
-          frameLengthItem =
-              getItemOp<Torch::IntType>(binder, rewriter, frameLength);
-        } else {
-          frameLengthItem = frameLength;
-        }
-        Value frameStepItem =
-            getItemOp<Torch::IntType>(binder, rewriter, frameStep);
-
-        if (windowIsNone) {
-          auto onesResultTy = rewriter.getType<Torch::ValueTensorType>(
-              ArrayRef<int64_t>({-1}), signalTy.getDtype());
-
-          Value none = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
-          Value sizes = rewriter.create<Torch::PrimListConstructOp>(
-              binder.getLoc(),
-              Torch::ListType::get(
-                  Torch::IntType::get(binder.op->getContext())),
-              SmallVector<Value>{frameLengthItem});
-          window = rewriter.create<Torch::AtenOnesOp>(
-              binder.getLoc(), onesResultTy, sizes, none, none, none, none);
-        }
-
-        FailureOr<Type> complexDtype;
-        if (signalTy.getDtype().isBF16()) {
-          return rewriter.notifyMatchFailure(
-              binder.op,
-              "unimplemented: support for bfloat16 type is unimplemented.");
-        }
-        if (signalTy.getDtype().isF16()) {
-          complexDtype = Torch::getTypeForScalarType(
-              binder.op->getContext(),
-              torch::torch_upstream::ScalarType::ComplexHalf);
-        } else if (signalTy.getDtype().isF32()) {
-          complexDtype = Torch::getTypeForScalarType(
-              binder.op->getContext(),
-              torch::torch_upstream::ScalarType::ComplexFloat);
-        } else {
-          complexDtype = Torch::getTypeForScalarType(
-              binder.op->getContext(),
-              torch::torch_upstream::ScalarType::ComplexDouble);
-        }
-
-        auto complexSignalTy = rewriter.getType<Torch::ValueTensorType>(
-            ArrayRef<int64_t>({signalShape[0], signalShape[1]}),
-            complexDtype.value());
-
-        // The onnx STFT op always passes in a float input, and if the input
-        // is intended to be complex, its shape will be [batch][length][2],
-        // where [...][0] is the real component, and [...][1] is the complex
-        // component. This complex input has to be made torch compatible before
-        // being passed into torch.stft, so it is necessary to call
-        // AtenViewAsComplexOp. In case of real input, the shape of the signal
-        // will be [batch][length][1], and therefore it will have to be squeezed
-        // at dim=2, before being passed into torch.stft.
-        if (signalShape[2] == 2) {
-          signal = rewriter.create<Torch::AtenViewAsComplexOp>(
-              binder.getLoc(), complexSignalTy, signal);
-        } else {
-          Value two = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(2));
-          auto newSignalTy = signalTy.getWithSizesAndDtype(
-              ArrayRef<int64_t>({signalShape[0], signalShape[1]}),
-              signalTy.getDtype());
-          signal = rewriter.create<Torch::AtenSqueezeDimOp>(
-              binder.getLoc(), newSignalTy, signal, two);
-        }
-
-        // In case the window is not given, we use frameLength
-        // as the length of the window.
-        Value windowLen;
-        if (!windowIsNone) {
-          windowLen = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(windowShape[0]));
-        } else {
-          windowLen = frameLengthItem;
-        }
-
-        Value falseVal =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), false);
-        Value trueVal =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
-        auto stftTy = complexSignalTy.getWithSizesAndDtype(
-            ArrayRef<int64_t>({resultShape[0], resultShape[2], resultShape[1]}),
-            complexSignalTy.getDtype());
-
-        // After torch.stft is called and the result is stored into the value
-        // stft, there is one thing to note: The resultType for the onnx op
-        // will have shape [batch][num_frames][length][2], while the shape of
-        // stft will be [batch][length][num_frames]. Before the value is
-        // converted to real through torch.view_as_real, we must permute the
-        // shape of stft to match the shape of resultType. Also, it is
-        // immaterial whether torch.view_as_real is called after or before the
-        // permutation; both outputs will be equivalent.
-        Value stft = rewriter.create<Torch::AtenStftOp>(
-            binder.getLoc(), stftTy, signal, frameLengthItem, frameStepItem,
-            windowLen, window, falseVal, onesided ? trueVal : falseVal,
-            trueVal);
-
-        auto permuteStftTy = complexSignalTy.getWithSizesAndDtype(
-            ArrayRef<int64_t>({resultShape[0], resultShape[1], resultShape[2]}),
-            complexSignalTy.getDtype());
-        Value permuteDims = createConstantIntList(binder, rewriter, {0, 2, 1});
-        Value permutedStft = rewriter.create<Torch::AtenPermuteOp>(
-            binder.getLoc(), permuteStftTy, stft, permuteDims);
-
-        rewriter.replaceOpWithNewOp<Torch::AtenViewAsRealOp>(
-            binder.op, resultType, permutedStft);
-        return success();
-      });
-  patterns.onOp(
-      "ReverseSequence", 10,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ReverseSequence", 10, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value input, sequenceLens;
         int64_t batchAxis, timeAxis;
@@ -3820,8 +3711,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         return success();
       });
   patterns.onOp(
-      "ScatterND", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "ScatterND", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;
         Value data, indices, updates;
         std::string reduction;
@@ -4120,8 +4010,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
   //
 
   patterns.onOp(
-      "SplitToSequence", 11,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "SplitToSequence", 11, [](OpBinder binder, PatternRewriter &rewriter) {
         Value self;
         Value split;
         int64_t axis;
@@ -4187,127 +4076,124 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
               binder.op, "Handling of this kind of inputs is not there");
         }
       });
-  patterns.onOp(
-      "Unique", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Value input;
-        int64_t axis, sorted;
-        SmallVector<Type> resultTypes;
+  patterns.onOp("Unique", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    Value input;
+    int64_t axis, sorted;
+    SmallVector<Type> resultTypes;
 
-        if (binder.tensorOperand(input) ||
-            binder.s64IntegerAttr(sorted, "sorted", 1) ||
-            binder.tensorResultTypes(resultTypes))
-          return failure();
+    if (binder.tensorOperand(input) ||
+        binder.s64IntegerAttr(sorted, "sorted", 1) ||
+        binder.tensorResultTypes(resultTypes))
+      return failure();
 
-        Value zero = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), 0);
+    Value zero = rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), 0);
 
-        auto inputTy = cast<Torch::ValueTensorType>(input.getType());
-        if (!inputTy.hasSizes()) {
+    auto inputTy = cast<Torch::ValueTensorType>(input.getType());
+    if (!inputTy.hasSizes()) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Expected input type to have sizes");
+    }
+    auto inputShape = inputTy.getSizes();
+    int64_t inputDim = static_cast<int64_t>(inputShape.size());
+
+    Value axisVal;
+    SmallVector<int64_t> outputTensorSizes(inputDim);
+    bool axisWasNone;
+    if (!binder.optionalS64IntegerAttr(axis, "axis")) {
+      if (axis < -1 * inputDim || axis > inputDim - 1)
+        return rewriter.notifyMatchFailure(binder.op, "invalid value for axis");
+      axisVal = rewriter.create<Torch::ConstantIntOp>(
+          binder.getLoc(), rewriter.getI64IntegerAttr(axis));
+      axisWasNone = false;
+    } else {
+      axisVal = zero;
+      axisWasNone = true;
+    }
+
+    Value sortedVal = rewriter.create<Torch::ConstantBoolOp>(
+        binder.getLoc(), rewriter.getBoolAttr(sorted));
+    Value trueVal =
+        rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
+
+    // The shape of inverse_indices is the same as input shape, but
+    // resulTypes[2] must be used to avoid live value after conversion.
+    Torch::ValueTensorType outputTy;
+    outputTy = cast<Torch::ValueTensorType>(resultTypes[0]);
+    Torch::ValueTensorType countsTy =
+        cast<Torch::ValueTensorType>(resultTypes[3]);
+    Torch::ValueTensorType inverseTy =
+        cast<Torch::ValueTensorType>(resultTypes[2]);
+
+    if (axisWasNone) {
+      int64_t inputNumel = 1;
+      for (auto elem : inputShape) {
+        if (elem == Torch::kUnknownSize) {
           return rewriter.notifyMatchFailure(
-              binder.op, "Expected input type to have sizes");
+              binder.op,
+              "Expected all sizes in input shape to be statically known");
         }
-        auto inputShape = inputTy.getSizes();
-        int64_t inputDim = static_cast<int64_t>(inputShape.size());
+        inputNumel *= elem;
+      }
+      auto flattenResultTy = rewriter.getType<Torch::ValueTensorType>(
+          ArrayRef({inputNumel}), inputTy.getDtype());
+      Value negativeOne =
+          rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), -1);
+      input = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
+          binder.getLoc(), flattenResultTy, input, zero, negativeOne);
+    }
 
-        Value axisVal;
-        SmallVector<int64_t> outputTensorSizes(inputDim);
-        bool axisWasNone;
-        if (!binder.optionalS64IntegerAttr(axis, "axis")) {
-          if (axis < -1 * inputDim || axis > inputDim - 1)
-            return rewriter.notifyMatchFailure(binder.op,
-                                               "invalid value for axis");
-          axisVal = rewriter.create<Torch::ConstantIntOp>(
-              binder.getLoc(), rewriter.getI64IntegerAttr(axis));
-          axisWasNone = false;
-        } else {
-          axisVal = zero;
-          axisWasNone = true;
-        }
+    Torch::AtenUniqueDimOp intermResults =
+        rewriter.create<Torch::AtenUniqueDimOp>(
+            binder.getLoc(), outputTy, inverseTy, countsTy, input, axisVal,
+            sortedVal, trueVal, trueVal);
 
-        Value sortedVal = rewriter.create<Torch::ConstantBoolOp>(
-            binder.getLoc(), rewriter.getBoolAttr(sorted));
-        Value trueVal =
-            rewriter.create<Torch::ConstantBoolOp>(binder.getLoc(), true);
+    SmallVector<Value> uniqueResults = intermResults.getResults();
 
-        // The shape of inverse_indices is the same as input shape, but
-        // resulTypes[2] must be used to avoid live value after conversion.
-        Torch::ValueTensorType outputTy;
-        outputTy = cast<Torch::ValueTensorType>(resultTypes[0]);
-        Torch::ValueTensorType countsTy =
-            cast<Torch::ValueTensorType>(resultTypes[3]);
-        Torch::ValueTensorType inverseTy =
-            cast<Torch::ValueTensorType>(resultTypes[2]);
+    // Calculate the indices where each of the unique elements first
+    // appeared in the original input tensor. Also, the counts tensor and
+    // the indices tensor have the same Dtype, int64, so reuse that here.
+    auto arangeResultType = rewriter.getType<Torch::ValueTensorType>(
+        ArrayRef<int64_t>({inputShape[0]}), countsTy.getOptionalDtype());
 
-        if (axisWasNone) {
-          int64_t inputNumel = 1;
-          for (auto elem : inputShape) {
-            if (elem == Torch::kUnknownSize) {
-              return rewriter.notifyMatchFailure(
-                  binder.op,
-                  "Expected all sizes in input shape to be statically known");
-            }
-            inputNumel *= elem;
-          }
-          auto flattenResultTy = rewriter.getType<Torch::ValueTensorType>(
-              ArrayRef({inputNumel}), inputTy.getDtype());
-          Value negativeOne =
-              rewriter.create<Torch::ConstantIntOp>(binder.getLoc(), -1);
-          input = rewriter.create<Torch::AtenFlattenUsingIntsOp>(
-              binder.getLoc(), flattenResultTy, input, zero, negativeOne);
-        }
+    Value inputDimZero = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(inputShape[0]));
+    Value int64Type = rewriter.create<Torch::ConstantIntOp>(
+        binder.getLoc(), rewriter.getI64IntegerAttr(4));
+    Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
 
-        Torch::AtenUniqueDimOp intermResults =
-            rewriter.create<Torch::AtenUniqueDimOp>(
-                binder.getLoc(), outputTy, inverseTy, countsTy, input, axisVal,
-                sortedVal, trueVal, trueVal);
+    Value perm = rewriter.create<Torch::AtenArangeOp>(
+        binder.getLoc(), arangeResultType, inputDimZero,
+        /*dtype=*/int64Type,
+        /*layout=*/noneVal, /*device=*/noneVal, /*pin_memory=*/noneVal);
 
-        SmallVector<Value> uniqueResults = intermResults.getResults();
+    // Inverse has the same shape as input, but the dtype is not the same.
+    Value flipDims = createConstantIntList(binder, rewriter, {0});
+    Value inverse = rewriter.create<Torch::AtenFlipOp>(
+        binder.getLoc(),
+        inputTy.getWithSizesAndDtype(inputShape, countsTy.getDtype()),
+        uniqueResults[1], flipDims);
+    perm = rewriter.create<Torch::AtenFlipOp>(
+        binder.getLoc(), cast<Torch::ValueTensorType>(perm.getType()), perm,
+        flipDims);
 
-        // Calculate the indices where each of the unique elements first
-        // appeared in the original input tensor. Also, the counts tensor and
-        // the indices tensor have the same Dtype, int64, so reuse that here.
-        auto arangeResultType = rewriter.getType<Torch::ValueTensorType>(
-            ArrayRef<int64_t>({inputShape[0]}), countsTy.getOptionalDtype());
+    auto newInverseTy = rewriter.getType<Torch::ValueTensorType>(
+        ArrayRef<int64_t>({outputTy.getSizes()[0]}), countsTy.getDtype());
+    Value newInverseSize =
+        createConstantIntList(binder, rewriter, {outputTy.getSizes()[0]});
+    Value newInverse = rewriter.create<Torch::AtenNewEmptyOp>(
+        binder.getLoc(), newInverseTy, inverse, newInverseSize,
+        /*dtype=*/int64Type, /*layout=*/noneVal, /*device=*/noneVal,
+        /*pin_memory=*/noneVal);
 
-        Value inputDimZero = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(inputShape[0]));
-        Value int64Type = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getI64IntegerAttr(4));
-        Value noneVal = rewriter.create<Torch::ConstantNoneOp>(binder.getLoc());
+    Value firstOccurIndices = rewriter.create<Torch::AtenScatterSrcOp>(
+        binder.getLoc(), resultTypes[1], newInverse, zero, inverse, perm);
 
-        Value perm = rewriter.create<Torch::AtenArangeOp>(
-            binder.getLoc(), arangeResultType, inputDimZero,
-            /*dtype=*/int64Type,
-            /*layout=*/noneVal, /*device=*/noneVal, /*pin_memory=*/noneVal);
-
-        // Inverse has the same shape as input, but the dtype is not the same.
-        Value flipDims = createConstantIntList(binder, rewriter, {0});
-        Value inverse = rewriter.create<Torch::AtenFlipOp>(
-            binder.getLoc(),
-            inputTy.getWithSizesAndDtype(inputShape, countsTy.getDtype()),
-            uniqueResults[1], flipDims);
-        perm = rewriter.create<Torch::AtenFlipOp>(
-            binder.getLoc(), cast<Torch::ValueTensorType>(perm.getType()), perm,
-            flipDims);
-
-        auto newInverseTy = rewriter.getType<Torch::ValueTensorType>(
-            ArrayRef<int64_t>({outputTy.getSizes()[0]}), countsTy.getDtype());
-        Value newInverseSize =
-            createConstantIntList(binder, rewriter, {outputTy.getSizes()[0]});
-        Value newInverse = rewriter.create<Torch::AtenNewEmptyOp>(
-            binder.getLoc(), newInverseTy, inverse, newInverseSize,
-            /*dtype=*/int64Type, /*layout=*/noneVal, /*device=*/noneVal,
-            /*pin_memory=*/noneVal);
-
-        Value firstOccurIndices = rewriter.create<Torch::AtenScatterSrcOp>(
-            binder.getLoc(), resultTypes[1], newInverse, zero, inverse, perm);
-
-        rewriter.replaceOp(binder.op, {uniqueResults[0], firstOccurIndices,
-                                       uniqueResults[1], uniqueResults[2]});
-        return success();
-      });
+    rewriter.replaceOp(binder.op, {uniqueResults[0], firstOccurIndices,
+                                   uniqueResults[1], uniqueResults[2]});
+    return success();
+  });
   patterns.onOp(
-      "TfIdfVectorizer", 9,
-      [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+      "TfIdfVectorizer", 9, [](OpBinder binder, PatternRewriter &rewriter) {
         llvm::SmallVector<int64_t> ngram_counts;
         llvm::SmallVector<int64_t> ngram_indexes;
         llvm::SmallVector<int64_t> pool_int64s;
@@ -4607,115 +4493,110 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         rewriter.replaceOp(binder.op, output);
         return success();
       });
-  patterns.onOp(
-      "Scan", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Location loc = binder.getLoc();
-        SmallVector<Value> operands;
-        int64_t numScanInputs;
-        if (binder.tensorOperandsList(operands) || operands.size() == 0 ||
-            binder.s64IntegerAttr(numScanInputs, "num_scan_inputs")) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Failed to get required inputs");
-        }
-        SmallVector<Type> resultTypes;
-        if (binder.tensorResultTypes(resultTypes)) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "result type bind failure");
-        }
-        Region *loopBodyIn;
-        if (binder.getRegionAtIndex(loopBodyIn, 0)) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Failed getting LoopBody Region");
-        }
+  patterns.onOp("Scan", 11, [](OpBinder binder, PatternRewriter &rewriter) {
+    Location loc = binder.getLoc();
+    SmallVector<Value> operands;
+    int64_t numScanInputs;
+    if (binder.tensorOperandsList(operands) || operands.size() == 0 ||
+        binder.s64IntegerAttr(numScanInputs, "num_scan_inputs")) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed to get required inputs");
+    }
+    SmallVector<Type> resultTypes;
+    if (binder.tensorResultTypes(resultTypes)) {
+      return rewriter.notifyMatchFailure(binder.op, "result type bind failure");
+    }
+    Region *loopBodyIn;
+    if (binder.getRegionAtIndex(loopBodyIn, 0)) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Failed getting LoopBody Region");
+    }
 
-        int64_t numInits = operands.size() - numScanInputs;
-        SmallVector<Value> initVals(operands.begin(),
-                                    operands.begin() + numInits);
-        SmallVector<Value> scanInputs(operands.begin() + numInits,
-                                      operands.end());
-        if (scanInputs.size() < 1) {
-          return rewriter.notifyMatchFailure(binder.op,
-                                             "Expects at least one scan input");
-        }
+    int64_t numInits = operands.size() - numScanInputs;
+    SmallVector<Value> initVals(operands.begin(), operands.begin() + numInits);
+    SmallVector<Value> scanInputs(operands.begin() + numInits, operands.end());
+    if (scanInputs.size() < 1) {
+      return rewriter.notifyMatchFailure(binder.op,
+                                         "Expects at least one scan input");
+    }
 
-        Value constZero = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(0));
-        Value constOne = rewriter.create<Torch::ConstantIntOp>(
-            loc, rewriter.getI64IntegerAttr(1));
-        SmallVector<Type> scanOutTypes;
-        for (unsigned i = numInits; i < resultTypes.size(); i++) {
-          auto scanOutTy = cast<Torch::ValueTensorType>(resultTypes[i]);
-          // TODO: Handle dynamic result types.
-          if (!scanOutTy.hasSizes() || !scanOutTy.areAllSizesKnown()) {
-            return rewriter.notifyMatchFailure(
-                binder.op, "Expects result type to be static");
-          }
-          Value sizeList =
-              createConstantIntList(binder, rewriter, scanOutTy.getSizes());
-          initVals.push_back(Torch::createInitTensor(rewriter, loc, scanOutTy,
-                                                     constZero, sizeList));
-          scanOutTypes.push_back(resultTypes[i]);
-        }
-        // Create torch.prim.Loop op.
-        Value maxTripCount = rewriter.create<Torch::AtenSizeIntOp>(
-            loc, scanInputs[0], constZero);
-        auto constBoolTrue = rewriter.create<Torch::ConstantBoolOp>(
-            binder.getLoc(), rewriter.getBoolAttr(true));
-        auto primLoop = rewriter.create<Torch::PrimLoopOp>(
-            loc, resultTypes, maxTripCount, constBoolTrue, initVals);
-        rewriter.cloneRegionBefore(*loopBodyIn, primLoop.getRegion(),
-                                   primLoop.getRegion().begin());
+    Value constZero = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(0));
+    Value constOne = rewriter.create<Torch::ConstantIntOp>(
+        loc, rewriter.getI64IntegerAttr(1));
+    SmallVector<Type> scanOutTypes;
+    for (unsigned i = numInits; i < resultTypes.size(); i++) {
+      auto scanOutTy = cast<Torch::ValueTensorType>(resultTypes[i]);
+      // TODO: Handle dynamic result types.
+      if (!scanOutTy.hasSizes() || !scanOutTy.areAllSizesKnown()) {
+        return rewriter.notifyMatchFailure(binder.op,
+                                           "Expects result type to be static");
+      }
+      Value sizeList =
+          createConstantIntList(binder, rewriter, scanOutTy.getSizes());
+      initVals.push_back(Torch::createInitTensor(rewriter, loc, scanOutTy,
+                                                 constZero, sizeList));
+      scanOutTypes.push_back(resultTypes[i]);
+    }
+    // Create torch.prim.Loop op.
+    Value maxTripCount =
+        rewriter.create<Torch::AtenSizeIntOp>(loc, scanInputs[0], constZero);
+    auto constBoolTrue = rewriter.create<Torch::ConstantBoolOp>(
+        binder.getLoc(), rewriter.getBoolAttr(true));
+    auto primLoop = rewriter.create<Torch::PrimLoopOp>(
+        loc, resultTypes, maxTripCount, constBoolTrue, initVals);
+    rewriter.cloneRegionBefore(*loopBodyIn, primLoop.getRegion(),
+                               primLoop.getRegion().begin());
 
-        // Insert index var as torch.int argument in the loop body, as
-        // the primLoopOp loopBody expects torch.int as first argument.
-        primLoop.getRegion().insertArgument(
-            0u, rewriter.getType<Torch::IntType>(), loc);
-        auto loopInd = primLoop.getRegion().getArgument(0);
+    // Insert index var as torch.int argument in the loop body, as
+    // the primLoopOp loopBody expects torch.int as first argument.
+    primLoop.getRegion().insertArgument(0u, rewriter.getType<Torch::IntType>(),
+                                        loc);
+    auto loopInd = primLoop.getRegion().getArgument(0);
 
-        // The block arguments of onnx.scan needs to be replaced with
-        // slice of scan inputs.
-        rewriter.setInsertionPointToStart(&primLoop.getRegion().front());
-        for (unsigned i = 0; i < numScanInputs; i++) {
-          auto loopBlockArg =
-              primLoop.getRegion().getArgument(numInits + 1 + i);
-          Value extract = rewriter.create<Torch::AtenSelectIntOp>(
-              loc, loopBlockArg.getType(), scanInputs[i], constZero, loopInd);
-          loopBlockArg.replaceAllUsesWith(extract);
-        }
-        primLoop.getRegion().front().eraseArguments(numInits + 1,
-                                                    /*count=*/numScanInputs);
+    // The block arguments of onnx.scan needs to be replaced with
+    // slice of scan inputs.
+    rewriter.setInsertionPointToStart(&primLoop.getRegion().front());
+    for (unsigned i = 0; i < numScanInputs; i++) {
+      auto loopBlockArg = primLoop.getRegion().getArgument(numInits + 1 + i);
+      Value extract = rewriter.create<Torch::AtenSelectIntOp>(
+          loc, loopBlockArg.getType(), scanInputs[i], constZero, loopInd);
+      loopBlockArg.replaceAllUsesWith(extract);
+    }
+    primLoop.getRegion().front().eraseArguments(numInits + 1,
+                                                /*count=*/numScanInputs);
 
-        // Collect the output slices to form scan outputs and replace the
-        // terminator.
-        SmallVector<Location> locs(scanOutTypes.size(), loc);
-        primLoop.getRegion().front().addArguments(scanOutTypes, locs);
+    // Collect the output slices to form scan outputs and replace the
+    // terminator.
+    SmallVector<Location> locs(scanOutTypes.size(), loc);
+    primLoop.getRegion().front().addArguments(scanOutTypes, locs);
 
-        PatternRewriter::InsertionGuard guard(rewriter);
-        Operation *terminator = primLoop.getRegion().front().getTerminator();
-        auto terminatorOperands = terminator->getOperands();
-        SmallVector<Value> resTerminatorOperands(
-            terminatorOperands.begin(), terminatorOperands.begin() + numInits);
-        SmallVector<Value> scanOutSlices(terminatorOperands.begin() + numInits,
-                                         terminatorOperands.end());
-        rewriter.setInsertionPoint(terminator);
-        for (unsigned i = 0; i < scanOutSlices.size(); i++) {
-          Value self = BlockArgument::Value(
-              primLoop.getRegion().getArgument(numInits + 1 + i));
-          FailureOr<Value> src = Torch::unsqueezeTensor(
-              rewriter, binder.op, scanOutSlices[i], constZero);
-          if (failed(src))
-            return failure();
-          Value scanOut = rewriter.create<Torch::AtenSliceScatterOp>(
-              loc, scanOutTypes[i], self, src.value(), constZero,
-              /*start=*/loopInd,
-              /*end=*/loopInd, constOne);
-          resTerminatorOperands.push_back(scanOut);
-        }
+    PatternRewriter::InsertionGuard guard(rewriter);
+    Operation *terminator = primLoop.getRegion().front().getTerminator();
+    auto terminatorOperands = terminator->getOperands();
+    SmallVector<Value> resTerminatorOperands(
+        terminatorOperands.begin(), terminatorOperands.begin() + numInits);
+    SmallVector<Value> scanOutSlices(terminatorOperands.begin() + numInits,
+                                     terminatorOperands.end());
+    rewriter.setInsertionPoint(terminator);
+    for (unsigned i = 0; i < scanOutSlices.size(); i++) {
+      Value self = BlockArgument::Value(
+          primLoop.getRegion().getArgument(numInits + 1 + i));
+      FailureOr<Value> src = Torch::unsqueezeTensor(
+          rewriter, binder.op, scanOutSlices[i], constZero);
+      if (failed(src))
+        return failure();
+      Value scanOut = rewriter.create<Torch::AtenSliceScatterOp>(
+          loc, scanOutTypes[i], self, src.value(), constZero,
+          /*start=*/loopInd,
+          /*end=*/loopInd, constOne);
+      resTerminatorOperands.push_back(scanOut);
+    }
 
-        Value terminatorCond = constBoolTrue;
-        rewriter.replaceOpWithNewOp<Torch::PrimLoopConditionOp>(
-            terminator, terminatorCond, resTerminatorOperands);
-        rewriter.replaceOp(binder.op, primLoop);
-        return success();
-      });
+    Value terminatorCond = constBoolTrue;
+    rewriter.replaceOpWithNewOp<Torch::PrimLoopConditionOp>(
+        terminator, terminatorCond, resTerminatorOperands);
+    rewriter.replaceOp(binder.op, primLoop);
+    return success();
+  });
 }

--- a/lib/Conversion/TorchOnnxToTorch/OnnxRecurrentLayerOpExpanders.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/OnnxRecurrentLayerOpExpanders.cpp
@@ -167,8 +167,7 @@ static Value StaticTranspose(ImplicitLocOpBuilder b, Value value, int64_t dim0,
   return b.create<AtenTransposeIntOp>(valueTy, value, dim0v, dim1v);
 }
 
-LogicalResult OnnxRnnExpander(OpBinder binder,
-                              ConversionPatternRewriter &rewriter) {
+LogicalResult OnnxRnnExpander(OpBinder binder, PatternRewriter &rewriter) {
   Location loc = binder.getLoc();
   mlir::ImplicitLocOpBuilder b(loc, rewriter);
 
@@ -651,8 +650,7 @@ LstmLayerOutput lstm_layer(ImplicitLocOpBuilder &b, Value X, Value initial_h,
 // @endcode
 //
 // @param binder The OpBinder object used for binding operands.
-LogicalResult OnnxLstmExpander(OpBinder binder,
-                               ConversionPatternRewriter &rewriter) {
+LogicalResult OnnxLstmExpander(OpBinder binder, PatternRewriter &rewriter) {
   Location loc = binder.getLoc();
   mlir::ImplicitLocOpBuilder b(loc, rewriter);
 
@@ -1061,8 +1059,7 @@ GruLayerOutput gru_layer(ImplicitLocOpBuilder &b, Value X, Value initial_h,
   return output;
 }
 
-LogicalResult OnnxGruExpander(OpBinder binder,
-                              ConversionPatternRewriter &rewriter) {
+LogicalResult OnnxGruExpander(OpBinder binder, PatternRewriter &rewriter) {
   Location loc = binder.getLoc();
   mlir::ImplicitLocOpBuilder b(loc, rewriter);
 

--- a/lib/Conversion/TorchOnnxToTorch/Patterns.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/Patterns.cpp
@@ -19,8 +19,7 @@ using namespace mlir::torch::onnx_c;
 #define DEBUG_TYPE "torch-onnx"
 
 LogicalResult OnnxCustomOpConversionPattern::matchAndRewrite(
-    Torch::OperatorOp op, OpAdaptor adaptor,
-    ConversionPatternRewriter &rewriter) const {
+    Torch::OperatorOp op, PatternRewriter &rewriter) const {
   auto foundIt = namedHandlers.find(op.getNameAttr());
   if (foundIt == namedHandlers.end())
     return failure();

--- a/lib/Conversion/TorchOnnxToTorch/Utils.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/Utils.cpp
@@ -15,9 +15,9 @@ using namespace mlir;
 using namespace mlir::torch;
 using namespace mlir::torch::onnx_c;
 
-Value mlir::torch::onnx_c::createConstantIntList(
-    OpBinder binder, ConversionPatternRewriter &rewriter,
-    ArrayRef<int64_t> cstInput) {
+Value mlir::torch::onnx_c::createConstantIntList(OpBinder binder,
+                                                 PatternRewriter &rewriter,
+                                                 ArrayRef<int64_t> cstInput) {
   SmallVector<Value> cstValue;
   for (int64_t i : cstInput) {
     cstValue.push_back(rewriter.create<Torch::ConstantIntOp>(
@@ -103,8 +103,8 @@ mlir::torch::onnx_c::onnxDtypeIntToTorchDtypeInt(int64_t dtypeIntOnnx) {
 }
 
 LogicalResult mlir::torch::onnx_c::createTorchTransposeOp(
-    ConversionPatternRewriter &rewriter, Location loc, Value input,
-    int64_t dimA, int64_t dimB, Value &transposed) {
+    PatternRewriter &rewriter, Location loc, Value input, int64_t dimA,
+    int64_t dimB, Value &transposed) {
   Type transposedType;
   if (failed(getTransposedType(cast<Torch::BaseTensorType>(input.getType()),
                                dimA, dimB, transposedType)))
@@ -119,8 +119,8 @@ LogicalResult mlir::torch::onnx_c::createTorchTransposeOp(
 }
 
 LogicalResult mlir::torch::onnx_c::createTorchPermuteOp(
-    OpBinder binder, ConversionPatternRewriter &rewriter, Location loc,
-    Value input, SmallVector<int64_t> permuteDims, Value &permuted) {
+    OpBinder binder, PatternRewriter &rewriter, Location loc, Value input,
+    SmallVector<int64_t> permuteDims, Value &permuted) {
   Type permutedType;
   if (failed(
           Torch::getPermutedType(cast<Torch::BaseTensorType>(input.getType()),


### PR DESCRIPTION
All operations should be printed to make it clear the total operations that failed to convert.