### PR TITLE
[onnx][importer] Sanitize '-' characters in TensorProto names

### DIFF
--- a/python/torch_mlir/extras/onnx_importer.py
+++ b/python/torch_mlir/extras/onnx_importer.py
@@ -739,6 +739,13 @@ class ContextCache:
     def _sanitize_name(self, name):
         if not name.isidentifier():
             name = "_" + name
+
+        # The presence of '-' characters in the initializer names can cause
+        # unintended side-effects when the IR is parsed during compilation.
+        # Simply replace all the occurrences of '-' in the name string when the
+        # dense resource is created.
+        name = name.replace("-", "_")
+
         return re.sub("[:/]", "_", name)
 
     def tensor_proto_to_attr(self, tp: onnx.TensorProto) -> Attribute:


### PR DESCRIPTION
Dense Resources cannot have `-` characters as part of the resource keys. Many ONNX models, however, do have these characters in `TensorProto` or initializer names.

This patch adds an unconditional replace function in the sanitization of initializer names that replaces all `-` characters with `_` (underscores) when the dense resources are created, which allows successful parsing of the IR.

In case the name was legal before sanitization, the function has no effect. Unnecessary additional time complexity is avoided by omitting an `if` condition to check containment.