### PR TITLE
[TorchToArith] Add a lowering for `AtenEqFloat`

### DIFF
--- a/lib/Conversion/TorchToArith/TorchToArith.cpp
+++ b/lib/Conversion/TorchToArith/TorchToArith.cpp
@@ -454,8 +454,11 @@ public:
     patterns.add<
         ConvertAtenIntComparisonOp<AtenLeIntOp, arith::CmpIPredicate::sle>>(
         typeConverter, context);
-    target.addIllegalOp<AtenGeFloatOp, AtenGtFloatOp, AtenGeFloatIntOp,
-                        AtenNeFloatIntOp, AtenGtFloatIntOp>();
+    target.addIllegalOp<AtenEqFloatOp, AtenGeFloatOp, AtenGtFloatOp,
+                        AtenGeFloatIntOp, AtenNeFloatIntOp, AtenGtFloatIntOp>();
+    patterns.add<
+        ConvertAtenFloatComparisonOp<AtenEqFloatOp, arith::CmpFPredicate::UEQ>>(
+        typeConverter, context);
     patterns.add<
         ConvertAtenFloatComparisonOp<AtenGeFloatOp, arith::CmpFPredicate::UGE>>(
         typeConverter, context);


### PR DESCRIPTION
Addresses an issue introduced by <https://github.com/llvm/torch-mlir/pull/3945> in an external test suite. 