### PR TITLE
Replace unmaintained `create-release` action

### DIFF
--- a/.github/workflows/oneshotSnapshotPackage.yml
+++ b/.github/workflows/oneshotSnapshotPackage.yml
@@ -43,16 +43,15 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
         with:
-          tag_name: ${{ env.tag_name }}
-          release_name: torch-mlir snapshot ${{ env.tag_name }}
+          tag: ${{ env.tag_name }}
+          name: torch-mlir snapshot ${{ env.tag_name }}
           body: |
             Automatic snapshot release of torch-mlir.
           draft: true
           prerelease: false
+          token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
 
       - name: "Invoke workflow :: Build and Test"
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/releaseSnapshotPackage.yml
+++ b/.github/workflows/releaseSnapshotPackage.yml
@@ -46,16 +46,15 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
         with:
-          tag_name: ${{ env.tag_name }}
-          release_name: torch-mlir snapshot ${{ env.tag_name }}
+          tag: ${{ env.tag_name }}
+          name: torch-mlir snapshot ${{ env.tag_name }}
           body: |
             Automatic snapshot release of torch-mlir.
           draft: true
           prerelease: false
+          token: ${{ secrets.WORKFLOW_INVOCATION_TOKEN }}
 
       - name: "Invoke workflow :: Build and Test"
         uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
This replaces the `actions/create-release` with
`ncipollo/release-action` as the former is unmaintained.