### PR TITLE
Fix `torch-mlir-import-onnx` entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "torch-mlir-import-onnx = torch_mlir.tools.import_onnx:_cli_main",
+            "torch-mlir-import-onnx = torch_mlir.tools.import_onnx.__main__:_cli_main",
             "torch-mlir-opt = torch_mlir.tools.opt.__main__:main",
         ],
     },


### PR DESCRIPTION
Due to the wrong entry point, calling `torch-mlir-import-onnx` currently fails with
```
$ torch-mlir-import-onnx
Traceback (most recent call last):
  File "venv-torch/bin/torch-mlir-import-onnx", line 5, in <module>
    from torch_mlir.tools.import_onnx import _cli_main
ImportError: cannot import name '_cli_main' from 'torch_mlir.tools.import_onnx' (unknown location)
```