### PR TITLE
Add tosa::getConstTensor with int8_t template

### DIFF
--- a/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
@@ -370,6 +370,10 @@ getConstTensor<bool>(PatternRewriter &, Operation *, ArrayRef<bool> vec,
                      ArrayRef<int64_t> shape, std::optional<Type> dtype);
 
 template std::optional<Value>
+getConstTensor<int8_t>(PatternRewriter &, Operation *, ArrayRef<int8_t> vec,
+                       ArrayRef<int64_t> shape, std::optional<Type> dtype);
+
+template std::optional<Value>
 getConstTensor<int32_t>(PatternRewriter &, Operation *, ArrayRef<int32_t> vec,
                         ArrayRef<int64_t> shape, std::optional<Type> dtype);
 


### PR DESCRIPTION
Add tosa::getConstTensor with int8_t template used in https://github.com/llvm/torch-mlir/pull/3827