### PR TITLE
Redefine TorchMLIRPythonModules to avoid building empty libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ option(TORCH_MLIR_OUT_OF_TREE_BUILD "Specifies an out of tree build" OFF)
 # But it will be manually enabled in CI build to enable the jit_ir_importer.build_tools.torch_ods_gen
 # and abstract_interp_lib_gen.py. Once pure python version of build_tools finished, no need to set it in CI.
 option(TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS "Enables PyTorch native extension features" OFF)
+if(TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS)
+  add_definitions(-DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS)
+endif()
 # NOTE: The JIT_IR_IMPORTER paths have become unsupportable due to age and lack of maintainers.
 # Turning this off disables the old TorchScript path, leaving FX based import as the current supported option.
 # The option will be retained for a time, and if a maintainer is interested in setting up testing for it,

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -96,14 +96,16 @@ set(_source_components
   TorchMLIRPythonSources
   TorchMLIRPythonExtensions
   TorchMLIRSiteInitialize
-
-  # Sources related to optional Torch extension dependent features. Typically
-  # empty unless if project features are enabled.
-  TorchMLIRPythonTorchExtensionsSources
 )
 
 if(TORCH_MLIR_ENABLE_STABLEHLO)
   list(APPEND _source_components StablehloPythonExtensions)
+endif()
+
+# Sources related to optional Torch extension dependent features. Typically
+# empty unless if project features are enabled.
+if(TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS)
+  list(APPEND _source_components TorchMLIRPythonTorchExtensionsSources)
 endif()
 
 add_mlir_python_common_capi_library(TorchMLIRAggregateCAPI

--- a/setup.py
+++ b/setup.py
@@ -220,11 +220,9 @@ INSTALL_REQUIRES = [
     "numpy",
     "packaging",
 ]
-EXT_MODULES = []
-if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS:
-    EXT_MODULES = [
-        CMakeExtension("torch_mlir._mlir_libs._torchMlir"),
-    ]
+EXT_MODULES = [
+    CMakeExtension("torch_mlir._mlir_libs._torchMlir"),
+]
 NAME = "torch-mlir-core"
 
 print("TEST")

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ class CMakeBuild(build_py):
             f"-DCMAKE_C_VISIBILITY_PRESET=hidden",
             f"-DCMAKE_CXX_VISIBILITY_PRESET=hidden",
             f"-DTORCH_MLIR_ENABLE_LTC={'ON' if TORCH_MLIR_ENABLE_LTC else 'OFF'}",
-            f"-DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=OFF",
+            f"-DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS={'OFF' if TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS else 'ON'}",
         ]
         if LLVM_INSTALL_DIR:
             cmake_config_args += [

--- a/setup.py
+++ b/setup.py
@@ -235,11 +235,6 @@ if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS:
             f"torch=={torch.__version__}".split("+", 1)[0],
         ]
     )
-    EXT_MODULES.extend(
-        [
-            CMakeExtension("torch_mlir._mlir_libs._jit_ir_importer"),
-        ]
-    )
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ PACKAGE_VERSION = os.getenv("TORCH_MLIR_PYTHON_PACKAGE_VERSION", "0.0.1")
 # If true, enable LTC build by default
 TORCH_MLIR_ENABLE_LTC = _check_env_flag("TORCH_MLIR_ENABLE_LTC", True)
 TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS = _check_env_flag(
-    "TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS", False
+    "TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS", True
 )
 LLVM_INSTALL_DIR = os.getenv("LLVM_INSTALL_DIR", None)
 SRC_DIR = pathlib.Path(__file__).parent.absolute()

--- a/setup.py
+++ b/setup.py
@@ -220,15 +220,16 @@ INSTALL_REQUIRES = [
     "numpy",
     "packaging",
 ]
-EXT_MODULES = [
-    CMakeExtension("torch_mlir._mlir_libs._torchMlir"),
-]
+EXT_MODULES = []
+if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS:
+    EXT_MODULES = [
+        CMakeExtension("torch_mlir._mlir_libs._torchMlir"),
+    ]
 NAME = "torch-mlir-core"
 
 print("TEST")
 # If building PyTorch extensions, customize.
 if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS:
-    print("HEREE")
     import torch
 
     NAME = "torch-mlir"

--- a/setup.py
+++ b/setup.py
@@ -225,8 +225,10 @@ EXT_MODULES = [
 ]
 NAME = "torch-mlir-core"
 
+print("TEST")
 # If building PyTorch extensions, customize.
 if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS:
+    print("HEREE")
     import torch
 
     NAME = "torch-mlir"

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ class CMakeBuild(build_py):
             f"-DCMAKE_C_VISIBILITY_PRESET=hidden",
             f"-DCMAKE_CXX_VISIBILITY_PRESET=hidden",
             f"-DTORCH_MLIR_ENABLE_LTC={'ON' if TORCH_MLIR_ENABLE_LTC else 'OFF'}",
-            f"-DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS={'OFF' if TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS else 'ON'}",
+            f"-DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=OFF",
         ]
         if LLVM_INSTALL_DIR:
             cmake_config_args += [
@@ -233,6 +233,11 @@ if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS:
     INSTALL_REQUIRES.extend(
         [
             f"torch=={torch.__version__}".split("+", 1)[0],
+        ]
+    )
+    EXT_MODULES.extend(
+        [
+            CMakeExtension("torch_mlir._mlir_libs._jit_ir_importer"),
         ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,6 @@ EXT_MODULES = [
 ]
 NAME = "torch-mlir-core"
 
-print("TEST")
 # If building PyTorch extensions, customize.
 if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS:
     import torch


### PR DESCRIPTION
Trying to build empty libraries causes weird failures based on clang/gcc and doesn't work with certain versions of python as well. We should avoid this wherever possible, and this specifically has been leading to the following issues/failures:

https://github.com/llvm/torch-mlir/issues/3663
https://github.com/llvm/torch-mlir-release/actions/runs/10558518843/job/29248139823