### PR TITLE
Disable building STABLEHLO and specify USE_MATH_DEFINES for windows builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ macro(torch_mlir_enable_werror)
   endif()
 endmacro()
 
+if(MSVC)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 #-------------------------------------------------------------------------------
 # Configure out-of-tree vs in-tree build
 #-------------------------------------------------------------------------------

--- a/build_tools/python_deploy/build_windows_ci.sh
+++ b/build_tools/python_deploy/build_windows_ci.sh
@@ -14,6 +14,7 @@ cmake -GNinja -Bbuild \
   -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
   -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD" \
   -DPython3_EXECUTABLE="$(which python)" \
+  -DTORCH_MLIR_ENABLE_STABLEHLO=OFF \
   $GITHUB_WORKSPACE/externals/llvm-project/llvm
 
 cmake --build build --config Release


### PR DESCRIPTION
I'm trying to build python wheel for windows similar to as done for linux in https://github.com/llvm/torch-mlir-release/ however turns out the build process on windows is broken without the following fixes:

1. Building stablehlo for windows fails due to https://github.com/openxla/stablehlo/issues/1772 -- so disabling stablehlo in `build_windows_ci.sh` that will be used for building the python wheels. 

2. Add `USE_MATH_DEFINES` to resolve `torch-mlir\lib\Conversion\TorchOnnxToTorch\DefaultDomainGtoP.cpp(709): error C2065: 'M_LOG10E': undeclared identifier`