### PR TITLE
Revert commits causing release build failure

### DIFF
--- a/python/TorchMLIRModule.cpp
+++ b/python/TorchMLIRModule.cpp
@@ -28,8 +28,4 @@ PYBIND11_MODULE(_torchMlir, m) {
         }
       },
       py::arg("context"), py::arg("load") = true);
-
-  m.def("get_int64_max", []() { return INT64_MAX; });
-
-  m.def("get_int64_min", []() { return INT64_MIN; });
 }


### PR DESCRIPTION
**Two commits are reverted:**
(1) https://github.com/llvm/torch-mlir/commit/2960538c6d145a2bd1efa52c56f2bcaa1ffc45aa
(2) https://github.com/llvm/torch-mlir/commit/fa39d91357e8ebbf375f211274dfb4bbbbbc5ccf

The release build is failing and the 2nd commit is suspected to be the reason. Some of the changes in this commit are unnecessary and must be dropped while reapplying. The 1st commit fixes some of the changes made in the 2nd commit and therefore the 1st commit is also reverted. It could be reapplied along with the 2nd one later on.

cc: @vivekkhandelwal1 