### PR TITLE
[Release] Fix binary name for downstream compatibility

### DIFF
--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -56,15 +56,15 @@ function run() {
       export PATH=$python_dir/bin:$orig_path
       echo ":::: Python version $(python3 --version)"
       case "$package" in
+        torch-mlir-ext)
+          clean_wheels torch_mlir_ext "$python_version"
+          build_torch_mlir_ext torch_mlir_ext "$python_version"
+          run_audit_wheel torch_mlir_ext "$python_version"
+          ;;
         torch-mlir)
           clean_wheels torch_mlir "$python_version"
           build_torch_mlir torch_mlir "$python_version"
           run_audit_wheel torch_mlir "$python_version"
-          ;;
-        torch-mlir-core)
-          clean_wheels torch_mlir_core "$python_version"
-          build_torch_mlir_core torch_mlir_core "$python_version"
-          run_audit_wheel torch_mlir_core "$python_version"
           ;;
         *)
           echo "Unrecognized package '$package'"
@@ -75,7 +75,7 @@ function run() {
   done
 }
 
-function build_torch_mlir() {
+function build_torch_mlir_ext() {
   local wheel_basename="$1"
   local python_version="$2"
   rm -rf "$output_dir"/build_venv
@@ -93,7 +93,7 @@ function build_torch_mlir() {
   rm -rf "$output_dir"/build_venv
 }
 
-function build_torch_mlir_core() {
+function build_torch_mlir() {
   local wheel_basename="$1"
   local python_version="$2"
   rm -rf "$output_dir"/build_venv

--- a/setup.py
+++ b/setup.py
@@ -223,13 +223,13 @@ INSTALL_REQUIRES = [
 EXT_MODULES = [
     CMakeExtension("torch_mlir._mlir_libs._torchMlir"),
 ]
-NAME = "torch-mlir-core"
+NAME = "torch-mlir"
 
 # If building PyTorch extensions, customize.
 if not TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS:
     import torch
 
-    NAME = "torch-mlir"
+    NAME = "torch-mlir-ext"
     INSTALL_REQUIRES.extend(
         [
             f"torch=={torch.__version__}".split("+", 1)[0],


### PR DESCRIPTION
As of Sep 14, the torch-mlir binary [wheels](https://github.com/llvm/torch-mlir-release/releases/tag/dev-wheels) got renamed to `torch-mlir-core` from `torch-mlir`: ![image](https://github.com/user-attachments/assets/152e4977-71ef-4f57-8757-6dc75f72b670) 

This was an unintended side-effect of the recent change of `TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS=True` (https://github.com/llvm/torch-mlir/pull/3711) which skips setting `NAME = "torch-mlir"` in [setup.py](https://github.com/llvm/torch-mlir/blob/main/setup.py#L226-L232).

To avoid having multiple downstreams fix their pip deps, this change allows using the same `torch-mlir` name for binaries, and reserves a separate `torch-mlir-ext` name for the (less popular) binaries with extensions enabled.