### PR TITLE
[torch-mlir] add MPACT as an example torch-mlir based compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Torch-MLIR is primarily a project that is integrated into compilers to bridge th
 
 * [IREE](https://github.com/iree-org/iree.git)
 * [Blade](https://github.com/alibaba/BladeDISC)
+* [MPACT](https://github.com/MPACT-ORG/mpact-compiler)
 
 While most of the project is exercised via testing paths, there are some ways that an end user can directly use the APIs without further integration:
 


### PR DESCRIPTION
Rationale:
In addition to IREE and Blade, MPACT provides an MLIR-based example of a PyTorch compiler that uses TORCH-MLIR. It also illustrates propagating sparsity from sparse PyTorch into MLIR, a feature that is not widespread in DL compilers yet.