### PR TITLE
[TorchToLinalg] Fix AtenReflectionPad2dOp lowering to not assert when dimensions unknown

### DIFF
--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -404,13 +404,13 @@ public:
     Value hDimSize = inputShape[hDim];
     Value vDimSize = inputShape[vDim];
 
-    if (inputType.getShape()[hDim] != kUnknownSize) {
+    if (inputType.getShape()[hDim] != ShapedType::kDynamic) {
       assert(getHPadArgument(LEFT) < inputType.getShape()[hDim] &&
              "Left padding too large");
       assert(getHPadArgument(RIGHT) < inputType.getShape()[hDim] &&
              "Right padding too large");
     }
-    if (inputType.getShape()[vDim] != kUnknownSize) {
+    if (inputType.getShape()[vDim] != ShapedType::kDynamic) {
       assert(getVPadArgument(TOP) < inputType.getShape()[vDim] &&
              "Top padding too large");
       assert(getVPadArgument(BOTTOM) < inputType.getShape()[vDim] &&

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -404,14 +404,18 @@ public:
     Value hDimSize = inputShape[hDim];
     Value vDimSize = inputShape[vDim];
 
-    assert(getHPadArgument(LEFT) < inputType.getShape()[hDim] &&
-           "Left padding too large");
-    assert(getHPadArgument(RIGHT) < inputType.getShape()[hDim] &&
-           "Right padding too large");
-    assert(getVPadArgument(TOP) < inputType.getShape()[vDim] &&
-           "Top padding too large");
-    assert(getVPadArgument(BOTTOM) < inputType.getShape()[vDim] &&
-           "Bottom padding too large");
+    if (inputType.getShape()[hDim] != kUnknownSize) {
+      assert(getHPadArgument(LEFT) < inputType.getShape()[hDim] &&
+             "Left padding too large");
+      assert(getHPadArgument(RIGHT) < inputType.getShape()[hDim] &&
+             "Right padding too large");
+    }
+    if (inputType.getShape()[vDim] != kUnknownSize) {
+      assert(getVPadArgument(TOP) < inputType.getShape()[vDim] &&
+             "Top padding too large");
+      assert(getVPadArgument(BOTTOM) < inputType.getShape()[vDim] &&
+             "Bottom padding too large");
+    }
 
     Type indexType = rewriter.getIndexType();
     Value zero = getConstant(rewriter, loc, 0, indexType);


### PR DESCRIPTION
The asserts make the compiler crash (with a misleading error) also when vertical or horizontal dimensions are unknown (which is a valid state at this stage).