### PR TITLE
Remove variable used for only assertion

### DIFF
--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -4001,10 +4001,9 @@ OpFoldResult AtenSliceTensorOp::fold(FoldAdaptor adaptor) {
     limit = limit < 0 ? limit + inType.getSizes()[dimInt] : limit;
     limit = limit < 0 ? -1 : limit;
     limit = std::min(limit, inType.getSizes()[dimInt]);
-    bool validIterArgs =
-        (stride > 0 && begin < limit) || (stride < 0 && begin > limit);
-    assert(validIterArgs &&
-           "aten.slice.Tensor iteration args are statically invalid.");
+    assert((stride > 0 && begin < limit) ||
+           (stride < 0 && begin > limit) &&
+               "aten.slice.Tensor iteration args are statically invalid.");
 
     int64_t inputRank = inType.getSizes().size();
     llvm::SmallVector<int64_t> inputStrides(inputRank, 1);


### PR DESCRIPTION
Removes a boolean variable that is used only for an assertion, and inlines the condition into the assertion.