### PR TITLE
Pin `actions/cache/{restore,save}` actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           submodules: true
 
       - name: Enable cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ env.CACHE_DIR }}
           key: build-test-cpp-asserts-manylinux-${{ matrix.torch-version }}-v2-${{ github.sha }}
@@ -65,7 +65,7 @@ jobs:
           bash build_tools/ci/build_posix.sh
 
       - name: Save cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: ${{ !cancelled() }}
         with:
           path: ${{ env.CACHE_DIR }}


### PR DESCRIPTION
Pins the actions to a specific version and hash. The rational for pinning actions is to follow the suggestions by OpenSSF Scorecard, see https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies.