### PR TITLE
Fix a bug for large models in onnx importer.

### DIFF
--- a/python/torch_mlir/tools/import_onnx/__main__.py
+++ b/python/torch_mlir/tools/import_onnx/__main__.py
@@ -137,7 +137,7 @@ def load_onnx_model(args: argparse.Namespace) -> onnx.ModelProto:
     # Load the temp file and the external data.
     inferred_model = onnx.load(temp_inferred_file, load_external_data=False)
     data_dir = Path(input_dir if args.temp_dir is None else args.data_dir)
-    onnx.load_external_data_for_model(inferred_model, data_dir)
+    onnx.load_external_data_for_model(inferred_model, str(data_dir))
 
     # Remove the inferred shape file unless asked to keep it
     if not args.keep_temps:


### PR DESCRIPTION
The method `onnx.load_external_data_for_model` function does not admit `pathlib.Path` as an input.