### PR TITLE
Support convolution with `valid` padding.

### DIFF
--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -832,6 +832,12 @@ public:
           op, "only support padding from a list construct");
     paddingIntValues = getTypeConvertedValues(rewriter, loc, getTypeConverter(),
                                               paddingIntValues);
+    if (paddingIntValues.size() == 1) {
+      for (size_t iDim = 1; iDim < numSpatialDims; iDim++) {
+        paddingIntValues.push_back(paddingIntValues[0]);
+      }
+    }
+
     SmallVector<Value> outputPaddingIntValues;
     if (!getListConstructElements(op.getOutputPadding(),
                                   outputPaddingIntValues))

--- a/lib/Conversion/TorchToStablehlo/Linear.cpp
+++ b/lib/Conversion/TorchToStablehlo/Linear.cpp
@@ -750,6 +750,11 @@ public:
       return rewriter.notifyMatchFailure(op,
                                          "non-const padding list unsupported");
     }
+    if (padding.size() == 1) {
+      for (auto iDim = 1; iDim < inputTy.getRank() - 2; iDim++) {
+        padding.push_back(padding[0]);
+      }
+    }
     SmallVector<int64_t> dilation;
     if (!matchPattern(op.getDilation(), m_TorchListOfConstantInts(dilation))) {
       return rewriter.notifyMatchFailure(op,

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -2178,6 +2178,9 @@ LogicalResult ConvertAtenOp<AtenConvolutionOp>::matchAndRewrite(
                     m_TorchListOfConstantInts(padding_2d)))
     return rewriter.notifyMatchFailure(op,
                                        "non-const padding list unsupported");
+  if (padding_2d.size() == 1) {
+    padding_2d.push_back(padding_2d[0]);
+  }
   // TOSA uses 4D padding {t, b, l, r} while Torch defines 2D padding {t, l}.
   // The Torch OFM computation uses 2*pad in each spatial direction, implying
   // the same t=b and l=r values for TOSA.

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -33,6 +33,9 @@ LINALG_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS | {
     # if a dimension is specified in all expand lists, and not in sumdim list.
     # This is a bug in the implementation of _trilinear in PyTorch.
     "Aten_TrilinearModuleZerodDimBug_basic",
+    # TorchScript to the backend contract fails for conv.padding specified as str
+    "Conv2dWithValidPaddingModule_basic",
+    "Conv2dWithSamePaddingModule_basic",
 }
 
 if torch_version_for_comparison() < version.parse("2.5.0.dev"):

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
@@ -191,6 +191,58 @@ def Conv2dWithPaddingDilationStrideStaticModule_grouped_multiplier(
     module.forward(tu.rand(5, 4, 10, 20))
 
 
+class Conv2dWithValidPaddingModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        torch.manual_seed(0)
+        self.conv = torch.nn.Conv2d(
+            1, 1, 1, stride=[1, 1], padding="valid", dilation=[1, 1], groups=1, bias=1
+        )
+        self.train(False)
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([1, 5, 6], torch.float32, True),
+        ]
+    )
+    def forward(self, x):
+        return self.conv(x)
+
+
+@register_test_case(module_factory=lambda: Conv2dWithValidPaddingModule())
+def Conv2dWithValidPaddingModule_basic(module, tu: TestUtils):
+    t = tu.rand(1, 5, 6)
+    module.forward(t)
+
+
+class Conv2dWithSamePaddingModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        torch.manual_seed(0)
+        self.conv = torch.nn.Conv2d(
+            1, 1, 1, stride=[1, 1], padding="same", dilation=[1, 1], groups=1, bias=1
+        )
+        self.train(False)
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([1, 5, 6], torch.float32, True),
+        ]
+    )
+    def forward(self, x):
+        return self.conv(x)
+
+
+@register_test_case(module_factory=lambda: Conv2dWithSamePaddingModule())
+def Conv2dWithSamePaddingModule_basic(module, tu: TestUtils):
+    t = tu.rand(1, 5, 6)
+    module.forward(t)
+
+
 # ==============================================================================
 
 


### PR DESCRIPTION
Convolution created with `valid` padding produces the `aten.convolution` op in the following fashion:

```
module {
  func.func @main(%arg0: !torch.vtensor<[1,64,57],f32>) -> !torch.vtensor<[1,64,57],f32> attributes {torch.assume_strict_symbolic_shapes} {
    %false = torch.constant.bool false
    %int1 = torch.constant.int 1
    %0 = torch.vtensor.literal(dense<0.536443591> : tensor<1xf32>) : !torch.vtensor<[1],f32>
    %1 = torch.vtensor.literal(dense<-7.486820e-03> : tensor<1x1x1x1xf32>) : !torch.vtensor<[1,1,1,1],f32>
    %int0 = torch.constant.int 0
    %2 = torch.aten.unsqueeze %arg0, %int0 : !torch.vtensor<[1,64,57],f32>, !torch.int -> !torch.vtensor<[1,1,64,57],f32>
    %3 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
    %4 = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
    %5 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
    %6 = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
    %7 = torch.aten.convolution %2, %1, %0, %3, %4, %5, %false, %6, %int1 : !torch.vtensor<[1,1,64,57],f32>, !torch.vtensor<[1,1,1,1],f32>, !torch.vtensor<[1],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,1,64,57],f32>
    %8 = torch.aten.squeeze.dim %7, %int0 : !torch.vtensor<[1,1,64,57],f32>, !torch.int -> !torch.vtensor<[1,64,57],f32>
    return %8 : !torch.vtensor<[1,64,57],f32>
  }
}
```

Note that the `padding` input to `aten.convolution` is 1-element whereas the lowerings expect them to be same as number of spatial dims in the input. This results in hitting the assertion in https://github.com/sahas3/torch-mlir/blob/dc7a1ff7d9134758128a637dca976f72c2366e59/lib/Conversion/TorchToLinalg/Utils.cpp#L78 for the `TorchToLinalg` pass. The failure modes for lowering to `tosa` and `stablehlo` are different but stems from the same root cause. 