### PR TITLE
[python] Make module imports relative in `fx.py` and `compiler_utils.py`

### DIFF
--- a/python/torch_mlir/compiler_utils.py
+++ b/python/torch_mlir/compiler_utils.py
@@ -10,8 +10,8 @@ import tempfile
 from typing import Union, List
 
 import torch
-from torch_mlir.passmanager import PassManager
-from torch_mlir.ir import StringAttr
+from .passmanager import PassManager
+from .ir import StringAttr
 
 
 class TensorPlaceholder:

--- a/python/torch_mlir/fx.py
+++ b/python/torch_mlir/fx.py
@@ -13,11 +13,11 @@ import torch.export
 import torch.nn as nn
 from torch.export import ExportedProgram
 
-from torch_mlir.extras.fx_importer import FxImporter, FxImporterHooks
-from torch_mlir import ir
-from torch_mlir.dialects import torch as torch_d
-from torch_mlir.extras.fx_decomp_util import get_decomposition_table
-from torch_mlir.compiler_utils import (
+from .extras.fx_importer import FxImporter, FxImporterHooks
+from . import ir
+from .dialects import torch as torch_d
+from .extras.fx_decomp_util import get_decomposition_table
+from .compiler_utils import (
     OutputType,
     run_pipeline_with_repro_report,
     lower_mlir_module,


### PR DESCRIPTION
This PR makes module imports relative in `fx.py` and `compiler_utils.py`. When torch-mlir python package is embedded into python package of other MLIR based project, there won't be `torch_mlir` top level package for absolute import.