### PR TITLE
Update instructions on creating a virtual env

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ While this is running, you can already setup the Python venv and dependencies in
 ## Setup your Python VirtualEnvironment and Dependencies
 
 ```shell
-python -m venv mlir_venv
+python3 -m venv mlir_venv
 source mlir_venv/bin/activate
 # Some older pip installs may not be able to handle the recent PyTorch deps
 python -m pip install --upgrade pip


### PR DESCRIPTION
The `python` command is only available on Ubuntu if the `python-is-python3` package is installed, see
https://packages.ubuntu.com/jammy/python-is-python3 and https://packages.ubuntu.com/jammy/all/python-is-python3/filelist. As Python 2 isn't supported anyway, it's safe to point to `python3` here instead.