### PR TITLE
Bump LLVM to 813f7c3

### DIFF
--- a/lib/Dialect/TorchConversion/Transforms/UnpackQuantTensor.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/UnpackQuantTensor.cpp
@@ -104,7 +104,8 @@ public:
       char mask = (1 << unpackedBitWidth) - 1;
       for (int b = 0; b < packRatio; b++) {
         newData[i * packRatio + b] =
-            APInt(unpackedBitWidth, (el & mask) >> (unpackedBitWidth * b));
+            APInt(unpackedBitWidth, (el & mask) >> (unpackedBitWidth * b),
+                  /*isSigned=*/false, /*implicitTrunc=*/true);
         mask = mask << unpackedBitWidth;
       }
     }


### PR DESCRIPTION
This commit bumps the llvm-project to https://github.com/llvm/llvm-project/commit/813f7c3820d00349fe23bfc6ba26159764541540.

This commit also updates the usage of `APInt` in `unpack-quant-tensor` pass by explicitly setting the `implicitTrunc` arg to be `True` whose default value was changed from True to False here https://github.com/llvm/llvm-project/commit/3494ee95902cef62f767489802e469c58a13ea04.