### PR TITLE
Revert "Revert "[BUILD] Add nanobind to build-requirements""

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -5,6 +5,7 @@ setuptools
 cmake
 ninja
 packaging
+nanobind>=2.4, <3.0
 
 # Workaround for what should be a torch dep
 # See discussion in #1174


### PR DESCRIPTION
Reverting this commit since the package is required and is not a reason for failure here: https://github.com/llvm/torch-mlir-release/actions/runs/13067265659

Reverts llvm/torch-mlir#3997