### PR TITLE
[RFC] Apply the trait `NoMemoryEffect` to most `ReadOnly` ops

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -22,7 +22,8 @@
 def Torch_AtenHardtanhOp : Torch_Op<"aten.hardtanh", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::hardtanh : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -71,7 +72,8 @@ def Torch_AtenHardtanh_Op : Torch_Op<"aten.hardtanh_", [
 def Torch_AtenEluOp : Torch_Op<"aten.elu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::elu : (Tensor, Scalar, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -122,7 +124,8 @@ def Torch_AtenElu_Op : Torch_Op<"aten.elu_", [
 def Torch_AtenReluOp : Torch_Op<"aten.relu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::relu : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -167,7 +170,8 @@ def Torch_AtenRelu_Op : Torch_Op<"aten.relu_", [
 def Torch_AtenRelu6Op : Torch_Op<"aten.relu6", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::relu6 : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -212,7 +216,8 @@ def Torch_AtenRelu6_Op : Torch_Op<"aten.relu6_", [
 def Torch_AtenLeakyReluOp : Torch_Op<"aten.leaky_relu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::leaky_relu : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -259,7 +264,8 @@ def Torch_AtenLeakyRelu_Op : Torch_Op<"aten.leaky_relu_", [
 def Torch_AtenRreluOp : Torch_Op<"aten.rrelu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::rrelu : (Tensor, Scalar, Scalar, bool, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -312,7 +318,8 @@ def Torch_AtenRrelu_Op : Torch_Op<"aten.rrelu_", [
 def Torch_AtenRreluWithNoiseOp : Torch_Op<"aten.rrelu_with_noise", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::rrelu_with_noise : (Tensor, Tensor, Scalar, Scalar, bool, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -367,7 +374,8 @@ def Torch_AtenRreluWithNoise_Op : Torch_Op<"aten.rrelu_with_noise_", [
 def Torch_AtenCeluOp : Torch_Op<"aten.celu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::celu : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -414,7 +422,8 @@ def Torch_AtenCelu_Op : Torch_Op<"aten.celu_", [
 def Torch_AtenSeluOp : Torch_Op<"aten.selu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::selu : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -459,7 +468,8 @@ def Torch_AtenSelu_Op : Torch_Op<"aten.selu_", [
 def Torch_AtenSigmoidOp : Torch_Op<"aten.sigmoid", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sigmoid : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -504,7 +514,8 @@ def Torch_AtenSigmoid_Op : Torch_Op<"aten.sigmoid_", [
 def Torch_AtenSinhOp : Torch_Op<"aten.sinh", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sinh : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -549,7 +560,8 @@ def Torch_AtenSinh_Op : Torch_Op<"aten.sinh_", [
 def Torch_AtenSgnOp : Torch_Op<"aten.sgn", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sgn : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -594,7 +606,8 @@ def Torch_AtenSgn_Op : Torch_Op<"aten.sgn_", [
 def Torch_AtenHardsigmoidOp : Torch_Op<"aten.hardsigmoid", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::hardsigmoid : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -639,7 +652,8 @@ def Torch_AtenHardsigmoid_Op : Torch_Op<"aten.hardsigmoid_", [
 def Torch_AtenHardswishOp : Torch_Op<"aten.hardswish", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::hardswish : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -684,7 +698,8 @@ def Torch_AtenHardswish_Op : Torch_Op<"aten.hardswish_", [
 def Torch_AtenErfOp : Torch_Op<"aten.erf", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::erf : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -729,7 +744,8 @@ def Torch_AtenErf_Op : Torch_Op<"aten.erf_", [
 def Torch_AtenErfinvOp : Torch_Op<"aten.erfinv", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::erfinv : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -774,7 +790,8 @@ def Torch_AtenErfinv_Op : Torch_Op<"aten.erfinv_", [
 def Torch_AtenSiluOp : Torch_Op<"aten.silu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::silu : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -819,7 +836,8 @@ def Torch_AtenSilu_Op : Torch_Op<"aten.silu_", [
 def Torch_AtenSinOp : Torch_Op<"aten.sin", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sin : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -864,7 +882,8 @@ def Torch_AtenSin_Op : Torch_Op<"aten.sin_", [
 def Torch_AtenAsinOp : Torch_Op<"aten.asin", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::asin : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -909,7 +928,8 @@ def Torch_AtenAsin_Op : Torch_Op<"aten.asin_", [
 def Torch_AtenAsinhOp : Torch_Op<"aten.asinh", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::asinh : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -954,7 +974,8 @@ def Torch_AtenAsinh_Op : Torch_Op<"aten.asinh_", [
 def Torch_AtenExpOp : Torch_Op<"aten.exp", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::exp : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -999,7 +1020,8 @@ def Torch_AtenExp_Op : Torch_Op<"aten.exp_", [
 def Torch_AtenExp2Op : Torch_Op<"aten.exp2", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::exp2 : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1044,7 +1066,8 @@ def Torch_AtenExp2_Op : Torch_Op<"aten.exp2_", [
 def Torch_AtenExpm1Op : Torch_Op<"aten.expm1", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::expm1 : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1089,7 +1112,8 @@ def Torch_AtenExpm1_Op : Torch_Op<"aten.expm1_", [
 def Torch_AtenCosOp : Torch_Op<"aten.cos", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cos : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1134,7 +1158,8 @@ def Torch_AtenCos_Op : Torch_Op<"aten.cos_", [
 def Torch_AtenCoshOp : Torch_Op<"aten.cosh", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cosh : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1179,7 +1204,8 @@ def Torch_AtenCosh_Op : Torch_Op<"aten.cosh_", [
 def Torch_AtenAcosOp : Torch_Op<"aten.acos", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::acos : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1224,7 +1250,8 @@ def Torch_AtenAcos_Op : Torch_Op<"aten.acos_", [
 def Torch_AtenAcoshOp : Torch_Op<"aten.acosh", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::acosh : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1269,7 +1296,8 @@ def Torch_AtenAcosh_Op : Torch_Op<"aten.acosh_", [
 def Torch_AtenTanOp : Torch_Op<"aten.tan", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tan : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1314,7 +1342,8 @@ def Torch_AtenTan_Op : Torch_Op<"aten.tan_", [
 def Torch_AtenTanhOp : Torch_Op<"aten.tanh", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tanh : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1359,7 +1388,8 @@ def Torch_AtenTanh_Op : Torch_Op<"aten.tanh_", [
 def Torch_AtenAtanOp : Torch_Op<"aten.atan", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::atan : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1404,7 +1434,8 @@ def Torch_AtenAtan_Op : Torch_Op<"aten.atan_", [
 def Torch_AtenAtanhOp : Torch_Op<"aten.atanh", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::atanh : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1449,7 +1480,8 @@ def Torch_AtenAtanh_Op : Torch_Op<"aten.atanh_", [
 def Torch_AtenAtan2Op : Torch_Op<"aten.atan2", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::atan2 : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1496,7 +1528,8 @@ def Torch_AtenAtan2_Op : Torch_Op<"aten.atan2_", [
 def Torch_AtenNegOp : Torch_Op<"aten.neg", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::neg : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1541,7 +1574,8 @@ def Torch_AtenNeg_Op : Torch_Op<"aten.neg_", [
 def Torch_AtenFracOp : Torch_Op<"aten.frac", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::frac : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1586,7 +1620,8 @@ def Torch_AtenFrac_Op : Torch_Op<"aten.frac_", [
 def Torch_AtenBitwiseNotOp : Torch_Op<"aten.bitwise_not", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bitwise_not : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1631,7 +1666,8 @@ def Torch_AtenBitwiseNot_Op : Torch_Op<"aten.bitwise_not_", [
 def Torch_AtenDivTensorOp : Torch_Op<"aten.div.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::div.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1678,7 +1714,8 @@ def Torch_AtenDiv_TensorOp : Torch_Op<"aten.div_.Tensor", [
 def Torch_AtenLogicalOrOp : Torch_Op<"aten.logical_or", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::logical_or : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1725,7 +1762,8 @@ def Torch_AtenLogicalOr_Op : Torch_Op<"aten.logical_or_", [
 def Torch_AtenLogicalAndOp : Torch_Op<"aten.logical_and", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::logical_and : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1772,7 +1810,8 @@ def Torch_AtenLogicalAnd_Op : Torch_Op<"aten.logical_and_", [
 def Torch_AtenLogicalXorOp : Torch_Op<"aten.logical_xor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::logical_xor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1819,7 +1858,8 @@ def Torch_AtenLogicalXor_Op : Torch_Op<"aten.logical_xor_", [
 def Torch_AtenLogicalNotOp : Torch_Op<"aten.logical_not", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::logical_not : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1864,7 +1904,8 @@ def Torch_AtenLogicalNot_Op : Torch_Op<"aten.logical_not_", [
 def Torch_AtenLerpTensorOp : Torch_Op<"aten.lerp.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::lerp.Tensor : (Tensor, Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -1913,7 +1954,8 @@ def Torch_AtenLerp_TensorOp : Torch_Op<"aten.lerp_.Tensor", [
 def Torch_AtenLerpScalarOp : Torch_Op<"aten.lerp.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::lerp.Scalar : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -1962,7 +2004,8 @@ def Torch_AtenLerp_ScalarOp : Torch_Op<"aten.lerp_.Scalar", [
 def Torch_AtenGtTensorOp : Torch_Op<"aten.gt.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::gt.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2009,7 +2052,8 @@ def Torch_AtenGt_TensorOp : Torch_Op<"aten.gt_.Tensor", [
 def Torch_AtenGeTensorOp : Torch_Op<"aten.ge.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ge.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2056,7 +2100,8 @@ def Torch_AtenGe_TensorOp : Torch_Op<"aten.ge_.Tensor", [
 def Torch_AtenLtTensorOp : Torch_Op<"aten.lt.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::lt.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2103,7 +2148,8 @@ def Torch_AtenLt_TensorOp : Torch_Op<"aten.lt_.Tensor", [
 def Torch_AtenLeTensorOp : Torch_Op<"aten.le.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::le.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2150,7 +2196,8 @@ def Torch_AtenLe_TensorOp : Torch_Op<"aten.le_.Tensor", [
 def Torch_AtenNeTensorOp : Torch_Op<"aten.ne.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ne.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2197,7 +2244,8 @@ def Torch_AtenNe_TensorOp : Torch_Op<"aten.ne_.Tensor", [
 def Torch_AtenDivScalarOp : Torch_Op<"aten.div.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::div.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -2244,7 +2292,8 @@ def Torch_AtenDiv_ScalarOp : Torch_Op<"aten.div_.Scalar", [
 def Torch_AtenFmodScalarOp : Torch_Op<"aten.fmod.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fmod.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -2291,7 +2340,8 @@ def Torch_AtenFmod_ScalarOp : Torch_Op<"aten.fmod_.Scalar", [
 def Torch_AtenMaskedFillScalarOp : Torch_Op<"aten.masked_fill.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::masked_fill.Scalar : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -2340,7 +2390,8 @@ def Torch_AtenMaskedFill_ScalarOp : Torch_Op<"aten.masked_fill_.Scalar", [
 def Torch_AtenClampOp : Torch_Op<"aten.clamp", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::clamp : (Tensor, Scalar?, Scalar?) -> (Tensor)`";
   let arguments = (ins
@@ -2389,7 +2440,8 @@ def Torch_AtenClamp_Op : Torch_Op<"aten.clamp_", [
 def Torch_AtenClampTensorOp : Torch_Op<"aten.clamp.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::clamp.Tensor : (Tensor, Tensor?, Tensor?) -> (Tensor)`";
   let arguments = (ins
@@ -2438,7 +2490,8 @@ def Torch_AtenClamp_TensorOp : Torch_Op<"aten.clamp_.Tensor", [
 def Torch_AtenClampMinOp : Torch_Op<"aten.clamp_min", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::clamp_min : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -2485,7 +2538,8 @@ def Torch_AtenClampMin_Op : Torch_Op<"aten.clamp_min_", [
 def Torch_AtenClampMinTensorOp : Torch_Op<"aten.clamp_min.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::clamp_min.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2532,7 +2586,8 @@ def Torch_AtenClampMin_TensorOp : Torch_Op<"aten.clamp_min_.Tensor", [
 def Torch_AtenClampMaxOp : Torch_Op<"aten.clamp_max", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::clamp_max : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -2579,7 +2634,8 @@ def Torch_AtenClampMax_Op : Torch_Op<"aten.clamp_max_", [
 def Torch_AtenClampMaxTensorOp : Torch_Op<"aten.clamp_max.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::clamp_max.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2626,7 +2682,8 @@ def Torch_AtenClampMax_TensorOp : Torch_Op<"aten.clamp_max_.Tensor", [
 def Torch_AtenLog2Op : Torch_Op<"aten.log2", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::log2 : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2671,7 +2728,8 @@ def Torch_AtenLog2_Op : Torch_Op<"aten.log2_", [
 def Torch_AtenLog10Op : Torch_Op<"aten.log10", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::log10 : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2716,7 +2774,8 @@ def Torch_AtenLog10_Op : Torch_Op<"aten.log10_", [
 def Torch_AtenSqrtOp : Torch_Op<"aten.sqrt", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sqrt : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2761,7 +2820,8 @@ def Torch_AtenSqrt_Op : Torch_Op<"aten.sqrt_", [
 def Torch_AtenLog1pOp : Torch_Op<"aten.log1p", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::log1p : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2806,7 +2866,8 @@ def Torch_AtenLog1p_Op : Torch_Op<"aten.log1p_", [
 def Torch_AtenLogitOp : Torch_Op<"aten.logit", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::logit : (Tensor, float?) -> (Tensor)`";
   let arguments = (ins
@@ -2853,7 +2914,8 @@ def Torch_AtenLogit_Op : Torch_Op<"aten.logit_", [
 def Torch_AtenRsqrtOp : Torch_Op<"aten.rsqrt", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::rsqrt : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2898,7 +2960,8 @@ def Torch_AtenRsqrt_Op : Torch_Op<"aten.rsqrt_", [
 def Torch_AtenAbsOp : Torch_Op<"aten.abs", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::abs : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2943,7 +3006,8 @@ def Torch_AtenAbs_Op : Torch_Op<"aten.abs_", [
 def Torch_AtenReciprocalOp : Torch_Op<"aten.reciprocal", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::reciprocal : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -2988,7 +3052,8 @@ def Torch_AtenReciprocal_Op : Torch_Op<"aten.reciprocal_", [
 def Torch_AtenBitwiseAndTensorOp : Torch_Op<"aten.bitwise_and.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bitwise_and.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3035,7 +3100,8 @@ def Torch_AtenBitwiseAnd_TensorOp : Torch_Op<"aten.bitwise_and_.Tensor", [
 def Torch_AtenBitwiseAndScalarOp : Torch_Op<"aten.bitwise_and.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bitwise_and.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -3082,7 +3148,8 @@ def Torch_AtenBitwiseAnd_ScalarOp : Torch_Op<"aten.bitwise_and_.Scalar", [
 def Torch_AtenBitwiseOrTensorOp : Torch_Op<"aten.bitwise_or.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bitwise_or.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3129,7 +3196,8 @@ def Torch_AtenBitwiseOr_TensorOp : Torch_Op<"aten.bitwise_or_.Tensor", [
 def Torch_AtenBitwiseXorTensorOp : Torch_Op<"aten.bitwise_xor.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bitwise_xor.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3176,7 +3244,8 @@ def Torch_AtenBitwiseXor_TensorOp : Torch_Op<"aten.bitwise_xor_.Tensor", [
 def Torch_AtenBitwiseLeftShiftTensorOp : Torch_Op<"aten.bitwise_left_shift.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bitwise_left_shift.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3223,7 +3292,8 @@ def Torch_AtenBitwiseLeftShift_TensorOp : Torch_Op<"aten.bitwise_left_shift_.Ten
 def Torch_AtenBitwiseRightShiftTensorOp : Torch_Op<"aten.bitwise_right_shift.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bitwise_right_shift.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3270,7 +3340,8 @@ def Torch_AtenBitwiseRightShift_TensorOp : Torch_Op<"aten.bitwise_right_shift_.T
 def Torch_AtenThresholdOp : Torch_Op<"aten.threshold", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::threshold : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -3319,7 +3390,8 @@ def Torch_AtenThreshold_Op : Torch_Op<"aten.threshold_", [
 def Torch_AtenSquareOp : Torch_Op<"aten.square", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::square : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3364,7 +3436,8 @@ def Torch_AtenSquare_Op : Torch_Op<"aten.square_", [
 def Torch_AtenZeroOp : Torch_Op<"aten.zero", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::zero : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3409,7 +3482,8 @@ def Torch_AtenZero_Op : Torch_Op<"aten.zero_", [
 def Torch_AtenFillScalarOp : Torch_Op<"aten.fill.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fill.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -3456,7 +3530,8 @@ def Torch_AtenFill_ScalarOp : Torch_Op<"aten.fill_.Scalar", [
 def Torch_AtenFillTensorOp : Torch_Op<"aten.fill.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fill.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3503,7 +3578,8 @@ def Torch_AtenFill_TensorOp : Torch_Op<"aten.fill_.Tensor", [
 def Torch_AtenCopysignTensorOp : Torch_Op<"aten.copysign.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::copysign.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3549,7 +3625,8 @@ def Torch_AtenCopysign_TensorOp : Torch_Op<"aten.copysign_.Tensor", [
 
 def Torch_AtenUnsqueezeOp : Torch_Op<"aten.unsqueeze", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::unsqueeze : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -3597,7 +3674,8 @@ def Torch_AtenUnsqueeze_Op : Torch_Op<"aten.unsqueeze_", [
 def Torch_AtenDivTensorModeOp : Torch_Op<"aten.div.Tensor_mode", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::div.Tensor_mode : (Tensor, Tensor, str?) -> (Tensor)`";
   let arguments = (ins
@@ -3648,7 +3726,8 @@ def Torch_AtenDiv_TensorModeOp : Torch_Op<"aten.div_.Tensor_mode", [
 def Torch_AtenDivScalarModeOp : Torch_Op<"aten.div.Scalar_mode", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::div.Scalar_mode : (Tensor, Scalar, str?) -> (Tensor)`";
   let arguments = (ins
@@ -3698,7 +3777,8 @@ def Torch_AtenDiv_ScalarModeOp : Torch_Op<"aten.div_.Scalar_mode", [
 def Torch_AtenMulTensorOp : Torch_Op<"aten.mul.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mul.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -3747,7 +3827,8 @@ def Torch_AtenMul_TensorOp : Torch_Op<"aten.mul_.Tensor", [
 def Torch_AtenAddTensorOp : Torch_Op<"aten.add.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::add.Tensor : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -3798,7 +3879,8 @@ def Torch_AtenAdd_TensorOp : Torch_Op<"aten.add_.Tensor", [
 def Torch_AtenSubTensorOp : Torch_Op<"aten.sub.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sub.Tensor : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -3849,7 +3931,8 @@ def Torch_AtenSub_TensorOp : Torch_Op<"aten.sub_.Tensor", [
 def Torch_AtenAddScalarOp : Torch_Op<"aten.add.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::add.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -3900,7 +3983,8 @@ def Torch_AtenAdd_ScalarOp : Torch_Op<"aten.add_.Scalar", [
 def Torch_AtenSubScalarOp : Torch_Op<"aten.sub.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sub.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -3951,7 +4035,8 @@ def Torch_AtenSub_ScalarOp : Torch_Op<"aten.sub_.Scalar", [
 def Torch_AtenMulScalarOp : Torch_Op<"aten.mul.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mul.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -4000,7 +4085,8 @@ def Torch_AtenMul_ScalarOp : Torch_Op<"aten.mul_.Scalar", [
 def Torch_AtenLdexpTensorOp : Torch_Op<"aten.ldexp.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ldexp.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4024,7 +4110,8 @@ def Torch_AtenLdexpTensorOp : Torch_Op<"aten.ldexp.Tensor", [
 def Torch_AtenSignbitOp : Torch_Op<"aten.signbit", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::signbit : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4047,7 +4134,8 @@ def Torch_AtenSignbitOp : Torch_Op<"aten.signbit", [
 def Torch_AtenEqTensorOp : Torch_Op<"aten.eq.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eq.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4095,7 +4183,8 @@ def Torch_AtenEq_TensorOp : Torch_Op<"aten.eq_.Tensor", [
 def Torch_AtenLeScalarOp : Torch_Op<"aten.le.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::le.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -4143,7 +4232,8 @@ def Torch_AtenLe_ScalarOp : Torch_Op<"aten.le_.Scalar", [
 def Torch_AtenLtScalarOp : Torch_Op<"aten.lt.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::lt.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -4191,7 +4281,8 @@ def Torch_AtenLt_ScalarOp : Torch_Op<"aten.lt_.Scalar", [
 def Torch_AtenGtScalarOp : Torch_Op<"aten.gt.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::gt.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -4239,7 +4330,8 @@ def Torch_AtenGt_ScalarOp : Torch_Op<"aten.gt_.Scalar", [
 def Torch_AtenGeScalarOp : Torch_Op<"aten.ge.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ge.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -4287,7 +4379,8 @@ def Torch_AtenGe_ScalarOp : Torch_Op<"aten.ge_.Scalar", [
 def Torch_AtenEqScalarOp : Torch_Op<"aten.eq.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eq.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -4335,7 +4428,8 @@ def Torch_AtenEq_ScalarOp : Torch_Op<"aten.eq_.Scalar", [
 def Torch_AtenNeScalarOp : Torch_Op<"aten.ne.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ne.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -4383,7 +4477,8 @@ def Torch_AtenNe_ScalarOp : Torch_Op<"aten.ne_.Scalar", [
 def Torch_AtenLogOp : Torch_Op<"aten.log", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::log : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4429,7 +4524,8 @@ def Torch_AtenLog_Op : Torch_Op<"aten.log_", [
 def Torch_AtenFloorOp : Torch_Op<"aten.floor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::floor : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4475,7 +4571,8 @@ def Torch_AtenFloor_Op : Torch_Op<"aten.floor_", [
 def Torch_AtenCeilOp : Torch_Op<"aten.ceil", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ceil : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4521,7 +4618,8 @@ def Torch_AtenCeil_Op : Torch_Op<"aten.ceil_", [
 def Torch_AtenRoundOp : Torch_Op<"aten.round", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::round : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4567,7 +4665,8 @@ def Torch_AtenRound_Op : Torch_Op<"aten.round_", [
 def Torch_AtenTruncOp : Torch_Op<"aten.trunc", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::trunc : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4613,7 +4712,8 @@ def Torch_AtenTrunc_Op : Torch_Op<"aten.trunc_", [
 def Torch_AtenSignOp : Torch_Op<"aten.sign", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sign : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4659,7 +4759,8 @@ def Torch_AtenSign_Op : Torch_Op<"aten.sign_", [
 def Torch_AtenMaskedFillTensorOp : Torch_Op<"aten.masked_fill.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::masked_fill.Tensor : (Tensor, Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -4709,7 +4810,8 @@ def Torch_AtenMaskedFill_TensorOp : Torch_Op<"aten.masked_fill_.Tensor", [
 def Torch_AtenAddcmulOp : Torch_Op<"aten.addcmul", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::addcmul : (Tensor, Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -4760,7 +4862,8 @@ def Torch_AtenAddcmul_Op : Torch_Op<"aten.addcmul_", [
 def Torch_AtenAddcdivOp : Torch_Op<"aten.addcdiv", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::addcdiv : (Tensor, Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -4811,7 +4914,8 @@ def Torch_AtenAddcdiv_Op : Torch_Op<"aten.addcdiv_", [
 def Torch_AtenFakeQuantizePerTensorAffineOp : Torch_Op<"aten.fake_quantize_per_tensor_affine", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fake_quantize_per_tensor_affine : (Tensor, float, int, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -4838,7 +4942,8 @@ def Torch_AtenFakeQuantizePerTensorAffineOp : Torch_Op<"aten.fake_quantize_per_t
 def Torch_AtenFakeQuantizePerTensorAffineCachemaskOp : Torch_Op<"aten.fake_quantize_per_tensor_affine_cachemask", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fake_quantize_per_tensor_affine_cachemask : (Tensor, float, int, int, int) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -4866,7 +4971,8 @@ def Torch_AtenFakeQuantizePerTensorAffineCachemaskOp : Torch_Op<"aten.fake_quant
 def Torch_AtenFakeQuantizePerTensorAffineTensorQparamsOp : Torch_Op<"aten.fake_quantize_per_tensor_affine.tensor_qparams", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fake_quantize_per_tensor_affine.tensor_qparams : (Tensor, Tensor, Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -4893,7 +4999,8 @@ def Torch_AtenFakeQuantizePerTensorAffineTensorQparamsOp : Torch_Op<"aten.fake_q
 def Torch_Aten_FakeQuantizePerTensorAffineCachemaskTensorQparamsOp : Torch_Op<"aten._fake_quantize_per_tensor_affine_cachemask_tensor_qparams", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_fake_quantize_per_tensor_affine_cachemask_tensor_qparams : (Tensor, Tensor, Tensor, Tensor, int, int) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -4922,7 +5029,8 @@ def Torch_Aten_FakeQuantizePerTensorAffineCachemaskTensorQparamsOp : Torch_Op<"a
 def Torch_AtenFakeQuantizePerChannelAffineOp : Torch_Op<"aten.fake_quantize_per_channel_affine", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fake_quantize_per_channel_affine : (Tensor, Tensor, Tensor, int, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -4950,7 +5058,8 @@ def Torch_AtenFakeQuantizePerChannelAffineOp : Torch_Op<"aten.fake_quantize_per_
 def Torch_AtenFakeQuantizePerChannelAffineCachemaskOp : Torch_Op<"aten.fake_quantize_per_channel_affine_cachemask", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fake_quantize_per_channel_affine_cachemask : (Tensor, Tensor, Tensor, int, int, int) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -4979,7 +5088,8 @@ def Torch_AtenFakeQuantizePerChannelAffineCachemaskOp : Torch_Op<"aten.fake_quan
 def Torch_AtenIsfiniteOp : Torch_Op<"aten.isfinite", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::isfinite : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5002,7 +5112,8 @@ def Torch_AtenIsfiniteOp : Torch_Op<"aten.isfinite", [
 def Torch_AtenMaximumOp : Torch_Op<"aten.maximum", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::maximum : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5026,7 +5137,8 @@ def Torch_AtenMaximumOp : Torch_Op<"aten.maximum", [
 def Torch_AtenMinimumOp : Torch_Op<"aten.minimum", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::minimum : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5050,7 +5162,8 @@ def Torch_AtenMinimumOp : Torch_Op<"aten.minimum", [
 def Torch_AtenFmaxOp : Torch_Op<"aten.fmax", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fmax : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5074,7 +5187,8 @@ def Torch_AtenFmaxOp : Torch_Op<"aten.fmax", [
 def Torch_AtenFminOp : Torch_Op<"aten.fmin", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fmin : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5098,7 +5212,8 @@ def Torch_AtenFminOp : Torch_Op<"aten.fmin", [
 def Torch_AtenMishOp : Torch_Op<"aten.mish", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mish : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5121,7 +5236,8 @@ def Torch_AtenMishOp : Torch_Op<"aten.mish", [
 def Torch_AtenXlogyTensorOp : Torch_Op<"aten.xlogy.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::xlogy.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5145,7 +5261,8 @@ def Torch_AtenXlogyTensorOp : Torch_Op<"aten.xlogy.Tensor", [
 def Torch_AtenRsubScalarOp : Torch_Op<"aten.rsub.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::rsub.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -5172,7 +5289,8 @@ def Torch_AtenRsubScalarOp : Torch_Op<"aten.rsub.Scalar", [
 def Torch_AtenGeluOp : Torch_Op<"aten.gelu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::gelu : (Tensor, str) -> (Tensor)`";
   let arguments = (ins
@@ -5196,7 +5314,8 @@ def Torch_AtenGeluOp : Torch_Op<"aten.gelu", [
 def Torch_AtenPowTensorScalarOp : Torch_Op<"aten.pow.Tensor_Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::pow.Tensor_Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -5220,7 +5339,8 @@ def Torch_AtenPowTensorScalarOp : Torch_Op<"aten.pow.Tensor_Scalar", [
 def Torch_AtenPowTensorTensorOp : Torch_Op<"aten.pow.Tensor_Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::pow.Tensor_Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5244,7 +5364,8 @@ def Torch_AtenPowTensorTensorOp : Torch_Op<"aten.pow.Tensor_Tensor", [
 def Torch_AtenPowScalarOp : Torch_Op<"aten.pow.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::pow.Scalar : (Scalar, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5268,7 +5389,8 @@ def Torch_AtenPowScalarOp : Torch_Op<"aten.pow.Scalar", [
 def Torch_AtenFloatPowerTensorTensorOp : Torch_Op<"aten.float_power.Tensor_Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::float_power.Tensor_Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5292,7 +5414,8 @@ def Torch_AtenFloatPowerTensorTensorOp : Torch_Op<"aten.float_power.Tensor_Tenso
 def Torch_AtenThresholdBackwardOp : Torch_Op<"aten.threshold_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::threshold_backward : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -5317,7 +5440,8 @@ def Torch_AtenThresholdBackwardOp : Torch_Op<"aten.threshold_backward", [
 def Torch_AtenFloorDivideOp : Torch_Op<"aten.floor_divide", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::floor_divide : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5341,7 +5465,8 @@ def Torch_AtenFloorDivideOp : Torch_Op<"aten.floor_divide", [
 def Torch_AtenSoftplusOp : Torch_Op<"aten.softplus", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::softplus : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -5366,7 +5491,8 @@ def Torch_AtenSoftplusOp : Torch_Op<"aten.softplus", [
 def Torch_AtenPreluOp : Torch_Op<"aten.prelu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::prelu : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5390,7 +5516,8 @@ def Torch_AtenPreluOp : Torch_Op<"aten.prelu", [
 def Torch_AtenRad2degOp : Torch_Op<"aten.rad2deg", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::rad2deg : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5413,7 +5540,8 @@ def Torch_AtenRad2degOp : Torch_Op<"aten.rad2deg", [
 def Torch_AtenComplexOp : Torch_Op<"aten.complex", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::complex : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5436,7 +5564,8 @@ def Torch_AtenComplexOp : Torch_Op<"aten.complex", [
 
 def Torch_AtenRealOp : Torch_Op<"aten.real", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::real : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5458,7 +5587,8 @@ def Torch_AtenRealOp : Torch_Op<"aten.real", [
 
 def Torch_AtenImagOp : Torch_Op<"aten.imag", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::imag : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5480,7 +5610,8 @@ def Torch_AtenImagOp : Torch_Op<"aten.imag", [
 
 def Torch_AtenViewAsComplexOp : Torch_Op<"aten.view_as_complex", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::view_as_complex : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5502,7 +5633,8 @@ def Torch_AtenViewAsComplexOp : Torch_Op<"aten.view_as_complex", [
 
 def Torch_AtenViewAsRealOp : Torch_Op<"aten.view_as_real", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::view_as_real : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5525,7 +5657,8 @@ def Torch_AtenViewAsRealOp : Torch_Op<"aten.view_as_real", [
 def Torch_AtenIscloseOp : Torch_Op<"aten.isclose", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::isclose : (Tensor, Tensor, float, float, bool) -> (Tensor)`";
   let arguments = (ins
@@ -5552,7 +5685,8 @@ def Torch_AtenIscloseOp : Torch_Op<"aten.isclose", [
 def Torch_AtenGluOp : Torch_Op<"aten.glu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::glu : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -5576,7 +5710,8 @@ def Torch_AtenGluOp : Torch_Op<"aten.glu", [
 def Torch_AtenLogSigmoidOp : Torch_Op<"aten.log_sigmoid", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::log_sigmoid : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5599,7 +5734,8 @@ def Torch_AtenLogSigmoidOp : Torch_Op<"aten.log_sigmoid", [
 def Torch_AtenHardshrinkOp : Torch_Op<"aten.hardshrink", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::hardshrink : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -5623,7 +5759,8 @@ def Torch_AtenHardshrinkOp : Torch_Op<"aten.hardshrink", [
 def Torch_AtenSoftshrinkOp : Torch_Op<"aten.softshrink", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::softshrink : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -5647,7 +5784,8 @@ def Torch_AtenSoftshrinkOp : Torch_Op<"aten.softshrink", [
 def Torch_AtenPolarOp : Torch_Op<"aten.polar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::polar : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -5671,7 +5809,8 @@ def Torch_AtenPolarOp : Torch_Op<"aten.polar", [
 def Torch_AtenUnbindCopyIntOp : Torch_Op<"aten.unbind_copy.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::unbind_copy.int : (Tensor, int) -> (Tensor[])`";
   let arguments = (ins
@@ -5695,7 +5834,8 @@ def Torch_AtenUnbindCopyIntOp : Torch_Op<"aten.unbind_copy.int", [
 def Torch_AtenSplitCopyTensorOp : Torch_Op<"aten.split_copy.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::split_copy.Tensor : (Tensor, int, int) -> (Tensor[])`";
   let arguments = (ins
@@ -5720,7 +5860,8 @@ def Torch_AtenSplitCopyTensorOp : Torch_Op<"aten.split_copy.Tensor", [
 def Torch_AtenSplitWithSizesCopyOp : Torch_Op<"aten.split_with_sizes_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::split_with_sizes_copy : (Tensor, int[], int) -> (Tensor[])`";
   let arguments = (ins
@@ -5745,7 +5886,8 @@ def Torch_AtenSplitWithSizesCopyOp : Torch_Op<"aten.split_with_sizes_copy", [
 def Torch_AtenUniformOp : Torch_Op<"aten.uniform", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::uniform : (Tensor, float, float, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -5796,7 +5938,8 @@ def Torch_AtenUniform_Op : Torch_Op<"aten.uniform_", [
 def Torch_AtenRandLikeOp : Torch_Op<"aten.rand_like", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::rand_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -5824,7 +5967,8 @@ def Torch_AtenRandLikeOp : Torch_Op<"aten.rand_like", [
 def Torch_AtenRandOp : Torch_Op<"aten.rand", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::rand : (int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -5851,7 +5995,8 @@ def Torch_AtenRandOp : Torch_Op<"aten.rand", [
 def Torch_AtenBernoulliOp : Torch_Op<"aten.bernoulli", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bernoulli : (Tensor, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -5898,7 +6043,8 @@ def Torch_AtenBernoulli_FloatOp : Torch_Op<"aten.bernoulli_.float", [
 def Torch_AtenBernoulliPOp : Torch_Op<"aten.bernoulli.p", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bernoulli.p : (Tensor, float, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -5923,7 +6069,8 @@ def Torch_AtenBernoulliPOp : Torch_Op<"aten.bernoulli.p", [
 def Torch_AtenExponentialOp : Torch_Op<"aten.exponential", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::exponential : (Tensor, float, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -5948,7 +6095,8 @@ def Torch_AtenExponentialOp : Torch_Op<"aten.exponential", [
 def Torch_AtenMultinomialOp : Torch_Op<"aten.multinomial", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::multinomial : (Tensor, int, bool, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -5974,7 +6122,8 @@ def Torch_AtenMultinomialOp : Torch_Op<"aten.multinomial", [
 def Torch_AtenRandintLowOp : Torch_Op<"aten.randint.low", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::randint.low : (int, int, int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -6003,7 +6152,8 @@ def Torch_AtenRandintLowOp : Torch_Op<"aten.randint.low", [
 def Torch_AtenRandintOp : Torch_Op<"aten.randint", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::randint : (int, int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -6031,7 +6181,8 @@ def Torch_AtenRandintOp : Torch_Op<"aten.randint", [
 def Torch_AtenBernoulliTensorOp : Torch_Op<"aten.bernoulli.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bernoulli.Tensor : (Tensor, Tensor, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -6080,7 +6231,8 @@ def Torch_AtenBernoulli_TensorOp : Torch_Op<"aten.bernoulli_.Tensor", [
 def Torch_AtenRandnOp : Torch_Op<"aten.randn", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::randn : (int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -6107,7 +6259,8 @@ def Torch_AtenRandnOp : Torch_Op<"aten.randn", [
 def Torch_AtenRandnGeneratorOp : Torch_Op<"aten.randn.generator", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::randn.generator : (int[], Generator?, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -6135,7 +6288,8 @@ def Torch_AtenRandnGeneratorOp : Torch_Op<"aten.randn.generator", [
 def Torch_AtenRandnLikeOp : Torch_Op<"aten.randn_like", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::randn_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -6163,7 +6317,8 @@ def Torch_AtenRandnLikeOp : Torch_Op<"aten.randn_like", [
 def Torch_AtenRandomOp : Torch_Op<"aten.random", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::random : (Tensor, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -6187,7 +6342,8 @@ def Torch_AtenRandomOp : Torch_Op<"aten.random", [
 def Torch_AtenRandomFromOp : Torch_Op<"aten.random.from", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::random.from : (Tensor, int, int?, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -6213,7 +6369,8 @@ def Torch_AtenRandomFromOp : Torch_Op<"aten.random.from", [
 def Torch_AtenTriuOp : Torch_Op<"aten.triu", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::triu : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -6260,7 +6417,8 @@ def Torch_AtenTriu_Op : Torch_Op<"aten.triu_", [
 def Torch_AtenTrilOp : Torch_Op<"aten.tril", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tril : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -6307,7 +6465,8 @@ def Torch_AtenTril_Op : Torch_Op<"aten.tril_", [
 def Torch_AtenIndexPutOp : Torch_Op<"aten.index_put", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::index_put : (Tensor, Tensor?[], Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -6358,7 +6517,8 @@ def Torch_AtenIndexPut_Op : Torch_Op<"aten.index_put_", [
 def Torch_AtenIndexPutHackedTwinOp : Torch_Op<"aten.index_put.hacked_twin", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::index_put.hacked_twin : (Tensor, Tensor[], Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -6409,7 +6569,8 @@ def Torch_AtenIndexPut_HackedTwinOp : Torch_Op<"aten.index_put_.hacked_twin", [
 def Torch_Aten_UnsafeIndexPutHackedTwinOp : Torch_Op<"aten._unsafe_index_put.hacked_twin", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_unsafe_index_put.hacked_twin : (Tensor, Tensor[], Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -6435,7 +6596,8 @@ def Torch_Aten_UnsafeIndexPutHackedTwinOp : Torch_Op<"aten._unsafe_index_put.hac
 def Torch_AtenLinearOp : Torch_Op<"aten.linear", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::linear : (Tensor, Tensor, Tensor?) -> (Tensor)`";
   let arguments = (ins
@@ -6460,7 +6622,8 @@ def Torch_AtenLinearOp : Torch_Op<"aten.linear", [
 def Torch_AtenMmOp : Torch_Op<"aten.mm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mm : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -6484,7 +6647,8 @@ def Torch_AtenMmOp : Torch_Op<"aten.mm", [
 def Torch_Aten_IntMmOp : Torch_Op<"aten._int_mm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_int_mm : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -6508,7 +6672,8 @@ def Torch_Aten_IntMmOp : Torch_Op<"aten._int_mm", [
 def Torch_AtenAddmmOp : Torch_Op<"aten.addmm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::addmm : (Tensor, Tensor, Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -6535,7 +6700,8 @@ def Torch_AtenAddmmOp : Torch_Op<"aten.addmm", [
 def Torch_AtenMatmulOp : Torch_Op<"aten.matmul", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::matmul : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -6559,7 +6725,8 @@ def Torch_AtenMatmulOp : Torch_Op<"aten.matmul", [
 def Torch_AtenMvOp : Torch_Op<"aten.mv", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mv : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -6583,7 +6750,8 @@ def Torch_AtenMvOp : Torch_Op<"aten.mv", [
 def Torch_AtenDotOp : Torch_Op<"aten.dot", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::dot : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -6608,7 +6776,8 @@ def Torch_AtenDotOp : Torch_Op<"aten.dot", [
 def Torch_AtenOuterOp : Torch_Op<"aten.outer", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::outer : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -6632,7 +6801,8 @@ def Torch_AtenOuterOp : Torch_Op<"aten.outer", [
 def Torch_AtenCosineSimilarityOp : Torch_Op<"aten.cosine_similarity", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cosine_similarity : (Tensor, Tensor, int, float) -> (Tensor)`";
   let arguments = (ins
@@ -6658,7 +6828,8 @@ def Torch_AtenCosineSimilarityOp : Torch_Op<"aten.cosine_similarity", [
 def Torch_AtenConv3dOp : Torch_Op<"aten.conv3d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::conv3d : (Tensor, Tensor, Tensor?, int[], int[], int[], int) -> (Tensor)`";
   let arguments = (ins
@@ -6687,7 +6858,8 @@ def Torch_AtenConv3dOp : Torch_Op<"aten.conv3d", [
 def Torch_AtenConv2dOp : Torch_Op<"aten.conv2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::conv2d : (Tensor, Tensor, Tensor?, int[], int[], int[], int) -> (Tensor)`";
   let arguments = (ins
@@ -6716,7 +6888,8 @@ def Torch_AtenConv2dOp : Torch_Op<"aten.conv2d", [
 def Torch_AtenConv1dOp : Torch_Op<"aten.conv1d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::conv1d : (Tensor, Tensor, Tensor?, int[], int[], int[], int) -> (Tensor)`";
   let arguments = (ins
@@ -6745,7 +6918,8 @@ def Torch_AtenConv1dOp : Torch_Op<"aten.conv1d", [
 def Torch_AtenConvTranspose1dOp : Torch_Op<"aten.conv_transpose1d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::conv_transpose1d : (Tensor, Tensor, Tensor?, int[], int[], int[], int, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -6775,7 +6949,8 @@ def Torch_AtenConvTranspose1dOp : Torch_Op<"aten.conv_transpose1d", [
 def Torch_AtenConvTranspose2dInputOp : Torch_Op<"aten.conv_transpose2d.input", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::conv_transpose2d.input : (Tensor, Tensor, Tensor?, int[], int[], int[], int, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -6805,7 +6980,8 @@ def Torch_AtenConvTranspose2dInputOp : Torch_Op<"aten.conv_transpose2d.input", [
 def Torch_AtenConvTranspose3dInputOp : Torch_Op<"aten.conv_transpose3d.input", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::conv_transpose3d.input : (Tensor, Tensor, Tensor?, int[], int[], int[], int, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -6835,7 +7011,8 @@ def Torch_AtenConvTranspose3dInputOp : Torch_Op<"aten.conv_transpose3d.input", [
 def Torch_AtenConvTbcOp : Torch_Op<"aten.conv_tbc", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::conv_tbc : (Tensor, Tensor, Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -6861,7 +7038,8 @@ def Torch_AtenConvTbcOp : Torch_Op<"aten.conv_tbc", [
 def Torch_AtenConvTbcBackwardOp : Torch_Op<"aten.conv_tbc_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::conv_tbc_backward : (Tensor, Tensor, Tensor, Tensor, int) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -6890,7 +7068,8 @@ def Torch_AtenConvTbcBackwardOp : Torch_Op<"aten.conv_tbc_backward", [
 def Torch_AtenConvolutionOp : Torch_Op<"aten.convolution", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::convolution : (Tensor, Tensor, Tensor?, int[], int[], int[], bool, int[], int) -> (Tensor)`";
   let arguments = (ins
@@ -6921,7 +7100,8 @@ def Torch_AtenConvolutionOp : Torch_Op<"aten.convolution", [
 def Torch_Aten_ConvolutionOp : Torch_Op<"aten._convolution", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_convolution : (Tensor, Tensor, Tensor?, int[], int[], int[], bool, int[], int, bool, bool, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -6956,7 +7136,8 @@ def Torch_Aten_ConvolutionOp : Torch_Op<"aten._convolution", [
 def Torch_Aten_ConvolutionDeprecatedOp : Torch_Op<"aten._convolution.deprecated", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_convolution.deprecated : (Tensor, Tensor, Tensor?, int[], int[], int[], bool, int[], int, bool, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -6990,7 +7171,8 @@ def Torch_Aten_ConvolutionDeprecatedOp : Torch_Op<"aten._convolution.deprecated"
 def Torch_AtenRollOp : Torch_Op<"aten.roll", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::roll : (Tensor, int[], int[]) -> (Tensor)`";
   let arguments = (ins
@@ -7015,7 +7197,8 @@ def Torch_AtenRollOp : Torch_Op<"aten.roll", [
 def Torch_AtenConvolutionBackwardOp : Torch_Op<"aten.convolution_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::convolution_backward : (Tensor, Tensor, Tensor, int[]?, int[], int[], int[], bool, int[], int, bool[]) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -7050,7 +7233,8 @@ def Torch_AtenConvolutionBackwardOp : Torch_Op<"aten.convolution_backward", [
 def Torch_AtenFlipOp : Torch_Op<"aten.flip", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::flip : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -7074,7 +7258,8 @@ def Torch_AtenFlipOp : Torch_Op<"aten.flip", [
 def Torch_AtenNativeBatchNormOp : Torch_Op<"aten.native_batch_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::native_batch_norm : (Tensor, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, float) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -7106,7 +7291,8 @@ def Torch_AtenNativeBatchNormOp : Torch_Op<"aten.native_batch_norm", [
 def Torch_AtenBatchNormOp : Torch_Op<"aten.batch_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::batch_norm : (Tensor, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, float, bool) -> (Tensor)`";
   let arguments = (ins
@@ -7137,7 +7323,8 @@ def Torch_AtenBatchNormOp : Torch_Op<"aten.batch_norm", [
 def Torch_AtenInstanceNormOp : Torch_Op<"aten.instance_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::instance_norm : (Tensor, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, float, bool) -> (Tensor)`";
   let arguments = (ins
@@ -7168,7 +7355,8 @@ def Torch_AtenInstanceNormOp : Torch_Op<"aten.instance_norm", [
 def Torch_AtenNativeGroupNormOp : Torch_Op<"aten.native_group_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::native_group_norm : (Tensor, Tensor?, Tensor?, int, int, int, int, float) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -7200,7 +7388,8 @@ def Torch_AtenNativeGroupNormOp : Torch_Op<"aten.native_group_norm", [
 def Torch_AtenGroupNormOp : Torch_Op<"aten.group_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::group_norm : (Tensor, int, Tensor?, Tensor?, float, bool) -> (Tensor)`";
   let arguments = (ins
@@ -7228,7 +7417,8 @@ def Torch_AtenGroupNormOp : Torch_Op<"aten.group_norm", [
 def Torch_AtenLayerNormOp : Torch_Op<"aten.layer_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::layer_norm : (Tensor, int[], Tensor?, Tensor?, float, bool) -> (Tensor)`";
   let arguments = (ins
@@ -7256,7 +7446,8 @@ def Torch_AtenLayerNormOp : Torch_Op<"aten.layer_norm", [
 def Torch_AtenRenormOp : Torch_Op<"aten.renorm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::renorm : (Tensor, Scalar, int, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -7283,7 +7474,8 @@ def Torch_AtenRenormOp : Torch_Op<"aten.renorm", [
 def Torch_AtenNormScalarOp : Torch_Op<"aten.norm.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::norm.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -7308,7 +7500,8 @@ def Torch_AtenNormScalarOp : Torch_Op<"aten.norm.Scalar", [
 def Torch_AtenNormScalarOptDimOp : Torch_Op<"aten.norm.ScalarOpt_dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::norm.ScalarOpt_dim : (Tensor, Scalar?, int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -7334,7 +7527,8 @@ def Torch_AtenNormScalarOptDimOp : Torch_Op<"aten.norm.ScalarOpt_dim", [
 def Torch_AtenNormalFunctionalOp : Torch_Op<"aten.normal_functional", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::normal_functional : (Tensor, float, float, Generator?) -> (Tensor)`";
   let arguments = (ins
@@ -7360,7 +7554,8 @@ def Torch_AtenNormalFunctionalOp : Torch_Op<"aten.normal_functional", [
 def Torch_AtenNativeLayerNormOp : Torch_Op<"aten.native_layer_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::native_layer_norm : (Tensor, int[], Tensor?, Tensor?, float) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -7389,7 +7584,8 @@ def Torch_AtenNativeLayerNormOp : Torch_Op<"aten.native_layer_norm", [
 def Torch_AtenMaxPool1dOp : Torch_Op<"aten.max_pool1d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_pool1d : (Tensor, int[], int[], int[], int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -7417,7 +7613,8 @@ def Torch_AtenMaxPool1dOp : Torch_Op<"aten.max_pool1d", [
 def Torch_AtenMaxPool1dWithIndicesOp : Torch_Op<"aten.max_pool1d_with_indices", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_pool1d_with_indices : (Tensor, int[], int[], int[], int[], bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -7446,7 +7643,8 @@ def Torch_AtenMaxPool1dWithIndicesOp : Torch_Op<"aten.max_pool1d_with_indices", 
 def Torch_AtenMaxPool2dOp : Torch_Op<"aten.max_pool2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_pool2d : (Tensor, int[], int[], int[], int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -7474,7 +7672,8 @@ def Torch_AtenMaxPool2dOp : Torch_Op<"aten.max_pool2d", [
 def Torch_AtenMaxUnpool2dOp : Torch_Op<"aten.max_unpool2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_unpool2d : (Tensor, Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -7499,7 +7698,8 @@ def Torch_AtenMaxUnpool2dOp : Torch_Op<"aten.max_unpool2d", [
 def Torch_AtenMaxPool2dWithIndicesOp : Torch_Op<"aten.max_pool2d_with_indices", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_pool2d_with_indices : (Tensor, int[], int[], int[], int[], bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -7529,7 +7729,8 @@ def Torch_AtenMaxPool2dWithIndicesOp : Torch_Op<"aten.max_pool2d_with_indices", 
 def Torch_AtenMaxPool2dWithIndicesBackwardOp : Torch_Op<"aten.max_pool2d_with_indices_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_pool2d_with_indices_backward : (Tensor, Tensor, int[], int[], int[], int[], bool, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -7559,7 +7760,8 @@ def Torch_AtenMaxPool2dWithIndicesBackwardOp : Torch_Op<"aten.max_pool2d_with_in
 def Torch_AtenMaxPool3dOp : Torch_Op<"aten.max_pool3d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_pool3d : (Tensor, int[], int[], int[], int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -7587,7 +7789,8 @@ def Torch_AtenMaxPool3dOp : Torch_Op<"aten.max_pool3d", [
 def Torch_AtenMaxUnpool3dOp : Torch_Op<"aten.max_unpool3d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_unpool3d : (Tensor, Tensor, int[], int[], int[]) -> (Tensor)`";
   let arguments = (ins
@@ -7614,7 +7817,8 @@ def Torch_AtenMaxUnpool3dOp : Torch_Op<"aten.max_unpool3d", [
 def Torch_AtenMaxPool3dWithIndicesOp : Torch_Op<"aten.max_pool3d_with_indices", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_pool3d_with_indices : (Tensor, int[], int[], int[], int[], bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -7644,7 +7848,8 @@ def Torch_AtenMaxPool3dWithIndicesOp : Torch_Op<"aten.max_pool3d_with_indices", 
 def Torch_AtenMaxPool3dWithIndicesBackwardOp : Torch_Op<"aten.max_pool3d_with_indices_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max_pool3d_with_indices_backward : (Tensor, Tensor, int[], int[], int[], int[], bool, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -7674,7 +7879,8 @@ def Torch_AtenMaxPool3dWithIndicesBackwardOp : Torch_Op<"aten.max_pool3d_with_in
 def Torch_AtenAvgPool1dOp : Torch_Op<"aten.avg_pool1d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::avg_pool1d : (Tensor, int[], int[], int[], bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -7702,7 +7908,8 @@ def Torch_AtenAvgPool1dOp : Torch_Op<"aten.avg_pool1d", [
 def Torch_AtenAvgPool2dOp : Torch_Op<"aten.avg_pool2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::avg_pool2d : (Tensor, int[], int[], int[], bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -7731,7 +7938,8 @@ def Torch_AtenAvgPool2dOp : Torch_Op<"aten.avg_pool2d", [
 def Torch_AtenAvgPool2dBackwardOp : Torch_Op<"aten.avg_pool2d_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::avg_pool2d_backward : (Tensor, Tensor, int[], int[], int[], bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -7761,7 +7969,8 @@ def Torch_AtenAvgPool2dBackwardOp : Torch_Op<"aten.avg_pool2d_backward", [
 def Torch_AtenAvgPool3dOp : Torch_Op<"aten.avg_pool3d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::avg_pool3d : (Tensor, int[], int[], int[], bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -7790,7 +7999,8 @@ def Torch_AtenAvgPool3dOp : Torch_Op<"aten.avg_pool3d", [
 def Torch_AtenAvgPool3dBackwardOp : Torch_Op<"aten.avg_pool3d_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::avg_pool3d_backward : (Tensor, Tensor, int[], int[], int[], bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -7820,7 +8030,8 @@ def Torch_AtenAvgPool3dBackwardOp : Torch_Op<"aten.avg_pool3d_backward", [
 def Torch_AtenSoftmaxIntOp : Torch_Op<"aten.softmax.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::softmax.int : (Tensor, int, int?) -> (Tensor)`";
   let arguments = (ins
@@ -7845,7 +8056,8 @@ def Torch_AtenSoftmaxIntOp : Torch_Op<"aten.softmax.int", [
 def Torch_AtenLogSoftmaxIntOp : Torch_Op<"aten.log_softmax.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::log_softmax.int : (Tensor, int, int?) -> (Tensor)`";
   let arguments = (ins
@@ -7870,7 +8082,8 @@ def Torch_AtenLogSoftmaxIntOp : Torch_Op<"aten.log_softmax.int", [
 def Torch_Aten_LogSoftmaxOp : Torch_Op<"aten._log_softmax", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_log_softmax : (Tensor, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -7895,7 +8108,8 @@ def Torch_Aten_LogSoftmaxOp : Torch_Op<"aten._log_softmax", [
 def Torch_AtenScatterSrcOp : Torch_Op<"aten.scatter.src", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::scatter.src : (Tensor, int, Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -7946,7 +8160,8 @@ def Torch_AtenScatter_SrcOp : Torch_Op<"aten.scatter_.src", [
 def Torch_AtenScatterValueOp : Torch_Op<"aten.scatter.value", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::scatter.value : (Tensor, int, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -7997,7 +8212,8 @@ def Torch_AtenScatter_ValueOp : Torch_Op<"aten.scatter_.value", [
 def Torch_AtenMaskedScatterOp : Torch_Op<"aten.masked_scatter", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::masked_scatter : (Tensor, Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -8046,7 +8262,8 @@ def Torch_AtenMaskedScatter_Op : Torch_Op<"aten.masked_scatter_", [
 def Torch_Aten__InterpolateSizeListScaleListOp : Torch_Op<"aten.__interpolate.size_list_scale_list", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__interpolate.size_list_scale_list : (Tensor, int[]?, float[]?, str, bool?, bool?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -8075,7 +8292,8 @@ def Torch_Aten__InterpolateSizeListScaleListOp : Torch_Op<"aten.__interpolate.si
 def Torch_AtenAdaptiveAvgPool1dOp : Torch_Op<"aten.adaptive_avg_pool1d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::adaptive_avg_pool1d : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -8099,7 +8317,8 @@ def Torch_AtenAdaptiveAvgPool1dOp : Torch_Op<"aten.adaptive_avg_pool1d", [
 def Torch_AtenAdaptiveAvgPool2dOp : Torch_Op<"aten.adaptive_avg_pool2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::adaptive_avg_pool2d : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -8123,7 +8342,8 @@ def Torch_AtenAdaptiveAvgPool2dOp : Torch_Op<"aten.adaptive_avg_pool2d", [
 def Torch_Aten_AdaptiveAvgPool2dOp : Torch_Op<"aten._adaptive_avg_pool2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_adaptive_avg_pool2d : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -8148,7 +8368,8 @@ def Torch_Aten_AdaptiveAvgPool2dOp : Torch_Op<"aten._adaptive_avg_pool2d", [
 def Torch_Aten_AdaptiveAvgPool2dBackwardOp : Torch_Op<"aten._adaptive_avg_pool2d_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_adaptive_avg_pool2d_backward : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -8172,7 +8393,8 @@ def Torch_Aten_AdaptiveAvgPool2dBackwardOp : Torch_Op<"aten._adaptive_avg_pool2d
 def Torch_AtenAdaptiveAvgPool3dOp : Torch_Op<"aten.adaptive_avg_pool3d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::adaptive_avg_pool3d : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -8196,7 +8418,8 @@ def Torch_AtenAdaptiveAvgPool3dOp : Torch_Op<"aten.adaptive_avg_pool3d", [
 def Torch_Aten_AdaptiveAvgPool3dOp : Torch_Op<"aten._adaptive_avg_pool3d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_adaptive_avg_pool3d : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -8220,7 +8443,8 @@ def Torch_Aten_AdaptiveAvgPool3dOp : Torch_Op<"aten._adaptive_avg_pool3d", [
 def Torch_Aten_AdaptiveAvgPool3dBackwardOp : Torch_Op<"aten._adaptive_avg_pool3d_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_adaptive_avg_pool3d_backward : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -8244,7 +8468,8 @@ def Torch_Aten_AdaptiveAvgPool3dBackwardOp : Torch_Op<"aten._adaptive_avg_pool3d
 def Torch_AtenAdaptiveMaxPool1dOp : Torch_Op<"aten.adaptive_max_pool1d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::adaptive_max_pool1d : (Tensor, int[]) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -8269,7 +8494,8 @@ def Torch_AtenAdaptiveMaxPool1dOp : Torch_Op<"aten.adaptive_max_pool1d", [
 def Torch_AtenAdaptiveMaxPool2dOp : Torch_Op<"aten.adaptive_max_pool2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::adaptive_max_pool2d : (Tensor, int[]) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -8294,7 +8520,8 @@ def Torch_AtenAdaptiveMaxPool2dOp : Torch_Op<"aten.adaptive_max_pool2d", [
 def Torch_AtenAdaptiveMaxPool3dOp : Torch_Op<"aten.adaptive_max_pool3d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::adaptive_max_pool3d : (Tensor, int[]) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -8319,7 +8546,8 @@ def Torch_AtenAdaptiveMaxPool3dOp : Torch_Op<"aten.adaptive_max_pool3d", [
 def Torch_AtenTopkOp : Torch_Op<"aten.topk", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::topk : (Tensor, int, int, bool, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -8346,7 +8574,8 @@ def Torch_AtenTopkOp : Torch_Op<"aten.topk", [
 
 def Torch_AtenTransposeIntOp : Torch_Op<"aten.transpose.int", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::transpose.int : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -8372,7 +8601,8 @@ def Torch_AtenTransposeIntOp : Torch_Op<"aten.transpose.int", [
 def Torch_AtenPixelShuffleOp : Torch_Op<"aten.pixel_shuffle", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::pixel_shuffle : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -8395,7 +8625,8 @@ def Torch_AtenPixelShuffleOp : Torch_Op<"aten.pixel_shuffle", [
 
 def Torch_AtenPermuteOp : Torch_Op<"aten.permute", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::permute : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -8419,7 +8650,8 @@ def Torch_AtenPermuteOp : Torch_Op<"aten.permute", [
 
 def Torch_AtenMovedimIntOp : Torch_Op<"aten.movedim.int", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::movedim.int : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -8444,7 +8676,8 @@ def Torch_AtenMovedimIntOp : Torch_Op<"aten.movedim.int", [
 def Torch_AtenBmmOp : Torch_Op<"aten.bmm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bmm : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -8468,7 +8701,8 @@ def Torch_AtenBmmOp : Torch_Op<"aten.bmm", [
 def Torch_AtenCumsumOp : Torch_Op<"aten.cumsum", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cumsum : (Tensor, int, int?) -> (Tensor)`";
   let arguments = (ins
@@ -8493,7 +8727,8 @@ def Torch_AtenCumsumOp : Torch_Op<"aten.cumsum", [
 def Torch_AtenCumprodOp : Torch_Op<"aten.cumprod", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cumprod : (Tensor, int, int?) -> (Tensor)`";
   let arguments = (ins
@@ -8518,7 +8753,8 @@ def Torch_AtenCumprodOp : Torch_Op<"aten.cumprod", [
 def Torch_AtenFloorDivideScalarOp : Torch_Op<"aten.floor_divide.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::floor_divide.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -8542,7 +8778,8 @@ def Torch_AtenFloorDivideScalarOp : Torch_Op<"aten.floor_divide.Scalar", [
 def Torch_AtenLogsumexpOp : Torch_Op<"aten.logsumexp", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::logsumexp : (Tensor, int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -8567,7 +8804,8 @@ def Torch_AtenLogsumexpOp : Torch_Op<"aten.logsumexp", [
 def Torch_AtenMeanDimOp : Torch_Op<"aten.mean.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mean.dim : (Tensor, int[]?, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -8593,7 +8831,8 @@ def Torch_AtenMeanDimOp : Torch_Op<"aten.mean.dim", [
 def Torch_Aten__And__TensorOp : Torch_Op<"aten.__and__.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__and__.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -8617,7 +8856,8 @@ def Torch_Aten__And__TensorOp : Torch_Op<"aten.__and__.Tensor", [
 def Torch_Aten__And__ScalarOp : Torch_Op<"aten.__and__.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__and__.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -8642,7 +8882,8 @@ def Torch_Aten__And__ScalarOp : Torch_Op<"aten.__and__.Scalar", [
 def Torch_Aten__Or__TensorOp : Torch_Op<"aten.__or__.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__or__.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -8667,7 +8908,8 @@ def Torch_Aten__Or__TensorOp : Torch_Op<"aten.__or__.Tensor", [
 def Torch_Aten__Lshift__ScalarOp : Torch_Op<"aten.__lshift__.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__lshift__.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -8691,7 +8933,8 @@ def Torch_Aten__Lshift__ScalarOp : Torch_Op<"aten.__lshift__.Scalar", [
 def Torch_Aten__Rshift__ScalarOp : Torch_Op<"aten.__rshift__.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__rshift__.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -8715,7 +8958,8 @@ def Torch_Aten__Rshift__ScalarOp : Torch_Op<"aten.__rshift__.Scalar", [
 def Torch_Aten_SoftmaxOp : Torch_Op<"aten._softmax", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_softmax : (Tensor, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -8740,7 +8984,8 @@ def Torch_Aten_SoftmaxOp : Torch_Op<"aten._softmax", [
 def Torch_Aten_SafeSoftmaxOp : Torch_Op<"aten._safe_softmax", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_safe_softmax : (Tensor, int, int?) -> (Tensor)`";
   let arguments = (ins
@@ -8765,7 +9010,8 @@ def Torch_Aten_SafeSoftmaxOp : Torch_Op<"aten._safe_softmax", [
 def Torch_AtenMeanOp : Torch_Op<"aten.mean", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mean : (Tensor, int?) -> (Tensor)`";
   let arguments = (ins
@@ -8789,7 +9035,8 @@ def Torch_AtenMeanOp : Torch_Op<"aten.mean", [
 def Torch_AtenStdOp : Torch_Op<"aten.std", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::std : (Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -8813,7 +9060,8 @@ def Torch_AtenStdOp : Torch_Op<"aten.std", [
 def Torch_AtenStdDimOp : Torch_Op<"aten.std.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::std.dim : (Tensor, int[]?, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -8839,7 +9087,8 @@ def Torch_AtenStdDimOp : Torch_Op<"aten.std.dim", [
 def Torch_AtenStdCorrectionOp : Torch_Op<"aten.std.correction", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::std.correction : (Tensor, int[]?, Scalar?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -8865,7 +9114,8 @@ def Torch_AtenStdCorrectionOp : Torch_Op<"aten.std.correction", [
 def Torch_AtenVarOp : Torch_Op<"aten.var", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::var : (Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -8889,7 +9139,8 @@ def Torch_AtenVarOp : Torch_Op<"aten.var", [
 def Torch_AtenVarDimOp : Torch_Op<"aten.var.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::var.dim : (Tensor, int[]?, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -8915,7 +9166,8 @@ def Torch_AtenVarDimOp : Torch_Op<"aten.var.dim", [
 def Torch_AtenVarCorrectionOp : Torch_Op<"aten.var.correction", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::var.correction : (Tensor, int[]?, Scalar?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -8941,7 +9193,8 @@ def Torch_AtenVarCorrectionOp : Torch_Op<"aten.var.correction", [
 def Torch_AtenVarMeanCorrectionOp : Torch_Op<"aten.var_mean.correction", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::var_mean.correction : (Tensor, int[]?, Scalar?, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -8968,7 +9221,8 @@ def Torch_AtenVarMeanCorrectionOp : Torch_Op<"aten.var_mean.correction", [
 def Torch_AtenVarMeanOp : Torch_Op<"aten.var_mean", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::var_mean : (Tensor, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -8993,7 +9247,8 @@ def Torch_AtenVarMeanOp : Torch_Op<"aten.var_mean", [
 def Torch_AtenVarMeanDimOp : Torch_Op<"aten.var_mean.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::var_mean.dim : (Tensor, int[]?, bool, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -9020,7 +9275,8 @@ def Torch_AtenVarMeanDimOp : Torch_Op<"aten.var_mean.dim", [
 def Torch_AtenNllLoss2dForwardOp : Torch_Op<"aten.nll_loss2d_forward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::nll_loss2d_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -9048,7 +9304,8 @@ def Torch_AtenNllLoss2dForwardOp : Torch_Op<"aten.nll_loss2d_forward", [
 def Torch_AtenNllLoss2dBackwardOp : Torch_Op<"aten.nll_loss2d_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::nll_loss2d_backward : (Tensor, Tensor, Tensor, Tensor?, int, int, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -9077,7 +9334,8 @@ def Torch_AtenNllLoss2dBackwardOp : Torch_Op<"aten.nll_loss2d_backward", [
 def Torch_AtenNllLossForwardOp : Torch_Op<"aten.nll_loss_forward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::nll_loss_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -9105,7 +9363,8 @@ def Torch_AtenNllLossForwardOp : Torch_Op<"aten.nll_loss_forward", [
 def Torch_AtenNllLossBackwardOp : Torch_Op<"aten.nll_loss_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::nll_loss_backward : (Tensor, Tensor, Tensor, Tensor?, int, int, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -9134,7 +9393,8 @@ def Torch_AtenNllLossBackwardOp : Torch_Op<"aten.nll_loss_backward", [
 def Torch_AtenBincountOp : Torch_Op<"aten.bincount", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bincount : (Tensor, Tensor?, int) -> (Tensor)`";
   let arguments = (ins
@@ -9159,7 +9419,8 @@ def Torch_AtenBincountOp : Torch_Op<"aten.bincount", [
 def Torch_AtenLinalgVectorNormOp : Torch_Op<"aten.linalg_vector_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::linalg_vector_norm : (Tensor, Scalar, int[]?, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -9186,7 +9447,8 @@ def Torch_AtenLinalgVectorNormOp : Torch_Op<"aten.linalg_vector_norm", [
 def Torch_AtenLinalgNormOp : Torch_Op<"aten.linalg_norm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::linalg_norm : (Tensor, Scalar?, int[]?, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -9213,7 +9475,8 @@ def Torch_AtenLinalgNormOp : Torch_Op<"aten.linalg_norm", [
 def Torch_AtenLinalgQrOp : Torch_Op<"aten.linalg_qr", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::linalg_qr : (Tensor, str) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -9238,7 +9501,8 @@ def Torch_AtenLinalgQrOp : Torch_Op<"aten.linalg_qr", [
 def Torch_AtenLinalgDetOp : Torch_Op<"aten.linalg_det", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::linalg_det : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -9261,7 +9525,8 @@ def Torch_AtenLinalgDetOp : Torch_Op<"aten.linalg_det", [
 def Torch_Aten_LinalgDetOp : Torch_Op<"aten._linalg_det", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_linalg_det : (Tensor) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -9286,7 +9551,8 @@ def Torch_Aten_LinalgDetOp : Torch_Op<"aten._linalg_det", [
 def Torch_AtenLinalgSlogdetOp : Torch_Op<"aten.linalg_slogdet", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::linalg_slogdet : (Tensor) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -9310,7 +9576,8 @@ def Torch_AtenLinalgSlogdetOp : Torch_Op<"aten.linalg_slogdet", [
 def Torch_AtenFrobeniusNormDimOp : Torch_Op<"aten.frobenius_norm.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::frobenius_norm.dim : (Tensor, int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -9335,7 +9602,8 @@ def Torch_AtenFrobeniusNormDimOp : Torch_Op<"aten.frobenius_norm.dim", [
 def Torch_AtenMseLossOp : Torch_Op<"aten.mse_loss", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mse_loss : (Tensor, Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -9360,7 +9628,8 @@ def Torch_AtenMseLossOp : Torch_Op<"aten.mse_loss", [
 def Torch_AtenMseLossBackwardOp : Torch_Op<"aten.mse_loss_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mse_loss_backward : (Tensor, Tensor, Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -9386,7 +9655,8 @@ def Torch_AtenMseLossBackwardOp : Torch_Op<"aten.mse_loss_backward", [
 def Torch_AtenL1LossOp : Torch_Op<"aten.l1_loss", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::l1_loss : (Tensor, Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -9411,7 +9681,8 @@ def Torch_AtenL1LossOp : Torch_Op<"aten.l1_loss", [
 def Torch_AtenUpsampleNearest2dBackwardOp : Torch_Op<"aten.upsample_nearest2d_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::upsample_nearest2d_backward : (Tensor, int[], int[], float?, float?) -> (Tensor)`";
   let arguments = (ins
@@ -9438,7 +9709,8 @@ def Torch_AtenUpsampleNearest2dBackwardOp : Torch_Op<"aten.upsample_nearest2d_ba
 def Torch_AtenCrossEntropyLossOp : Torch_Op<"aten.cross_entropy_loss", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cross_entropy_loss : (Tensor, Tensor, Tensor?, int, int, float) -> (Tensor)`";
   let arguments = (ins
@@ -9466,7 +9738,8 @@ def Torch_AtenCrossEntropyLossOp : Torch_Op<"aten.cross_entropy_loss", [
 def Torch_AtenNonzeroOp : Torch_Op<"aten.nonzero", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::nonzero : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -9489,7 +9762,8 @@ def Torch_AtenNonzeroOp : Torch_Op<"aten.nonzero", [
 def Torch_AtenNonzeroNumpyOp : Torch_Op<"aten.nonzero_numpy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::nonzero_numpy : (Tensor) -> (Tensor[])`";
   let arguments = (ins
@@ -9512,7 +9786,8 @@ def Torch_AtenNonzeroNumpyOp : Torch_Op<"aten.nonzero_numpy", [
 def Torch_AtenNonzeroStaticOp : Torch_Op<"aten.nonzero_static", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::nonzero_static : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -9537,7 +9812,8 @@ def Torch_AtenNonzeroStaticOp : Torch_Op<"aten.nonzero_static", [
 def Torch_AtenBinaryCrossEntropyOp : Torch_Op<"aten.binary_cross_entropy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::binary_cross_entropy : (Tensor, Tensor, Tensor?, int) -> (Tensor)`";
   let arguments = (ins
@@ -9563,7 +9839,8 @@ def Torch_AtenBinaryCrossEntropyOp : Torch_Op<"aten.binary_cross_entropy", [
 def Torch_AtenBinaryCrossEntropyBackwardOp : Torch_Op<"aten.binary_cross_entropy_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::binary_cross_entropy_backward : (Tensor, Tensor, Tensor, Tensor?, int) -> (Tensor)`";
   let arguments = (ins
@@ -9590,7 +9867,8 @@ def Torch_AtenBinaryCrossEntropyBackwardOp : Torch_Op<"aten.binary_cross_entropy
 def Torch_AtenBinaryCrossEntropyWithLogitsOp : Torch_Op<"aten.binary_cross_entropy_with_logits", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::binary_cross_entropy_with_logits : (Tensor, Tensor, Tensor?, Tensor?, int) -> (Tensor)`";
   let arguments = (ins
@@ -9617,7 +9895,8 @@ def Torch_AtenBinaryCrossEntropyWithLogitsOp : Torch_Op<"aten.binary_cross_entro
 def Torch_AtenLogSigmoidForwardOp : Torch_Op<"aten.log_sigmoid_forward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::log_sigmoid_forward : (Tensor) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -9641,7 +9920,8 @@ def Torch_AtenLogSigmoidForwardOp : Torch_Op<"aten.log_sigmoid_forward", [
 def Torch_AtenLogSigmoidBackwardOp : Torch_Op<"aten.log_sigmoid_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::log_sigmoid_backward : (Tensor, Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -9666,7 +9946,8 @@ def Torch_AtenLogSigmoidBackwardOp : Torch_Op<"aten.log_sigmoid_backward", [
 def Torch_AtenSigmoidBackwardOp : Torch_Op<"aten.sigmoid_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sigmoid_backward : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -9690,7 +9971,8 @@ def Torch_AtenSigmoidBackwardOp : Torch_Op<"aten.sigmoid_backward", [
 def Torch_AtenCosineEmbeddingLossOp : Torch_Op<"aten.cosine_embedding_loss", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cosine_embedding_loss : (Tensor, Tensor, Tensor, float, int) -> (Tensor)`";
   let arguments = (ins
@@ -9717,7 +9999,8 @@ def Torch_AtenCosineEmbeddingLossOp : Torch_Op<"aten.cosine_embedding_loss", [
 def Torch_AtenDiagEmbedOp : Torch_Op<"aten.diag_embed", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::diag_embed : (Tensor, int, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -9743,7 +10026,8 @@ def Torch_AtenDiagEmbedOp : Torch_Op<"aten.diag_embed", [
 def Torch_Aten_WeightNormInterfaceOp : Torch_Op<"aten._weight_norm_interface", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_weight_norm_interface : (Tensor, Tensor, int) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -9769,7 +10053,8 @@ def Torch_Aten_WeightNormInterfaceOp : Torch_Op<"aten._weight_norm_interface", [
 def Torch_AtenRot90Op : Torch_Op<"aten.rot90", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::rot90 : (Tensor, int, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -9795,7 +10080,8 @@ def Torch_AtenRot90Op : Torch_Op<"aten.rot90", [
 def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -9820,7 +10106,8 @@ def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
 def Torch_AtenReplicationPad2dOp : Torch_Op<"aten.replication_pad2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::replication_pad2d : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -9844,7 +10131,8 @@ def Torch_AtenReplicationPad2dOp : Torch_Op<"aten.replication_pad2d", [
 def Torch_AtenReflectionPad1dOp : Torch_Op<"aten.reflection_pad1d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::reflection_pad1d : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -9868,7 +10156,8 @@ def Torch_AtenReflectionPad1dOp : Torch_Op<"aten.reflection_pad1d", [
 def Torch_AtenReflectionPad2dOp : Torch_Op<"aten.reflection_pad2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::reflection_pad2d : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -9892,7 +10181,8 @@ def Torch_AtenReflectionPad2dOp : Torch_Op<"aten.reflection_pad2d", [
 def Torch_AtenPadOp : Torch_Op<"aten.pad", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::pad : (Tensor, int[], str, float?) -> (Tensor)`";
   let arguments = (ins
@@ -9917,7 +10207,8 @@ def Torch_AtenPadOp : Torch_Op<"aten.pad", [
 
 def Torch_AtenSqueezeDimOp : Torch_Op<"aten.squeeze.dim", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::squeeze.dim : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -9941,7 +10232,8 @@ def Torch_AtenSqueezeDimOp : Torch_Op<"aten.squeeze.dim", [
 
 def Torch_AtenSqueezeOp : Torch_Op<"aten.squeeze", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::squeeze : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -9964,7 +10256,8 @@ def Torch_AtenSqueezeOp : Torch_Op<"aten.squeeze", [
 
 def Torch_AtenFlattenUsingIntsOp : Torch_Op<"aten.flatten.using_ints", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::flatten.using_ints : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -9989,7 +10282,8 @@ def Torch_AtenFlattenUsingIntsOp : Torch_Op<"aten.flatten.using_ints", [
 
 def Torch_AtenUnflattenIntOp : Torch_Op<"aten.unflatten.int", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::unflatten.int : (Tensor, int, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -10016,7 +10310,8 @@ def Torch_AtenUnflattenIntOp : Torch_Op<"aten.unflatten.int", [
 def Torch_AtenDimOp : Torch_Op<"aten.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::dim : (Tensor) -> (int)`";
   let arguments = (ins
@@ -10040,7 +10335,8 @@ def Torch_AtenDimOp : Torch_Op<"aten.dim", [
 def Torch_AtenSizeOp : Torch_Op<"aten.size", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::size : (Tensor) -> (int[])`";
   let arguments = (ins
@@ -10064,7 +10360,8 @@ def Torch_AtenSizeOp : Torch_Op<"aten.size", [
 def Torch_AtenBoolTensorOp : Torch_Op<"aten.Bool.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Bool.Tensor : (Tensor) -> (bool)`";
   let arguments = (ins
@@ -10087,7 +10384,8 @@ def Torch_AtenBoolTensorOp : Torch_Op<"aten.Bool.Tensor", [
 def Torch_AtenIsFloatingPointOp : Torch_Op<"aten.is_floating_point", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::is_floating_point : (Tensor) -> (bool)`";
   let arguments = (ins
@@ -10111,7 +10409,8 @@ def Torch_AtenIsFloatingPointOp : Torch_Op<"aten.is_floating_point", [
 def Torch_AtenOnesOp : Torch_Op<"aten.ones", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ones : (int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10139,7 +10438,8 @@ def Torch_AtenOnesOp : Torch_Op<"aten.ones", [
 def Torch_AtenNewOnesOp : Torch_Op<"aten.new_ones", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::new_ones : (Tensor, int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10167,7 +10467,8 @@ def Torch_AtenNewOnesOp : Torch_Op<"aten.new_ones", [
 def Torch_AtenZerosOp : Torch_Op<"aten.zeros", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::zeros : (int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10195,7 +10496,8 @@ def Torch_AtenZerosOp : Torch_Op<"aten.zeros", [
 def Torch_AtenNewZerosOp : Torch_Op<"aten.new_zeros", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::new_zeros : (Tensor, int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10223,7 +10525,8 @@ def Torch_AtenNewZerosOp : Torch_Op<"aten.new_zeros", [
 def Torch_AtenEyeOp : Torch_Op<"aten.eye", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eye : (int, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10250,7 +10553,8 @@ def Torch_AtenEyeOp : Torch_Op<"aten.eye", [
 def Torch_AtenEyeMOp : Torch_Op<"aten.eye.m", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eye.m : (int, int, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10278,7 +10582,8 @@ def Torch_AtenEyeMOp : Torch_Op<"aten.eye.m", [
 def Torch_AtenTensorOp : Torch_Op<"aten.tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tensor : (t[], int?, Device?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -10305,7 +10610,8 @@ def Torch_AtenTensorOp : Torch_Op<"aten.tensor", [
 def Torch_AtenTensorBoolOp : Torch_Op<"aten.tensor.bool", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tensor.bool : (bool, int?, Device?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -10331,7 +10637,8 @@ def Torch_AtenTensorBoolOp : Torch_Op<"aten.tensor.bool", [
 def Torch_AtenTensorIntOp : Torch_Op<"aten.tensor.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tensor.int : (int, int?, Device?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -10358,7 +10665,8 @@ def Torch_AtenTensorIntOp : Torch_Op<"aten.tensor.int", [
 def Torch_AtenScalarTensorOp : Torch_Op<"aten.scalar_tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::scalar_tensor : (Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10385,7 +10693,8 @@ def Torch_AtenScalarTensorOp : Torch_Op<"aten.scalar_tensor", [
 def Torch_Aten_ShapeAsTensorOp : Torch_Op<"aten._shape_as_tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_shape_as_tensor : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10409,7 +10718,8 @@ def Torch_Aten_ShapeAsTensorOp : Torch_Op<"aten._shape_as_tensor", [
 def Torch_AtenIsnanOp : Torch_Op<"aten.isnan", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::isnan : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10432,7 +10742,8 @@ def Torch_AtenIsnanOp : Torch_Op<"aten.isnan", [
 def Torch_AtenIsinfOp : Torch_Op<"aten.isinf", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::isinf : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10455,7 +10766,8 @@ def Torch_AtenIsinfOp : Torch_Op<"aten.isinf", [
 def Torch_AtenIsneginfOp : Torch_Op<"aten.isneginf", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::isneginf : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10478,7 +10790,8 @@ def Torch_AtenIsneginfOp : Torch_Op<"aten.isneginf", [
 def Torch_AtenIsposinfOp : Torch_Op<"aten.isposinf", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::isposinf : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10501,7 +10814,8 @@ def Torch_AtenIsposinfOp : Torch_Op<"aten.isposinf", [
 def Torch_AtenAllOp : Torch_Op<"aten.all", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::all : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10524,7 +10838,8 @@ def Torch_AtenAllOp : Torch_Op<"aten.all", [
 def Torch_AtenAllBoolOp : Torch_Op<"aten.all.bool", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::all.bool : (bool[]) -> (bool)`";
   let arguments = (ins
@@ -10547,7 +10862,8 @@ def Torch_AtenAllBoolOp : Torch_Op<"aten.all.bool", [
 def Torch_AtenAllDimOp : Torch_Op<"aten.all.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::all.dim : (Tensor, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -10572,7 +10888,8 @@ def Torch_AtenAllDimOp : Torch_Op<"aten.all.dim", [
 def Torch_AtenAnyOp : Torch_Op<"aten.any", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::any : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10595,7 +10912,8 @@ def Torch_AtenAnyOp : Torch_Op<"aten.any", [
 def Torch_AtenAnyDimOp : Torch_Op<"aten.any.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::any.dim : (Tensor, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -10620,7 +10938,8 @@ def Torch_AtenAnyDimOp : Torch_Op<"aten.any.dim", [
 def Torch_AtenArangeOp : Torch_Op<"aten.arange", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::arange : (Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10647,7 +10966,8 @@ def Torch_AtenArangeOp : Torch_Op<"aten.arange", [
 def Torch_AtenArangeStartOp : Torch_Op<"aten.arange.start", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::arange.start : (Scalar, Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10675,7 +10995,8 @@ def Torch_AtenArangeStartOp : Torch_Op<"aten.arange.start", [
 def Torch_AtenArangeStartStepOp : Torch_Op<"aten.arange.start_step", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::arange.start_step : (Scalar, Scalar, Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -10728,7 +11049,8 @@ def Torch_AtenArangeStartOutOp : Torch_Op<"aten.arange.start_out", [
 def Torch_AtenArgmaxOp : Torch_Op<"aten.argmax", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::argmax : (Tensor, int?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -10753,7 +11075,8 @@ def Torch_AtenArgmaxOp : Torch_Op<"aten.argmax", [
 def Torch_AtenArgminOp : Torch_Op<"aten.argmin", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::argmin : (Tensor, int?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -10778,7 +11101,8 @@ def Torch_AtenArgminOp : Torch_Op<"aten.argmin", [
 def Torch_AtenOneHotOp : Torch_Op<"aten.one_hot", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::one_hot : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -10802,7 +11126,8 @@ def Torch_AtenOneHotOp : Torch_Op<"aten.one_hot", [
 def Torch_AtenAtleast1dOp : Torch_Op<"aten.atleast_1d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::atleast_1d : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10825,7 +11150,8 @@ def Torch_AtenAtleast1dOp : Torch_Op<"aten.atleast_1d", [
 def Torch_AtenAtleast2dOp : Torch_Op<"aten.atleast_2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::atleast_2d : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10848,7 +11174,8 @@ def Torch_AtenAtleast2dOp : Torch_Op<"aten.atleast_2d", [
 def Torch_AtenEinsumOp : Torch_Op<"aten.einsum", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::einsum : (str, Tensor[], int[]?) -> (Tensor)`";
   let arguments = (ins
@@ -10873,7 +11200,8 @@ def Torch_AtenEinsumOp : Torch_Op<"aten.einsum", [
 def Torch_AtenTraceOp : Torch_Op<"aten.trace", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::trace : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10896,7 +11224,8 @@ def Torch_AtenTraceOp : Torch_Op<"aten.trace", [
 def Torch_AtenBucketizeTensorOp : Torch_Op<"aten.bucketize.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::bucketize.Tensor : (Tensor, Tensor, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -10922,7 +11251,8 @@ def Torch_AtenBucketizeTensorOp : Torch_Op<"aten.bucketize.Tensor", [
 def Torch_AtenCloneOp : Torch_Op<"aten.clone", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::clone : (Tensor, int?) -> (Tensor)`";
   let arguments = (ins
@@ -10947,7 +11277,8 @@ def Torch_AtenCloneOp : Torch_Op<"aten.clone", [
 def Torch_AtenLiftFreshCopyOp : Torch_Op<"aten.lift_fresh_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::lift_fresh_copy : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -10969,7 +11300,8 @@ def Torch_AtenLiftFreshCopyOp : Torch_Op<"aten.lift_fresh_copy", [
 
 def Torch_AtenContiguousOp : Torch_Op<"aten.contiguous", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::contiguous : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -10993,7 +11325,8 @@ def Torch_AtenContiguousOp : Torch_Op<"aten.contiguous", [
 def Torch_AtenCopyOp : Torch_Op<"aten.copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::copy : (Tensor, Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -11042,7 +11375,8 @@ def Torch_AtenCopy_Op : Torch_Op<"aten.copy_", [
 def Torch_Aten_ToCopyOp : Torch_Op<"aten._to_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_to_copy : (Tensor, int?, int?, Device?, bool?, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -11070,7 +11404,8 @@ def Torch_Aten_ToCopyOp : Torch_Op<"aten._to_copy", [
 
 def Torch_AtenDetachOp : Torch_Op<"aten.detach", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::detach : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -11094,7 +11429,8 @@ def Torch_AtenDetachOp : Torch_Op<"aten.detach", [
 def Torch_AtenDeviceWithIndexOp : Torch_Op<"aten.device.with_index", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::device.with_index : (str, int) -> (Device)`";
   let arguments = (ins
@@ -11118,7 +11454,8 @@ def Torch_AtenDeviceWithIndexOp : Torch_Op<"aten.device.with_index", [
 
 def Torch_AtenCudaOp : Torch_Op<"aten.cuda", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cuda : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -11142,7 +11479,8 @@ def Torch_AtenCudaOp : Torch_Op<"aten.cuda", [
 def Torch_AtenEmbeddingOp : Torch_Op<"aten.embedding", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::embedding : (Tensor, Tensor, int, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -11169,7 +11507,8 @@ def Torch_AtenEmbeddingOp : Torch_Op<"aten.embedding", [
 def Torch_AtenEmbeddingBagPaddingIdxOp : Torch_Op<"aten.embedding_bag.padding_idx", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::embedding_bag.padding_idx : (Tensor, Tensor, Tensor, bool, int, bool, Tensor?, bool, int?) -> (Tensor, Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -11203,7 +11542,8 @@ def Torch_AtenEmbeddingBagPaddingIdxOp : Torch_Op<"aten.embedding_bag.padding_id
 def Torch_Aten_EmbeddingBagOp : Torch_Op<"aten._embedding_bag", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_embedding_bag : (Tensor, Tensor, Tensor, bool, int, bool, Tensor?, bool, int) -> (Tensor, Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -11237,7 +11577,8 @@ def Torch_Aten_EmbeddingBagOp : Torch_Op<"aten._embedding_bag", [
 def Torch_AtenEmptyLikeOp : Torch_Op<"aten.empty_like", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::empty_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -11265,7 +11606,8 @@ def Torch_AtenEmptyLikeOp : Torch_Op<"aten.empty_like", [
 def Torch_AtenNewEmptyOp : Torch_Op<"aten.new_empty", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::new_empty : (Tensor, int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -11293,7 +11635,8 @@ def Torch_AtenNewEmptyOp : Torch_Op<"aten.new_empty", [
 def Torch_AtenNewEmptyStridedOp : Torch_Op<"aten.new_empty_strided", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::new_empty_strided : (Tensor, int[], int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -11322,7 +11665,8 @@ def Torch_AtenNewEmptyStridedOp : Torch_Op<"aten.new_empty_strided", [
 def Torch_AtenZerosLikeOp : Torch_Op<"aten.zeros_like", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::zeros_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -11350,7 +11694,8 @@ def Torch_AtenZerosLikeOp : Torch_Op<"aten.zeros_like", [
 def Torch_AtenOnesLikeOp : Torch_Op<"aten.ones_like", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ones_like : (Tensor, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -11378,7 +11723,8 @@ def Torch_AtenOnesLikeOp : Torch_Op<"aten.ones_like", [
 def Torch_AtenEmptyMemoryFormatOp : Torch_Op<"aten.empty.memory_format", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::empty.memory_format : (int[], int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -11406,7 +11752,8 @@ def Torch_AtenEmptyMemoryFormatOp : Torch_Op<"aten.empty.memory_format", [
 def Torch_AtenEmptyStridedOp : Torch_Op<"aten.empty_strided", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::empty_strided : (int[], int[], int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -11433,7 +11780,8 @@ def Torch_AtenEmptyStridedOp : Torch_Op<"aten.empty_strided", [
 
 def Torch_AtenExpandOp : Torch_Op<"aten.expand", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::expand : (Tensor, int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -11457,7 +11805,8 @@ def Torch_AtenExpandOp : Torch_Op<"aten.expand", [
 
 def Torch_AtenExpandAsOp : Torch_Op<"aten.expand_as", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::expand_as : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -11480,7 +11829,8 @@ def Torch_AtenExpandAsOp : Torch_Op<"aten.expand_as", [
 
 def Torch_AtenBroadcastToOp : Torch_Op<"aten.broadcast_to", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::broadcast_to : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -11505,7 +11855,8 @@ def Torch_AtenBroadcastToOp : Torch_Op<"aten.broadcast_to", [
 def Torch_AtenIndexTensorOp : Torch_Op<"aten.index.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::index.Tensor : (Tensor, Tensor?[]) -> (Tensor)`";
   let arguments = (ins
@@ -11529,7 +11880,8 @@ def Torch_AtenIndexTensorOp : Torch_Op<"aten.index.Tensor", [
 def Torch_AtenIndexTensorHackedTwinOp : Torch_Op<"aten.index.Tensor_hacked_twin", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::index.Tensor_hacked_twin : (Tensor, Tensor[]) -> (Tensor)`";
   let arguments = (ins
@@ -11553,7 +11905,8 @@ def Torch_AtenIndexTensorHackedTwinOp : Torch_Op<"aten.index.Tensor_hacked_twin"
 def Torch_AtenIndexSelectOp : Torch_Op<"aten.index_select", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::index_select : (Tensor, int, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -11579,7 +11932,8 @@ def Torch_AtenIndexSelectOp : Torch_Op<"aten.index_select", [
 def Torch_Aten_IndexPutImplOp : Torch_Op<"aten._index_put_impl", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_index_put_impl : (Tensor, Tensor?[], Tensor, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -11632,7 +11986,8 @@ def Torch_Aten_IndexPutImpl_Op : Torch_Op<"aten._index_put_impl_", [
 def Torch_AtenItemOp : Torch_Op<"aten.item", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::item : (Tensor) -> (Scalar)`";
   let arguments = (ins
@@ -11656,7 +12011,8 @@ def Torch_AtenItemOp : Torch_Op<"aten.item", [
 def Torch_AtenMaskedSelectOp : Torch_Op<"aten.masked_select", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::masked_select : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -11680,7 +12036,8 @@ def Torch_AtenMaskedSelectOp : Torch_Op<"aten.masked_select", [
 def Torch_AtenNumelOp : Torch_Op<"aten.numel", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::numel : (Tensor) -> (int)`";
   let arguments = (ins
@@ -11704,7 +12061,8 @@ def Torch_AtenNumelOp : Torch_Op<"aten.numel", [
 def Torch_AtenRepeatOp : Torch_Op<"aten.repeat", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::repeat : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -11728,7 +12086,8 @@ def Torch_AtenRepeatOp : Torch_Op<"aten.repeat", [
 def Torch_AtenRepeatInterleaveSelfIntOp : Torch_Op<"aten.repeat_interleave.self_int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::repeat_interleave.self_int : (Tensor, int, int?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -11754,7 +12113,8 @@ def Torch_AtenRepeatInterleaveSelfIntOp : Torch_Op<"aten.repeat_interleave.self_
 def Torch_AtenTileOp : Torch_Op<"aten.tile", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tile : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -11777,7 +12137,8 @@ def Torch_AtenTileOp : Torch_Op<"aten.tile", [
 
 def Torch_AtenReshapeOp : Torch_Op<"aten.reshape", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::reshape : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -11801,7 +12162,8 @@ def Torch_AtenReshapeOp : Torch_Op<"aten.reshape", [
 
 def Torch_AtenReshapeAsOp : Torch_Op<"aten.reshape_as", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::reshape_as : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -11824,7 +12186,8 @@ def Torch_AtenReshapeAsOp : Torch_Op<"aten.reshape_as", [
 
 def Torch_Aten_ReshapeAliasOp : Torch_Op<"aten._reshape_alias", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_reshape_alias : (Tensor, int[], int[]) -> (Tensor)`";
   let arguments = (ins
@@ -11849,7 +12212,8 @@ def Torch_Aten_ReshapeAliasOp : Torch_Op<"aten._reshape_alias", [
 def Torch_AtenResizeOp : Torch_Op<"aten.resize", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::resize : (Tensor, int[], int?) -> (Tensor)`";
   let arguments = (ins
@@ -11896,7 +12260,8 @@ def Torch_AtenResize_Op : Torch_Op<"aten.resize_", [
 
 def Torch_AtenSelectIntOp : Torch_Op<"aten.select.int", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::select.int : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -11922,7 +12287,8 @@ def Torch_AtenSelectIntOp : Torch_Op<"aten.select.int", [
 def Torch_AtenSizeIntOp : Torch_Op<"aten.size.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::size.int : (Tensor, int) -> (int)`";
   let arguments = (ins
@@ -11947,7 +12313,8 @@ def Torch_AtenSizeIntOp : Torch_Op<"aten.size.int", [
 def Torch_AtenSumOp : Torch_Op<"aten.sum", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sum : (Tensor, int?) -> (Tensor)`";
   let arguments = (ins
@@ -11971,7 +12338,8 @@ def Torch_AtenSumOp : Torch_Op<"aten.sum", [
 def Torch_AtenSumDimIntListOp : Torch_Op<"aten.sum.dim_IntList", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sum.dim_IntList : (Tensor, int[]?, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -11997,7 +12365,8 @@ def Torch_AtenSumDimIntListOp : Torch_Op<"aten.sum.dim_IntList", [
 def Torch_AtenProdDimIntOp : Torch_Op<"aten.prod.dim_int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::prod.dim_int : (Tensor, int, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -12023,7 +12392,8 @@ def Torch_AtenProdDimIntOp : Torch_Op<"aten.prod.dim_int", [
 def Torch_AtenProdOp : Torch_Op<"aten.prod", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::prod : (Tensor, int?) -> (Tensor)`";
   let arguments = (ins
@@ -12047,7 +12417,8 @@ def Torch_AtenProdOp : Torch_Op<"aten.prod", [
 def Torch_AtenMaxOp : Torch_Op<"aten.max", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -12070,7 +12441,8 @@ def Torch_AtenMaxOp : Torch_Op<"aten.max", [
 def Torch_AtenMaxOtherOp : Torch_Op<"aten.max.other", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max.other : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -12095,7 +12467,8 @@ def Torch_AtenMaxOtherOp : Torch_Op<"aten.max.other", [
 def Torch_AtenMaxDimOp : Torch_Op<"aten.max.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::max.dim : (Tensor, int, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -12121,7 +12494,8 @@ def Torch_AtenMaxDimOp : Torch_Op<"aten.max.dim", [
 def Torch_AtenAmaxOp : Torch_Op<"aten.amax", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::amax : (Tensor, int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -12146,7 +12520,8 @@ def Torch_AtenAmaxOp : Torch_Op<"aten.amax", [
 def Torch_AtenMinOp : Torch_Op<"aten.min", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::min : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -12169,7 +12544,8 @@ def Torch_AtenMinOp : Torch_Op<"aten.min", [
 def Torch_AtenMinOtherOp : Torch_Op<"aten.min.other", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::min.other : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -12194,7 +12570,8 @@ def Torch_AtenMinOtherOp : Torch_Op<"aten.min.other", [
 def Torch_AtenMinDimOp : Torch_Op<"aten.min.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::min.dim : (Tensor, int, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -12220,7 +12597,8 @@ def Torch_AtenMinDimOp : Torch_Op<"aten.min.dim", [
 def Torch_AtenAminOp : Torch_Op<"aten.amin", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::amin : (Tensor, int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -12245,7 +12623,8 @@ def Torch_AtenAminOp : Torch_Op<"aten.amin", [
 def Torch_AtenAminmaxOp : Torch_Op<"aten.aminmax", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::aminmax : (Tensor, int?, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -12270,7 +12649,8 @@ def Torch_AtenAminmaxOp : Torch_Op<"aten.aminmax", [
 
 def Torch_AtenToDtypeOp : Torch_Op<"aten.to.dtype", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::to.dtype : (Tensor, int, bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -12297,7 +12677,8 @@ def Torch_AtenToDtypeOp : Torch_Op<"aten.to.dtype", [
 
 def Torch_AtenToDtypeLayoutOp : Torch_Op<"aten.to.dtype_layout", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::to.dtype_layout : (Tensor, int?, int?, Device?, bool?, bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -12328,7 +12709,8 @@ def Torch_AtenToDtypeLayoutOp : Torch_Op<"aten.to.dtype_layout", [
 
 def Torch_AtenToOtherOp : Torch_Op<"aten.to.other", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::to.other : (Tensor, Tensor, bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -12355,7 +12737,8 @@ def Torch_AtenToOtherOp : Torch_Op<"aten.to.other", [
 
 def Torch_AtenToPrimDeviceOp : Torch_Op<"aten.to.prim_Device", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::to.prim_Device : (Tensor, Device?, int?, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -12381,7 +12764,8 @@ def Torch_AtenToPrimDeviceOp : Torch_Op<"aten.to.prim_Device", [
 
 def Torch_AtenToDeviceOp : Torch_Op<"aten.to.device", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::to.device : (Tensor, Device, int, bool, bool, int?) -> (Tensor)`";
   let arguments = (ins
@@ -12409,7 +12793,8 @@ def Torch_AtenToDeviceOp : Torch_Op<"aten.to.device", [
 def Torch_Aten_CastFloatOp : Torch_Op<"aten._cast_Float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_cast_Float : (Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -12434,7 +12819,8 @@ def Torch_Aten_CastFloatOp : Torch_Op<"aten._cast_Float", [
 def Torch_Aten_CastLongOp : Torch_Op<"aten._cast_Long", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_cast_Long : (Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -12459,7 +12845,8 @@ def Torch_Aten_CastLongOp : Torch_Op<"aten._cast_Long", [
 def Torch_AtenTypeAsOp : Torch_Op<"aten.type_as", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::type_as : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -12482,7 +12869,8 @@ def Torch_AtenTypeAsOp : Torch_Op<"aten.type_as", [
 
 def Torch_AtenViewOp : Torch_Op<"aten.view", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::view : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -12506,7 +12894,8 @@ def Torch_AtenViewOp : Torch_Op<"aten.view", [
 
 def Torch_AtenViewDtypeOp : Torch_Op<"aten.view.dtype", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::view.dtype : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -12530,7 +12919,8 @@ def Torch_AtenViewDtypeOp : Torch_Op<"aten.view.dtype", [
 def Torch_Aten_UnsafeViewOp : Torch_Op<"aten._unsafe_view", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_unsafe_view : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -12554,7 +12944,8 @@ def Torch_Aten_UnsafeViewOp : Torch_Op<"aten._unsafe_view", [
 def Torch_AtenWhereSelfOp : Torch_Op<"aten.where.self", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::where.self : (Tensor, Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -12580,7 +12971,8 @@ def Torch_AtenWhereSelfOp : Torch_Op<"aten.where.self", [
 def Torch_AtenWhereScalarOp : Torch_Op<"aten.where.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::where.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -12607,7 +12999,8 @@ def Torch_AtenWhereScalarOp : Torch_Op<"aten.where.Scalar", [
 def Torch_AtenWhereScalarOtherOp : Torch_Op<"aten.where.ScalarOther", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::where.ScalarOther : (Tensor, Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -12633,7 +13026,8 @@ def Torch_AtenWhereScalarOtherOp : Torch_Op<"aten.where.ScalarOther", [
 def Torch_AtenWhereScalarSelfOp : Torch_Op<"aten.where.ScalarSelf", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::where.ScalarSelf : (Tensor, Scalar, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -12659,7 +13053,8 @@ def Torch_AtenWhereScalarSelfOp : Torch_Op<"aten.where.ScalarSelf", [
 def Torch_AtenNanToNumOp : Torch_Op<"aten.nan_to_num", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::nan_to_num : (Tensor, float?, float?, float?) -> (Tensor)`";
   let arguments = (ins
@@ -12684,7 +13079,8 @@ def Torch_AtenNanToNumOp : Torch_Op<"aten.nan_to_num", [
 
 def Torch_AtenSliceTensorOp : Torch_Op<"aten.slice.Tensor", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::slice.Tensor : (Tensor, int, int?, int?, int) -> (Tensor)`";
   let arguments = (ins
@@ -12712,7 +13108,8 @@ def Torch_AtenSliceTensorOp : Torch_Op<"aten.slice.Tensor", [
 def Torch_AtenLenTensorOp : Torch_Op<"aten.len.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::len.Tensor : (Tensor) -> (int)`";
   let arguments = (ins
@@ -12734,7 +13131,8 @@ def Torch_AtenLenTensorOp : Torch_Op<"aten.len.Tensor", [
 
 def Torch_AtenCpuOp : Torch_Op<"aten.cpu", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cpu : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -12757,7 +13155,8 @@ def Torch_AtenCpuOp : Torch_Op<"aten.cpu", [
 def Torch_AtenGatherOp : Torch_Op<"aten.gather", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::gather : (Tensor, int, Tensor, bool) -> (Tensor)`";
   let arguments = (ins
@@ -12783,7 +13182,8 @@ def Torch_AtenGatherOp : Torch_Op<"aten.gather", [
 def Torch_AtenScatterAddOp : Torch_Op<"aten.scatter_add", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::scatter_add : (Tensor, int, Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -12834,7 +13234,8 @@ def Torch_AtenScatterAdd_Op : Torch_Op<"aten.scatter_add_", [
 def Torch_AtenScatterReduceTwoOp : Torch_Op<"aten.scatter_reduce.two", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::scatter_reduce.two : (Tensor, int, Tensor, Tensor, str, bool) -> (Tensor)`";
   let arguments = (ins
@@ -12889,7 +13290,8 @@ def Torch_AtenScatterReduce_TwoOp : Torch_Op<"aten.scatter_reduce_.two", [
 def Torch_AtenIntImplicitOp : Torch_Op<"aten.IntImplicit", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::IntImplicit : (Tensor) -> (int)`";
   let arguments = (ins
@@ -12913,7 +13315,8 @@ def Torch_AtenIntImplicitOp : Torch_Op<"aten.IntImplicit", [
 def Torch_AtenFloatImplicitOp : Torch_Op<"aten.FloatImplicit", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::FloatImplicit : (Tensor) -> (float)`";
   let arguments = (ins
@@ -12937,7 +13340,8 @@ def Torch_AtenFloatImplicitOp : Torch_Op<"aten.FloatImplicit", [
 def Torch_AtenTensorFloatOp : Torch_Op<"aten.tensor.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tensor.float : (float, int?, Device?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -12964,7 +13368,8 @@ def Torch_AtenTensorFloatOp : Torch_Op<"aten.tensor.float", [
 def Torch_AtenIntTensorOp : Torch_Op<"aten.Int.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Int.Tensor : (Tensor) -> (int)`";
   let arguments = (ins
@@ -12989,7 +13394,8 @@ def Torch_AtenIntTensorOp : Torch_Op<"aten.Int.Tensor", [
 def Torch_AtenFloatTensorOp : Torch_Op<"aten.Float.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Float.Tensor : (Tensor) -> (float)`";
   let arguments = (ins
@@ -13013,7 +13419,8 @@ def Torch_AtenFloatTensorOp : Torch_Op<"aten.Float.Tensor", [
 def Torch_AtenDropoutOp : Torch_Op<"aten.dropout", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::dropout : (Tensor, float, bool) -> (Tensor)`";
   let arguments = (ins
@@ -13062,7 +13469,8 @@ def Torch_AtenDropout_Op : Torch_Op<"aten.dropout_", [
 def Torch_AtenNativeDropoutOp : Torch_Op<"aten.native_dropout", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::native_dropout : (Tensor, float, bool?) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -13087,7 +13495,8 @@ def Torch_AtenNativeDropoutOp : Torch_Op<"aten.native_dropout", [
 
 def Torch_AtenTOp : Torch_Op<"aten.t", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::t : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -13109,7 +13518,8 @@ def Torch_AtenTOp : Torch_Op<"aten.t", [
 
 def Torch_AtenNumpyTOp : Torch_Op<"aten.numpy_T", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::numpy_T : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -13132,7 +13542,8 @@ def Torch_AtenNumpyTOp : Torch_Op<"aten.numpy_T", [
 def Torch_AtenFullOp : Torch_Op<"aten.full", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::full : (int[], Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -13161,7 +13572,8 @@ def Torch_AtenFullOp : Torch_Op<"aten.full", [
 def Torch_AtenFullLikeOp : Torch_Op<"aten.full_like", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::full_like : (Tensor, Scalar, int?, int?, Device?, bool?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -13190,7 +13602,8 @@ def Torch_AtenFullLikeOp : Torch_Op<"aten.full_like", [
 def Torch_AtenNewFullOp : Torch_Op<"aten.new_full", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::new_full : (Tensor, int[], Scalar, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -13219,7 +13632,8 @@ def Torch_AtenNewFullOp : Torch_Op<"aten.new_full", [
 def Torch_AtenBaddbmmOp : Torch_Op<"aten.baddbmm", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::baddbmm : (Tensor, Tensor, Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -13272,7 +13686,8 @@ def Torch_AtenBaddbmm_Op : Torch_Op<"aten.baddbmm_", [
 def Torch_AtenHannWindowPeriodicOp : Torch_Op<"aten.hann_window.periodic", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::hann_window.periodic : (int, bool, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -13300,7 +13715,8 @@ def Torch_AtenHannWindowPeriodicOp : Torch_Op<"aten.hann_window.periodic", [
 def Torch_AtenFftFftOp : Torch_Op<"aten.fft_fft", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fft_fft : (Tensor, int?, int, str?) -> (Tensor)`";
   let arguments = (ins
@@ -13326,7 +13742,8 @@ def Torch_AtenFftFftOp : Torch_Op<"aten.fft_fft", [
 def Torch_AtenFftIfftOp : Torch_Op<"aten.fft_ifft", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fft_ifft : (Tensor, int?, int, str?) -> (Tensor)`";
   let arguments = (ins
@@ -13352,7 +13769,8 @@ def Torch_AtenFftIfftOp : Torch_Op<"aten.fft_ifft", [
 def Torch_AtenFmodTensorOp : Torch_Op<"aten.fmod.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::fmod.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -13376,7 +13794,8 @@ def Torch_AtenFmodTensorOp : Torch_Op<"aten.fmod.Tensor", [
 def Torch_AtenUniqueConsecutiveOp : Torch_Op<"aten.unique_consecutive", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::unique_consecutive : (Tensor, bool, bool, int?) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -13404,7 +13823,8 @@ def Torch_AtenUniqueConsecutiveOp : Torch_Op<"aten.unique_consecutive", [
 def Torch_AtenUniqueDimOp : Torch_Op<"aten.unique_dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::unique_dim : (Tensor, int, bool, bool, bool) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -13433,7 +13853,8 @@ def Torch_AtenUniqueDimOp : Torch_Op<"aten.unique_dim", [
 def Torch_AtenLinspaceOp : Torch_Op<"aten.linspace", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::linspace : (Scalar, Scalar, int, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -13462,7 +13883,8 @@ def Torch_AtenLinspaceOp : Torch_Op<"aten.linspace", [
 def Torch_AtenLinalgCrossOp : Torch_Op<"aten.linalg_cross", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::linalg_cross : (Tensor, Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -13488,7 +13910,8 @@ def Torch_AtenLinalgCrossOp : Torch_Op<"aten.linalg_cross", [
 def Torch_AtenCol2imOp : Torch_Op<"aten.col2im", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::col2im : (Tensor, int[], int[], int[], int[], int[]) -> (Tensor)`";
   let arguments = (ins
@@ -13516,7 +13939,8 @@ def Torch_AtenCol2imOp : Torch_Op<"aten.col2im", [
 def Torch_AtenKthvalueOp : Torch_Op<"aten.kthvalue", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::kthvalue : (Tensor, int, int, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -13544,7 +13968,8 @@ def Torch_AtenKthvalueOp : Torch_Op<"aten.kthvalue", [
 def Torch_AtenStftOp : Torch_Op<"aten.stft", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::stft : (Tensor, int, int?, int?, Tensor?, bool, bool?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -13574,7 +13999,8 @@ def Torch_AtenStftOp : Torch_Op<"aten.stft", [
 def Torch_AtenAliasCopyOp : Torch_Op<"aten.alias_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::alias_copy : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -13596,7 +14022,8 @@ def Torch_AtenAliasCopyOp : Torch_Op<"aten.alias_copy", [
 
 def Torch_AtenAliasOp : Torch_Op<"aten.alias", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::alias : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -13620,7 +14047,8 @@ def Torch_AtenAliasOp : Torch_Op<"aten.alias", [
 def Torch_AtenAsStridedCopyOp : Torch_Op<"aten.as_strided_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::as_strided_copy : (Tensor, int[], int[], int?) -> (Tensor)`";
   let arguments = (ins
@@ -13645,7 +14073,8 @@ def Torch_AtenAsStridedCopyOp : Torch_Op<"aten.as_strided_copy", [
 
 def Torch_AtenAsStridedOp : Torch_Op<"aten.as_strided", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::as_strided : (Tensor, int[], int[], int?) -> (Tensor)`";
   let arguments = (ins
@@ -13670,7 +14099,8 @@ def Torch_AtenAsStridedOp : Torch_Op<"aten.as_strided", [
 
 def Torch_AtenDiagonalOp : Torch_Op<"aten.diagonal", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::diagonal : (Tensor, int, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -13696,7 +14126,8 @@ def Torch_AtenDiagonalOp : Torch_Op<"aten.diagonal", [
 def Torch_AtenDiagonalCopyOp : Torch_Op<"aten.diagonal_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::diagonal_copy : (Tensor, int, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -13722,7 +14153,8 @@ def Torch_AtenDiagonalCopyOp : Torch_Op<"aten.diagonal_copy", [
 def Torch_AtenExpandCopyOp : Torch_Op<"aten.expand_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::expand_copy : (Tensor, int[], bool) -> (Tensor)`";
   let arguments = (ins
@@ -13747,7 +14179,8 @@ def Torch_AtenExpandCopyOp : Torch_Op<"aten.expand_copy", [
 def Torch_AtenPermuteCopyOp : Torch_Op<"aten.permute_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::permute_copy : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -13771,7 +14204,8 @@ def Torch_AtenPermuteCopyOp : Torch_Op<"aten.permute_copy", [
 def Torch_Aten_ReshapeAliasCopyOp : Torch_Op<"aten._reshape_alias_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_reshape_alias_copy : (Tensor, int[], int[]) -> (Tensor)`";
   let arguments = (ins
@@ -13796,7 +14230,8 @@ def Torch_Aten_ReshapeAliasCopyOp : Torch_Op<"aten._reshape_alias_copy", [
 def Torch_AtenSelectCopyIntOp : Torch_Op<"aten.select_copy.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::select_copy.int : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -13821,7 +14256,8 @@ def Torch_AtenSelectCopyIntOp : Torch_Op<"aten.select_copy.int", [
 def Torch_AtenDetachCopyOp : Torch_Op<"aten.detach_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::detach_copy : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -13844,7 +14280,8 @@ def Torch_AtenDetachCopyOp : Torch_Op<"aten.detach_copy", [
 def Torch_AtenSliceCopyTensorOp : Torch_Op<"aten.slice_copy.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::slice_copy.Tensor : (Tensor, int, int?, int?, int) -> (Tensor)`";
   let arguments = (ins
@@ -13871,7 +14308,8 @@ def Torch_AtenSliceCopyTensorOp : Torch_Op<"aten.slice_copy.Tensor", [
 def Torch_AtenSqueezeCopyOp : Torch_Op<"aten.squeeze_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::squeeze_copy : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -13894,7 +14332,8 @@ def Torch_AtenSqueezeCopyOp : Torch_Op<"aten.squeeze_copy", [
 def Torch_AtenSqueezeCopyDimOp : Torch_Op<"aten.squeeze_copy.dim", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::squeeze_copy.dim : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -13918,7 +14357,8 @@ def Torch_AtenSqueezeCopyDimOp : Torch_Op<"aten.squeeze_copy.dim", [
 def Torch_AtenTCopyOp : Torch_Op<"aten.t_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::t_copy : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -13941,7 +14381,8 @@ def Torch_AtenTCopyOp : Torch_Op<"aten.t_copy", [
 def Torch_AtenTransposeCopyIntOp : Torch_Op<"aten.transpose_copy.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::transpose_copy.int : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -13966,7 +14407,8 @@ def Torch_AtenTransposeCopyIntOp : Torch_Op<"aten.transpose_copy.int", [
 def Torch_AtenUnsqueezeCopyOp : Torch_Op<"aten.unsqueeze_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::unsqueeze_copy : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -13990,7 +14432,8 @@ def Torch_AtenUnsqueezeCopyOp : Torch_Op<"aten.unsqueeze_copy", [
 def Torch_AtenViewCopyOp : Torch_Op<"aten.view_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::view_copy : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -14014,7 +14457,8 @@ def Torch_AtenViewCopyOp : Torch_Op<"aten.view_copy", [
 def Torch_AtenViewCopyDtypeOp : Torch_Op<"aten.view_copy.dtype", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::view_copy.dtype : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -14037,7 +14481,8 @@ def Torch_AtenViewCopyDtypeOp : Torch_Op<"aten.view_copy.dtype", [
 
 def Torch_AtenUnfoldOp : Torch_Op<"aten.unfold", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::unfold : (Tensor, int, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -14063,7 +14508,8 @@ def Torch_AtenUnfoldOp : Torch_Op<"aten.unfold", [
 def Torch_AtenUnfoldCopyOp : Torch_Op<"aten.unfold_copy", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::unfold_copy : (Tensor, int, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -14089,7 +14535,8 @@ def Torch_AtenUnfoldCopyOp : Torch_Op<"aten.unfold_copy", [
 def Torch_AtenIm2colOp : Torch_Op<"aten.im2col", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::im2col : (Tensor, int[], int[], int[], int[]) -> (Tensor)`";
   let arguments = (ins
@@ -14116,7 +14563,8 @@ def Torch_AtenIm2colOp : Torch_Op<"aten.im2col", [
 def Torch_AtenScatterReduceOp : Torch_Op<"aten.scatter.reduce", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::scatter.reduce : (Tensor, int, Tensor, Tensor, str) -> (Tensor)`";
   let arguments = (ins
@@ -14143,7 +14591,8 @@ def Torch_AtenScatterReduceOp : Torch_Op<"aten.scatter.reduce", [
 def Torch_AtenSelectScatterOp : Torch_Op<"aten.select_scatter", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::select_scatter : (Tensor, Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -14169,7 +14618,8 @@ def Torch_AtenSelectScatterOp : Torch_Op<"aten.select_scatter", [
 def Torch_AtenSliceScatterOp : Torch_Op<"aten.slice_scatter", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::slice_scatter : (Tensor, Tensor, int, int?, int?, int) -> (Tensor)`";
   let arguments = (ins
@@ -14197,7 +14647,8 @@ def Torch_AtenSliceScatterOp : Torch_Op<"aten.slice_scatter", [
 def Torch_AtenDiagonalScatterOp : Torch_Op<"aten.diagonal_scatter", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::diagonal_scatter : (Tensor, Tensor, int, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -14224,7 +14675,8 @@ def Torch_AtenDiagonalScatterOp : Torch_Op<"aten.diagonal_scatter", [
 def Torch_AtenAsStridedScatterOp : Torch_Op<"aten.as_strided_scatter", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::as_strided_scatter : (Tensor, Tensor, int[], int[], int?) -> (Tensor)`";
   let arguments = (ins
@@ -14251,7 +14703,8 @@ def Torch_AtenAsStridedScatterOp : Torch_Op<"aten.as_strided_scatter", [
 def Torch_AtenUpsampleNearest1dOp : Torch_Op<"aten.upsample_nearest1d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::upsample_nearest1d : (Tensor, int[], float?) -> (Tensor)`";
   let arguments = (ins
@@ -14276,7 +14729,8 @@ def Torch_AtenUpsampleNearest1dOp : Torch_Op<"aten.upsample_nearest1d", [
 def Torch_AtenUpsampleNearest1dVecOp : Torch_Op<"aten.upsample_nearest1d.vec", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::upsample_nearest1d.vec : (Tensor, int[]?, float[]?) -> (Tensor)`";
   let arguments = (ins
@@ -14301,7 +14755,8 @@ def Torch_AtenUpsampleNearest1dVecOp : Torch_Op<"aten.upsample_nearest1d.vec", [
 def Torch_AtenUpsampleNearest2dOp : Torch_Op<"aten.upsample_nearest2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::upsample_nearest2d : (Tensor, int[], float?, float?) -> (Tensor)`";
   let arguments = (ins
@@ -14327,7 +14782,8 @@ def Torch_AtenUpsampleNearest2dOp : Torch_Op<"aten.upsample_nearest2d", [
 def Torch_AtenUpsampleNearest2dVecOp : Torch_Op<"aten.upsample_nearest2d.vec", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::upsample_nearest2d.vec : (Tensor, int[]?, float[]?) -> (Tensor)`";
   let arguments = (ins
@@ -14352,7 +14808,8 @@ def Torch_AtenUpsampleNearest2dVecOp : Torch_Op<"aten.upsample_nearest2d.vec", [
 def Torch_AtenUpsampleBilinear2dOp : Torch_Op<"aten.upsample_bilinear2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::upsample_bilinear2d : (Tensor, int[], bool, float?, float?) -> (Tensor)`";
   let arguments = (ins
@@ -14379,7 +14836,8 @@ def Torch_AtenUpsampleBilinear2dOp : Torch_Op<"aten.upsample_bilinear2d", [
 def Torch_AtenUpsampleBilinear2dVecOp : Torch_Op<"aten.upsample_bilinear2d.vec", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::upsample_bilinear2d.vec : (Tensor, int[]?, bool, float[]?) -> (Tensor)`";
   let arguments = (ins
@@ -14405,7 +14863,8 @@ def Torch_AtenUpsampleBilinear2dVecOp : Torch_Op<"aten.upsample_bilinear2d.vec",
 def Torch_AtenScaledDotProductAttentionOp : Torch_Op<"aten.scaled_dot_product_attention", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::scaled_dot_product_attention : (Tensor, Tensor, Tensor, Tensor?, float, bool, float?, bool) -> (Tensor)`";
   let arguments = (ins
@@ -14435,7 +14894,8 @@ def Torch_AtenScaledDotProductAttentionOp : Torch_Op<"aten.scaled_dot_product_at
 def Torch_AtenGridSamplerOp : Torch_Op<"aten.grid_sampler", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::grid_sampler : (Tensor, Tensor, int, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -14462,7 +14922,8 @@ def Torch_AtenGridSamplerOp : Torch_Op<"aten.grid_sampler", [
 def Torch_Aten_TrilinearOp : Torch_Op<"aten._trilinear", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_trilinear : (Tensor, Tensor, Tensor, int[], int[], int[], int[], int) -> (Tensor)`";
   let arguments = (ins
@@ -14492,7 +14953,8 @@ def Torch_Aten_TrilinearOp : Torch_Op<"aten._trilinear", [
 def Torch_Aten__Contains__StrOp : Torch_Op<"aten.__contains__.str", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__contains__.str : (Dict(str, t), str) -> (bool)`";
   let arguments = (ins
@@ -14517,7 +14979,8 @@ def Torch_Aten__Contains__StrOp : Torch_Op<"aten.__contains__.str", [
 def Torch_Aten__Contains__IntListOp : Torch_Op<"aten.__contains__.int_list", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__contains__.int_list : (int[], int) -> (bool)`";
   let arguments = (ins
@@ -14541,7 +15004,8 @@ def Torch_Aten__Contains__IntListOp : Torch_Op<"aten.__contains__.int_list", [
 
 def Torch_Aten__Getitem__DictStrOp : Torch_Op<"aten.__getitem__.Dict_str", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__getitem__.Dict_str : (Dict(str, t), str) -> (t)`";
   let arguments = (ins
@@ -14587,7 +15051,8 @@ def Torch_Aten_SetItemStrOp : Torch_Op<"aten._set_item.str", [
 
 def Torch_AtenKeysStrOp : Torch_Op<"aten.keys.str", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::keys.str : (Dict(str, t)) -> (str[])`";
   let arguments = (ins
@@ -14609,7 +15074,8 @@ def Torch_AtenKeysStrOp : Torch_Op<"aten.keys.str", [
 
 def Torch_AtenGetDefaultStrOp : Torch_Op<"aten.get.default_str", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::get.default_str : (Dict(str, t), str, t) -> (t)`";
   let arguments = (ins
@@ -14655,7 +15121,8 @@ def Torch_AtenDeleteDictStrOp : Torch_Op<"aten.Delete.Dict_str", [
 def Torch_AtenCatOp : Torch_Op<"aten.cat", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::cat : (Tensor[], int) -> (Tensor)`";
   let arguments = (ins
@@ -14681,7 +15148,8 @@ def Torch_AtenCatOp : Torch_Op<"aten.cat", [
 def Torch_AtenStackOp : Torch_Op<"aten.stack", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::stack : (Tensor[], int) -> (Tensor)`";
   let arguments = (ins
@@ -14705,7 +15173,8 @@ def Torch_AtenStackOp : Torch_Op<"aten.stack", [
 def Torch_AtenHstackOp : Torch_Op<"aten.hstack", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::hstack : (Tensor[]) -> (Tensor)`";
   let arguments = (ins
@@ -14728,7 +15197,8 @@ def Torch_AtenHstackOp : Torch_Op<"aten.hstack", [
 def Torch_AtenColumnStackOp : Torch_Op<"aten.column_stack", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::column_stack : (Tensor[]) -> (Tensor)`";
   let arguments = (ins
@@ -14773,7 +15243,8 @@ def Torch_AtenAppendTOp : Torch_Op<"aten.append.t", [
 def Torch_AtenAddTOp : Torch_Op<"aten.add.t", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::add.t : (t[], t[]) -> (t[])`";
   let arguments = (ins
@@ -14798,7 +15269,8 @@ def Torch_AtenAddTOp : Torch_Op<"aten.add.t", [
 def Torch_AtenEqIntListOp : Torch_Op<"aten.eq.int_list", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eq.int_list : (int[], int[]) -> (bool)`";
   let arguments = (ins
@@ -14823,7 +15295,8 @@ def Torch_AtenEqIntListOp : Torch_Op<"aten.eq.int_list", [
 def Torch_AtenListTOp : Torch_Op<"aten.list.t", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::list.t : (t[]) -> (t[])`";
   let arguments = (ins
@@ -14846,7 +15319,8 @@ def Torch_AtenListTOp : Torch_Op<"aten.list.t", [
 def Torch_AtenSliceTOp : Torch_Op<"aten.slice.t", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::slice.t : (t[], int?, int?, int) -> (t[])`";
   let arguments = (ins
@@ -14895,7 +15369,8 @@ def Torch_AtenInsertTOp : Torch_Op<"aten.insert.t", [
 def Torch_AtenNeIntListOp : Torch_Op<"aten.ne.int_list", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ne.int_list : (int[], int[]) -> (bool)`";
   let arguments = (ins
@@ -14919,7 +15394,8 @@ def Torch_AtenNeIntListOp : Torch_Op<"aten.ne.int_list", [
 def Torch_AtenAnyBoolOp : Torch_Op<"aten.any.bool", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::any.bool : (bool[]) -> (bool)`";
   let arguments = (ins
@@ -14965,7 +15441,8 @@ def Torch_AtenSortIntOp : Torch_Op<"aten.sort.int", [
 def Torch_AtenSortOp : Torch_Op<"aten.sort", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sort : (Tensor, int, bool) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -14991,7 +15468,8 @@ def Torch_AtenSortOp : Torch_Op<"aten.sort", [
 
 def Torch_AtenSplitTensorOp : Torch_Op<"aten.split.Tensor", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::split.Tensor : (Tensor, int, int) -> (Tensor[])`";
   let arguments = (ins
@@ -15015,7 +15493,8 @@ def Torch_AtenSplitTensorOp : Torch_Op<"aten.split.Tensor", [
 
 def Torch_AtenSplitWithSizesOp : Torch_Op<"aten.split_with_sizes", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::split_with_sizes : (Tensor, int[], int) -> (Tensor[])`";
   let arguments = (ins
@@ -15039,7 +15518,8 @@ def Torch_AtenSplitWithSizesOp : Torch_Op<"aten.split_with_sizes", [
 
 def Torch_AtenSplitSizesOp : Torch_Op<"aten.split.sizes", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::split.sizes : (Tensor, int[], int) -> (Tensor[])`";
   let arguments = (ins
@@ -15064,7 +15544,8 @@ def Torch_AtenSplitSizesOp : Torch_Op<"aten.split.sizes", [
 
 def Torch_AtenTensorSplitSectionsOp : Torch_Op<"aten.tensor_split.sections", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tensor_split.sections : (Tensor, int, int) -> (Tensor[])`";
   let arguments = (ins
@@ -15088,7 +15569,8 @@ def Torch_AtenTensorSplitSectionsOp : Torch_Op<"aten.tensor_split.sections", [
 
 def Torch_AtenUnbindIntOp : Torch_Op<"aten.unbind.int", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::unbind.int : (Tensor, int) -> (Tensor[])`";
   let arguments = (ins
@@ -15111,7 +15593,8 @@ def Torch_AtenUnbindIntOp : Torch_Op<"aten.unbind.int", [
 
 def Torch_AtenChunkOp : Torch_Op<"aten.chunk", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::chunk : (Tensor, int, int) -> (Tensor[])`";
   let arguments = (ins
@@ -15136,7 +15619,8 @@ def Torch_AtenChunkOp : Torch_Op<"aten.chunk", [
 def Torch_AtenMeshgridOp : Torch_Op<"aten.meshgrid", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::meshgrid : (Tensor[]) -> (Tensor[])`";
   let arguments = (ins
@@ -15160,7 +15644,8 @@ def Torch_AtenMeshgridOp : Torch_Op<"aten.meshgrid", [
 def Torch_AtenMeshgridIndexingOp : Torch_Op<"aten.meshgrid.indexing", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::meshgrid.indexing : (Tensor[], str) -> (Tensor[])`";
   let arguments = (ins
@@ -15184,7 +15669,8 @@ def Torch_AtenMeshgridIndexingOp : Torch_Op<"aten.meshgrid.indexing", [
 def Torch_AtenAddStrOp : Torch_Op<"aten.add.str", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::add.str : (str, str) -> (str)`";
   let arguments = (ins
@@ -15208,7 +15694,8 @@ def Torch_AtenAddStrOp : Torch_Op<"aten.add.str", [
 def Torch_AtenEqStrOp : Torch_Op<"aten.eq.str", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eq.str : (str, str) -> (bool)`";
   let arguments = (ins
@@ -15233,7 +15720,8 @@ def Torch_AtenEqStrOp : Torch_Op<"aten.eq.str", [
 def Torch_AtenNeStrOp : Torch_Op<"aten.ne.str", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ne.str : (str, str) -> (bool)`";
   let arguments = (ins
@@ -15258,7 +15746,8 @@ def Torch_AtenNeStrOp : Torch_Op<"aten.ne.str", [
 def Torch_AtenLenStrOp : Torch_Op<"aten.len.str", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::len.str : (str) -> (int)`";
   let arguments = (ins
@@ -15282,7 +15771,8 @@ def Torch_AtenLenStrOp : Torch_Op<"aten.len.str", [
 def Torch_AtenStrOp : Torch_Op<"aten.str", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::str : (t) -> (str)`";
   let arguments = (ins
@@ -15304,7 +15794,8 @@ def Torch_AtenStrOp : Torch_Op<"aten.str", [
 
 def Torch_AtenFormatOp : Torch_Op<"aten.format", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::format : (...) -> (str)`";
   let arguments = (ins
@@ -15319,7 +15810,8 @@ def Torch_AtenFormatOp : Torch_Op<"aten.format", [
 def Torch_AtenJoinOp : Torch_Op<"aten.join", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::join : (str, str[]) -> (str)`";
   let arguments = (ins
@@ -15366,7 +15858,8 @@ def Torch_AtenWarnOp : Torch_Op<"aten.warn", [
 def Torch_Aten__Contains__StrListOp : Torch_Op<"aten.__contains__.str_list", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__contains__.str_list : (str[], str) -> (bool)`";
   let arguments = (ins
@@ -15391,7 +15884,8 @@ def Torch_Aten__Contains__StrListOp : Torch_Op<"aten.__contains__.str_list", [
 def Torch_AtenFloatScalarOp : Torch_Op<"aten.Float.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Float.Scalar : (Scalar) -> (float)`";
   let arguments = (ins
@@ -15415,7 +15909,8 @@ def Torch_AtenFloatScalarOp : Torch_Op<"aten.Float.Scalar", [
 def Torch_AtenFloatStrOp : Torch_Op<"aten.Float.str", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Float.str : (str) -> (float)`";
   let arguments = (ins
@@ -15438,7 +15933,8 @@ def Torch_AtenFloatStrOp : Torch_Op<"aten.Float.str", [
 def Torch_AtenIntFloatOp : Torch_Op<"aten.Int.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Int.float : (float) -> (int)`";
   let arguments = (ins
@@ -15462,7 +15958,8 @@ def Torch_AtenIntFloatOp : Torch_Op<"aten.Int.float", [
 def Torch_AtenIntScalarOp : Torch_Op<"aten.Int.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Int.Scalar : (Scalar) -> (int)`";
   let arguments = (ins
@@ -15486,7 +15983,8 @@ def Torch_AtenIntScalarOp : Torch_Op<"aten.Int.Scalar", [
 def Torch_AtenIntBoolOp : Torch_Op<"aten.Int.bool", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Int.bool : (bool) -> (int)`";
   let arguments = (ins
@@ -15510,7 +16008,8 @@ def Torch_AtenIntBoolOp : Torch_Op<"aten.Int.bool", [
 def Torch_Aten__RangeLengthOp : Torch_Op<"aten.__range_length", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__range_length : (int, int, int) -> (int)`";
   let arguments = (ins
@@ -15536,7 +16035,8 @@ def Torch_Aten__RangeLengthOp : Torch_Op<"aten.__range_length", [
 def Torch_Aten__DeriveIndexOp : Torch_Op<"aten.__derive_index", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__derive_index : (int, int, int) -> (int)`";
   let arguments = (ins
@@ -15562,7 +16062,8 @@ def Torch_Aten__DeriveIndexOp : Torch_Op<"aten.__derive_index", [
 def Torch_AtenGtIntOp : Torch_Op<"aten.gt.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::gt.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -15587,7 +16088,8 @@ def Torch_AtenGtIntOp : Torch_Op<"aten.gt.int", [
 def Torch_AtenGeIntOp : Torch_Op<"aten.ge.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ge.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -15612,7 +16114,8 @@ def Torch_AtenGeIntOp : Torch_Op<"aten.ge.int", [
 def Torch_AtenLtIntOp : Torch_Op<"aten.lt.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::lt.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -15637,7 +16140,8 @@ def Torch_AtenLtIntOp : Torch_Op<"aten.lt.int", [
 def Torch_AtenLeIntOp : Torch_Op<"aten.le.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::le.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -15662,7 +16166,8 @@ def Torch_AtenLeIntOp : Torch_Op<"aten.le.int", [
 def Torch_AtenNeIntOp : Torch_Op<"aten.ne.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ne.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -15687,7 +16192,8 @@ def Torch_AtenNeIntOp : Torch_Op<"aten.ne.int", [
 def Torch_AtenEqIntOp : Torch_Op<"aten.eq.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eq.int : (int, int) -> (bool)`";
   let arguments = (ins
@@ -15712,7 +16218,8 @@ def Torch_AtenEqIntOp : Torch_Op<"aten.eq.int", [
 def Torch_AtenFloordivIntOp : Torch_Op<"aten.floordiv.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::floordiv.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -15738,7 +16245,8 @@ def Torch_AtenFloordivIntOp : Torch_Op<"aten.floordiv.int", [
 def Torch_AtenRemainderIntOp : Torch_Op<"aten.remainder.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::remainder.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -15763,7 +16271,8 @@ def Torch_AtenRemainderIntOp : Torch_Op<"aten.remainder.int", [
 def Torch_AtenRemainderScalarOp : Torch_Op<"aten.remainder.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::remainder.Scalar : (Tensor, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -15788,7 +16297,8 @@ def Torch_AtenRemainderScalarOp : Torch_Op<"aten.remainder.Scalar", [
 def Torch_AtenRemainderTensorOp : Torch_Op<"aten.remainder.Tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::remainder.Tensor : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -15812,7 +16322,8 @@ def Torch_AtenRemainderTensorOp : Torch_Op<"aten.remainder.Tensor", [
 def Torch_AtenAddIntOp : Torch_Op<"aten.add.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::add.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -15837,7 +16348,8 @@ def Torch_AtenAddIntOp : Torch_Op<"aten.add.int", [
 def Torch_AtenSubIntOp : Torch_Op<"aten.sub.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sub.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -15862,7 +16374,8 @@ def Torch_AtenSubIntOp : Torch_Op<"aten.sub.int", [
 def Torch_AtenMulIntOp : Torch_Op<"aten.mul.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mul.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -15888,7 +16401,8 @@ def Torch_AtenMulIntOp : Torch_Op<"aten.mul.int", [
 def Torch_AtenMulIntFloatOp : Torch_Op<"aten.mul.int_float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mul.int_float : (int, float) -> (float)`";
   let arguments = (ins
@@ -15913,7 +16427,8 @@ def Torch_AtenMulIntFloatOp : Torch_Op<"aten.mul.int_float", [
 def Torch_AtenDivIntOp : Torch_Op<"aten.div.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::div.int : (int, int) -> (float)`";
   let arguments = (ins
@@ -15938,7 +16453,8 @@ def Torch_AtenDivIntOp : Torch_Op<"aten.div.int", [
 def Torch_AtenNegIntOp : Torch_Op<"aten.neg.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::neg.int : (int) -> (int)`";
   let arguments = (ins
@@ -15962,7 +16478,8 @@ def Torch_AtenNegIntOp : Torch_Op<"aten.neg.int", [
 def Torch_AtenLogIntOp : Torch_Op<"aten.log.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::log.int : (int) -> (float)`";
   let arguments = (ins
@@ -15985,7 +16502,8 @@ def Torch_AtenLogIntOp : Torch_Op<"aten.log.int", [
 def Torch_AtenAddFloatIntOp : Torch_Op<"aten.add.float_int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::add.float_int : (float, int) -> (float)`";
   let arguments = (ins
@@ -16010,7 +16528,8 @@ def Torch_AtenAddFloatIntOp : Torch_Op<"aten.add.float_int", [
 def Torch_AtenSubFloatOp : Torch_Op<"aten.sub.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sub.float : (float, float) -> (float)`";
   let arguments = (ins
@@ -16035,7 +16554,8 @@ def Torch_AtenSubFloatOp : Torch_Op<"aten.sub.float", [
 def Torch_AtenMulFloatOp : Torch_Op<"aten.mul.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mul.float : (float, float) -> (float)`";
   let arguments = (ins
@@ -16060,7 +16580,8 @@ def Torch_AtenMulFloatOp : Torch_Op<"aten.mul.float", [
 def Torch_AtenDivFloatOp : Torch_Op<"aten.div.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::div.float : (float, float) -> (float)`";
   let arguments = (ins
@@ -16085,7 +16606,8 @@ def Torch_AtenDivFloatOp : Torch_Op<"aten.div.float", [
 def Torch_AtenNegFloatOp : Torch_Op<"aten.neg.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::neg.float : (float) -> (float)`";
   let arguments = (ins
@@ -16109,7 +16631,8 @@ def Torch_AtenNegFloatOp : Torch_Op<"aten.neg.float", [
 def Torch_AtenEqFloatOp : Torch_Op<"aten.eq.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eq.float : (float, float) -> (bool)`";
   let arguments = (ins
@@ -16134,7 +16657,8 @@ def Torch_AtenEqFloatOp : Torch_Op<"aten.eq.float", [
 def Torch_AtenGtFloatOp : Torch_Op<"aten.gt.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::gt.float : (float, float) -> (bool)`";
   let arguments = (ins
@@ -16159,7 +16683,8 @@ def Torch_AtenGtFloatOp : Torch_Op<"aten.gt.float", [
 def Torch_AtenGeFloatOp : Torch_Op<"aten.ge.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ge.float : (float, float) -> (bool)`";
   let arguments = (ins
@@ -16184,7 +16709,8 @@ def Torch_AtenGeFloatOp : Torch_Op<"aten.ge.float", [
 def Torch_AtenLtFloatOp : Torch_Op<"aten.lt.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::lt.float : (float, float) -> (bool)`";
   let arguments = (ins
@@ -16209,7 +16735,8 @@ def Torch_AtenLtFloatOp : Torch_Op<"aten.lt.float", [
 def Torch_AtenLtFloatIntOp : Torch_Op<"aten.lt.float_int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::lt.float_int : (float, int) -> (bool)`";
   let arguments = (ins
@@ -16233,7 +16760,8 @@ def Torch_AtenLtFloatIntOp : Torch_Op<"aten.lt.float_int", [
 def Torch_AtenGeFloatIntOp : Torch_Op<"aten.ge.float_int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ge.float_int : (float, int) -> (bool)`";
   let arguments = (ins
@@ -16257,7 +16785,8 @@ def Torch_AtenGeFloatIntOp : Torch_Op<"aten.ge.float_int", [
 def Torch_AtenNeFloatIntOp : Torch_Op<"aten.ne.float_int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ne.float_int : (float, int) -> (bool)`";
   let arguments = (ins
@@ -16281,7 +16810,8 @@ def Torch_AtenNeFloatIntOp : Torch_Op<"aten.ne.float_int", [
 def Torch_AtenGtFloatIntOp : Torch_Op<"aten.gt.float_int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::gt.float_int : (float, int) -> (bool)`";
   let arguments = (ins
@@ -16305,7 +16835,8 @@ def Torch_AtenGtFloatIntOp : Torch_Op<"aten.gt.float_int", [
 def Torch_AtenPowIntFloatOp : Torch_Op<"aten.pow.int_float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::pow.int_float : (int, float) -> (float)`";
   let arguments = (ins
@@ -16330,7 +16861,8 @@ def Torch_AtenPowIntFloatOp : Torch_Op<"aten.pow.int_float", [
 def Torch_Aten__And__BoolOp : Torch_Op<"aten.__and__.bool", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__and__.bool : (bool, bool) -> (bool)`";
   let arguments = (ins
@@ -16354,7 +16886,8 @@ def Torch_Aten__And__BoolOp : Torch_Op<"aten.__and__.bool", [
 def Torch_AtenEqBoolOp : Torch_Op<"aten.eq.bool", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eq.bool : (bool, bool) -> (bool)`";
   let arguments = (ins
@@ -16379,7 +16912,8 @@ def Torch_AtenEqBoolOp : Torch_Op<"aten.eq.bool", [
 def Torch_AtenNeBoolOp : Torch_Op<"aten.ne.bool", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ne.bool : (bool, bool) -> (bool)`";
   let arguments = (ins
@@ -16403,7 +16937,8 @@ def Torch_AtenNeBoolOp : Torch_Op<"aten.ne.bool", [
 
 def Torch_Aten__Is__Op : Torch_Op<"aten.__is__", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__is__ : (t1, t2) -> (bool)`";
   let arguments = (ins
@@ -16427,7 +16962,8 @@ def Torch_Aten__Is__Op : Torch_Op<"aten.__is__", [
 
 def Torch_Aten__Isnot__Op : Torch_Op<"aten.__isnot__", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__isnot__ : (t1, t2) -> (bool)`";
   let arguments = (ins
@@ -16452,7 +16988,8 @@ def Torch_Aten__Isnot__Op : Torch_Op<"aten.__isnot__", [
 def Torch_Aten__Not__Op : Torch_Op<"aten.__not__", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__not__ : (bool) -> (bool)`";
   let arguments = (ins
@@ -16476,7 +17013,8 @@ def Torch_Aten__Not__Op : Torch_Op<"aten.__not__", [
 def Torch_Aten__Or__BoolOp : Torch_Op<"aten.__or__.bool", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__or__.bool : (bool, bool) -> (bool)`";
   let arguments = (ins
@@ -16501,7 +17039,8 @@ def Torch_Aten__Or__BoolOp : Torch_Op<"aten.__or__.bool", [
 def Torch_AtenLenTOp : Torch_Op<"aten.len.t", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::len.t : (t[]) -> (int)`";
   let arguments = (ins
@@ -16526,7 +17065,8 @@ def Torch_AtenLenTOp : Torch_Op<"aten.len.t", [
 def Torch_AtenMulLeftTOp : Torch_Op<"aten.mul.left_t", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mul.left_t : (t[], int) -> (t[])`";
   let arguments = (ins
@@ -16550,7 +17090,8 @@ def Torch_AtenMulLeftTOp : Torch_Op<"aten.mul.left_t", [
 
 def Torch_Aten__Getitem__TOp : Torch_Op<"aten.__getitem__.t", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::__getitem__.t : (t[], int) -> (t)`";
   let arguments = (ins
@@ -16598,7 +17139,8 @@ def Torch_Aten_SetItemTOp : Torch_Op<"aten._set_item.t", [
 def Torch_AtenMulOp : Torch_Op<"aten.mul", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::mul : (Scalar, Scalar) -> (Scalar)`";
   let arguments = (ins
@@ -16623,7 +17165,8 @@ def Torch_AtenMulOp : Torch_Op<"aten.mul", [
 def Torch_AtenDivOp : Torch_Op<"aten.div", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::div : (Scalar, Scalar) -> (float)`";
   let arguments = (ins
@@ -16648,7 +17191,8 @@ def Torch_AtenDivOp : Torch_Op<"aten.div", [
 def Torch_AtenAddOp : Torch_Op<"aten.add", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::add : (Scalar, Scalar) -> (Scalar)`";
   let arguments = (ins
@@ -16673,7 +17217,8 @@ def Torch_AtenAddOp : Torch_Op<"aten.add", [
 def Torch_AtenSubOp : Torch_Op<"aten.sub", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sub : (Scalar, Scalar) -> (Scalar)`";
   let arguments = (ins
@@ -16698,7 +17243,8 @@ def Torch_AtenSubOp : Torch_Op<"aten.sub", [
 def Torch_AtenCeilScalarOp : Torch_Op<"aten.ceil.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ceil.Scalar : (Scalar) -> (Scalar)`";
   let arguments = (ins
@@ -16722,7 +17268,8 @@ def Torch_AtenCeilScalarOp : Torch_Op<"aten.ceil.Scalar", [
 def Torch_AtenSqrtIntOp : Torch_Op<"aten.sqrt.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::sqrt.int : (int) -> (float)`";
   let arguments = (ins
@@ -16746,7 +17293,8 @@ def Torch_AtenSqrtIntOp : Torch_Op<"aten.sqrt.int", [
 def Torch_AtenBoolFloatOp : Torch_Op<"aten.Bool.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Bool.float : (float) -> (bool)`";
   let arguments = (ins
@@ -16770,7 +17318,8 @@ def Torch_AtenBoolFloatOp : Torch_Op<"aten.Bool.float", [
 def Torch_AtenBoolIntOp : Torch_Op<"aten.Bool.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::Bool.int : (int) -> (bool)`";
   let arguments = (ins
@@ -16794,7 +17343,8 @@ def Torch_AtenBoolIntOp : Torch_Op<"aten.Bool.int", [
 def Torch_AtenEqDeviceOp : Torch_Op<"aten.eq.device", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::eq.device : (Device, Device) -> (bool)`";
   let arguments = (ins
@@ -16818,7 +17368,8 @@ def Torch_AtenEqDeviceOp : Torch_Op<"aten.eq.device", [
 def Torch_AtenCeilFloatOp : Torch_Op<"aten.ceil.float", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ceil.float : (float) -> (int)`";
   let arguments = (ins
@@ -16841,7 +17392,8 @@ def Torch_AtenCeilFloatOp : Torch_Op<"aten.ceil.float", [
 
 def Torch_AtenNarrowOp : Torch_Op<"aten.narrow", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::narrow : (Tensor, int, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -16866,7 +17418,8 @@ def Torch_AtenNarrowOp : Torch_Op<"aten.narrow", [
 
 def Torch_AtenNarrowTensorOp : Torch_Op<"aten.narrow.Tensor", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::narrow.Tensor : (Tensor, int, Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -16892,7 +17445,8 @@ def Torch_AtenNarrowTensorOp : Torch_Op<"aten.narrow.Tensor", [
 def Torch_AtenScalarImplicitOp : Torch_Op<"aten.ScalarImplicit", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::ScalarImplicit : (Tensor) -> (Scalar)`";
   let arguments = (ins
@@ -16916,7 +17470,8 @@ def Torch_AtenScalarImplicitOp : Torch_Op<"aten.ScalarImplicit", [
 def Torch_AtenTriuIndicesOp : Torch_Op<"aten.triu_indices", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::triu_indices : (int, int, int, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -16946,7 +17501,8 @@ def Torch_AtenTriuIndicesOp : Torch_Op<"aten.triu_indices", [
 def Torch_AtenTrilIndicesOp : Torch_Op<"aten.tril_indices", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tril_indices : (int, int, int, int?, int?, Device?, bool?) -> (Tensor)`";
   let arguments = (ins
@@ -16976,7 +17532,8 @@ def Torch_AtenTrilIndicesOp : Torch_Op<"aten.tril_indices", [
 def Torch_AtenDeg2radOp : Torch_Op<"aten.deg2rad", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::deg2rad : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -16999,7 +17556,8 @@ def Torch_AtenDeg2radOp : Torch_Op<"aten.deg2rad", [
 def Torch_Aten_SoftmaxBackwardDataOp : Torch_Op<"aten._softmax_backward_data", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -17025,7 +17583,8 @@ def Torch_Aten_SoftmaxBackwardDataOp : Torch_Op<"aten._softmax_backward_data", [
 def Torch_AtenTanhBackwardOp : Torch_Op<"aten.tanh_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::tanh_backward : (Tensor, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -17049,7 +17608,8 @@ def Torch_AtenTanhBackwardOp : Torch_Op<"aten.tanh_backward", [
 def Torch_AtenHardtanhBackwardOp : Torch_Op<"aten.hardtanh_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::hardtanh_backward : (Tensor, Tensor, Scalar, Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -17075,7 +17635,8 @@ def Torch_AtenHardtanhBackwardOp : Torch_Op<"aten.hardtanh_backward", [
 def Torch_AtenGeluBackwardOp : Torch_Op<"aten.gelu_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::gelu_backward : (Tensor, Tensor, str) -> (Tensor)`";
   let arguments = (ins
@@ -17100,7 +17661,8 @@ def Torch_AtenGeluBackwardOp : Torch_Op<"aten.gelu_backward", [
 def Torch_Aten_LogSoftmaxBackwardDataOp : Torch_Op<"aten._log_softmax_backward_data", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_log_softmax_backward_data : (Tensor, Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -17126,7 +17688,8 @@ def Torch_Aten_LogSoftmaxBackwardDataOp : Torch_Op<"aten._log_softmax_backward_d
 def Torch_AtenNativeLayerNormBackwardOp : Torch_Op<"aten.native_layer_norm_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::native_layer_norm_backward : (Tensor, Tensor, int[], Tensor, Tensor, Tensor?, Tensor?, bool[]) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -17158,7 +17721,8 @@ def Torch_AtenNativeLayerNormBackwardOp : Torch_Op<"aten.native_layer_norm_backw
 def Torch_AtenEmbeddingDenseBackwardOp : Torch_Op<"aten.embedding_dense_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::embedding_dense_backward : (Tensor, Tensor, int, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -17185,7 +17749,8 @@ def Torch_AtenEmbeddingDenseBackwardOp : Torch_Op<"aten.embedding_dense_backward
 def Torch_AtenNativeBatchNormBackwardOp : Torch_Op<"aten.native_batch_norm_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::native_batch_norm_backward : (Tensor, Tensor, Tensor?, Tensor?, Tensor?, Tensor?, Tensor?, bool, float, bool[]) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -17219,7 +17784,8 @@ def Torch_AtenNativeBatchNormBackwardOp : Torch_Op<"aten.native_batch_norm_backw
 def Torch_AtenNativeGroupNormBackwardOp : Torch_Op<"aten.native_group_norm_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::native_group_norm_backward : (Tensor, Tensor, Tensor, Tensor, Tensor?, int, int, int, int, bool[]) -> (Tensor, Tensor, Tensor)`";
   let arguments = (ins
@@ -17253,7 +17819,8 @@ def Torch_AtenNativeGroupNormBackwardOp : Torch_Op<"aten.native_group_norm_backw
 def Torch_AtenNativeDropoutBackwardOp : Torch_Op<"aten.native_dropout_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::native_dropout_backward : (Tensor, Tensor, float) -> (Tensor)`";
   let arguments = (ins
@@ -17278,7 +17845,8 @@ def Torch_AtenNativeDropoutBackwardOp : Torch_Op<"aten.native_dropout_backward",
 def Torch_AtenEluBackwardOp : Torch_Op<"aten.elu_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::elu_backward : (Tensor, Scalar, Scalar, Scalar, bool, Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -17306,7 +17874,8 @@ def Torch_AtenEluBackwardOp : Torch_Op<"aten.elu_backward", [
 def Torch_AtenLeakyReluBackwardOp : Torch_Op<"aten.leaky_relu_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::leaky_relu_backward : (Tensor, Tensor, Scalar, bool) -> (Tensor)`";
   let arguments = (ins
@@ -17332,7 +17901,8 @@ def Torch_AtenLeakyReluBackwardOp : Torch_Op<"aten.leaky_relu_backward", [
 def Torch_AtenRreluWithNoiseBackwardOp : Torch_Op<"aten.rrelu_with_noise_backward", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::rrelu_with_noise_backward : (Tensor, Tensor, Tensor, Scalar, Scalar, bool, bool) -> (Tensor)`";
   let arguments = (ins
@@ -17361,7 +17931,8 @@ def Torch_AtenRreluWithNoiseBackwardOp : Torch_Op<"aten.rrelu_with_noise_backwar
 def Torch_AtenQuantizePerChannelOp : Torch_Op<"aten.quantize_per_channel", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::quantize_per_channel : (Tensor, Tensor, Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -17388,7 +17959,8 @@ def Torch_AtenQuantizePerChannelOp : Torch_Op<"aten.quantize_per_channel", [
 def Torch_AtenQuantizePerTensorOp : Torch_Op<"aten.quantize_per_tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::quantize_per_tensor : (Tensor, float, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -17414,7 +17986,8 @@ def Torch_AtenQuantizePerTensorOp : Torch_Op<"aten.quantize_per_tensor", [
 def Torch_AtenDequantizeSelfOp : Torch_Op<"aten.dequantize.self", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::dequantize.self : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -17437,7 +18010,8 @@ def Torch_AtenDequantizeSelfOp : Torch_Op<"aten.dequantize.self", [
 def Torch_AtenDequantizeTensorOp : Torch_Op<"aten.dequantize.tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::dequantize.tensor : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -17460,7 +18034,8 @@ def Torch_AtenDequantizeTensorOp : Torch_Op<"aten.dequantize.tensor", [
 def Torch_AtenIntReprOp : Torch_Op<"aten.int_repr", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::int_repr : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -17483,7 +18058,8 @@ def Torch_AtenIntReprOp : Torch_Op<"aten.int_repr", [
 def Torch_Aten_MakePerChannelQuantizedTensorOp : Torch_Op<"aten._make_per_channel_quantized_tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_make_per_channel_quantized_tensor : (Tensor, Tensor, Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -17509,7 +18085,8 @@ def Torch_Aten_MakePerChannelQuantizedTensorOp : Torch_Op<"aten._make_per_channe
 def Torch_Aten_MakePerTensorQuantizedTensorOp : Torch_Op<"aten._make_per_tensor_quantized_tensor", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `aten::_make_per_tensor_quantized_tensor : (Tensor, float, int) -> (Tensor)`";
   let arguments = (ins
@@ -17534,7 +18111,8 @@ def Torch_Aten_MakePerTensorQuantizedTensorOp : Torch_Op<"aten._make_per_tensor_
 def Torch_PrimLayoutOp : Torch_Op<"prim.layout", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::layout : (Tensor) -> (int)`";
   let arguments = (ins
@@ -17557,7 +18135,8 @@ def Torch_PrimLayoutOp : Torch_Op<"prim.layout", [
 def Torch_PrimTupleIndexOp : Torch_Op<"prim.TupleIndex", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::TupleIndex : (Any, int) -> (Any)`";
   let arguments = (ins
@@ -17582,7 +18161,8 @@ def Torch_PrimTupleIndexOp : Torch_Op<"prim.TupleIndex", [
 def Torch_PrimDeviceOp : Torch_Op<"prim.device", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::device : (Tensor) -> (Device)`";
   let arguments = (ins
@@ -17606,7 +18186,8 @@ def Torch_PrimDeviceOp : Torch_Op<"prim.device", [
 def Torch_PrimDtypeOp : Torch_Op<"prim.dtype", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::dtype : (Tensor) -> (int)`";
   let arguments = (ins
@@ -17645,7 +18226,8 @@ def Torch_PrimTupleUnpackOp : Torch_Op<"prim.TupleUnpack", [
 def Torch_PrimNumToTensorScalarOp : Torch_Op<"prim.NumToTensor.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::NumToTensor.Scalar : (Scalar) -> (Tensor)`";
   let arguments = (ins
@@ -17669,7 +18251,8 @@ def Torch_PrimNumToTensorScalarOp : Torch_Op<"prim.NumToTensor.Scalar", [
 def Torch_PrimMinSelfIntOp : Torch_Op<"prim.min.self_int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::min.self_int : (int[]) -> (int)`";
   let arguments = (ins
@@ -17693,7 +18276,8 @@ def Torch_PrimMinSelfIntOp : Torch_Op<"prim.min.self_int", [
 def Torch_PrimMinIntOp : Torch_Op<"prim.min.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::min.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -17718,7 +18302,8 @@ def Torch_PrimMinIntOp : Torch_Op<"prim.min.int", [
 def Torch_PrimMaxSelfIntOp : Torch_Op<"prim.max.self_int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::max.self_int : (int[]) -> (int)`";
   let arguments = (ins
@@ -17741,7 +18326,8 @@ def Torch_PrimMaxSelfIntOp : Torch_Op<"prim.max.self_int", [
 def Torch_PrimMaxIntOp : Torch_Op<"prim.max.int", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::max.int : (int, int) -> (int)`";
   let arguments = (ins
@@ -17790,7 +18376,8 @@ def Torch_PrimUninitializedOp : Torch_Op<"prim.Uninitialized", [
     Pure,
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::Uninitialized : () -> (Any)`";
   let arguments = (ins
@@ -17813,7 +18400,8 @@ def Torch_PrimUninitializedOp : Torch_Op<"prim.Uninitialized", [
 def Torch_PrimUncheckedCastOp : Torch_Op<"prim.unchecked_cast", [
     DeclareOpInterfaceMethods<CastOpInterface>,
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::unchecked_cast : (t) -> (t)`";
   let arguments = (ins
@@ -17864,7 +18452,8 @@ def Torch_PrimTolistOp : Torch_Op<"prim.tolist", [
 def Torch_PrimAbsScalarOp : Torch_Op<"prim.abs.Scalar", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prim::abs.Scalar : (Scalar) -> (Scalar)`";
   let arguments = (ins
@@ -17887,7 +18476,8 @@ def Torch_PrimAbsScalarOp : Torch_Op<"prim.abs.Scalar", [
 def Torch_PrimsConvertElementTypeOp : Torch_Op<"prims.convert_element_type", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prims::convert_element_type : (Tensor, int) -> (Tensor)`";
   let arguments = (ins
@@ -17912,7 +18502,8 @@ def Torch_PrimsConvertElementTypeOp : Torch_Op<"prims.convert_element_type", [
 def Torch_PrimsVarOp : Torch_Op<"prims.var", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prims::var : (Tensor, int[]?, float?, int?) -> (Tensor)`";
   let arguments = (ins
@@ -17938,7 +18529,8 @@ def Torch_PrimsVarOp : Torch_Op<"prims.var", [
 def Torch_PrimsSqrtOp : Torch_Op<"prims.sqrt", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prims::sqrt : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -17961,7 +18553,8 @@ def Torch_PrimsSqrtOp : Torch_Op<"prims.sqrt", [
 def Torch_PrimsCollapseOp : Torch_Op<"prims.collapse", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prims::collapse : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -17985,7 +18578,8 @@ def Torch_PrimsCollapseOp : Torch_Op<"prims.collapse", [
 
 def Torch_PrimsSplitDimOp : Torch_Op<"prims.split_dim", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prims::split_dim : (Tensor, int, int) -> (Tensor)`";
   let arguments = (ins
@@ -18009,7 +18603,8 @@ def Torch_PrimsSplitDimOp : Torch_Op<"prims.split_dim", [
 
 def Torch_PrimsSqueezeOp : Torch_Op<"prims.squeeze", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prims::squeeze : (Tensor, int[]) -> (Tensor)`";
   let arguments = (ins
@@ -18032,7 +18627,8 @@ def Torch_PrimsSqueezeOp : Torch_Op<"prims.squeeze", [
 
 def Torch_PrimsViewOfOp : Torch_Op<"prims.view_of", [
     AllowsTypeRefinement,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prims::view_of : (Tensor) -> (Tensor)`";
   let arguments = (ins
@@ -18056,7 +18652,8 @@ def Torch_PrimsViewOfOp : Torch_Op<"prims.view_of", [
 def Torch_PrimsIotaOp : Torch_Op<"prims.iota", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `prims::iota : (int, int, int, int, Device, bool) -> (Tensor)`";
   let arguments = (ins
@@ -18085,7 +18682,8 @@ def Torch_QuantizedLinearOp : Torch_Op<"quantized.linear", [
     HasValueSemantics,
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `quantized::linear : (Tensor, __torch__.torch.classes.quantized.LinearPackedParamsBase, float, int) -> (Tensor)`";
   let arguments = (ins
@@ -18111,7 +18709,8 @@ def Torch_QuantizedLinearOp : Torch_Op<"quantized.linear", [
 def Torch_TorchvisionDeformConv2dOp : Torch_Op<"torchvision.deform_conv2d", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `torchvision::deform_conv2d : (Tensor, Tensor, Tensor, Tensor, Tensor, int, int, int, int, int, int, int, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -18147,7 +18746,8 @@ def Torch_TorchvisionDeformConv2dOp : Torch_Op<"torchvision.deform_conv2d", [
 def Torch_TorchvisionRoiAlignOp : Torch_Op<"torchvision.roi_align", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `torchvision::roi_align : (Tensor, Tensor, float, int, int, int, bool) -> (Tensor)`";
   let arguments = (ins
@@ -18176,7 +18776,8 @@ def Torch_TorchvisionRoiAlignOp : Torch_Op<"torchvision.roi_align", [
 def Torch_TorchvisionRoiPoolOp : Torch_Op<"torchvision.roi_pool", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `torchvision::roi_pool : (Tensor, Tensor, float, int, int) -> (Tensor, Tensor)`";
   let arguments = (ins
@@ -18204,7 +18805,8 @@ def Torch_TorchvisionRoiPoolOp : Torch_Op<"torchvision.roi_pool", [
 def Torch_TorchvisionNmsOp : Torch_Op<"torchvision.nms", [
     AllowsTypeRefinement,
     HasValueSemantics,
-    ReadOnly
+    ReadOnly,
+    NoMemoryEffect
   ]> {
   let summary = "Generated op for `torchvision::nms : (Tensor, Tensor, float) -> (Tensor)`";
   let arguments = (ins

--- a/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
+++ b/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
@@ -242,6 +242,7 @@ def emit_op(
     has_folder: bool = False,
     has_canonicalizer: bool = False,
     has_verifier: bool = False,
+    has_memory_effects: bool = False,
 ):
     """Main entry point for op emission.
 
@@ -257,6 +258,12 @@ def emit_op(
         traits += ["HasValueSemantics"]
     if operator.is_readonly():
         traits += ["ReadOnly"]
+    # If a ReadOnly op has no returns, it is likely to have side effects.
+    # E.g. `prim.RaiseException` and `prim.Print`
+    # Besides ops with no returned values, there may be other ReadOnly ops with memory effects.
+    # In such cases, these ops can be emitted with `has_memory_effects=True` to avoid this trait.
+    if operator.is_readonly() and len(operator.returns) != 0 and not has_memory_effects:
+        traits += ["NoMemoryEffect"]
 
     raw_emit_op(
         operator,

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -1557,7 +1557,6 @@ func.func @torch.prim.unchecked_cast$derefine(%arg0: !torch.list<int>) -> !torch
 
 // CHECK-LABEL:   func.func @torch.aten.Int.Tensor(
 // CHECK-SAME:            %[[NUM:.*]]: !torch.int) -> !torch.int {
-// CHECK:           %[[T:.*]] = torch.prim.NumToTensor.Scalar %[[NUM]] : !torch.int -> !torch.vtensor<[],si64>
 // CHECK:           return %[[NUM]] : !torch.int
 func.func @torch.aten.Int.Tensor(%arg0: !torch.int) -> !torch.int {
   %tensor = torch.prim.NumToTensor.Scalar %arg0: !torch.int -> !torch.vtensor<[],si64>
@@ -1585,7 +1584,6 @@ func.func @torch.aten.Int.float() -> !torch.int {
 
 // CHECK-LABEL:   func.func @torch.aten.Float.Tensor(
 // CHECK-SAME:            %[[NUM:.*]]: !torch.float) -> !torch.float {
-// CHECK:           %[[T:.*]] = torch.prim.NumToTensor.Scalar %[[NUM]] : !torch.float -> !torch.vtensor<[],f64>
 // CHECK:           return %[[NUM]] : !torch.float
 func.func @torch.aten.Float.Tensor(%arg0: !torch.float) -> !torch.float {
   %tensor = torch.prim.NumToTensor.Scalar %arg0: !torch.float -> !torch.vtensor<[],f64>


### PR DESCRIPTION
In my understanding, the trait `ReadOnly` implies that the memory for input values does not get modified by the operation. 

This is similar to `NoMemoryEffect`, with a few exceptions. Ops like `prim.RaiseException`  and `prim.Print` are `ReadOnly`, but have effects like terminating the program and printing, respectively. 

There may be other `ReadOnly` ops with side effects. As a hypothetical example, there might be a comparison op that checks if two tensors are the same type, prints some debug info, and also returns a boolean value. In the event that such an op is discovered, I've added a keyword argument to the `emit_op` function to explicitly label an operation as `has_memory_effects=True` to avoid adding the `NoMemoryEffect` trait to the tablegen definition. 

My primary motivation for this change is to remove the need to have one-off `RemoveUnused` patterns for ops that we want to remove when dead, but adding this trait also has the very appealing effect of dramatically simplifying torch-IR for some models. Specifically for ONNX models, it is not uncommon to have patterns that consistently call "onnx.Shape" on the same exact tensor, only to extract a different element from the shape. That redundant IR doesn't get CSE'd until converting to a core mlir dialect like linalg/tensor/arith. 