### PR TITLE
Fix no return in NDEBUG builds

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -190,7 +190,7 @@ Type getTorchScalarType(
   if (isa<FloatType>(elementTypeForGivenTensor))
     return rewriter.getType<Torch::FloatType>();
 
-  assert(false && "dtype for given tensor expected to be either int or float");
+  llvm_unreachable("dtype for given tensor expected to be either int or float");
 }
 
 Value extractTorchScalar(


### PR DESCRIPTION
Uses `llvm_unreachable` to mark path unreachable to fix compiler error

```
DefaultDomainQtoZ.cpp:194:1: error: non-void function does not return a value in all control paths
```