### PR TITLE
Fix Slice Folder OOB Crash and onnx.Shape lowering

### DIFF
--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -3998,6 +3998,7 @@ OpFoldResult AtenSliceTensorOp::fold(FoldAdaptor adaptor) {
     int64_t limit = end.getValue().getSExtValue();
     int64_t stride = step.getValue().getSExtValue();
     begin = begin < 0 ? begin + inType.getSizes()[dimInt] : begin;
+    begin = std::max(begin, (int64_t)0);
     limit = limit < 0 ? limit + inType.getSizes()[dimInt] : limit;
     limit = limit < 0 ? -1 : limit;
     limit = std::min(limit, inType.getSizes()[dimInt]);
@@ -4038,6 +4039,14 @@ OpFoldResult AtenSliceTensorOp::fold(FoldAdaptor adaptor) {
       }
     };
     recursiveIter(recursiveIter, 0, 0);
+    if ((int64_t)values.size() != count) {
+      emitError(
+          "Op has incorrect result shape for provided arguments.\nNum elements "
+          "present in slice: " +
+          std::to_string(values.size()) +
+          "\nNum elements implied by result type: " + std::to_string(count));
+      return nullptr;
+    }
     return DenseElementsAttr::get(outType.toBuiltinTensor(), values);
   }
 

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -3998,7 +3998,7 @@ OpFoldResult AtenSliceTensorOp::fold(FoldAdaptor adaptor) {
     int64_t limit = end.getValue().getSExtValue();
     int64_t stride = step.getValue().getSExtValue();
     begin = begin < 0 ? begin + inType.getSizes()[dimInt] : begin;
-    begin = std::max(begin, (int64_t)0);
+    begin = std::max<int64_t>(begin, 0);
     limit = limit < 0 ? limit + inType.getSizes()[dimInt] : limit;
     limit = limit < 0 ? -1 : limit;
     limit = std::min(limit, inType.getSizes()[dimInt]);
@@ -4039,7 +4039,7 @@ OpFoldResult AtenSliceTensorOp::fold(FoldAdaptor adaptor) {
       }
     };
     recursiveIter(recursiveIter, 0, 0);
-    if ((int64_t)values.size() != count) {
+    if (static_cast<int64_t>(values.size()) != count) {
       emitError(
           "Op has incorrect result shape for provided arguments.\nNum elements "
           "present in slice: " +

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -8817,6 +8817,8 @@ public:
       result = *squeezeTensorInfo;
     }
     rewriter.replaceOp(op, result);
+    result = rewriter.create<Torch::TensorStaticInfoCastOp>(loc, op.getType(),
+                                                            result);
     return success();
   }
 };

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -8817,8 +8817,6 @@ public:
       result = *squeezeTensorInfo;
     }
     rewriter.replaceOp(op, result);
-    result = rewriter.create<Torch::TensorStaticInfoCastOp>(loc, op.getType(),
-                                                            result);
     return success();
   }
 };

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -2330,6 +2330,32 @@ func.func @torch.aten.slice.tensor$fold_full_slice(%arg0: !torch.vtensor<[?],f32
   return %0 : !torch.vtensor<[?],f32>
 }
 
+//  CHECK-LABEL:    @torch.aten.slice.tensor$fold_oob_start
+//        CHECK:        %[[LIT:.*]] = torch.vtensor.literal(dense<[0, 1, 2]> : tensor<3xsi64>) : !torch.vtensor<[3],si64>
+//        CHECK:        return %[[LIT]] : !torch.vtensor<[3],si64>
+func.func @torch.aten.slice.tensor$fold_oob_start() -> !torch.vtensor<[3],si64> {
+  %0 = torch.vtensor.literal(dense<[0,1,2,3]> : tensor<4xsi64>) : !torch.vtensor<[4],si64>
+  %int1 = torch.constant.int 1
+  %int-1  = torch.constant.int -1
+  %int-10 = torch.constant.int -10
+  %int0 = torch.constant.int 0
+  %1 = torch.aten.slice.Tensor %0, %int0, %int-10, %int-1, %int1 : !torch.vtensor<[4], si64>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[3], si64>
+  return %1 : !torch.vtensor<[3],si64>
+}
+
+//  CHECK-LABEL:    @torch.aten.slice.tensor$nofold_invalid_shape
+//        CHECK:    %[[SLICE:.*]] = torch.aten.slice.Tensor
+//        CHECK:    return %[[SLICE]]
+func.func @torch.aten.slice.tensor$nofold_invalid_shape() -> !torch.vtensor<[4],si64> {
+  %0 = torch.vtensor.literal(dense<[0,1,2,3]> : tensor<4xsi64>) : !torch.vtensor<[4],si64>
+  %int1 = torch.constant.int 1
+  %int-1  = torch.constant.int -1
+  %int-10 = torch.constant.int -10
+  %int0 = torch.constant.int 0
+  %1 = torch.aten.slice.Tensor %0, %int0, %int-10, %int-1, %int1 : !torch.vtensor<[4], si64>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4], si64>
+  return %1 : !torch.vtensor<[4],si64>
+}
+
 //  CHECK-LABEL:    @torch.aten.slice.tensor$no_fold_step
 //        CHECK: torch.aten.slice.Tensor
 func.func @torch.aten.slice.tensor$no_fold_step(%arg0: !torch.vtensor<[?],f32>, %dim: !torch.int) -> !torch.vtensor<[?],f32> {


### PR DESCRIPTION
1. Clamps OOB start index to 0 in slice folder
2. Adds a more descriptive `emitError` in slice folder if the creation of the `DenseElementsAttr` would fail due to a bad result shape.
3. Fixes the `onnx.Shape` lowering to default to `inputRank` for `end` instead of `-1`. When `end==-1` the last element was missing when slicing. 