### PR TITLE
refactor(ONNX): standardizes newest TorchOnnxToTorch helpers

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -235,10 +235,10 @@ Value createTorchList(ConversionPatternRewriter &rewriter, Location givenLoc,
       givenLoc, someTorchListType, givenTorchElements);
 }
 
-Value createScalarSublist(ConversionPatternRewriter &rewriter,
-                          Location givenLoc,
-                          /* movingForwardsThrough */ Value given1DTensor,
-                          /*            startingAt */ int64_t givenIndex) {
+Value createTorchScalarSublist(ConversionPatternRewriter &rewriter,
+                               Location givenLoc,
+                               /* movingForwardsThrough */ Value given1DTensor,
+                               /*            startingAt */ int64_t givenIndex) {
   SmallVector<Value> runningTorchScalars;
 
   for (int indexOfEachScalar = givenIndex;
@@ -2896,7 +2896,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
                 rewriter.getStringAttr(errorMessageForEachDim));
           };
 
-          supportedScaleFactors = createScalarSublist(
+          supportedScaleFactors = createTorchScalarSublist(
               rewriter, loc, proposedScaleFactors, assumedForemostSpatialDim);
           supportedSizes = noneVal;
         } else if (numberOfOperands == 4) {
@@ -2927,8 +2927,8 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           };
 
           supportedScaleFactors = noneVal;
-          supportedSizes = createScalarSublist(rewriter, loc, proposedSizes,
-                                               assumedForemostSpatialDim);
+          supportedSizes = createTorchScalarSublist(
+              rewriter, loc, proposedSizes, assumedForemostSpatialDim);
         } else
           return rewriter.notifyMatchFailure(binder.op, "unknown scaling mode");
 
@@ -3450,7 +3450,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
               binder.op, "supports upto 3d upsampling only");
 
         int64_t assumedForemostSpatialDim = 2;
-        Value scalesValueList = createScalarSublist(
+        Value scalesValueList = createTorchScalarSublist(
             rewriter, binder.getLoc(), scales, assumedForemostSpatialDim);
         if (mode == "linear") {
           if (resultRank == 4)

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -187,9 +187,9 @@ int64_t lengthOfListIn(Value given1DTensor) {
   return sizesOfSome1DTensor[soleDimInAny1DTensor];
 }
 
-Type getTorchScalarType(
-    /* forElementIn */ Torch::BaseTensorType givenTensorType,
-    /*        using */ ConversionPatternRewriter &rewriter) {
+Type getTorchScalarTypeForElements(
+    ConversionPatternRewriter &rewriter,
+    /* in */ Torch::BaseTensorType givenTensorType) {
   auto elementTypeForGivenTensor = givenTensorType.getDtype();
 
   if (isa<IntegerType>(elementTypeForGivenTensor))
@@ -215,7 +215,8 @@ Value extractTorchScalar(
   Value selectionIndex =
       rewriter.create<Torch::ConstantIntOp>(givenLoc, givenIndex);
 
-  auto someTorchScalarType = getTorchScalarType(some1DTensorType, rewriter);
+  auto someTorchScalarType =
+      getTorchScalarTypeForElements(rewriter, some1DTensorType);
 
   Value selectionFromGiven1DTensor = rewriter.create<Torch::AtenSelectIntOp>(
       givenLoc, selectionTypeForSome1DTensor, given1DTensor, frontDim,

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -239,16 +239,16 @@ Value createScalarSublist(ConversionPatternRewriter &rewriter,
                           Location givenLoc,
                           /* movingForwardsThrough */ Value given1DTensor,
                           /*            startingAt */ int64_t givenIndex) {
-  SmallVector<Value> runningScalarSublist;
+  SmallVector<Value> runningTorchScalars;
 
   for (int indexOfEachScalar = givenIndex;
        indexOfEachScalar < lengthOfListIn(given1DTensor); indexOfEachScalar++) {
     Value eachScalar = createTorchScalarForElement(
         rewriter, givenLoc, given1DTensor, indexOfEachScalar);
-    runningScalarSublist.push_back(eachScalar);
+    runningTorchScalars.push_back(eachScalar);
   }
 
-  return createTorchList(rewriter, givenLoc, runningScalarSublist);
+  return createTorchList(rewriter, givenLoc, runningTorchScalars);
 }
 } // namespace
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -218,6 +218,16 @@ Value extractTorchScalar(
                                             selectionFromGiven1DTensor);
 }
 
+Value createTorchList(ConversionPatternRewriter &rewriter, Location givenLoc,
+                      /* from */ SmallVector<Value> givenTorchElements) {
+  auto someTorchElement = givenTorchElements.front();
+  auto someTorchElementType = someTorchElement.getType();
+  Type someTorchListType = Torch::ListType::get(someTorchElementType);
+
+  return rewriter.create<Torch::PrimListConstructOp>(
+      givenLoc, someTorchListType, givenTorchElements);
+}
+
 Value createScalarSublist(
     /*                    at */ Location givenLoc,
     /* movingForwardsThrough */ Value given1DTensor,
@@ -236,11 +246,7 @@ Value createScalarSublist(
     runningScalarSublist.push_back(eachScalar);
   }
 
-  auto someTorchScalarType = runningScalarSublist.front().getType();
-  Type someTorchScalarListType = Torch::ListType::get(someTorchScalarType);
-
-  return rewriter.create<Torch::PrimListConstructOp>(
-      givenLoc, someTorchScalarListType, runningScalarSublist);
+  return createTorchList(rewriter, givenLoc, runningScalarSublist);
 }
 } // namespace
 

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -235,11 +235,10 @@ Value createTorchList(ConversionPatternRewriter &rewriter, Location givenLoc,
       givenLoc, someTorchListType, givenTorchElements);
 }
 
-Value createScalarSublist(
-    /*                    at */ Location givenLoc,
-    /* movingForwardsThrough */ Value given1DTensor,
-    /*            startingAt */ int64_t givenIndex,
-    /*                 using */ ConversionPatternRewriter &rewriter) {
+Value createScalarSublist(ConversionPatternRewriter &rewriter,
+                          Location givenLoc,
+                          /* movingForwardsThrough */ Value given1DTensor,
+                          /*            startingAt */ int64_t givenIndex) {
   SmallVector<Value> runningScalarSublist;
 
   for (int indexOfEachScalar = givenIndex;
@@ -2898,7 +2897,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           };
 
           supportedScaleFactors = createScalarSublist(
-              loc, proposedScaleFactors, assumedForemostSpatialDim, rewriter);
+              rewriter, loc, proposedScaleFactors, assumedForemostSpatialDim);
           supportedSizes = noneVal;
         } else if (numberOfOperands == 4) {
           Value proposedSizes = operands[3];
@@ -2928,8 +2927,8 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           };
 
           supportedScaleFactors = noneVal;
-          supportedSizes = createScalarSublist(
-              loc, proposedSizes, assumedForemostSpatialDim, rewriter);
+          supportedSizes = createScalarSublist(rewriter, loc, proposedSizes,
+                                               assumedForemostSpatialDim);
         } else
           return rewriter.notifyMatchFailure(binder.op, "unknown scaling mode");
 
@@ -3452,7 +3451,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
 
         int64_t assumedForemostSpatialDim = 2;
         Value scalesValueList = createScalarSublist(
-            binder.getLoc(), scales, assumedForemostSpatialDim, rewriter);
+            rewriter, binder.getLoc(), scales, assumedForemostSpatialDim);
         if (mode == "linear") {
           if (resultRank == 4)
             mode = "bilinear";

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -243,9 +243,9 @@ Value createScalarSublist(ConversionPatternRewriter &rewriter,
 
   for (int indexOfEachScalar = givenIndex;
        indexOfEachScalar < lengthOfListIn(given1DTensor); indexOfEachScalar++) {
-    Value eachScalar = createTorchScalarForElement(
+    Value eachTorchScalar = createTorchScalarForElement(
         rewriter, givenLoc, given1DTensor, indexOfEachScalar);
-    runningTorchScalars.push_back(eachScalar);
+    runningTorchScalars.push_back(eachTorchScalar);
   }
 
   return createTorchList(rewriter, givenLoc, runningTorchScalars);

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -180,6 +180,13 @@ LogicalResult reduceOpImpl(OpBinder binder, ConversionPatternRewriter &rewriter,
   return success();
 }
 
+int64_t lengthOfListIn(Value given1DTensor) {
+  auto some1DTensorType = cast<Torch::BaseTensorType>(given1DTensor.getType());
+  auto sizesOfSome1DTensor = some1DTensorType.getSizes();
+  size_t soleDimInAny1DTensor = 0;
+  return sizesOfSome1DTensor[soleDimInAny1DTensor];
+}
+
 Type getTorchScalarType(
     /* forElementIn */ Torch::BaseTensorType givenTensorType,
     /*        using */ ConversionPatternRewriter &rewriter) {
@@ -233,14 +240,10 @@ Value createScalarSublist(
     /* movingForwardsThrough */ Value given1DTensor,
     /*            startingAt */ int64_t givenIndex,
     /*                 using */ ConversionPatternRewriter &rewriter) {
-  auto some1DTensorType = cast<Torch::BaseTensorType>(given1DTensor.getType());
-  auto sizesOfSome1DTensor = some1DTensorType.getSizes();
-  auto lengthOfFullList = sizesOfSome1DTensor[0];
-
   SmallVector<Value> runningScalarSublist;
 
-  for (int indexOfEachScalar = givenIndex; indexOfEachScalar < lengthOfFullList;
-       indexOfEachScalar++) {
+  for (int indexOfEachScalar = givenIndex;
+       indexOfEachScalar < lengthOfListIn(given1DTensor); indexOfEachScalar++) {
     Value eachScalar = extractTorchScalar(givenLoc, indexOfEachScalar,
                                           given1DTensor, rewriter);
     runningScalarSublist.push_back(eachScalar);


### PR DESCRIPTION
- extracts out two more helpers with potentially broad usage
- standardizes their function signatures for future use with ImplicitLocOpBuilder