### PR TITLE
Refreshes docs/development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,4 @@
-# Checkout and build from source
+# Environment
 
 ## Check out the code
 
@@ -31,7 +31,6 @@ it with the following `apt` command on Ubuntu/Debian.
 sudo apt install python3-dev
 ```
 
-
 ## (Optional) Set up pre-commit
 
 This project uses [pre-commit](https://pre-commit.com/) in its CI. You can
@@ -45,15 +44,21 @@ pip install pre-commit
 pre-commit install
 ```
 
-## CMake Build
+# Building
+
+## With CMake
+
+### Configure for Building...
 
 Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is the most straightforward, as it will build LLVM dependencies as well.
 
-### Building torch-mlir in-tree
+#### ...with LLVM "in-tree" using...
 
-The following command generates configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build. This will build LLVM as well as torch-mlir and its subprojects.  On Windows, use the "Developer PowerShell for Visual Studio" to ensure that the compiler and linker binaries are in the `PATH` variable.
+The following commands generate configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build. This will build LLVM as well as torch-mlir and its subprojects.  On Windows, use the "Developer PowerShell for Visual Studio" to ensure that the compiler and linker binaries are in the `PATH` variable.
 
-This requires `lld`, `clang`, `ccache`, and other dependencies for building `libtorch` / `PyTorch` wheels from source. If you run into issues because of these, try the [simplified build command](#simplified-build).
+##### ...Base + Optimization Options
+
+This requires `lld`, `clang`, `ccache`, and other dependencies for building `libtorch` / `PyTorch` wheels from source. If you run into issues because of these, try the [simplified build command](#base-options).
 
 ```shell
 cmake -GNinja -Bbuild \
@@ -85,7 +90,7 @@ cmake -GNinja -Bbuild \
   -DLIBTORCH_VARIANT=shared
 ```
 
-# Simplified build
+##### ...Base Options
 
 If you're running into issues with the above build command, consider using the following:
 
@@ -101,7 +106,7 @@ cmake -GNinja -Bbuild \
   externals/llvm-project/llvm
 ```
 
-#### Flags to enable MLIR debugging:
+#### Options to enable MLIR debugging
 
 * Enabling `--debug` and `--debug-only` flags (see [MLIR docs](https://mlir.llvm.org/getting_started/Debugging/)) for the `torch-mlir-opt` tool
 ```shell
@@ -109,7 +114,7 @@ cmake -GNinja -Bbuild \
   -DLLVM_ENABLE_ASSERTIONS=ON \
 ```
 
-#### Flags to run end-to-end tests:
+#### Options to run end-to-end tests
 
 Running the end-to-end execution tests locally requires enabling the native PyTorch extension features and the JIT IR importer, which depends on the
 former and defaults to `ON` if not changed:
@@ -118,7 +123,7 @@ former and defaults to `ON` if not changed:
   -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON \
 ```
 
-### Building against a pre-built LLVM
+#### ...with LLVM "out-of-tree"
 
 If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following command as template:
 ```shell
@@ -135,8 +140,7 @@ The same QoL CMake flags can be used to enable clang, ccache, and lld. Be sure t
 
 Be aware that the installed version of LLVM needs in general to match the committed version in `externals/llvm-project`. Using a different version may or may not work.
 
-
-### Build commands
+### Initiate Build
 
 After either cmake run (in-tree/out-of-tree), use one of the following commands to build the project:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -122,6 +122,24 @@ Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is 
 
 The following commands generate configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build. This will build LLVM as well as torch-mlir and its subprojects.
 
+###### ...Base Options
+
+If you don't anticipate needing to frequently rebuild LLVM "in-tree", run:
+
+```shell
+cmake -GNinja -Bbuild \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DPython3_FIND_VIRTUALENV=ONLY \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DLLVM_TARGETS_TO_BUILD=host \
+  `# For building LLVM "in-tree"` \
+  externals/llvm-project/llvm \
+  -DLLVM_ENABLE_PROJECTS=mlir \
+  -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
+  -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD"
+```
+
 ###### ...Base + Optimization Options
 This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If you encounter issues when you run this, try the [simplified build command](#base-options) instead.
 
@@ -154,24 +172,6 @@ cmake -GNinja -Bbuild \
   -DLIBTORCH_SRC_BUILD=ON \
   `# Set the variant of libtorch to build / link against. (shared|static and optionally cxxabi11)` \
   -DLIBTORCH_VARIANT=shared
-```
-
-###### ...Base Options
-
-If you don't anticipate needing to frequently rebuild LLVM "in-tree", run:
-
-```shell
-cmake -GNinja -Bbuild \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DLLVM_ENABLE_ASSERTIONS=ON \
-  -DPython3_FIND_VIRTUALENV=ONLY \
-  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-  -DLLVM_TARGETS_TO_BUILD=host \
-  `# For building LLVM "in-tree"` \
-  externals/llvm-project/llvm \
-  -DLLVM_ENABLE_PROJECTS=mlir \
-  -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
-  -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD"
 ```
 
 ##### ..."out-of-tree"

--- a/docs/development.md
+++ b/docs/development.md
@@ -169,23 +169,6 @@ cmake -GNinja -Bbuild \
   externals/llvm-project/llvm
 ```
 
-#### Options to enable MLIR debugging
-
-* Enabling `--debug` and `--debug-only` flags (see [MLIR docs](https://mlir.llvm.org/getting_started/Debugging/)) for the `torch-mlir-opt` tool
-```shell
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \ # or =Debug
-  -DLLVM_ENABLE_ASSERTIONS=ON \
-```
-
-#### Options to run end-to-end tests
-
-Running the end-to-end execution tests locally requires enabling the native PyTorch extension features and the JIT IR importer, which depends on the
-former and defaults to `ON` if not changed:
-```shell
-  -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON \
-  -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON \
-```
-
 #### ...with LLVM "out-of-tree"
 
 If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following command as template:
@@ -202,6 +185,23 @@ cmake -GNinja -Bbuild \
 The same QoL CMake flags can be used to enable clang, ccache, and lld. Be sure to have built LLVM with `-DLLVM_ENABLE_PROJECTS=mlir`.
 
 Be aware that the installed version of LLVM needs in general to match the committed version in `externals/llvm-project`. Using a different version may or may not work.
+
+#### Options to enable MLIR debugging
+
+* Enabling `--debug` and `--debug-only` flags (see [MLIR docs](https://mlir.llvm.org/getting_started/Debugging/)) for the `torch-mlir-opt` tool
+```shell
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \ # or =Debug
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+```
+
+#### Options to run end-to-end tests
+
+Running the end-to-end execution tests locally requires enabling the native PyTorch extension features and the JIT IR importer, which depends on the
+former and defaults to `ON` if not changed:
+```shell
+  -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON \
+  -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON \
+```
 
 ### Initiate Build
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,13 +44,13 @@
     python -m pip install -r requirements.txt -r torchvision-requirements.txt
     ```
 
-Also, ensure that you have the appropriate `python-dev` package installed
-to access the Python development libraries / headers. For example, you can install
-it with the following `apt` command on Ubuntu/Debian.
+1. Install the libraries and headers required for development
 
-```shell
-sudo apt install python3-dev
-```
+    - For Ubuntu or Debian, run:
+
+      ```shell
+      sudo apt install python3-dev
+      ```
 
 ## (Optional) Set up pre-commit
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,11 +33,13 @@
     python3 -m venv mlir_venv
     ```
 
-1. Activate the Python environment
+## Activate the Python environment
 
-    ```shell
-    source mlir_venv/bin/activate
-    ```
+```shell
+source mlir_venv/bin/activate
+```
+
+## Install Dependencies
 
 1. Get the latest version of pip
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -183,30 +183,33 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 ### Initiate Build
 
 1. [Configure the build](#configure-for-building) if you haven't already done so.
-1. Use one of the following commands to build the project:
-    - Build everything (including LLVM if in-tree)
+1. Append the base command:
+
+    ```shell
+    cmake --build build
+    ```
+
+1. **If you want to...**
+    - **...build _just_ torch-mlir (not all of LLVM)**, append:
 
       ```shell
-      cmake --build build
+       --target tools/torch-mlir/all
       ```
 
-    - Build just torch-mlir (not all of LLVM)
+      - NOTE: skipping this will result in _everything_ being built, which includes LLVM if configured as "in-tree"
+    - **...run unit tests**, append:
 
       ```shell
-      cmake --build build --target tools/torch-mlir/all
+       --target check-torch-mlir
       ```
 
-    - Run unit tests.
+    - **...run Python regression tests**, append:
 
       ```shell
-      cmake --build build --target check-torch-mlir
+       --target check-torch-mlir-python
       ```
 
-    - Run Python regression tests.
-
-      ```shell
-      cmake --build build --target check-torch-mlir-python
-      ```
+1. Execute the command with the desired targets, if any.
 
 ## Setup Python Environment to export the built Python packages
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -83,13 +83,22 @@ We recommend linting and formatting your commits _before_ the CI has a chance to
 
 ## With CMake
 
+### (Optional) Enable Build Optimizations
+
+For workflows that demand frequent rebuilds, the following steps will allow you to specify options during configuration that enable build optimizations.
+
+#### On Windows
+
+  1. Set up Developer PowerShell [for Visual Studio](https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022#start-in-visual-studio)
+  1. Ensure that the compiler and linker binaries are in the `PATH` variable.
+
 ### Configure for Building...
 
 Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is the most straightforward, as it will build LLVM dependencies as well.
 
 #### ...with LLVM "in-tree" using...
 
-The following commands generate configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build. This will build LLVM as well as torch-mlir and its subprojects.  On Windows, use the "Developer PowerShell for Visual Studio" to ensure that the compiler and linker binaries are in the `PATH` variable.
+The following commands generate configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build. This will build LLVM as well as torch-mlir and its subprojects.
 
 ##### ...Base + Optimization Options
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -188,13 +188,19 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
     ```shell
     # Build just torch-mlir (not all of LLVM)
     cmake --build build --target tools/torch-mlir/all
+    ```
 
+    ```shell
     # Run unit tests.
     cmake --build build --target check-torch-mlir
+    ```
 
+    ```shell
     # Run Python regression tests.
     cmake --build build --target check-torch-mlir-python
+    ```
 
+    ```shell
     # Build everything (including LLVM if in-tree)
     cmake --build build
     ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -184,26 +184,29 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
 1. [Configure the build](#configure-for-building) if you haven't already done so.
 1. Use one of the following commands to build the project:
+    - Build just torch-mlir (not all of LLVM)
 
-    ```shell
-    # Build just torch-mlir (not all of LLVM)
-    cmake --build build --target tools/torch-mlir/all
-    ```
+      ```shell
+      cmake --build build --target tools/torch-mlir/all
+      ```
 
-    ```shell
-    # Run unit tests.
-    cmake --build build --target check-torch-mlir
-    ```
+    - Run unit tests.
 
-    ```shell
-    # Run Python regression tests.
-    cmake --build build --target check-torch-mlir-python
-    ```
+      ```shell
+      cmake --build build --target check-torch-mlir
+      ```
 
-    ```shell
-    # Build everything (including LLVM if in-tree)
-    cmake --build build
-    ```
+    - Run Python regression tests.
+
+      ```shell
+      cmake --build build --target check-torch-mlir-python
+      ```
+
+    - Build everything (including LLVM if in-tree)
+
+      ```shell
+      cmake --build build
+      ```
 
 ## Setup Python Environment to export the built Python packages
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -184,6 +184,12 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
 1. [Configure the build](#configure-for-building) if you haven't already done so.
 1. Use one of the following commands to build the project:
+    - Build everything (including LLVM if in-tree)
+
+      ```shell
+      cmake --build build
+      ```
+
     - Build just torch-mlir (not all of LLVM)
 
       ```shell
@@ -200,12 +206,6 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
       ```shell
       cmake --build build --target check-torch-mlir-python
-      ```
-
-    - Build everything (including LLVM if in-tree)
-
-      ```shell
-      cmake --build build
       ```
 
 ## Setup Python Environment to export the built Python packages

--- a/docs/development.md
+++ b/docs/development.md
@@ -114,13 +114,15 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
 ### Configure for Building...
 
+#### ...with LLVM...
+
 Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is the most straightforward, as it will build LLVM dependencies as well.
 
-#### ...with LLVM "in-tree" using...
+##### ..."in-tree" using...
 
 The following commands generate configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build. This will build LLVM as well as torch-mlir and its subprojects.
 
-##### ...Base + Optimization Options
+###### ...Base + Optimization Options
 This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If you encounter issues when you run this, try the [simplified build command](#base-options) instead.
 
 ```shell
@@ -153,7 +155,7 @@ cmake -GNinja -Bbuild \
   -DLIBTORCH_VARIANT=shared
 ```
 
-##### ...Base Options
+###### ...Base Options
 
 If you're running into issues with the above build command, consider using the following:
 
@@ -169,7 +171,7 @@ cmake -GNinja -Bbuild \
   externals/llvm-project/llvm
 ```
 
-#### ...with LLVM "out-of-tree"
+##### ..."out-of-tree"
 
 If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following command as template:
 ```shell

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,17 +17,32 @@
    - Optionally, use `--depth=1` to make a shallow clone of the submodules.
    - While this is running, you can already setup the Python venv and dependencies in the next step.
 
-## Setup your Python VirtualEnvironment and Dependencies
+## Set up the Python environment
 
-```shell
-python3 -m venv mlir_venv
-source mlir_venv/bin/activate
-# Some older pip installs may not be able to handle the recent PyTorch deps
-python -m pip install --upgrade pip
-# Install latest PyTorch nightlies and build requirements.
-python -m pip install -r requirements.txt
-python -m pip install -r torchvision-requirements.txt
-```
+1. Install Python VirtualEnvironment + MLIR variant
+
+    ```shell
+    python3 -m venv mlir_venv
+    ```
+
+1. Activate the Python environment
+
+    ```shell
+    source mlir_venv/bin/activate
+    ```
+
+1. Get the latest version of pip
+
+    ```shell
+    python -m pip install --upgrade pip
+    ```
+
+    - Some older pip installs may not be able to handle the recent PyTorch deps
+1. Install the latest requirements.
+
+    ```shell
+    python -m pip install -r requirements.txt -r torchvision-requirements.txt
+    ```
 
 Also, ensure that you have the appropriate `python-dev` package installed
 to access the Python development libraries / headers. For example, you can install

--- a/docs/development.md
+++ b/docs/development.md
@@ -114,6 +114,7 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
 ### Configure for Building
 
+1. [Activate the Python environment](#activate-the-python-environment)
 1. Append (not "run") command with "common" options:
 
     ```shell

--- a/docs/development.md
+++ b/docs/development.md
@@ -162,6 +162,7 @@ If you're running into issues with the above build command, consider using the f
 ```shell
 cmake -GNinja -Bbuild \
   -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
   -DPython3_FIND_VIRTUALENV=ONLY \
   -DLLVM_ENABLE_PROJECTS=mlir \
   -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
@@ -177,6 +178,7 @@ If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, 
 ```shell
 cmake -GNinja -Bbuild \
   -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
   -DPython3_FIND_VIRTUALENV=ONLY \
   -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir/" \
   -DLLVM_DIR="$LLVM_INSTALL_DIR/lib/cmake/llvm/" \

--- a/docs/development.md
+++ b/docs/development.md
@@ -182,21 +182,22 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
 ### Initiate Build
 
-[Configure the build](#configure-for-building) if you haven't already done so. Then, use one of the following commands to build the project:
+1. [Configure the build](#configure-for-building) if you haven't already done so.
+1. Use one of the following commands to build the project:
 
-```shell
-# Build just torch-mlir (not all of LLVM)
-cmake --build build --target tools/torch-mlir/all
+    ```shell
+    # Build just torch-mlir (not all of LLVM)
+    cmake --build build --target tools/torch-mlir/all
 
-# Run unit tests.
-cmake --build build --target check-torch-mlir
+    # Run unit tests.
+    cmake --build build --target check-torch-mlir
 
-# Run Python regression tests.
-cmake --build build --target check-torch-mlir-python
+    # Run Python regression tests.
+    cmake --build build --target check-torch-mlir-python
 
-# Build everything (including LLVM if in-tree)
-cmake --build build
-```
+    # Build everything (including LLVM if in-tree)
+    cmake --build build
+    ```
 
 ## Setup Python Environment to export the built Python packages
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -182,7 +182,7 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
 ### Initiate Build
 
-After either cmake run (in-tree/out-of-tree), use one of the following commands to build the project:
+[Configure the build](#configure-for-building) if you haven't already done so. Then, use one of the following commands to build the project:
 
 ```shell
 # Build just torch-mlir (not all of LLVM)

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,13 +129,7 @@ cmake -GNinja -Bbuild \
 
 Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is the most straightforward, as it will build LLVM dependencies as well.
 
-##### ..."in-tree" using...
-
-The following commands generate configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build. This will build LLVM as well as torch-mlir and its subprojects.
-
-###### ...Base Options
-
-If you don't anticipate needing to frequently rebuild LLVM "in-tree", append:
+##### ..."in-tree"
 
 ```shell
   \
@@ -146,16 +140,15 @@ If you don't anticipate needing to frequently rebuild LLVM "in-tree", append:
   -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD"
 ```
 
-###### ...Base + Optimization Options
-This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If these options cause issues, use just the [base options](#base-options) for now.
+- NOTE: uses external/llvm-project/llvm as the main build, so LLVM will be built in additional to torch-mlir and its sub-projects.
+
+###### (Optional) Append options to enable build optimizations
+This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If these options cause issues, just skip them for now.
+
+If you do anticipate needing to frequently rebuild LLVM "in-tree", append:
 
 ```shell
   \
-  `# For building LLVM "in-tree"` \
-  externals/llvm-project/llvm \
-  -DLLVM_ENABLE_PROJECTS=mlir \
-  -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
-  -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD" \
   `# use clang`\
   -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
   `# use ccache to cache build results` \

--- a/docs/development.md
+++ b/docs/development.md
@@ -127,15 +127,16 @@ This will build `libtorch` / `PyTorch` wheels from source and requires [the enab
 
 ```shell
 cmake -GNinja -Bbuild \
-  externals/llvm-project/llvm \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_ENABLE_ASSERTIONS=ON \
   -DPython3_FIND_VIRTUALENV=ONLY \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DLLVM_TARGETS_TO_BUILD=host \
+  `# For building LLVM "in-tree"` \
+  externals/llvm-project/llvm \
   -DLLVM_ENABLE_PROJECTS=mlir \
   -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
   -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD" \
-  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-  -DLLVM_TARGETS_TO_BUILD=host \
   `# use clang`\
   -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
   `# use ccache to cache build results` \
@@ -164,12 +165,13 @@ cmake -GNinja -Bbuild \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_ENABLE_ASSERTIONS=ON \
   -DPython3_FIND_VIRTUALENV=ONLY \
-  -DLLVM_ENABLE_PROJECTS=mlir \
-  -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
-  -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD" \
   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
   -DLLVM_TARGETS_TO_BUILD=host \
-  externals/llvm-project/llvm
+  `# For building LLVM "in-tree"` \
+  externals/llvm-project/llvm \
+  -DLLVM_ENABLE_PROJECTS=mlir \
+  -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
+  -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD"
 ```
 
 ##### ..."out-of-tree"
@@ -180,10 +182,11 @@ cmake -GNinja -Bbuild \
   -DCMAKE_BUILD_TYPE=Release \
   -DLLVM_ENABLE_ASSERTIONS=ON \
   -DPython3_FIND_VIRTUALENV=ONLY \
-  -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir/" \
-  -DLLVM_DIR="$LLVM_INSTALL_DIR/lib/cmake/llvm/" \
   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
   -DLLVM_TARGETS_TO_BUILD=host \
+  `# For building LLVM "out-of-tree"` \
+  -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir/" \
+  -DLLVM_DIR="$LLVM_INSTALL_DIR/lib/cmake/llvm/"
   .
 ```
 The same QoL CMake flags can be used to enable clang, ccache, and lld. Be sure to have built LLVM with `-DLLVM_ENABLE_PROJECTS=mlir`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,10 +142,24 @@ Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is 
 
 - NOTE: uses external/llvm-project/llvm as the main build, so LLVM will be built in additional to torch-mlir and its sub-projects.
 
-###### (Optional) Append options to enable build optimizations
+##### ..."out-of-tree"
+
+If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following options as a template:
+```shell
+  \
+  `# For building LLVM "out-of-tree"` \
+  -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir/" \
+  -DLLVM_DIR="$LLVM_INSTALL_DIR/lib/cmake/llvm/"
+```
+
+Be sure to have built LLVM with `-DLLVM_ENABLE_PROJECTS=mlir`.
+
+Be aware that the installed version of LLVM needs in general to match the committed version in `externals/llvm-project`. Using a different version may or may not work.
+
+#### (Optional) Append options to enable build optimizations
 This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If these options cause issues, just skip them for now.
 
-If you do anticipate needing to frequently rebuild LLVM "in-tree", append:
+If you anticipate needing to frequently rebuild LLVM, append:
 
 ```shell
   \
@@ -167,20 +181,6 @@ If you do anticipate needing to frequently rebuild LLVM "in-tree", append:
   `# Set the variant of libtorch to build / link against. (shared|static and optionally cxxabi11)` \
   -DLIBTORCH_VARIANT=shared
 ```
-
-##### ..."out-of-tree"
-
-If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following options as a template:
-```shell
-  \
-  `# For building LLVM "out-of-tree"` \
-  -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir/" \
-  -DLLVM_DIR="$LLVM_INSTALL_DIR/lib/cmake/llvm/"
-  .
-```
-The same QoL CMake flags can be used to enable clang, ccache, and lld. Be sure to have built LLVM with `-DLLVM_ENABLE_PROJECTS=mlir`.
-
-Be aware that the installed version of LLVM needs in general to match the committed version in `externals/llvm-project`. Using a different version may or may not work.
 
 #### (Optional) Append options that enable MLIR debugging
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -118,12 +118,15 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
 ```shell
 cmake -GNinja -Bbuild \
-  -DCMAKE_BUILD_TYPE=Release \
+  `# Enables "--debug" and "--debug-only" flags for the "torch-mlir-opt" tool` \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DLLVM_ENABLE_ASSERTIONS=ON \
   -DPython3_FIND_VIRTUALENV=ONLY \
   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
   -DLLVM_TARGETS_TO_BUILD=host
 ```
+
+[About MLIR debugging](https://mlir.llvm.org/getting_started/Debugging/)
 
 #### Specify LLVM options
 
@@ -179,15 +182,6 @@ If you anticipate needing to frequently rebuild LLVM, append:
 ```
 
 This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If these options cause issues, just skip them for now.
-
-#### (Optional) Append options that enable MLIR debugging
-
-* Enabling `--debug` and `--debug-only` flags (see [MLIR docs](https://mlir.llvm.org/getting_started/Debugging/)) for the `torch-mlir-opt` tool
-```shell
-  \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \ # or =Debug
-  -DLLVM_ENABLE_ASSERTIONS=ON
-```
 
 #### (Optional) Append options that enable end-to-end tests
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -114,7 +114,18 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
 ### Configure for Building
 
-#### Choose command LLVM built...
+#### Append (not "run") command with "common" options
+
+```shell
+cmake -GNinja -Bbuild \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DPython3_FIND_VIRTUALENV=ONLY \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DLLVM_TARGETS_TO_BUILD=host
+```
+
+#### Choose options LLVM built...
 
 Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is the most straightforward, as it will build LLVM dependencies as well.
 
@@ -127,12 +138,7 @@ The following commands generate configuration files to build the project *in-tre
 If you don't anticipate needing to frequently rebuild LLVM "in-tree", append:
 
 ```shell
-cmake -GNinja -Bbuild \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DLLVM_ENABLE_ASSERTIONS=ON \
-  -DPython3_FIND_VIRTUALENV=ONLY \
-  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-  -DLLVM_TARGETS_TO_BUILD=host \
+  \
   `# For building LLVM "in-tree"` \
   externals/llvm-project/llvm \
   -DLLVM_ENABLE_PROJECTS=mlir \
@@ -141,15 +147,10 @@ cmake -GNinja -Bbuild \
 ```
 
 ###### ...Base + Optimization Options
-This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If you encounter issues when you run this, try the [simplified build command](#base-options) instead.
+This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If these options cause issues, use just the [base options](#base-options) for now.
 
 ```shell
-cmake -GNinja -Bbuild \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DLLVM_ENABLE_ASSERTIONS=ON \
-  -DPython3_FIND_VIRTUALENV=ONLY \
-  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-  -DLLVM_TARGETS_TO_BUILD=host \
+  \
   `# For building LLVM "in-tree"` \
   externals/llvm-project/llvm \
   -DLLVM_ENABLE_PROJECTS=mlir \
@@ -176,14 +177,9 @@ cmake -GNinja -Bbuild \
 
 ##### ..."out-of-tree"
 
-If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following command as template:
+If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following options as a template:
 ```shell
-cmake -GNinja -Bbuild \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DLLVM_ENABLE_ASSERTIONS=ON \
-  -DPython3_FIND_VIRTUALENV=ONLY \
-  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-  -DLLVM_TARGETS_TO_BUILD=host \
+  \
   `# For building LLVM "out-of-tree"` \
   -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir/" \
   -DLLVM_DIR="$LLVM_INSTALL_DIR/lib/cmake/llvm/"

--- a/docs/development.md
+++ b/docs/development.md
@@ -139,6 +139,7 @@ Be aware that the installed version of LLVM needs in general to match the commit
 ### Build commands
 
 After either cmake run (in-tree/out-of-tree), use one of the following commands to build the project:
+
 ```shell
 # Build just torch-mlir (not all of LLVM)
 cmake --build build --target tools/torch-mlir/all
@@ -173,6 +174,7 @@ To test the MLIR output to torch dialect, you can use `test/python/fx_importer/b
 
 Make sure you have activated the virtualenv and set the `PYTHONPATH` above
 (if running on Windows, modify the environment variable as shown above):
+
 ```shell
 source mlir_venv/bin/activate
 export PYTHONPATH=`pwd`/build/tools/torch-mlir/python_packages/torch_mlir:`pwd`/test/python/fx_importer
@@ -187,6 +189,7 @@ This path doesn't give access to the current generation work that is being drive
 and may lead to errors.
 
 Same as above, but with different python path and example:
+
 ```shell
 export PYTHONPATH=`pwd`/build/tools/torch-mlir/python_packages/torch_mlir:`pwd`/projects/pt1/examples
 python projects/pt1/examples/torchscript_resnet18_all_output_types.py
@@ -197,6 +200,7 @@ This will display the Resnet18 network example in three dialects: TORCH, LINALG 
 The main functionality is on `torch_mlir.torchscript.compile()`'s `output_type`.
 
 Ex:
+
 ```python
 module = torch_mlir.torchscript.compile(resnet18, torch.ones(1, 3, 224, 224), output_type="torch")
 ```
@@ -206,6 +210,7 @@ module = torch_mlir.torchscript.compile(resnet18, torch.ones(1, 3, 224, 224), ou
 ## Jupyter
 
 Jupyter notebook:
+
 ```shell
 python -m ipykernel install --user --name=torch-mlir --env PYTHONPATH "$PYTHONPATH"
 # Open in jupyter, and then navigate to
@@ -237,17 +242,21 @@ manually `source`'d in a shell.
 Torch-MLIR can also be built using Bazel (apart from the official CMake build) for users that depend on Bazel in their workflows. To build `torch-mlir-opt` using Bazel, follow these steps:
 
 1. Launch an interactive docker container with the required deps installed:
+
 ```shell
 ./utils/bazel/docker/run_docker.sh
 ```
 
 2. Build torch-mlir:
+
 ```shell
 bazel build @torch-mlir//:torch-mlir-opt
 ```
+
 The built binary should be at `bazel-bin/external/torch-mlir/torch-mlir-opt`.
 
 3. Test torch-mlir (lit test only):
+
 ```shell
 bazel test @torch-mlir//test/...
 ```
@@ -255,6 +264,7 @@ bazel test @torch-mlir//test/...
 We welcome patches to torch-mlir's Bazel build. If you do contribute,
 please complete your PR with an invocation of buildifier to ensure
 the BUILD files are formatted consistently:
+
 ```shell
 bazel run @torch-mlir//:buildifier
 ```
@@ -287,6 +297,7 @@ TM_PACKAGES="in-tree" ./build_tools/python_deploy/build_linux_packages.sh
 ### Out-of-Tree builds
 
 Build LLVM/MLIR first and then build Torch-MLIR referencing that build
+
 ```shell
 TM_PACKAGES="out-of-tree" ./build_tools/python_deploy/build_linux_packages.sh
 ```
@@ -339,38 +350,48 @@ The following additional environmental variables can be used to customize your d
 
 * Custom Release Docker image:
   Defaults to `stellaraccident/manylinux2014_x86_64-bazel-5.1.0:latest`
+
 ```shell
   TM_RELEASE_DOCKER_IMAGE="stellaraccident/manylinux2014_x86_64-bazel-5.1.0:latest"
 ```
+
 * Custom CI Docker image:
   Defaults to `powderluv/torch-mlir-ci:latest`. This assumes an Ubuntu LTS like image. You can build your own with `./build_tools/docker/Dockerfile`
+
 ```shell
   TM_CI_DOCKER_IMAGE="powderluv/torch-mlir-ci:latest"
 ```
 
 * Custom Python Versions for Release builds:
   Version of Python to use in Release builds. Ignored in CIs. Defaults to `cp38-cp38 cp39-cp39 cp310-cp310`
+
 ```shell
   TM_PYTHON_VERSIONS="cp38-cp38 cp39-cp39 cp310-cp310"
 ```
 
 * Location to store Release build wheels
+
 ```shell
   TM_OUTPUT_DIR="./build_tools/python_deploy/wheelhouse"
 ```
 
 * What "packages" to build:
   Defaults to torch-mlir. Options are `torch-mlir out-of-tree in-tree`
+
 ```shell
   TM_PACKAGES="torch-mlir out-of-tree in-tree"
 ```
+
 * Use pre-built Pytorch:
   Defaults to using pre-built Pytorch. Setting it to `OFF` builds from source
+
 ```shell
   TM_USE_PYTORCH_BINARY="OFF"
 ```
+
 * Skip running tests
   Skip running tests if you want quick build only iteration. Default set to `OFF`
+
 ```shell
   TM_SKIP_TESTS="OFF"
 ```
@@ -389,6 +410,7 @@ CMAKE_GENERATOR=Ninja python setup.py bdist_wheel
 
 To package a completed CMake build directory,
 you can use the `TORCH_MLIR_CMAKE_BUILD_DIR` and `TORCH_MLIR_CMAKE_ALREADY_BUILT` environment variables:
+
 ```shell
 TORCH_MLIR_CMAKE_BUILD_DIR=build/ TORCH_MLIR_CMAKE_ALREADY_BUILT=1 python setup.py bdist_wheel
 ```
@@ -490,6 +512,7 @@ Most of the unit tests use the [`FileCheck` tool](https://llvm.org/docs/CommandG
 # PyTorch source builds and custom PyTorch versions
 
 Torch-MLIR by default builds with the latest nightly PyTorch version. This can be toggled to build from latest PyTorch source with
+
 ```
 -DTORCH_MLIR_USE_INSTALLED_PYTORCH=OFF
 -DTORCH_MLIR_SRC_PYTORCH_REPO=vivekkhandelwal1/pytorch # Optional. Github path. Defaults to pytorch/pytorch

--- a/docs/development.md
+++ b/docs/development.md
@@ -164,15 +164,7 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
       `# if using clang <= 13, replace --ld-path=ld.lld with -fuse-ld=lld` \
       -DCMAKE_EXE_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
       -DCMAKE_MODULE_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
-      -DCMAKE_SHARED_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
-      `# Enabling libtorch binary cache instead of downloading the latest libtorch everytime.` \
-      `# Testing against a mismatched version of libtorch may cause failures` \
-      -DLIBTORCH_CACHE=ON \
-      `# Enable an experimental path to build libtorch (and PyTorch wheels) from source,` \
-      `# instead of downloading them` \
-      -DLIBTORCH_SRC_BUILD=ON \
-      `# Set the variant of libtorch to build / link against. (shared|static and optionally cxxabi11)` \
-      -DLIBTORCH_VARIANT=shared
+      -DCMAKE_SHARED_LINKER_FLAGS_INIT="--ld-path=ld.lld"
     ```
 
     - This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,15 +1,21 @@
 # Environment
 
-## Check out the code
+## Pull down the project
 
-```shell
-git clone https://github.com/llvm/torch-mlir
-cd torch-mlir
-git submodule update --init --progress
-```
+1. ```shell
+   git clone https://github.com/llvm/torch-mlir
+   ```
 
-Optionally, use `--depth=1` to make a shallow clone of the submodules.
-While this is running, you can already setup the Python venv and dependencies in the next step.
+1. ```shell
+   cd torch-mlir
+   ```
+
+1. ```shell
+   git submodule update --init --progress
+   ```
+
+   - Optionally, use `--depth=1` to make a shallow clone of the submodules.
+   - While this is running, you can already setup the Python venv and dependencies in the next step.
 
 ## Setup your Python VirtualEnvironment and Dependencies
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -112,9 +112,9 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
   1. Set up Developer PowerShell [for Visual Studio](https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022#start-in-visual-studio)
   1. Ensure that the compiler and linker binaries are in the `PATH` variable.
 
-### Configure for Building...
+### Configure for Building
 
-#### ...with LLVM...
+#### Choose command LLVM built...
 
 Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is the most straightforward, as it will build LLVM dependencies as well.
 
@@ -124,7 +124,7 @@ The following commands generate configuration files to build the project *in-tre
 
 ###### ...Base Options
 
-If you don't anticipate needing to frequently rebuild LLVM "in-tree", run:
+If you don't anticipate needing to frequently rebuild LLVM "in-tree", append:
 
 ```shell
 cmake -GNinja -Bbuild \
@@ -193,22 +193,28 @@ The same QoL CMake flags can be used to enable clang, ccache, and lld. Be sure t
 
 Be aware that the installed version of LLVM needs in general to match the committed version in `externals/llvm-project`. Using a different version may or may not work.
 
-#### Options to enable MLIR debugging
+#### (Optional) Append options that enable MLIR debugging
 
 * Enabling `--debug` and `--debug-only` flags (see [MLIR docs](https://mlir.llvm.org/getting_started/Debugging/)) for the `torch-mlir-opt` tool
 ```shell
+  \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \ # or =Debug
-  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DLLVM_ENABLE_ASSERTIONS=ON
 ```
 
-#### Options to run end-to-end tests
+#### (Optional) Append options that enable end-to-end tests
 
 Running the end-to-end execution tests locally requires enabling the native PyTorch extension features and the JIT IR importer, which depends on the
 former and defaults to `ON` if not changed:
 ```shell
+  \
   -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON \
-  -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON \
+  -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON
 ```
+
+#### Run assembled command
+
+Execute the command once you've appended the options pertaining to your workflow.
 
 ### Initiate Build
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -114,89 +114,78 @@ For workflows that demand frequent rebuilds, the following steps will allow you 
 
 ### Configure for Building
 
-#### Append (not "run") command with "common" options
+1. Append (not "run") command with "common" options:
 
-```shell
-cmake -GNinja -Bbuild \
-  `# Enables "--debug" and "--debug-only" flags for the "torch-mlir-opt" tool` \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-  -DLLVM_ENABLE_ASSERTIONS=ON \
-  -DPython3_FIND_VIRTUALENV=ONLY \
-  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-  -DLLVM_TARGETS_TO_BUILD=host
-```
+    ```shell
+    cmake -GNinja -Bbuild \
+      `# Enables "--debug" and "--debug-only" flags for the "torch-mlir-opt" tool` \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DLLVM_ENABLE_ASSERTIONS=ON \
+      -DPython3_FIND_VIRTUALENV=ONLY \
+      -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+      -DLLVM_TARGETS_TO_BUILD=host
+    ```
 
-[About MLIR debugging](https://mlir.llvm.org/getting_started/Debugging/)
+    - [About MLIR debugging](https://mlir.llvm.org/getting_started/Debugging/)
+1. Specify LLVM options
+    1. **If building "in-tree"**, append:
 
-#### Specify LLVM options
+        ```shell
+          \
+          `# For building LLVM "in-tree"` \
+          externals/llvm-project/llvm \
+          -DLLVM_ENABLE_PROJECTS=mlir \
+          -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
+          -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD"
+        ```
 
-##### If building "in-tree", append:
+        - NOTE: uses external/llvm-project/llvm as the main build, so LLVM will be built in additional to torch-mlir and its sub-projects.
+    1. **If building "out-of-tree" in separate directory**, append:
 
-```shell
-  \
-  `# For building LLVM "in-tree"` \
-  externals/llvm-project/llvm \
-  -DLLVM_ENABLE_PROJECTS=mlir \
-  -DLLVM_EXTERNAL_PROJECTS="torch-mlir" \
-  -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD"
-```
+        ```shell
+          \
+          `# For building LLVM "out-of-tree"` \
+          -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir/" \
+          -DLLVM_DIR="$LLVM_INSTALL_DIR/lib/cmake/llvm/"
+        ```
 
-- NOTE: uses external/llvm-project/llvm as the main build, so LLVM will be built in additional to torch-mlir and its sub-projects.
+        - Be sure to have built LLVM with `-DLLVM_ENABLE_PROJECTS=mlir`.
+        - Be aware that the installed version of LLVM needs in general to match the committed version in `externals/llvm-project`. Using a different version may or may not work.
+1. **If you anticipate needing to frequently rebuild LLVM**, append:
 
-##### If building "out-of-tree" in separate directory, append:
+    ```shell
+      \
+      `# use clang`\
+      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+      `# use ccache to cache build results` \
+      -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      `# use LLD to link in seconds, rather than minutes` \
+      `# if using clang <= 13, replace --ld-path=ld.lld with -fuse-ld=lld` \
+      -DCMAKE_EXE_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
+      -DCMAKE_MODULE_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
+      -DCMAKE_SHARED_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
+      `# Enabling libtorch binary cache instead of downloading the latest libtorch everytime.` \
+      `# Testing against a mismatched version of libtorch may cause failures` \
+      -DLIBTORCH_CACHE=ON \
+      `# Enable an experimental path to build libtorch (and PyTorch wheels) from source,` \
+      `# instead of downloading them` \
+      -DLIBTORCH_SRC_BUILD=ON \
+      `# Set the variant of libtorch to build / link against. (shared|static and optionally cxxabi11)` \
+      -DLIBTORCH_VARIANT=shared
+    ```
 
-```shell
-  \
-  `# For building LLVM "out-of-tree"` \
-  -DMLIR_DIR="$LLVM_INSTALL_DIR/lib/cmake/mlir/" \
-  -DLLVM_DIR="$LLVM_INSTALL_DIR/lib/cmake/llvm/"
-```
+    - This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations).
+    - If these options cause issues, just skip them for now.
+1. **If you need to enable local end-to-end tests**, append:
 
-Be sure to have built LLVM with `-DLLVM_ENABLE_PROJECTS=mlir`.
+    ```shell
+      \
+      -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON \
+      -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON
+    ```
 
-Be aware that the installed version of LLVM needs in general to match the committed version in `externals/llvm-project`. Using a different version may or may not work.
-
-#### (Optional) Append options to enable build optimizations
-
-If you anticipate needing to frequently rebuild LLVM, append:
-
-```shell
-  \
-  `# use clang`\
-  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
-  `# use ccache to cache build results` \
-  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-  `# use LLD to link in seconds, rather than minutes` \
-  `# if using clang <= 13, replace --ld-path=ld.lld with -fuse-ld=lld` \
-  -DCMAKE_EXE_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
-  -DCMAKE_MODULE_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
-  -DCMAKE_SHARED_LINKER_FLAGS_INIT="--ld-path=ld.lld" \
-  `# Enabling libtorch binary cache instead of downloading the latest libtorch everytime.` \
-  `# Testing against a mismatched version of libtorch may cause failures` \
-  -DLIBTORCH_CACHE=ON \
-  `# Enable an experimental path to build libtorch (and PyTorch wheels) from source,` \
-  `# instead of downloading them` \
-  -DLIBTORCH_SRC_BUILD=ON \
-  `# Set the variant of libtorch to build / link against. (shared|static and optionally cxxabi11)` \
-  -DLIBTORCH_VARIANT=shared
-```
-
-This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If these options cause issues, just skip them for now.
-
-#### (Optional) Append options that enable end-to-end tests
-
-```shell
-  \
-  -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON \
-  -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON
-```
-
-Running the end-to-end execution tests locally requires enabling the native PyTorch extension features and the JIT IR importer, which depends on the
-former and defaults to `ON` if not changed:
-
-#### Run assembled command
-
-Execute the command once you've appended the options pertaining to your workflow.
+    - NOTE: The JIT IR importer depends on the native PyTorch extension features and defaults to `ON` if not changed.
+1. Run assembled command (once you've appended the options pertaining to your workflow)
 
 ### Initiate Build
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -158,7 +158,7 @@ cmake -GNinja -Bbuild \
 
 ###### ...Base Options
 
-If you're running into issues with the above build command, consider using the following:
+If you don't anticipate needing to frequently rebuild LLVM "in-tree", run:
 
 ```shell
 cmake -GNinja -Bbuild \

--- a/docs/development.md
+++ b/docs/development.md
@@ -87,6 +87,26 @@ We recommend linting and formatting your commits _before_ the CI has a chance to
 
 For workflows that demand frequent rebuilds, the following steps will allow you to specify options during configuration that enable build optimizations.
 
+#### On Ubuntu
+
+1. Install [Clang](https://clang.llvm.org/index.html)
+
+    ```shell
+    sudo apt install clang
+    ```
+
+1. Install [ccache](https://ccache.dev/)
+
+    ```shell
+    sudo apt install ccache
+    ```
+
+1. Install [LLD](https://lld.llvm.org/)
+
+    ```shell
+    sudo apt install lld
+    ```
+
 #### On Windows
 
   1. Set up Developer PowerShell [for Visual Studio](https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022#start-in-visual-studio)
@@ -101,8 +121,7 @@ Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is 
 The following commands generate configuration files to build the project *in-tree*, that is, using llvm/llvm-project as the main build. This will build LLVM as well as torch-mlir and its subprojects.
 
 ##### ...Base + Optimization Options
-
-This requires `lld`, `clang`, `ccache`, and other dependencies for building `libtorch` / `PyTorch` wheels from source. If you run into issues because of these, try the [simplified build command](#base-options).
+This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If you encounter issues when you run this, try the [simplified build command](#base-options) instead.
 
 ```shell
 cmake -GNinja -Bbuild \

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,14 @@
 
 ## Set up the Python environment
 
+1. Install the libraries and headers required for development
+
+    - For Ubuntu or Debian, run:
+
+      ```shell
+      sudo apt install python3-dev
+      ```
+
 1. Install Python VirtualEnvironment + MLIR variant
 
     ```shell
@@ -44,13 +52,6 @@
     python -m pip install -r requirements.txt -r torchvision-requirements.txt
     ```
 
-1. Install the libraries and headers required for development
-
-    - For Ubuntu or Debian, run:
-
-      ```shell
-      sudo apt install python3-dev
-      ```
 
 ## (Optional) Set up pre-commit
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -191,13 +191,14 @@ This will build `libtorch` / `PyTorch` wheels from source and requires [the enab
 
 #### (Optional) Append options that enable end-to-end tests
 
-Running the end-to-end execution tests locally requires enabling the native PyTorch extension features and the JIT IR importer, which depends on the
-former and defaults to `ON` if not changed:
 ```shell
   \
   -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON \
   -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON
 ```
+
+Running the end-to-end execution tests locally requires enabling the native PyTorch extension features and the JIT IR importer, which depends on the
+former and defaults to `ON` if not changed:
 
 #### Run assembled command
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,19 +54,30 @@ source mlir_venv/bin/activate
     python -m pip install -r requirements.txt -r torchvision-requirements.txt
     ```
 
+## Set up pre-commit hooks
 
-## (Optional) Set up pre-commit
+We recommend linting and formatting your commits _before_ the CI has a chance to complain about it.
 
-This project uses [pre-commit](https://pre-commit.com/) in its CI. You can
-install it locally too in order to lint and fix your code prior to the CI
-complaining about it.
+1. Install [pre-commit](https://pre-commit.com/)
 
-```shell
-pip install pre-commit
-# You can run interactively with `pre-commit run`
-# or install hooks so it runs automatically:
-pre-commit install
-```
+    ```shell
+    pip install pre-commit
+    ```
+
+    - This is the same package used by the CI.
+1. Either:
+    - Run the hooks manually.
+
+      ```shell
+      pre-commit run
+      ```
+
+      OR
+    - Install them so they run automatically.
+
+      ```shell
+      pre-commit install
+      ```
 
 # Building
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -125,11 +125,9 @@ cmake -GNinja -Bbuild \
   -DLLVM_TARGETS_TO_BUILD=host
 ```
 
-#### Choose options LLVM built...
+#### Specify LLVM options
 
-Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is the most straightforward, as it will build LLVM dependencies as well.
-
-##### ..."in-tree"
+##### If building "in-tree", append:
 
 ```shell
   \
@@ -142,9 +140,8 @@ Two setups are possible to build: in-tree and out-of-tree. The in-tree setup is 
 
 - NOTE: uses external/llvm-project/llvm as the main build, so LLVM will be built in additional to torch-mlir and its sub-projects.
 
-##### ..."out-of-tree"
+##### If building "out-of-tree" in separate directory, append:
 
-If you have built llvm-project separately in the directory `$LLVM_INSTALL_DIR`, you can also build the project *out-of-tree* using the following options as a template:
 ```shell
   \
   `# For building LLVM "out-of-tree"` \

--- a/docs/development.md
+++ b/docs/development.md
@@ -154,7 +154,6 @@ Be sure to have built LLVM with `-DLLVM_ENABLE_PROJECTS=mlir`.
 Be aware that the installed version of LLVM needs in general to match the committed version in `externals/llvm-project`. Using a different version may or may not work.
 
 #### (Optional) Append options to enable build optimizations
-This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If these options cause issues, just skip them for now.
 
 If you anticipate needing to frequently rebuild LLVM, append:
 
@@ -178,6 +177,8 @@ If you anticipate needing to frequently rebuild LLVM, append:
   `# Set the variant of libtorch to build / link against. (shared|static and optionally cxxabi11)` \
   -DLIBTORCH_VARIANT=shared
 ```
+
+This will build `libtorch` / `PyTorch` wheels from source and requires [the enablement mentioned earlier](#optional-enable-build-optimizations). If these options cause issues, just skip them for now.
 
 #### (Optional) Append options that enable MLIR debugging
 


### PR DESCRIPTION
First PR, super stoked! 🥳

### Context
As part of Turbine Camp, I was referred to this doc to build Torch-MLIR on my Linux VM. It has a lot of potential, and I decided it to nudge it in a productive direction a bunch of times as I actually used the doc.

### Approach
I tried to make the commits here "atomic", i.e. each one is a singular unit of work such that the file "works better"/"makes more sense" post-commit than pre-commit. 

The majority of the commits in this PR is the story of how I "refactored" the doc step by step to look the way it does. I wrote them with Future Us in mind, so please don't squash haha.

Ready when you are, @marbre!