### PR TITLE
[CI] Disable LTC build from CI

### DIFF
--- a/build_tools/ci/build_posix.sh
+++ b/build_tools/ci/build_posix.sh
@@ -50,7 +50,7 @@ cmake -S "$repo_root/externals/llvm-project/llvm" -B "$build_dir" \
   -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$repo_root" \
   -DLLVM_TARGETS_TO_BUILD=host \
   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-  -DTORCH_MLIR_ENABLE_LTC=ON \
+  -DTORCH_MLIR_ENABLE_LTC=OFF \
   -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON
 echo "::endgroup::"
 


### PR DESCRIPTION
This commit disables the LTC build from the Torch-MLIR CI since after the recent GH runner version upgrade the Torch-MLIR build in CI is failing with an LTC related error.

The tracking issue for the same can be found here: https://github.com/llvm/torch-mlir/issues/3910