### PR TITLE
[stablehlo] improve broadcast batch matmul lowering

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -36,7 +36,7 @@ def AtenDotModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
-class BroadcastMatmul(torch.nn.Module):
+class BroadcastMatmulStatic(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -44,8 +44,6 @@ class BroadcastMatmul(torch.nn.Module):
     @annotate_args(
         [
             None,
-            # ([-1, -1, -1, -1], torch.float32, True),
-            # ([-1, -1, -1, -1], torch.float32, True),
             ([5, 1, 3, 4], torch.float32, True),
             ([1, 10, 4, 5], torch.float32, True),
         ]
@@ -54,10 +52,57 @@ class BroadcastMatmul(torch.nn.Module):
         return torch.matmul(lhs, rhs)
                                                                
 
+@register_test_case(module_factory=lambda: BroadcastMatmulStatic())
+def BroadcastMatmulStatic_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5, 1, 3, 4), tu.rand(1, 10, 4, 5))
+
+
+# ==============================================================================
+
+
+class BroadcastMatmul(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1, -1, -1], torch.float32, True),
+            ([-1, -1, -1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
 @register_test_case(module_factory=lambda: BroadcastMatmul())
 def BroadcastMatmul_basic(module, tu: TestUtils):
     module.forward(tu.rand(5, 1, 3, 4), tu.rand(1, 10, 4, 5))
-    # module.forward(tu.rand(5, 1, 3, 4), tu.rand(4, 5))
+
+
+# ==============================================================================
+
+
+class BatchMatmulNoBroadcast(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1, -1, -1], torch.float32, True),
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: BatchMatmulNoBroadcast())
+def BatchMatmulNoBroadcast_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5, 1, 3, 4), tu.rand(4, 5))
 
 
 # ==============================================================================

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -36,6 +36,33 @@ def AtenDotModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class BroadcastMatmul(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            # ([-1, -1, -1, -1], torch.float32, True),
+            # ([-1, -1, -1, -1], torch.float32, True),
+            ([5, 1, 3, 4], torch.float32, True),
+            ([1, 10, 4, 5], torch.float32, True),
+        ]
+    )
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+                                                               
+
+@register_test_case(module_factory=lambda: BroadcastMatmul())
+def BroadcastMatmul_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5, 1, 3, 4), tu.rand(1, 10, 4, 5))
+    # module.forward(tu.rand(5, 1, 3, 4), tu.rand(4, 5))
+
+
+# ==============================================================================
+
+
 class MatmulDot(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/slice_like.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/slice_like.py
@@ -395,8 +395,8 @@ class SliceScatterNegativeEndModule(torch.nn.Module):
     @annotate_args(
         [
             None,
-            ([-1, -1], torch.float32, True),
-            ([-1, -1], torch.float32, True),
+            ([6, 8], torch.float32, True),
+            ([2, 8], torch.float32, True),
         ]
     )
     def forward(self, x, src):


### PR DESCRIPTION
1. enable dynamic shape lowering in batch matmul
2. remove `stablehlo.dynamic_broadcast_in_dim `op for broadcast case supported by `stablehlo.dot_general`