### PR TITLE
refactor(ONNX): replaces `getValueList` helper with `createScalarSublist`

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -222,8 +222,10 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
     someTorchScalarType = Torch::FloatType::get(context);
   }
 
+  Type someTorchScalarListType = Torch::ListType::get(someTorchScalarType);
+
   return rewriter.create<Torch::PrimListConstructOp>(
-      binder.getLoc(), Torch::ListType::get(someTorchScalarType), itemList);
+      binder.getLoc(), someTorchScalarListType, itemList);
 }
 } // namespace
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -220,10 +220,10 @@ Value extractTorchScalar(
 
 Value getValueList(
     /*                    at */ Location givenLoc,
-    /* movingForwardsThrough */ Value operand,
+    /* movingForwardsThrough */ Value given1DTensor,
     /*            startingAt */ int64_t givenIndex,
     /*                 using */ ConversionPatternRewriter &rewriter) {
-  auto operandType = cast<Torch::BaseTensorType>(operand.getType());
+  auto operandType = cast<Torch::BaseTensorType>(given1DTensor.getType());
   auto sizes = operandType.getSizes();
   auto lengthOfFullList = sizes[0];
 
@@ -231,8 +231,8 @@ Value getValueList(
 
   for (int indexOfEachScalar = givenIndex; indexOfEachScalar < lengthOfFullList;
        indexOfEachScalar++) {
-    Value eachScalar =
-        extractTorchScalar(givenLoc, indexOfEachScalar, operand, rewriter);
+    Value eachScalar = extractTorchScalar(givenLoc, indexOfEachScalar,
+                                          given1DTensor, rewriter);
     runningScalarSublist.push_back(eachScalar);
   }
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -216,17 +216,14 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
   }
   auto xTy = cast<Torch::ValueTensorType>(operand.getType());
   Type someTorchScalarType;
-  Value ValueList;
   if (isa<IntegerType>(xTy.getDtype())) {
     someTorchScalarType = Torch::IntType::get(context);
   } else {
     someTorchScalarType = Torch::FloatType::get(context);
   }
 
-  ValueList = rewriter.create<Torch::PrimListConstructOp>(
+  return rewriter.create<Torch::PrimListConstructOp>(
       binder.getLoc(), Torch::ListType::get(someTorchScalarType), itemList);
-
-  return ValueList;
 }
 } // namespace
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -225,10 +225,11 @@ Value getValueList(
     /*                 using */ ConversionPatternRewriter &rewriter) {
   auto operandType = cast<Torch::BaseTensorType>(operand.getType());
   auto sizes = operandType.getSizes();
+  auto lengthOfFullList = sizes[0];
 
   SmallVector<Value> itemList;
 
-  for (int i = givenIndex; i < sizes[0]; i++) {
+  for (int i = givenIndex; i < lengthOfFullList; i++) {
     Value item = extractTorchScalar(givenLoc, i, operand, rewriter);
     itemList.push_back(item);
   }

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -183,8 +183,8 @@ LogicalResult reduceOpImpl(OpBinder binder, ConversionPatternRewriter &rewriter,
 Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
                    Value operand) {
   SmallVector<Value> itemList;
-  auto sizes = dyn_cast<Torch::ValueTensorType>(operand.getType()).getSizes();
   auto operandType = cast<Torch::BaseTensorType>(operand.getType());
+  auto sizes = operandType.getSizes();
 
   SmallVector<int64_t> selectSizes;
   selectSizes.push_back(1);

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -223,10 +223,12 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
   auto operandType = cast<Torch::BaseTensorType>(operand.getType());
   auto sizes = operandType.getSizes();
 
+  auto loc = binder.getLoc();
+
   SmallVector<Value> itemList;
 
   for (int i = 2; i < sizes[0]; i++) {
-    Value item = extractTorchScalar(binder.getLoc(), i, operand, rewriter);
+    Value item = extractTorchScalar(loc, i, operand, rewriter);
     itemList.push_back(item);
   }
 
@@ -234,7 +236,7 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
   Type someTorchScalarListType = Torch::ListType::get(someTorchScalarType);
 
   return rewriter.create<Torch::PrimListConstructOp>(
-      binder.getLoc(), someTorchScalarListType, itemList);
+      loc, someTorchScalarListType, itemList);
 }
 } // namespace
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -218,8 +218,10 @@ Value extractTorchScalar(
                                             selectionFromGiven1DTensor);
 }
 
-Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
-                   Value operand) {
+Value getValueList(
+    /*                  with */ OpBinder binder,
+    /*                 using */ ConversionPatternRewriter &rewriter,
+    /* movingForwardsThrough */ Value operand) {
   auto operandType = cast<Torch::BaseTensorType>(operand.getType());
   auto sizes = operandType.getSizes();
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -218,7 +218,7 @@ Value extractTorchScalar(
                                             selectionFromGiven1DTensor);
 }
 
-Value getValueList(
+Value createScalarSublist(
     /*                    at */ Location givenLoc,
     /* movingForwardsThrough */ Value given1DTensor,
     /*            startingAt */ int64_t givenIndex,
@@ -2828,14 +2828,16 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
 
         if (operands.size() < 4) {
           Value scaleOperand = operands[2];
-          scalesValueList = getValueList(binder.getLoc(), scaleOperand,
-                                         assumedForemostSpatialDim, rewriter);
+          scalesValueList =
+              createScalarSublist(binder.getLoc(), scaleOperand,
+                                  assumedForemostSpatialDim, rewriter);
           sizesValueList = noneVal;
         } else {
           Value sizeOperand = operands[3];
           scalesValueList = noneVal;
-          sizesValueList = getValueList(binder.getLoc(), sizeOperand,
-                                        assumedForemostSpatialDim, rewriter);
+          sizesValueList =
+              createScalarSublist(binder.getLoc(), sizeOperand,
+                                  assumedForemostSpatialDim, rewriter);
         }
         if (isa<Torch::NoneType>(scalesValueList.getType()) &&
             isa<Torch::NoneType>(sizesValueList.getType())) {
@@ -3359,7 +3361,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
               binder.op, "supports upto 3d upsampling only");
 
         int64_t assumedForemostSpatialDim = 2;
-        Value scalesValueList = getValueList(
+        Value scalesValueList = createScalarSublist(
             binder.getLoc(), scales, assumedForemostSpatialDim, rewriter);
         if (mode == "linear") {
           if (resultRank == 4)

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -227,18 +227,18 @@ Value getValueList(
   auto sizes = operandType.getSizes();
   auto lengthOfFullList = sizes[0];
 
-  SmallVector<Value> itemList;
+  SmallVector<Value> runningScalarSublist;
 
   for (int i = givenIndex; i < lengthOfFullList; i++) {
     Value item = extractTorchScalar(givenLoc, i, operand, rewriter);
-    itemList.push_back(item);
+    runningScalarSublist.push_back(item);
   }
 
-  auto someTorchScalarType = itemList.front().getType();
+  auto someTorchScalarType = runningScalarSublist.front().getType();
   Type someTorchScalarListType = Torch::ListType::get(someTorchScalarType);
 
   return rewriter.create<Torch::PrimListConstructOp>(
-      givenLoc, someTorchScalarListType, itemList);
+      givenLoc, someTorchScalarListType, runningScalarSublist);
 }
 } // namespace
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -230,8 +230,8 @@ Value getValueList(
   SmallVector<Value> runningScalarSublist;
 
   for (int i = givenIndex; i < lengthOfFullList; i++) {
-    Value item = extractTorchScalar(givenLoc, i, operand, rewriter);
-    runningScalarSublist.push_back(item);
+    Value eachScalar = extractTorchScalar(givenLoc, i, operand, rewriter);
+    runningScalarSublist.push_back(eachScalar);
   }
 
   auto someTorchScalarType = runningScalarSublist.front().getType();

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -184,8 +184,7 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
                    Value operand) {
   SmallVector<Value> itemList;
   auto sizes = dyn_cast<Torch::ValueTensorType>(operand.getType()).getSizes();
-  Torch::BaseTensorType operandType =
-      cast<Torch::BaseTensorType>(operand.getType());
+  auto operandType = cast<Torch::BaseTensorType>(operand.getType());
 
   SmallVector<int64_t> selectSizes;
   selectSizes.push_back(1);

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -195,7 +195,6 @@ Type getTorchScalarType(
 
 Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
                    Value operand) {
-  SmallVector<Value> itemList;
   auto operandType = cast<Torch::BaseTensorType>(operand.getType());
   auto sizes = operandType.getSizes();
 
@@ -213,6 +212,8 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
   Value zero = rewriter.create<Torch::ConstantIntOp>(
       binder.getLoc(), rewriter.getType<Torch::IntType>(),
       rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+
+  SmallVector<Value> itemList;
 
   for (int i = 2; i < sizes[0]; i++) {
     Value selectIndex = rewriter.create<Torch::ConstantIntOp>(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -204,7 +204,6 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
       binder.getLoc(), rewriter.getType<Torch::IntType>(),
       rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
 
-  MLIRContext *context = binder.op->getContext();
   for (int i = 2; i < sizes[0]; i++) {
     Value selectIndex = rewriter.create<Torch::ConstantIntOp>(
         binder.getLoc(), rewriter.getType<Torch::IntType>(),
@@ -214,14 +213,8 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
     Value item = extract(operand, ext);
     itemList.push_back(item);
   }
-  auto xTy = cast<Torch::ValueTensorType>(operand.getType());
-  Type someTorchScalarType;
-  if (isa<IntegerType>(xTy.getDtype())) {
-    someTorchScalarType = Torch::IntType::get(context);
-  } else {
-    someTorchScalarType = Torch::FloatType::get(context);
-  }
 
+  auto someTorchScalarType = itemList.front().getType();
   Type someTorchScalarListType = Torch::ListType::get(someTorchScalarType);
 
   return rewriter.create<Torch::PrimListConstructOp>(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -215,15 +215,16 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
     itemList.push_back(item);
   }
   auto xTy = cast<Torch::ValueTensorType>(operand.getType());
+  Type someTorchScalarType;
   Value ValueList;
   if (isa<IntegerType>(xTy.getDtype())) {
+    someTorchScalarType = Torch::IntType::get(context);
     ValueList = rewriter.create<Torch::PrimListConstructOp>(
-        binder.getLoc(), Torch::ListType::get(Torch::IntType::get(context)),
-        itemList);
+        binder.getLoc(), Torch::ListType::get(someTorchScalarType), itemList);
   } else {
+    someTorchScalarType = Torch::FloatType::get(context);
     ValueList = rewriter.create<Torch::PrimListConstructOp>(
-        binder.getLoc(), Torch::ListType::get(Torch::FloatType::get(context)),
-        itemList);
+        binder.getLoc(), Torch::ListType::get(someTorchScalarType), itemList);
   }
   return ValueList;
 }

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -219,13 +219,13 @@ Value getValueList(OpBinder binder, ConversionPatternRewriter &rewriter,
   Value ValueList;
   if (isa<IntegerType>(xTy.getDtype())) {
     someTorchScalarType = Torch::IntType::get(context);
-    ValueList = rewriter.create<Torch::PrimListConstructOp>(
-        binder.getLoc(), Torch::ListType::get(someTorchScalarType), itemList);
   } else {
     someTorchScalarType = Torch::FloatType::get(context);
-    ValueList = rewriter.create<Torch::PrimListConstructOp>(
-        binder.getLoc(), Torch::ListType::get(someTorchScalarType), itemList);
   }
+
+  ValueList = rewriter.create<Torch::PrimListConstructOp>(
+      binder.getLoc(), Torch::ListType::get(someTorchScalarType), itemList);
+
   return ValueList;
 }
 } // namespace

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -220,8 +220,8 @@ Value extractTorchScalar(
 
 Value getValueList(
     /*                    at */ Location givenLoc,
-    /*                 using */ ConversionPatternRewriter &rewriter,
-    /* movingForwardsThrough */ Value operand) {
+    /* movingForwardsThrough */ Value operand,
+    /*                 using */ ConversionPatternRewriter &rewriter) {
   auto operandType = cast<Torch::BaseTensorType>(operand.getType());
   auto sizes = operandType.getSizes();
 
@@ -2822,12 +2822,12 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         if (operands.size() < 4) {
           Value scaleOperand = operands[2];
           scalesValueList =
-              getValueList(binder.getLoc(), rewriter, scaleOperand);
+              getValueList(binder.getLoc(), scaleOperand, rewriter);
           sizesValueList = noneVal;
         } else {
           Value sizeOperand = operands[3];
           scalesValueList = noneVal;
-          sizesValueList = getValueList(binder.getLoc(), rewriter, sizeOperand);
+          sizesValueList = getValueList(binder.getLoc(), sizeOperand, rewriter);
         }
         if (isa<Torch::NoneType>(scalesValueList.getType()) &&
             isa<Torch::NoneType>(sizesValueList.getType())) {
@@ -3350,7 +3350,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           return rewriter.notifyMatchFailure(
               binder.op, "supports upto 3d upsampling only");
 
-        Value scalesValueList = getValueList(binder.getLoc(), rewriter, scales);
+        Value scalesValueList = getValueList(binder.getLoc(), scales, rewriter);
         if (mode == "linear") {
           if (resultRank == 4)
             mode = "bilinear";

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -223,8 +223,8 @@ Value getValueList(
     /* movingForwardsThrough */ Value given1DTensor,
     /*            startingAt */ int64_t givenIndex,
     /*                 using */ ConversionPatternRewriter &rewriter) {
-  auto operandType = cast<Torch::BaseTensorType>(given1DTensor.getType());
-  auto sizes = operandType.getSizes();
+  auto some1DTensorType = cast<Torch::BaseTensorType>(given1DTensor.getType());
+  auto sizes = some1DTensorType.getSizes();
   auto lengthOfFullList = sizes[0];
 
   SmallVector<Value> runningScalarSublist;

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -229,8 +229,10 @@ Value getValueList(
 
   SmallVector<Value> runningScalarSublist;
 
-  for (int i = givenIndex; i < lengthOfFullList; i++) {
-    Value eachScalar = extractTorchScalar(givenLoc, i, operand, rewriter);
+  for (int indexOfEachScalar = givenIndex; indexOfEachScalar < lengthOfFullList;
+       indexOfEachScalar++) {
+    Value eachScalar =
+        extractTorchScalar(givenLoc, indexOfEachScalar, operand, rewriter);
     runningScalarSublist.push_back(eachScalar);
   }
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -224,8 +224,8 @@ Value getValueList(
     /*            startingAt */ int64_t givenIndex,
     /*                 using */ ConversionPatternRewriter &rewriter) {
   auto some1DTensorType = cast<Torch::BaseTensorType>(given1DTensor.getType());
-  auto sizes = some1DTensorType.getSizes();
-  auto lengthOfFullList = sizes[0];
+  auto sizesOfSome1DTensor = some1DTensorType.getSizes();
+  auto lengthOfFullList = sizesOfSome1DTensor[0];
 
   SmallVector<Value> runningScalarSublist;
 

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -2803,8 +2803,9 @@ func.func @test_upsample_nearest(%arg0: !torch.vtensor<[1,1,2,2],f32>, %arg1: !t
   // CHECK: %[[INT2:.*]] = torch.constant.int 2
   // CHECK: %[[SELECT:.*]] = torch.aten.select.int %arg1, %[[INT0]], %[[INT2]] : !torch.vtensor<[4],f32>, !torch.int, !torch.int -> !torch.vtensor<[1],f32>
   // CHECK: %[[SCALE:.*]] = torch.aten.item %[[SELECT]] : !torch.vtensor<[1],f32> -> !torch.float
+  // CHECK: %[[INT0_0:.*]] = torch.constant.int 0
   // CHECK: %[[INT3:.*]] = torch.constant.int 3
-  // CHECK: %[[SELECT_0:.*]] = torch.aten.select.int %arg1, %[[INT0]], %[[INT3]] : !torch.vtensor<[4],f32>, !torch.int, !torch.int -> !torch.vtensor<[1],f32>
+  // CHECK: %[[SELECT_0:.*]] = torch.aten.select.int %arg1, %[[INT0_0]], %[[INT3]] : !torch.vtensor<[4],f32>, !torch.int, !torch.int -> !torch.vtensor<[1],f32>
   // CHECK: %[[SCALE_0:.*]] = torch.aten.item %[[SELECT_0]] : !torch.vtensor<[1],f32> -> !torch.float
   // CHECK: %[[SCALE_LIST:.*]] = torch.prim.ListConstruct %[[SCALE]], %[[SCALE_0]] : (!torch.float, !torch.float) -> !torch.list<float>
   // CHECK: %[[MODE:.*]] = torch.constant.str "nearest"
@@ -2824,8 +2825,9 @@ func.func @test_upsample_bilinear(%arg0: !torch.vtensor<[1,1,2,2],f32>, %arg1: !
   // CHECK: %[[INT2:.*]] = torch.constant.int 2
   // CHECK: %[[SELECT:.*]] = torch.aten.select.int %arg1, %[[INT0]], %[[INT2]] : !torch.vtensor<[4],f32>, !torch.int, !torch.int -> !torch.vtensor<[1],f32>
   // CHECK: %[[SCALE:.*]] = torch.aten.item %[[SELECT]] : !torch.vtensor<[1],f32> -> !torch.float
+  // CHECK: %[[INT0_0:.*]] = torch.constant.int 0
   // CHECK: %[[INT3:.*]] = torch.constant.int 3
-  // CHECK: %[[SELECT_0:.*]] = torch.aten.select.int %arg1, %[[INT0]], %[[INT3]] : !torch.vtensor<[4],f32>, !torch.int, !torch.int -> !torch.vtensor<[1],f32>
+  // CHECK: %[[SELECT_0:.*]] = torch.aten.select.int %arg1, %[[INT0_0]], %[[INT3]] : !torch.vtensor<[4],f32>, !torch.int, !torch.int -> !torch.vtensor<[1],f32>
   // CHECK: %[[SCALE_0:.*]] = torch.aten.item %[[SELECT_0]] : !torch.vtensor<[1],f32> -> !torch.float
   // CHECK: %[[SCALE_LIST:.*]] = torch.prim.ListConstruct %[[SCALE]], %[[SCALE_0]] : (!torch.float, !torch.float) -> !torch.list<float>
   // CHECK: %[[MODE:.*]] = torch.constant.str "bilinear"


### PR DESCRIPTION
A preliminary refactor to support #3945 
- extracts several new helper functions
- removes cruft