### PR TITLE
Enable TOSA conversions in bazel build rules

### DIFF
--- a/build_tools/autogen_ltc_backend.py
+++ b/build_tools/autogen_ltc_backend.py
@@ -34,7 +34,8 @@ TORCH_MLIR_DIR = Path(__file__).resolve().parent.parent
 try:
     from yaml import CSafeLoader as Loader
 except ImportError:
-    from yaml import SafeLoader as Loader #type:ignore[assignment, misc]
+    from yaml import SafeLoader as Loader  # type:ignore[assignment, misc]
+
 
 def reindent(text, prefix=""):
     return indent(dedent(text), prefix)

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -278,6 +278,7 @@ gentbl_cc_library(
             [
                 "-gen-pass-decls",
                 "-DTORCH_MLIR_ENABLE_STABLEHLO",
+                "-DTORCH_MLIR_ENABLE_TOSA",
             ],
             "include/torch-mlir/Conversion/Passes.h.inc",
         ),
@@ -334,6 +335,7 @@ gentbl_cc_library(
             [
                 "-gen-pass-decls",
                 "-DTORCH_MLIR_ENABLE_STABLEHLO",
+                "-DTORCH_MLIR_ENABLE_TOSA",
             ],
             "include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h.inc",
         ),
@@ -887,6 +889,7 @@ cc_library(
     copts = [
         "-DTORCH_MLIR_ENABLE_REFBACKEND",
         "-DTORCH_MLIR_ENABLE_STABLEHLO",
+        "-DTORCH_MLIR_ENABLE_TOSA",
     ],
     strip_include_prefix = "include",
     deps = [


### PR DESCRIPTION
Follows https://github.com/llvm/torch-mlir/pull/4021.

Also pushes a small pre-commit fix.

Bazel CI triggered here: 
