### PR TITLE
[docs] Refresh add_ops.md

### DIFF
--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -9,6 +9,7 @@ This document was previously known as `turbine-camp.md` to Nod.ai. "Turbine Camp
 Written & maintained by @renxida
 
 Guides by other folks that were used during the creation of this document:
+
 - [Chi Liu](https://gist.github.com/AmosLewis/dd31ab37517977b1c499d06495b4adc2)
 - [Sunsoon](https://docs.google.com/document/d/1H79DwW_wnVzUU81EogwY5ueXgnl-QzKet1p2lnqPar4/edit?pli=1)
 
@@ -26,6 +27,7 @@ The details of how we do it and helpful commands to help you set up each repo is
 PS: IREE is pronounced Eerie, and hence the ghost icon.
 
 ## How to begin
+
 0. Set up torch-mlir according to the instructions here: https://github.com/llvm/torch-mlir/blob/main/docs/development.md
 1. You will start by adding support for 2 ops in torch-mlir, to get you familiar with the center of our pipeline. Begin by reading [torch-mlir's documentation on how to implement a new torch op](https://github.com/llvm/torch-mlir/blob/main/docs/Torch-ops-E2E-implementation.md), and set up `llvm/torch_mlir` using https://github.com/llvm/torch-mlir/blob/main/docs/development.md
 2. Pick 1 of the yet-unimplemented from the following. You should choose something that looks easy to you. **Make sure you create an issue by clicking the little "target" icon to the right of the op, thereby marking the op as yours**
@@ -39,6 +41,7 @@ PS: IREE is pronounced Eerie, and hence the ghost icon.
 ### How to TorchToLinalg
 
 You will need to do 5 things:
+
 - make sure -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON is added during build. This is to enable the python file used in `build_tools/update_torch_ods.sh` and `build_tools/update_abstract_interp_lib.sh`
 - make sure the op exists in `torch_ods_gen.py`, and then run `build_tools/update_torch_ods.sh`, and then build. This generates `GeneratedTorchOps.td`, which is used to generate the cpp and h files where ops function signatures are defined.
     - Reference [torch op registry](https://github.com/pytorch/pytorch/blob/7451dd058564b5398af79bfc1e2669d75f9ecfa2/torch/csrc/jit/passes/utils/op_registry.cpp#L21)
@@ -48,16 +51,19 @@ You will need to do 5 things:
 - implement the op in one of the `lib/Conversion/TorchToLinalg/*.cpp` files
 
 Reference Examples
+
 - [A Dec 2023 example with the most up to date lowering](https://github.com/llvm/torch-mlir/pull/2640/files)
 - [Chi's simple example of adding op lowering](https://github.com/llvm/torch-mlir/pull/1454) useful instructions and referring links for you to understand the op lowering pipeline in torch-mlir in the comments
 
 Resources:
+
 - how to set up torch-mlir: [https://github.com/llvm/torch-mlir/blob/main/docs/development.md](https://github.com/llvm/torch-mlir/blob/main/docs/development.md#checkout-and-build-from-source)
 - torch-mlir doc on how to debug and test: [ttps://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing](https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing)
 - [torch op registry](https://github.com/pytorch/pytorch/blob/7451dd058564b5398af79bfc1e2669d75f9ecfa2/torch/csrc/jit/passes/utils/op_registry.cpp#L21)
 - [torch shape functions](https://github.com/pytorch/pytorch/blob/7451dd058564b5398af79bfc1e2669d75f9ecfa2/torch/jit/_shape_functions.py#L1311)
 
 ### How to TorchOnnxToTorch
+
 0. Generate the big folder of ONNX IR. Use https://github.com/llvm/torch-mlir/blob/main/test/python/onnx_importer/import_smoke_test.py . Alternatively, if you're trying to support a certain model, convert that model to onnx IR with
    ```
    optimum-cli export onnx --model facebook/opt-125M fb-opt
@@ -68,6 +74,7 @@ Resources:
 4. Test the conversion by running `./build/bin/torch-mlir-opt -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch your_mlir_file.mlir`. For more details, see https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing . Xida usually creates a separate MLIR file to test it to his satisfaction before integrating it into one of the files at `torch-mlir/test/Conversion/TorchOnnxToTorch`.
 
 Helpful examples:
+
 - [A Dec 2023 example where an ONNX op is implemented](https://github.com/llvm/torch-mlir/pull/2641/files#diff-b584b152020af6d2e5dbf62a08b2f25ed5afc2c299228383b9651d22d44b5af4R493)
 - [Vivek's example of ONNX op lowering](https://github.com/llvm/torch-mlir/commit/dc9ea08db5ac295b4b3f91fc776fef6a702900b9)
 
@@ -78,14 +85,17 @@ Helpful examples:
 
 ## Contacts
 People who've worked on this for a while
+
 - Vivek (@vivek97 on discord)
 - Chi.Liu@amd.com
 
 Recent Turbine Camp Attendees, from recent to less recent
+
 - Xida.ren@amd.com (@xida_ren on discord)
 - Sungsoon.Cho@amd.com
 
 ## Links
+
 - IMPORTANT: read the LLVM style guide: https://llvm.org/docs/CodingStandards.html#use-early-exits-and-continue-to-simplify-code
 - Tutorials
   - [Sungsoon's Shark Getting Started Google Doc](https://docs.google.com/document/d/1H79DwW_wnVzUU81EogwY5ueXgnl-QzKet1p2lnqPar4/edit?pli=1)

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -66,7 +66,7 @@ Resources:
 
 1. Generate the big folder of ONNX IR. Use <https://github.com/llvm/torch-mlir/blob/main/test/python/onnx_importer/import_smoke_test.py> . Alternatively, if you're trying to support a certain model, convert that model to onnx IR with
 
-   ```
+   ```shell
    optimum-cli export onnx --model facebook/opt-125M fb-opt
    python -m torch_mlir.tools.import_onnx fb-opt/model.onnx -o fb-opt-125m.onnx.mlir
    ```

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -38,6 +38,8 @@ PS: IREE is pronounced Eerie, and hence the ghost icon.
 
 </details>
 
+## How to Add a Conversion for an Operator
+
 ### How to TorchToLinalg
 
 You will need to do 5 things:

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -18,9 +18,9 @@ Guides by other folks that were used during the creation of this document:
 Nod-ai maintains the pipeline below, which allows us to take a ML model from e.g. huggingface, and compile it to a variety of devices including llvm-cpu, rocm and cuda and more as an optimized `vmfb` binary.
 
 1. The pipeline begins with a huggingface model, or some other supported source like llama.cpp.
-2. [nod-ai/SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine) takes a huggingface model and exports a `.mlir` file.
-3. **[llvm/torch-mlir](https://github.com/llvm/torch-mlir)**, which you will be working on in turbine-camp, will lower torchscript, torch dialect, and torch aten ops further into a mixture `linalg` or `math` MLIR dialects (with occasionally other dialects in the mix)
-4. [IREE](https://github.com/openxla/iree) converts the final `.mlir` file into a binary (typically `.vmfb`) for running on a device (llvm-cpu, rocm, vulcan, cuda, etc).
+1. [nod-ai/SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine) takes a huggingface model and exports a `.mlir` file.
+1. **[llvm/torch-mlir](https://github.com/llvm/torch-mlir)**, which you will be working on in turbine-camp, will lower torchscript, torch dialect, and torch aten ops further into a mixture `linalg` or `math` MLIR dialects (with occasionally other dialects in the mix)
+1. [IREE](https://github.com/openxla/iree) converts the final `.mlir` file into a binary (typically `.vmfb`) for running on a device (llvm-cpu, rocm, vulcan, cuda, etc).
 
 The details of how we do it and helpful commands to help you set up each repo is in [Sungsoon's Shark Getting Started Google Doc](https://docs.google.com/document/d/1H79DwW_wnVzUU81EogwY5ueXgnl-QzKet1p2lnqPar4/edit?pli=1)
 
@@ -28,13 +28,13 @@ PS: IREE is pronounced Eerie, and hence the ghost icon.
 
 ## How to begin
 
-0. Set up torch-mlir according to the instructions here: <https://github.com/llvm/torch-mlir/blob/main/docs/development.md>
+1. Set up torch-mlir according to the instructions here: <https://github.com/llvm/torch-mlir/blob/main/docs/development.md>
 1. You will start by adding support for 2 ops in torch-mlir, to get you familiar with the center of our pipeline. Begin by reading [torch-mlir's documentation on how to implement a new torch op](https://github.com/llvm/torch-mlir/blob/main/docs/Torch-ops-E2E-implementation.md), and set up `llvm/torch_mlir` using <https://github.com/llvm/torch-mlir/blob/main/docs/development.md>
-2. Pick 1 of the yet-unimplemented from the following. You should choose something that looks easy to you. **Make sure you create an issue by clicking the little "target" icon to the right of the op, thereby marking the op as yours**
+1. Pick 1 of the yet-unimplemented from the following. You should choose something that looks easy to you. **Make sure you create an issue by clicking the little "target" icon to the right of the op, thereby marking the op as yours**
     - [TorchToLinalg ops tracking issue](https://github.com/nod-ai/SHARK-Turbine/issues/347)
     - [TorchOnnnxToTorch ops tracking issue](https://github.com/nod-ai/SHARK-Turbine/issues/215)
-3. Implement it. For torch -> linalg, see the how to torchop section below. For Onnx ops, see how to onnx below.
-5. Make a pull request and reference your issue. When the pull request is closed, also close your issue to mark the op as done
+1. Implement it. For torch -> linalg, see the how to torchop section below. For Onnx ops, see how to onnx below.
+1. Make a pull request and reference your issue. When the pull request is closed, also close your issue to mark the op as done
 
 </details>
 
@@ -64,16 +64,16 @@ Resources:
 
 ### How to TorchOnnxToTorch
 
-0. Generate the big folder of ONNX IR. Use <https://github.com/llvm/torch-mlir/blob/main/test/python/onnx_importer/import_smoke_test.py> . Alternatively, if you're trying to support a certain model, convert that model to onnx IR with
+1. Generate the big folder of ONNX IR. Use <https://github.com/llvm/torch-mlir/blob/main/test/python/onnx_importer/import_smoke_test.py> . Alternatively, if you're trying to support a certain model, convert that model to onnx IR with
 
    ```
    optimum-cli export onnx --model facebook/opt-125M fb-opt
    python -m torch_mlir.tools.import_onnx fb-opt/model.onnx -o fb-opt-125m.onnx.mlir
    ```
 
-2. Find an instance of the Op that you're trying to implement inside the smoke tests folder or the generated model IR, and write a test case. Later you will save it to one of the files in `torch-mlir/test/Conversion/TorchOnnxToTorch`, but for now feel free to put it anywhere.
-3. Implement the op in `lib/Conversion/TorchOnnxToTorch/something.cpp`.
-4. Test the conversion by running `./build/bin/torch-mlir-opt -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch your_mlir_file.mlir`. For more details, see <https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing> . Xida usually creates a separate MLIR file to test it to his satisfaction before integrating it into one of the files at `torch-mlir/test/Conversion/TorchOnnxToTorch`.
+1. Find an instance of the Op that you're trying to implement inside the smoke tests folder or the generated model IR, and write a test case. Later you will save it to one of the files in `torch-mlir/test/Conversion/TorchOnnxToTorch`, but for now feel free to put it anywhere.
+1. Implement the op in `lib/Conversion/TorchOnnxToTorch/something.cpp`.
+1. Test the conversion by running `./build/bin/torch-mlir-opt -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch your_mlir_file.mlir`. For more details, see <https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing> . Xida usually creates a separate MLIR file to test it to his satisfaction before integrating it into one of the files at `torch-mlir/test/Conversion/TorchOnnxToTorch`.
 
 Helpful examples:
 

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -44,9 +44,9 @@ You will need to do 5 things:
 
 - make sure -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON is added during build. This is to enable the python file used in `build_tools/update_torch_ods.sh` and `build_tools/update_abstract_interp_lib.sh`
 - make sure the op exists in `torch_ods_gen.py`, and then run `build_tools/update_torch_ods.sh`, and then build. This generates `GeneratedTorchOps.td`, which is used to generate the cpp and h files where ops function signatures are defined.
-    - Reference [torch op registry](https://github.com/pytorch/pytorch/blob/7451dd058564b5398af79bfc1e2669d75f9ecfa2/torch/csrc/jit/passes/utils/op_registry.cpp#L21)
+  - Reference [torch op registry](https://github.com/pytorch/pytorch/blob/7451dd058564b5398af79bfc1e2669d75f9ecfa2/torch/csrc/jit/passes/utils/op_registry.cpp#L21)
 - make sure the op exists in `abstract_interp_lib_gen.py`, and then run `build_tools/update_abstract_interp_lib.sh`, and then build. This generates `AbstractInterpLib.cpp`, which is used to generate the cpp and h files where ops function signatures are defined.
-    - Reference [torch shape functions](https://github.com/pytorch/pytorch/blob/7451dd058564b5398af79bfc1e2669d75f9ecfa2/torch/jit/_shape_functions.py#L1311)
+  - Reference [torch shape functions](https://github.com/pytorch/pytorch/blob/7451dd058564b5398af79bfc1e2669d75f9ecfa2/torch/jit/_shape_functions.py#L1311)
 - write test cases. They live in `projects/pt1`. See the [Dec 2023 example](https://github.com/llvm/torch-mlir/pull/2640/files).
 - implement the op in one of the `lib/Conversion/TorchToLinalg/*.cpp` files
 

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -67,7 +67,7 @@ Recent Turbine Camp Attendees, from recent to less recent
 
 ## Links
 
-- IMPORTANT: read the LLVM style guide: <https://llvm.org/docs/CodingStandards.html#use-early-exits-and-continue-to-simplify-code>
+- IMPORTANT: read the LLVM style guide: <https://llvm.org/docs/CodingStandards.html#style-issues>
 - Tutorials
   - [Sungsoon's Shark Getting Started Google Doc](https://docs.google.com/document/d/1H79DwW_wnVzUU81EogwY5ueXgnl-QzKet1p2lnqPar4/edit?pli=1)
     - This document contains commands that would help you set up shark and run demos

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -65,10 +65,12 @@ Resources:
 ### How to TorchOnnxToTorch
 
 0. Generate the big folder of ONNX IR. Use https://github.com/llvm/torch-mlir/blob/main/test/python/onnx_importer/import_smoke_test.py . Alternatively, if you're trying to support a certain model, convert that model to onnx IR with
+
    ```
    optimum-cli export onnx --model facebook/opt-125M fb-opt
    python -m torch_mlir.tools.import_onnx fb-opt/model.onnx -o fb-opt-125m.onnx.mlir
    ```
+
 2. Find an instance of the Op that you're trying to implement inside the smoke tests folder or the generated model IR, and write a test case. Later you will save it to one of the files in `torch-mlir/test/Conversion/TorchOnnxToTorch`, but for now feel free to put it anywhere.
 3. Implement the op in `lib/Conversion/TorchOnnxToTorch/something.cpp`.
 4. Test the conversion by running `./build/bin/torch-mlir-opt -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch your_mlir_file.mlir`. For more details, see https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing . Xida usually creates a separate MLIR file to test it to his satisfaction before integrating it into one of the files at `torch-mlir/test/Conversion/TorchOnnxToTorch`.
@@ -169,4 +171,5 @@ under `torch-mlir`
     "cmake.cmakePath": "/home/xida/miniconda/envs/torch-mlir/bin/cmake", // make sure this is a cmake that knows where your python is
 }
 ```
+
 The important things to note are the `cmake.configureArgs`, which specify the location of your torch mlir, and the `cmake.sourceDirectory`, which indicates that CMAKE should not build from the current directory and should instead build from `externals/llvm-project/llvm`

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -2,41 +2,7 @@
 
 Collected links and contacts for how to add ops to torch-mlir.
 
-<details>
-<summary>Turbine Camp: Start Here</summary>
-This document was previously known as `turbine-camp.md` to Nod.ai. "Turbine Camp" is part of Nod.ai's onboarding process. Welcome to turbine camp. This document originated at Nod.ai as a part of onboardding process, where new nod-ai folks learn about the architecture of our work by adding support for 2 ops to torch-mlir. I decided to put this into torch mlir because a lot of this is about torch-mlir.
-
-Written & maintained by @renxida
-
-Guides by other folks that were used during the creation of this document:
-
-- [Chi Liu](https://gist.github.com/AmosLewis/dd31ab37517977b1c499d06495b4adc2)
-- [Sunsoon](https://docs.google.com/document/d/1H79DwW_wnVzUU81EogwY5ueXgnl-QzKet1p2lnqPar4/edit?pli=1)
-
-## Before you begin...
-
-Nod-ai maintains the pipeline below, which allows us to take a ML model from e.g. huggingface, and compile it to a variety of devices including llvm-cpu, rocm and cuda and more as an optimized `vmfb` binary.
-
-1. The pipeline begins with a huggingface model, or some other supported source like llama.cpp.
-1. [nod-ai/SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine) takes a huggingface model and exports a `.mlir` file.
-1. **[llvm/torch-mlir](https://github.com/llvm/torch-mlir)**, which you will be working on in turbine-camp, will lower torchscript, torch dialect, and torch aten ops further into a mixture `linalg` or `math` MLIR dialects (with occasionally other dialects in the mix)
-1. [IREE](https://github.com/openxla/iree) converts the final `.mlir` file into a binary (typically `.vmfb`) for running on a device (llvm-cpu, rocm, vulcan, cuda, etc).
-
-The details of how we do it and helpful commands to help you set up each repo is in [Sungsoon's Shark Getting Started Google Doc](https://docs.google.com/document/d/1H79DwW_wnVzUU81EogwY5ueXgnl-QzKet1p2lnqPar4/edit?pli=1)
-
-PS: IREE is pronounced Eerie, and hence the ghost icon.
-
-## How to begin
-
-1. Set up torch-mlir according to the instructions here: <https://github.com/llvm/torch-mlir/blob/main/docs/development.md>
-1. You will start by adding support for 2 ops in torch-mlir, to get you familiar with the center of our pipeline. Begin by reading [torch-mlir's documentation on how to implement a new torch op](https://github.com/llvm/torch-mlir/blob/main/docs/Torch-ops-E2E-implementation.md), and set up `llvm/torch_mlir` using <https://github.com/llvm/torch-mlir/blob/main/docs/development.md>
-1. Pick 1 of the yet-unimplemented from the following. You should choose something that looks easy to you. **Make sure you create an issue by clicking the little "target" icon to the right of the op, thereby marking the op as yours**
-    - [TorchToLinalg ops tracking issue](https://github.com/nod-ai/SHARK-Turbine/issues/347)
-    - [TorchOnnnxToTorch ops tracking issue](https://github.com/nod-ai/SHARK-Turbine/issues/215)
-1. Implement it. For torch -> linalg, see the how to torchop section below. For Onnx ops, see how to onnx below.
-1. Make a pull request and reference your issue. When the pull request is closed, also close your issue to mark the op as done
-
-</details>
+## [How to Add a Torch Operator](https://github.com/llvm/torch-mlir/blob/main/docs/Torch-ops-E2E-implementation.md)
 
 ## How to Add a Conversion for an Operator
 

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -86,6 +86,7 @@ Helpful examples:
 `. Please don't just paste the generated tests - reference them to write your own
 
 ## Contacts
+
 People who've worked on this for a while
 
 - Vivek (@vivek97 on discord)
@@ -126,6 +127,7 @@ https://gist.github.com/AmosLewis/dd31ab37517977b1c499d06495b4adc2
 https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing
 
 ## How to set up vs code and intellisence for [torch-mlir]
+
 Xida: This is optional. If you're using VS code like me, you might want to set it up so you can use the jump to definition / references, auto fix, and other features.
 
 Feel free to contact me on discord if you have trouble figuring this out.

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -28,8 +28,8 @@ PS: IREE is pronounced Eerie, and hence the ghost icon.
 
 ## How to begin
 
-0. Set up torch-mlir according to the instructions here: https://github.com/llvm/torch-mlir/blob/main/docs/development.md
-1. You will start by adding support for 2 ops in torch-mlir, to get you familiar with the center of our pipeline. Begin by reading [torch-mlir's documentation on how to implement a new torch op](https://github.com/llvm/torch-mlir/blob/main/docs/Torch-ops-E2E-implementation.md), and set up `llvm/torch_mlir` using https://github.com/llvm/torch-mlir/blob/main/docs/development.md
+0. Set up torch-mlir according to the instructions here: <https://github.com/llvm/torch-mlir/blob/main/docs/development.md>
+1. You will start by adding support for 2 ops in torch-mlir, to get you familiar with the center of our pipeline. Begin by reading [torch-mlir's documentation on how to implement a new torch op](https://github.com/llvm/torch-mlir/blob/main/docs/Torch-ops-E2E-implementation.md), and set up `llvm/torch_mlir` using <https://github.com/llvm/torch-mlir/blob/main/docs/development.md>
 2. Pick 1 of the yet-unimplemented from the following. You should choose something that looks easy to you. **Make sure you create an issue by clicking the little "target" icon to the right of the op, thereby marking the op as yours**
     - [TorchToLinalg ops tracking issue](https://github.com/nod-ai/SHARK-Turbine/issues/347)
     - [TorchOnnnxToTorch ops tracking issue](https://github.com/nod-ai/SHARK-Turbine/issues/215)
@@ -64,7 +64,7 @@ Resources:
 
 ### How to TorchOnnxToTorch
 
-0. Generate the big folder of ONNX IR. Use https://github.com/llvm/torch-mlir/blob/main/test/python/onnx_importer/import_smoke_test.py . Alternatively, if you're trying to support a certain model, convert that model to onnx IR with
+0. Generate the big folder of ONNX IR. Use <https://github.com/llvm/torch-mlir/blob/main/test/python/onnx_importer/import_smoke_test.py> . Alternatively, if you're trying to support a certain model, convert that model to onnx IR with
 
    ```
    optimum-cli export onnx --model facebook/opt-125M fb-opt
@@ -73,7 +73,7 @@ Resources:
 
 2. Find an instance of the Op that you're trying to implement inside the smoke tests folder or the generated model IR, and write a test case. Later you will save it to one of the files in `torch-mlir/test/Conversion/TorchOnnxToTorch`, but for now feel free to put it anywhere.
 3. Implement the op in `lib/Conversion/TorchOnnxToTorch/something.cpp`.
-4. Test the conversion by running `./build/bin/torch-mlir-opt -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch your_mlir_file.mlir`. For more details, see https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing . Xida usually creates a separate MLIR file to test it to his satisfaction before integrating it into one of the files at `torch-mlir/test/Conversion/TorchOnnxToTorch`.
+4. Test the conversion by running `./build/bin/torch-mlir-opt -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch your_mlir_file.mlir`. For more details, see <https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing> . Xida usually creates a separate MLIR file to test it to his satisfaction before integrating it into one of the files at `torch-mlir/test/Conversion/TorchOnnxToTorch`.
 
 Helpful examples:
 
@@ -90,16 +90,16 @@ Helpful examples:
 People who've worked on this for a while
 
 - Vivek (@vivek97 on discord)
-- Chi.Liu@amd.com
+- <Chi.Liu@amd.com>
 
 Recent Turbine Camp Attendees, from recent to less recent
 
-- Xida.ren@amd.com (@xida_ren on discord)
-- Sungsoon.Cho@amd.com
+- <Xida.ren@amd.com> (@xida_ren on discord)
+- <Sungsoon.Cho@amd.com>
 
 ## Links
 
-- IMPORTANT: read the LLVM style guide: https://llvm.org/docs/CodingStandards.html#use-early-exits-and-continue-to-simplify-code
+- IMPORTANT: read the LLVM style guide: <https://llvm.org/docs/CodingStandards.html#use-early-exits-and-continue-to-simplify-code>
 - Tutorials
   - [Sungsoon's Shark Getting Started Google Doc](https://docs.google.com/document/d/1H79DwW_wnVzUU81EogwY5ueXgnl-QzKet1p2lnqPar4/edit?pli=1)
     - This document contains commands that would help you set up shark and run demos
@@ -120,11 +120,11 @@ Recent Turbine Camp Attendees, from recent to less recent
 
 ## Chi's useful commands for debugging torch mlir
 
-https://gist.github.com/AmosLewis/dd31ab37517977b1c499d06495b4adc2
+<https://gist.github.com/AmosLewis/dd31ab37517977b1c499d06495b4adc2>
 
 ## How to write test cases and test your new op
 
-https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing
+<https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing>
 
 ## How to set up vs code and intellisence for [torch-mlir]
 

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -25,14 +25,14 @@ Reference Examples
 
 Resources:
 
-- how to set up torch-mlir: [https://github.com/llvm/torch-mlir/blob/main/docs/development.md](https://github.com/llvm/torch-mlir/blob/main/docs/development.md#checkout-and-build-from-source)
-- torch-mlir doc on how to debug and test: [ttps://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing](https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing)
+- [how to set up torch-mlir](https://github.com/llvm/torch-mlir/blob/main/docs/development.md)
+- [torch-mlir doc on how to debug and test](https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing)
 - [torch op registry](https://github.com/pytorch/pytorch/blob/7451dd058564b5398af79bfc1e2669d75f9ecfa2/torch/csrc/jit/passes/utils/op_registry.cpp#L21)
 - [torch shape functions](https://github.com/pytorch/pytorch/blob/7451dd058564b5398af79bfc1e2669d75f9ecfa2/torch/jit/_shape_functions.py#L1311)
 
 ### How to TorchOnnxToTorch
 
-1. Generate the big folder of ONNX IR. Use <https://github.com/llvm/torch-mlir/blob/main/test/python/onnx_importer/import_smoke_test.py> . Alternatively, if you're trying to support a certain model, convert that model to onnx IR with
+1. Generate the big folder of ONNX IR. Use [this Python script](https://github.com/llvm/torch-mlir/blob/main/test/python/onnx_importer/import_smoke_test.py). Alternatively, if you're trying to support a certain model, convert that model to onnx IR with
 
    ```shell
    optimum-cli export onnx --model facebook/opt-125M fb-opt
@@ -41,7 +41,7 @@ Resources:
 
 1. Find an instance of the Op that you're trying to implement inside the smoke tests folder or the generated model IR, and write a test case. Later you will save it to one of the files in `torch-mlir/test/Conversion/TorchOnnxToTorch`, but for now feel free to put it anywhere.
 1. Implement the op in `lib/Conversion/TorchOnnxToTorch/something.cpp`.
-1. Test the conversion by running `./build/bin/torch-mlir-opt -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch your_mlir_file.mlir`. For more details, see <https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing> . Xida usually creates a separate MLIR file to test it to his satisfaction before integrating it into one of the files at `torch-mlir/test/Conversion/TorchOnnxToTorch`.
+1. Test the conversion by running `./build/bin/torch-mlir-opt -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch your_mlir_file.mlir`. For more details, see [the testing section of the doc on development](https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing). Xida usually creates a separate MLIR file to test it to his satisfaction before integrating it into one of the files at `torch-mlir/test/Conversion/TorchOnnxToTorch`.
 
 Helpful examples:
 
@@ -58,16 +58,16 @@ Helpful examples:
 People who've worked on this for a while
 
 - Vivek (@vivek97 on discord)
-- <Chi.Liu@amd.com>
+- [Chi Liu](mailto:Chi.Liu@amd.com)
 
 Recent Turbine Camp Attendees, from recent to less recent
 
-- <Xida.ren@amd.com> (@xida_ren on discord)
-- <Sungsoon.Cho@amd.com>
+- [Xida Ren](mailto:Xida.ren@amd.com) (@xida_ren on discord)
+- [Sungsoon Cho](mailto:Sungsoon.Cho@amd.com)
 
 ## Links
 
-- IMPORTANT: read the LLVM style guide: <https://llvm.org/docs/CodingStandards.html#style-issues>
+- IMPORTANT: read [the LLVM style guide](https://llvm.org/docs/CodingStandards.html#style-issues)
 - Tutorials
   - [Sungsoon's Shark Getting Started Google Doc](https://docs.google.com/document/d/1H79DwW_wnVzUU81EogwY5ueXgnl-QzKet1p2lnqPar4/edit?pli=1)
     - This document contains commands that would help you set up shark and run demos
@@ -86,13 +86,9 @@ Recent Turbine Camp Attendees, from recent to less recent
     - [Model and Op Support](https://github.com/nod-ai/SHARK-Turbine/issues/119)
     - [ONNX op support](https://github.com/nod-ai/SHARK-Turbine/issues/215)
 
-## Chi's useful commands for debugging torch mlir
+## [Chi's useful commands for debugging torch mlir](https://gist.github.com/AmosLewis/dd31ab37517977b1c499d06495b4adc2)
 
-<https://gist.github.com/AmosLewis/dd31ab37517977b1c499d06495b4adc2>
-
-## How to write test cases and test your new op
-
-<https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing>
+## [How to write test cases and test your new op](https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing)
 
 ## How to set up vs code and intellisence for [torch-mlir]
 

--- a/docs/add_ops.md
+++ b/docs/add_ops.md
@@ -115,7 +115,6 @@ Recent Turbine Camp Attendees, from recent to less recent
     - [Model and Op Support](https://github.com/nod-ai/SHARK-Turbine/issues/119)
     - [ONNX op support](https://github.com/nod-ai/SHARK-Turbine/issues/215)
 
-
 ## Chi's useful commands for debugging torch mlir
 
 https://gist.github.com/AmosLewis/dd31ab37517977b1c499d06495b4adc2
@@ -123,8 +122,6 @@ https://gist.github.com/AmosLewis/dd31ab37517977b1c499d06495b4adc2
 ## How to write test cases and test your new op
 
 https://github.com/llvm/torch-mlir/blob/main/docs/development.md#testing
-
-
 
 ## How to set up vs code and intellisence for [torch-mlir]
 Xida: This is optional. If you're using VS code like me, you might want to set it up so you can use the jump to definition / references, auto fix, and other features.


### PR DESCRIPTION
- removes section regarding Turbine Camp
  - Each line of detail either:
    - already existed internally in Confluence
      OR
    - was severely out of date!
  - Was beyond the concerns of Torch-MLIR
- adjusts link to LLVM style guide
  - was directed to a specific style guide rule rather than the start of the style guide in general
- adds missing h2
- cleans up style using markdown linter
  - prefers formatted links over intentionally bare URLs
  - enforces explicitly-define language in code blocks
  - prefers implicitly-ordered, 1-based lists
    - avoids less-common 0-based lists since that would require deviation from the default linter config
  - wraps bare urls/emails
  - enforces unordered list nested indentation
  - enforces space around headers
  - enforces space around code fence blocks
  - removes extraneous blank lines
  - enforces space around list blocks