### PR TITLE
Update GH actions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Actions are pinned with hashes as suggested by OpenSSF Scorecard, see https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies. Those actions now get upgraded on a monthly intervall with Dependabot, https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot, as already in main repository, see
https://github.com/llvm/llvm-project/blob/48d0ef1a07993139e1acf65910704255443103a5/.github/dependabot.yml#L1-L10.