### PR TITLE
Replace `ubuntu-latest` with specific version

### DIFF
--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   ubuntu-build:
     name: ubuntu-x86_64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Prepare workspace

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -273,7 +273,7 @@ jobs:
           path: dist
 
   publish_releases:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - build_linux
       - build_linux_arm64

--- a/.github/workflows/gh-pages-releases.yml
+++ b/.github/workflows/gh-pages-releases.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   scrape_and_publish_releases:
     name: "Scrape and publish releases"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Don't run this in everyone's forks.
     if: github.repository == 'llvm/torch-mlir'

--- a/.github/workflows/merge-rollpytorch.yml
+++ b/.github/workflows/merge-rollpytorch.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   merge-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.repository == 'llvm/torch-mlir' &&
       github.event.workflow_run.actor.login == 'stellaraccident' &&

--- a/.github/workflows/pre-commit-all.yml
+++ b/.github/workflows/pre-commit-all.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/releaseSnapshotPackage.yml
+++ b/.github/workflows/releaseSnapshotPackage.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release_snapshot_package:
     name: "Tag snapshot release"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Don't run this in everyone's forks.
     if: github.repository == 'llvm/torch-mlir'
     steps:


### PR DESCRIPTION
While `ubuntu-latest` uses Ubuntu 22.04 for now, thils will change soon (rollout already started), see
https://github.com/actions/runner-images/issues/10636. The version can be updated from 22.04 to 24.04 in a follow up.