### PR TITLE
[Linalg] Add conversion between bf16 and f16 

### DIFF
--- a/lib/Conversion/Utils/Utils.cpp
+++ b/lib/Conversion/Utils/Utils.cpp
@@ -335,6 +335,10 @@ Value convertScalarToDtype(OpBuilder &b, Location loc, Value scalar, Type dtype,
 
   if (auto dtypeFloat = dyn_cast<mlir::FloatType>(dtype)) {
     if (auto scalarFloat = dyn_cast<mlir::FloatType>(scalarType)) {
+      if (scalarFloat.getWidth() == 16 && dtypeFloat.getWidth() == 16) {
+        auto scalarF32 = b.create<arith::ExtFOp>(loc, b.getF32Type(), scalar);
+        return b.create<arith::TruncFOp>(loc, dtype, scalarF32);
+      }
       if (scalarFloat.getWidth() > dtypeFloat.getWidth())
         return b.create<arith::TruncFOp>(loc, dtype, scalar);
       // Only scalarFloat width < dtypeFloat width can reach here.

--- a/test/Conversion/TorchToLinalg/elementwise.mlir
+++ b/test/Conversion/TorchToLinalg/elementwise.mlir
@@ -106,29 +106,11 @@ func.func @elementwise_sinh(%arg0: !torch.vtensor<[3],f32>) -> !torch.vtensor<[3
 // -----
 
 // CHECK-LABEL:   func.func @elementwise_todtype_bf162f16(
-// CHECK-SAME:        %[[VAL_0:.*]]: !torch.vtensor<[1,?,32,128],bf16>) -> !torch.vtensor<[1,?,32,128],f16> {
-// CHECK:           %[[INPUT:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[1,?,32,128],bf16> -> tensor<1x?x32x128xbf16>
-// CHECK:           %[[INT5:.*]] = torch.constant.int 5
-// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
-// CHECK:           %[[NONE:.*]] = torch.constant.none
-// CHECK:           %[[CONSTANT1_1:.*]] = arith.constant 1 : index
-// CHECK:           %[[CONSTANT1:.*]] = arith.constant 1 : index
-// CHECK:           %[[DIM:.*]] = tensor.dim %[[INPUT]], %[[CONSTANT1]] : tensor<1x?x32x128xbf16>
-// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 2 : index
-// CHECK:           %[[CONSTANT_32:.*]] = arith.constant 32 : index
-// CHECK:           %[[CONSTANT_3:.*]] = arith.constant 3 : index
-// CHECK:           %[[CONSTANT_128:.*]] = arith.constant 128 : index
-// CHECK:           %[[EMPTY:.*]] = tensor.empty(%[[DIM]]) : tensor<1x?x32x128xf16>
-// CHECK:           %[[GENERIC:.*]] = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%[[INPUT]] : tensor<1x?x32x128xbf16>) outs(%[[EMPTY]] : tensor<1x?x32x128xf16>) {
-// CHECK:           ^bb0(%[[LHS:.*]]: bf16, %[[RHS:.*]]: f16):
-// CHECK:             %[[EXTF:.*]] = arith.extf %[[LHS]] : bf16 to f32
-// CHECK:             %[[TRUNCF:.*]] = arith.truncf %[[EXTF]] : f32 to f16
-// CHECK:             linalg.yield %[[TRUNCF]] : f16
-// CHECK:           } -> tensor<1x?x32x128xf16>
-// CHECK:           %[[CAST:.*]] = tensor.cast %[[GENERIC]] : tensor<1x?x32x128xf16> to tensor<1x?x32x128xf16>
-// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[CAST]] : tensor<1x?x32x128xf16> -> !torch.vtensor<[1,?,32,128],f16>
-// CHECK:           return %[[RESULT]] : !torch.vtensor<[1,?,32,128],f16>
-// CHECK:         }
+// CHECK:                linalg.generic
+// CHECK:                  arith.extf
+// CHECK-SAME:               bf16 to f32
+// CHECK:                  arith.truncf
+// CHECK-SAME:               f32 to f16
 func.func @elementwise_todtype_bf162f16(%arg0: !torch.vtensor<[1,?,32,128],bf16>) -> !torch.vtensor<[1,?,32,128],f16> {
   %int5 = torch.constant.int 5
   %false = torch.constant.bool false


### PR DESCRIPTION
To fix issue https://github.com/llvm/torch-mlir/issues/3962 : 'arith.extf' op operand type 'bf16' and result type 'f16' are cast incompatible