### PR TITLE
Fix logical `or`/`and` usage for MSVC compilation.

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -2346,7 +2346,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         ArrayRef<int64_t> inputShape = inputTensorType.getSizes();
         unsigned inputRank = inputShape.size();
         // only handle 2D, 3D and 5D pooling cases
-        if (inputRank > 5 or inputRank < 3) {
+        if (inputRank > 5 || inputRank < 3) {
           return failure();
         }
         if (!resultType || !resultType.hasSizes()) {
@@ -2454,7 +2454,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
                                              "Unimplemented: unranked tensor");
         unsigned rank = *maybeRank;
         // only 1D, 2D and 3D LpPool is supported.
-        if (rank > 5 or rank < 3) {
+        if (rank > 5 || rank < 3) {
           return failure();
         }
 

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -9780,7 +9780,7 @@ public:
     auto targetSizes = targetType.getSizes();
     int64_t selfRank = selfSizes.size();
     int64_t targetRank = targetSizes.size();
-    if (selfRank <= 0 or selfRank > 2) {
+    if (selfRank <= 0 || selfRank > 2) {
       return rewriter.notifyMatchFailure(op, "input tensor should be 1D or 2D");
     }
     if (targetRank > 1) {
@@ -9788,8 +9788,8 @@ public:
                                          "target tensor shoule be 0D or 1D!");
     }
 
-    if (selfRank != 1 or targetRank != 0) {
-      if (!(selfSizes[0] == kUnknownSize and targetSizes[0] == kUnknownSize) and
+    if (selfRank != 1 || targetRank != 0) {
+      if (!(selfSizes[0] == kUnknownSize && targetSizes[0] == kUnknownSize) &&
           selfSizes[0] != targetSizes[0]) {
         return rewriter.notifyMatchFailure(
             op,
@@ -9907,7 +9907,7 @@ public:
         zeroTensor);
 
     Value totalWeight;
-    if (reduction == 0 and selfRank > 1) {
+    if (reduction == 0 && selfRank > 1) {
       auto zeroFloat =
           rewriter.create<ConstantFloatOp>(loc, rewriter.getF64FloatAttr(0.0));
       Value twSize = rewriter.create<PrimListConstructOp>(


### PR DESCRIPTION
The `or`/`and` alternate spellings are not supported on all compilers without additinoal flags (https://learn.microsoft.com/en-us/cpp/cpp/logical-or-operator-pipe-pipe?view=msvc-170#operator-keyword-for-).

This code started producing errors in the downstream IREE project when building with MSVC on Windows: https://github.com/iree-org/iree/actions/runs/12985792116/job/36211327035#step:9:7446

```
[6452/8792] Building CXX object compiler\plugins\input\Torch\torch-mlir\CMakeFiles\iree_compiler_plugins_input_Torch_torch-mlir_TorchDialectPasses.objects.dir\__\__\__\__\__\third_party\torch-mlir\lib\Dialect\Torch\Transforms\DecomposeComplexOps.cpp.obj
FAILED: compiler/plugins/input/Torch/torch-mlir/CMakeFiles/iree_compiler_plugins_input_Torch_torch-mlir_TorchDialectPasses.objects.dir/__/__/__/__/__/third_party/torch-mlir/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp.obj 
C:\ProgramData\chocolatey\bin\ccache "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\bin\Hostx64\x64\cl.exe"  /nologo /TP  -IC:\home\runner\_work\iree\iree -IC:\mnt\azure\b\093843 -IC:\home\runner\_work\iree\iree\third_party\torch-mlir\include -IC:\home\runner\_work\iree\iree\compiler\plugins\input\Torch -IC:\mnt\azure\b\093843\compiler\plugins\input\Torch -IC:\home\runner\_work\iree\iree\third_party\llvm-project\llvm\include -IC:\mnt\azure\b\093843\llvm-project\include -IC:\home\runner\_work\iree\iree\third_party\llvm-project\mlir\include -IC:\mnt\azure\b\093843\llvm-project\tools\mlir\include -IC:\home\runner\_work\iree\iree\third_party\llvm-project\lld\include -IC:\mnt\azure\b\093843\llvm-project\tools\lld\include /DWIN32 /D_WINDOWS /EHsc /Z7 /O2 /Ob1  -std:c++17 -MD /wd4996 /Zc:preprocessor /DWIN32_LEAN_AND_MEAN /DNOMINMAX /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS /D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES /D_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING /GR- /bigobj /W3 /wd4200 /wd4018 /wd4146 /wd4244 /wd4267 /wd4005 /wd4065 /wd4141 /wd4624 /wd4576 /wd5105 /showIncludes /Focompiler\plugins\input\Torch\torch-mlir\CMakeFiles\iree_compiler_plugins_input_Torch_torch-mlir_TorchDialectPasses.objects.dir\__\__\__\__\__\third_party\torch-mlir\lib\Dialect\Torch\Transforms\DecomposeComplexOps.cpp.obj /Fdcompiler\plugins\input\Torch\torch-mlir\CMakeFiles\iree_compiler_plugins_input_Torch_torch-mlir_TorchDialectPasses.objects.dir\ /FS -c C:\home\runner\_work\iree\iree\third_party\torch-mlir\lib\Dialect\Torch\Transforms\DecomposeComplexOps.cpp
C:\home\runner\_work\iree\iree\third_party\torch-mlir\lib\Dialect\Torch\Transforms\DecomposeComplexOps.cpp(9783): error C2146: syntax error: missing ')' before identifier 'or'
C:\home\runner\_work\iree\iree\third_party\torch-mlir\lib\Dialect\Torch\Transforms\DecomposeComplexOps.cpp(9783): error C2065: 'or': undeclared identifier
C:\home\runner\_work\iree\iree\third_party\torch-mlir\lib\Dialect\Torch\Transforms\DecomposeComplexOps.cpp(9783): error C2146: syntax error: missing ';' before identifier 'selfRank'
C:\home\runner\_work\iree\iree\third_party\torch-mlir\lib\Dialect\Torch\Transforms\DecomposeComplexOps.cpp(9783): error C2059: syntax error: ')'
C:\home\runner\_work\iree\iree\third_party\torch-mlir\lib\Dialect\Torch\Transforms\DecomposeComplexOps.cpp(9784): error C2059: syntax error: 'return'
C:\home\runner\_work\iree\iree\third_party\torch-mlir\lib\Dialect\Torch\Transforms\DecomposeComplexOps.cpp(9786): error C2059: syntax error: 'if'
```