### PR TITLE
Backend-legal-ops argument for fx lowering

### DIFF
--- a/python/torch_mlir/fx.py
+++ b/python/torch_mlir/fx.py
@@ -29,7 +29,7 @@ def _module_lowering(
     output_type,
     torch_mod,
     extra_library_file_name=None,
-    backend_legal_ops=None
+    backend_legal_ops=None,
 ):
 
     if output_type == OutputType.RAW:
@@ -41,12 +41,20 @@ def _module_lowering(
     backend_legal_op_arg_str = ""
     if backend_legal_ops is not None:
         if not len(backend_legal_ops) == 0:
-            backend_legal_op_arg_str = "backend-legal-ops=" + ",".join(backend_legal_ops)
-    
+            backend_legal_op_arg_str = "backend-legal-ops=" + ",".join(
+                backend_legal_ops
+            )
+
     if extra_library_file_name is None:
         extra_library_file_name = ""
-    option_string = "{" + backend_legal_op_arg_str + " extra-library=" + extra_library_file_name + "}"
-    
+    option_string = (
+        "{"
+        + backend_legal_op_arg_str
+        + " extra-library="
+        + extra_library_file_name
+        + "}"
+    )
+
     run_pipeline_with_repro_report(
         torch_mod,
         f"builtin.module(func.func(torch-match-quantized-custom-ops), torchdynamo-export-to-torch-backend-pipeline{option_string})",
@@ -107,7 +115,10 @@ def export_and_import(
         )
 
     return _module_lowering(
-        enable_ir_printing, OutputType.get(output_type), fx_importer.module, backend_legal_ops=backend_legal_ops
+        enable_ir_printing,
+        OutputType.get(output_type),
+        fx_importer.module,
+        backend_legal_ops=backend_legal_ops,
     )
 
 
@@ -129,5 +140,8 @@ def stateless_fx_import(
         fx_importer = FxImporter(context=context, hooks=hooks)
     fx_importer.import_stateless_graph(gm.graph, func_name=model_name)
     return _module_lowering(
-        enable_ir_printing, OutputType.get(output_type), fx_importer.module, backend_legal_ops=backend_legal_ops
+        enable_ir_printing,
+        OutputType.get(output_type),
+        fx_importer.module,
+        backend_legal_ops=backend_legal_ops,
     )


### PR DESCRIPTION
Added `backend-legal-ops` argument in `fx.import_and_export` to stop decomposition of certain torch ops.  This PR is based on this [issue](https://github.com/llvm/torch-mlir/issues/3953)