### PR TITLE
Create scatter op with unique indicies

### DIFF
--- a/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
+++ b/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
@@ -932,9 +932,12 @@ public:
     // 2.) `values` is mapped to `updates` in scatter op.
     // 3.) `input` is mapped to `original` in scatter op.
     bool invalidInputTypeFound = false;
+    // If accumulate == false, the behavior is undefined if the indicies aren't
+    // unique.
+    bool uniqueIndices = !accumulate;
     Value scatterOp = createTMTensorScatterOp(
         rewriter, loc, values, indices, input, indicesMap,
-        /*uniqueIndices=*/false,
+        /*uniqueIndices=*/uniqueIndices,
         [&](OpBuilder &b, Location loc, Value valuesElement,
             Value inputElement) {
           Value yieldValue = valuesElement;


### PR DESCRIPTION
For the op `index_put_`, if accumulate == false, the behavior is undefined if the indicies aren't unique (https://pytorch.org/docs/stable/generated/torch.Tensor.index_put_.html). So, when converting `AtenIndexPutHackedTwinOp` to a TMTensor scatter op, mark the indices as unique if when `accumulate == false`.

This should have no functional effect (unless users are relying on UB) and assuming unique indices has the benefit of unlocking better optimizations in further compiler stages.