### PR TITLE
[cmake] Enable accepting external stablehlo project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,12 @@ option(TORCH_MLIR_ENABLE_STABLEHLO "Add stablehlo dialect" ON)
 if(TORCH_MLIR_ENABLE_STABLEHLO)
   add_definitions(-DTORCH_MLIR_ENABLE_STABLEHLO)
 endif()
+# It is possible that both stablehlo and torch_mlir projects are used in some compiler project.
+# In this case, we don't want to use stablehlo that is downloaded by torch_mlir (in external/stablehlo)
+# folder but instead want to use stablehlo that is part of top level compiler project.
+# With TORCH_MLIR_USE_EXTERNAL_STABLEHLO enables, it is assumed that top level compiler project makes
+# stablehlo targets AND includes available (for example with `add_subdirectory` and `include_directories`).
+option(TORCH_MLIR_USE_EXTERNAL_STABLEHLO "Use stablehlo from top level project" OFF)
 
 option(TORCH_MLIR_OUT_OF_TREE_BUILD "Specifies an out of tree build" OFF)
 
@@ -142,7 +148,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 function(torch_mlir_target_includes target)
   set(_dirs
-    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${MLIR_GENERATED_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${TORCH_MLIR_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${TORCH_MLIR_BINARY_DIR}/include>
   )
@@ -232,7 +239,8 @@ endif()
 # Getting this wrong results in building large parts of the stablehlo
 # project that we don't actually depend on. Further some of those parts
 # do not even compile on all platforms.
-if (TORCH_MLIR_ENABLE_STABLEHLO)
+# Only configure StableHLO if it isn't provided from a top-level project
+if (TORCH_MLIR_ENABLE_STABLEHLO AND NOT TORCH_MLIR_USE_EXTERNAL_STABLEHLO)
   set(STABLEHLO_BUILD_EMBEDDED ON)
   set(STABLEHLO_ENABLE_BINDINGS_PYTHON ON)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/externals/stablehlo


### PR DESCRIPTION
This MR enables `torch_mlir` project to accept path to external stablehlo and include those directories. This in turn enables `torch_mlir` to be part of bigger compiler project when `stablehlo` is already a
dependency.