### PR TITLE
Fix sanitizers issues

### DIFF
--- a/lib/Dialect/TorchConversion/Transforms/UnpackQuantTensor.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/UnpackQuantTensor.cpp
@@ -101,7 +101,7 @@ public:
                                APInt(unpackedBitWidth, 0));
     for (int i = 0, e = data.size(); i < e; ++i) {
       auto el = data[i];
-      char mask = (1 << unpackedBitWidth) - 1;
+      uint8_t mask = (1 << unpackedBitWidth) - 1;
       for (int b = 0; b < packRatio; b++) {
         newData[i * packRatio + b] =
             APInt(unpackedBitWidth, (el & mask) >> (unpackedBitWidth * b),

--- a/projects/jit_ir_common/csrc/jit_ir_importer/mlir_utils.h
+++ b/projects/jit_ir_common/csrc/jit_ir_importer/mlir_utils.h
@@ -69,11 +69,15 @@ inline void addToMlirOperationState(MlirOperationState &state,
 
 inline void addToMlirOperationState(MlirOperationState &state,
                                     const std::vector<MlirType> &resultTypes) {
+  if (resultTypes.empty())
+    return; // must not proceed when resultTypes.data() is nullptr.
   mlirOperationStateAddResults(&state, resultTypes.size(), resultTypes.data());
 }
 
 inline void addToMlirOperationState(MlirOperationState &state,
                                     c10::ArrayRef<MlirType> resultTypes) {
+  if (resultTypes.empty())
+    return; // must not proceed when resultTypes.data() is nullptr.
   mlirOperationStateAddResults(&state, resultTypes.size(), resultTypes.data());
 }
 


### PR DESCRIPTION
ubsan detected 'lib/Dialect/TorchConversion/Transforms/UnpackQuantTensor.cpp:109:21: runtime error: left shift of negative value -16' and asan detected `memcpy` with nullptr when we passed and empty vector with `.data() == nullptr` to mlirOperationStateAddResults.

Detected using https://github.com/llvm/torch-mlir/pull/4046