### PR TITLE
[onnx_importer] Fix constant bool tensor importing

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -2910,6 +2910,30 @@ def NumelZeroRankModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class BoolTensorConstantModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+        ]
+    )
+    def forward(self):
+        return torch.tensor(
+            [1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1], dtype=torch.bool
+        )
+
+
+@register_test_case(module_factory=lambda: BoolTensorConstantModule())
+def BoolTensorConstantModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+# ==============================================================================
+
+
 class BoolTensorReturnFalseModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/python/torch_mlir/extras/onnx_importer.py
+++ b/python/torch_mlir/extras/onnx_importer.py
@@ -1132,12 +1132,7 @@ ELEM_TYPE_INLINE_TENSOR_PROTO_CB = {
         np.asarray(tp.float_data, dtype=np.float32).reshape(tp.dims), signless=False
     ),
     onnx.TensorProto.DataType.BOOL: lambda tp: DenseElementsAttr.get(
-        np.packbits(
-            np.asarray(tp.int32_data, dtype=np.bool_).reshape(tp.dims),
-            axis=None,
-            bitorder="little",
-        ),
-        signless=False,
+        np.asarray(tp.int32_data, dtype=np.bool_).reshape(tp.dims), signless=False
     ),
     onnx.TensorProto.DataType.UINT8: lambda tp: DenseElementsAttr.get(
         np.asarray(tp.int32_data, dtype=np.uint8).reshape(tp.dims), signless=False


### PR DESCRIPTION
A constant tensor of bools is imported as something like
```
%0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<[105, 108, 44]> : tensor<3xui8>} : () -> !torch.vtensor<[22],i1>
```
which leads to incompatible types errors
```
b.mlir:4:10: error: 'torch.vtensor.literal' op inferred type(s) '!torch.vtensor<[3],ui8>' are incompatible with return type(s) of operation '!torch.vtensor<[22],i1>'
    %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<[105, 108, 44]> : tensor<3xui8>} : () -> !torch.vtensor<[22],i1> 
```

This PR fixes the translation by removing the `numpy.packbits()` processing.

Note about e2eshark tests: some tests (e.g. `test_sequence_map_identity_1_sequence_expanded`) contain scalar constant boolean tensors. Compilation of the constant part seems to work fine, but this is due to the dimension size of the tensor being 1, which means types are compatible.