### PR TITLE
refactor(ONNX): enforces `opLocation` naming convention

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
@@ -24,7 +24,7 @@ LogicalResult windowFunctionImpl(OpBinder binder,
                                  Torch::ValueTensorType resultType,
                                  int64_t output_datatype, int64_t periodic) {
 
-  Location loc = binder.getLoc();
+  auto loc = binder.getLoc();
   ImplicitLocOpBuilder b(loc, rewriter);
 
   double isPeriodicFp = static_cast<double>(periodic);
@@ -355,7 +355,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
             binder.tensorResultTypeAtIndex(resultType, 0))
           return failure();
 
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Value cstFalse = rewriter.create<Torch::ConstantBoolOp>(loc, false);
         Value cstMomentum = rewriter.create<Torch::ConstantFloatOp>(
             loc, rewriter.getF64FloatAttr(momentum));
@@ -1290,7 +1290,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
       });
   patterns.onOp(
       "Conv", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Torch::ValueTensorType resultType;
         Value input, weight;
         int64_t group;
@@ -2325,7 +2325,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
                 });
   patterns.onOp(
       "Dropout", 12, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Torch::ValueTensorType resultType;
         int64_t numOperands = binder.op->getNumOperands();
         SmallVector<Value> operands;
@@ -2407,7 +2407,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
   patterns.onOp(
       "DynamicQuantizeLinear", 11,
       [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Value input;
         Torch::ValueTensorType resultType, scaleType, zeroPointType;
         if (binder.tensorOperand(input) ||
@@ -2496,7 +2496,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
                 });
   patterns.onOp("Elu", 6,
                 [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-                  Location loc = binder.getLoc();
+                  auto loc = binder.getLoc();
                   Torch::ValueTensorType resultType;
                   Value input;
                   float alpha;
@@ -2955,7 +2955,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
           return failure();
         }
 
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Value a0 = rewriter.create<Torch::ConstantFloatOp>(
             loc, rewriter.getF64FloatAttr(0.42));
         Value a1 = rewriter.create<Torch::ConstantFloatOp>(
@@ -2986,7 +2986,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
           return failure();
         }
 
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Value a0 = rewriter.create<Torch::ConstantFloatOp>(
             loc, rewriter.getF64FloatAttr(0.5));
         Value a1 = rewriter.create<Torch::ConstantFloatOp>(
@@ -3017,7 +3017,7 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
           return failure();
         }
 
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Value a0 = rewriter.create<Torch::ConstantFloatOp>(
             loc, rewriter.getF64FloatAttr(0.543478));
         Value a1 = rewriter.create<Torch::ConstantFloatOp>(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -1330,7 +1330,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
 
         Value outputShapeList =
             createConstantIntList(binder, rewriter, pooledShape);
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
 
         auto inputTy = cast<Torch::ValueTensorType>(input.getType());
         auto roisTy = cast<Torch::ValueTensorType>(rois.getType());
@@ -1696,7 +1696,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             binder.s64IntegerAttr(batchDimCount, "batch_dims", 0))
           return failure();
 
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         auto dataTy = cast<Torch::ValueTensorType>(data.getType());
         auto indicesTy = cast<Torch::ValueTensorType>(indices.getType());
         if (!dataTy || !dataTy.hasSizes())
@@ -1957,7 +1957,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             binder.tensorResultType(resultType) ||
             binder.s64IntegerAttr(axis, "axis", 0))
           return failure();
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         auto ctx = binder.op->getContext();
         auto indicesTy = cast<Torch::ValueTensorType>(indices.getType());
         auto dataTy = cast<Torch::ValueTensorType>(data.getType());
@@ -2692,7 +2692,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         // https://onnx.ai/onnx/operators/onnx__LRN.html
 
         // squared = operand^2
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Torch::ValueTensorType inTy =
             cast<Torch::ValueTensorType>(operand.getType());
         Value sqOperand = rewriter.create<Torch::AtenMulTensorOp>(
@@ -2803,7 +2803,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         int64_t dataRank = dataTensor.getRank();
         int64_t padsSize = 2 * dataRank;
 
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
 
         // get pads (earlier versions use an attribute, newer versions use a
         // tensor input)
@@ -3688,7 +3688,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
   patterns.onOp(
       "NonMaxSuppression", 10,
       [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Torch::ValueTensorType resultType;
         SmallVector<Value> operands;
         int64_t centerPointBox;

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -945,7 +945,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         // discussion can be found here:
         // https://github.com/pytorch/pytorch/issues/9410
         // So, for now, we unroll into multiple unsqueezes.
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Torch::ValueTensorType resultType;
         Value data, axes;
         if (binder.tensorOperands(data, axes) ||
@@ -1766,7 +1766,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           return rewriter.notifyMatchFailure(
               binder.op, "Expected result type to be a ranked tensor type");
 
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
 
         // Binding `axes` from its arguments or through a default value
         Value axes;
@@ -2860,7 +2860,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
               binder.op, "unsupported: roi max pooling without default "
                          "coordTfMode and sampling_ratio");
 
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         // concatenate the batchIndices to the rois to get rois as a num_roisx5
         // tensor. The batchIndices tensor is an int64 tensor, and needs to be
         // converted to float before concatenation.
@@ -3029,7 +3029,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
       });
   patterns.onOp(
       "Shrink", 9, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         Torch::ValueTensorType resultType;
         Value input;
         float bias, lambd;
@@ -3665,7 +3665,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
                          "none(default)");
         }
 
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         auto dataTy = dyn_cast<Torch::ValueTensorType>(data.getType());
         auto indicesTy = dyn_cast<Torch::ValueTensorType>(indices.getType());
         auto updatesTy = dyn_cast<Torch::ValueTensorType>(updates.getType());
@@ -4451,7 +4451,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
       });
   patterns.onOp(
       "Scan", 11, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Location loc = binder.getLoc();
+        auto loc = binder.getLoc();
         SmallVector<Value> operands;
         int64_t numScanInputs;
         if (binder.tensorOperandsList(operands) || operands.size() == 0 ||

--- a/lib/Conversion/TorchOnnxToTorch/OnnxRecurrentLayerOpExpanders.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/OnnxRecurrentLayerOpExpanders.cpp
@@ -169,7 +169,7 @@ static Value StaticTranspose(ImplicitLocOpBuilder b, Value value, int64_t dim0,
 
 LogicalResult OnnxRnnExpander(OpBinder binder,
                               ConversionPatternRewriter &rewriter) {
-  Location loc = binder.getLoc();
+  auto loc = binder.getLoc();
   mlir::ImplicitLocOpBuilder b(loc, rewriter);
 
   auto intType = b.getType<IntType>();
@@ -655,7 +655,7 @@ LstmLayerOutput lstm_layer(ImplicitLocOpBuilder &b, Value X, Value initial_h,
 // @param binder The OpBinder object used for binding operands.
 LogicalResult OnnxLstmExpander(OpBinder binder,
                                ConversionPatternRewriter &rewriter) {
-  Location loc = binder.getLoc();
+  auto loc = binder.getLoc();
   mlir::ImplicitLocOpBuilder b(loc, rewriter);
 
   std::string direction;
@@ -1266,7 +1266,7 @@ GruLayerOutput gru_layer(ImplicitLocOpBuilder &b, Value X, Value initial_h,
 
 LogicalResult OnnxGruExpander(OpBinder binder,
                               ConversionPatternRewriter &rewriter) {
-  Location loc = binder.getLoc();
+  auto loc = binder.getLoc();
   mlir::ImplicitLocOpBuilder b(loc, rewriter);
 
   auto intType = b.getType<IntType>();

--- a/lib/Conversion/TorchOnnxToTorch/OnnxRecurrentLayerOpExpanders.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/OnnxRecurrentLayerOpExpanders.cpp
@@ -169,8 +169,8 @@ static Value StaticTranspose(ImplicitLocOpBuilder b, Value value, int64_t dim0,
 
 LogicalResult OnnxRnnExpander(OpBinder binder,
                               ConversionPatternRewriter &rewriter) {
-  auto loc = binder.getLoc();
-  mlir::ImplicitLocOpBuilder b(loc, rewriter);
+  auto opLocation = binder.getLoc();
+  mlir::ImplicitLocOpBuilder b(opLocation, rewriter);
 
   auto intType = b.getType<IntType>();
   Value cstNone = b.create<ConstantNoneOp>();
@@ -342,7 +342,8 @@ LogicalResult OnnxRnnExpander(OpBinder binder,
 
   // Create B and initial_h if not provided,
   // using same dtype as X
-  Value cstXDtype = getDtypeIntValueForType(rewriter, loc, xTy.getDtype());
+  Value cstXDtype =
+      getDtypeIntValueForType(rewriter, opLocation, xTy.getDtype());
   if (B == nullptr) {
     SmallVector<int64_t> BShape = {num_directions, 2 * hidden_size};
     SmallVector<Value> BShapeListContents = {
@@ -655,8 +656,8 @@ LstmLayerOutput lstm_layer(ImplicitLocOpBuilder &b, Value X, Value initial_h,
 // @param binder The OpBinder object used for binding operands.
 LogicalResult OnnxLstmExpander(OpBinder binder,
                                ConversionPatternRewriter &rewriter) {
-  auto loc = binder.getLoc();
-  mlir::ImplicitLocOpBuilder b(loc, rewriter);
+  auto opLocation = binder.getLoc();
+  mlir::ImplicitLocOpBuilder b(opLocation, rewriter);
 
   std::string direction;
 
@@ -832,7 +833,8 @@ LogicalResult OnnxLstmExpander(OpBinder binder,
       b.getType<ListType>(intType),
       ValueRange({cstNumDirections, cstBatchSize, cstHiddenSize}));
 
-  Value cstDtype = getDtypeIntValueForType(rewriter, loc, xTy.getDtype());
+  Value cstDtype =
+      getDtypeIntValueForType(rewriter, opLocation, xTy.getDtype());
 
   Value initial_h;
   if (binder.tensorOperandAtIndex(initial_h, 5)) {
@@ -1266,8 +1268,8 @@ GruLayerOutput gru_layer(ImplicitLocOpBuilder &b, Value X, Value initial_h,
 
 LogicalResult OnnxGruExpander(OpBinder binder,
                               ConversionPatternRewriter &rewriter) {
-  auto loc = binder.getLoc();
-  mlir::ImplicitLocOpBuilder b(loc, rewriter);
+  auto opLocation = binder.getLoc();
+  mlir::ImplicitLocOpBuilder b(opLocation, rewriter);
 
   auto intType = b.getType<IntType>();
   Value cstNone = b.create<ConstantNoneOp>();
@@ -1371,7 +1373,8 @@ LogicalResult OnnxGruExpander(OpBinder binder,
     Value hShape = b.create<PrimListConstructOp>(
         b.getType<ListType>(intType),
         ValueRange({cstNumDirections, cstBatchSize, cstHiddenSize}));
-    Value cstDtype = getDtypeIntValueForType(rewriter, loc, xTy.getDtype());
+    Value cstDtype =
+        getDtypeIntValueForType(rewriter, opLocation, xTy.getDtype());
     initial_h =
         b.create<AtenZerosOp>(hTy, hShape, cstDtype, cstNone, cstNone, cstNone);
   } else {
@@ -1395,7 +1398,8 @@ LogicalResult OnnxGruExpander(OpBinder binder,
   bool linear_before_reset = linear_before_reset_int != 0;
 
   // fill in B
-  Value cstXDtype = getDtypeIntValueForType(rewriter, loc, xTy.getDtype());
+  Value cstXDtype =
+      getDtypeIntValueForType(rewriter, opLocation, xTy.getDtype());
   if (B == nullptr) {
     SmallVector<int64_t> BShape = {num_directions, 6 * hidden_size};
     SmallVector<Value> BShapeListContents = {


### PR DESCRIPTION
1. `loc`: when searching "loc" across the codebase, this appears in contexts where it could mean "location", "locale", "lines of code", etc.
    - Avoiding abbreviations reduces this ambiguity.
2. `location`: Now the question to answer is "The location of what, exactly?" without having to ping a colleague or scrub the codebase. We see `auto location = binder.getLoc()`, so the (incorrect) inference is "ah the location of the binder, I guess", so we use that to modify the word "location"
3. `binderLocation`: Turns out that "binder" is short for "opBinder", meaning this is actually "location of _op_". So, we switch the "modifying noun"
4. `opLocation`: bakes in the understanding that probably required preceding engineers (like me) to spend their time (and others') clarifying.
    - Adding 7 characters to "loc" avoids time to grok, avoids unnecessary roping in of other engineers, and makes it easier to onboard other engineers.
    - Overall, this is easier to build upon from an organizational standpoint.

A longer, more specific name usually has less false positives in search vs a short generic one! This makes reversion easier than it was to do the conversion to begin with. On top of that, this particular name did not exist in the codebase prior to this commit, so the name was "available".