### PR TITLE
fix dangling arrayref by extending temporary object lifetime

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -4019,7 +4019,7 @@ LogicalResult ConvertAtenOp<AtenIndexSelectOp>::matchAndRewrite(
 
   auto index = adaptor.getIndex();
   auto indexType = dyn_cast<RankedTensorType>(index.getType());
-  auto indexShape = indexType.getShape();
+  auto indexShape = SmallVector<int64_t>(indexType.getShape());
 
   if (!indexType)
     return rewriter.notifyMatchFailure(


### PR DESCRIPTION
In the following code, makeShapeTorchCompatible returns a SmallVector, while indexShape is an ArrayRef, which will lead to a lifetime bug.