### PR TITLE
[torch] Rework `torch.repeat` to not broadcast unary case

### DIFF
--- a/lib/Conversion/TorchToLinalg/Utils.cpp
+++ b/lib/Conversion/TorchToLinalg/Utils.cpp
@@ -475,8 +475,10 @@ LogicalResult torch_to_linalg::broadcastToGivenShape(
       }
     }
 
-    input = rewriter.create<tensor::CollapseShapeOp>(op->getLoc(), input,
-                                                     collapseExprs);
+    if (collapseExprs.size() < inputRank) {
+      input = rewriter.create<tensor::CollapseShapeOp>(op->getLoc(), input,
+                                                       collapseExprs);
+    }
 
     SmallVector<AffineExpr> inputExprs;
     for (int64_t i = 0, e = inputRank; i < e; ++i) {

--- a/lib/Conversion/TorchToLinalg/Utils.cpp
+++ b/lib/Conversion/TorchToLinalg/Utils.cpp
@@ -475,7 +475,7 @@ LogicalResult torch_to_linalg::broadcastToGivenShape(
       }
     }
 
-    if (collapseExprs.size() < inputRank) {
+    if (collapseExprs.size() < static_cast<size_t>(inputRank)) {
       input = rewriter.create<tensor::CollapseShapeOp>(op->getLoc(), input,
                                                        collapseExprs);
     }

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -4427,7 +4427,7 @@ public:
       return rewriter.notifyMatchFailure(op, "input sizes unknown");
 
     auto unsqueeze = [&](Value input, int64_t dim) {
-      auto inputTy = input.getType().cast<ValueTensorType>();
+      auto inputTy = cast<ValueTensorType>(input.getType());
       auto oldSizes = inputTy.getSizes();
 
       llvm::SmallVector<int64_t> sizes;
@@ -4459,7 +4459,7 @@ public:
     llvm::SmallVector<int> unsqueezeDims;
     for (int i = 0; i < batch; ++i) {
       self = unsqueeze(self, i);
-      selfTy = self.getType().cast<ValueTensorType>();
+      selfTy = cast<ValueTensorType>(self.getType());
       unsqueezeDims.push_back(i);
     }
 
@@ -4468,7 +4468,7 @@ public:
         continue;
       int64_t dim = i + unsqueezeDims.size() - batch;
       self = unsqueeze(self, dim);
-      selfTy = self.getType().cast<ValueTensorType>();
+      selfTy = cast<ValueTensorType>(self.getType());
       unsqueezeDims.push_back(dim);
     }
 

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -4501,22 +4501,15 @@ public:
                                                selfTy.getOptionalDtype());
     self = rewriter.create<AtenBroadcastToOp>(loc, selfTy, self, lengthv);
 
-    auto mulDim = [](int64_t lhs, int64_t rhs) {
-      if (lhs == Torch::kUnknownSize || rhs == Torch::kUnknownSize)
-        return Torch::kUnknownSize;
-      return lhs * rhs;
-    };
-
+    auto outShape = cast<ValueTensorType>(op.getResult().getType()).getSizes();
     for (int i = batch, s = repeats.size(); i < s; ++i) {
       if (repeatInts[i] == 1)
         continue;
 
       auto selfShape = selfTy.getSizes();
       llvm::SmallVector<int64_t> flattenShape;
-      for (int j = 0; j < i; ++j)
-        flattenShape.push_back(selfTy.getSizes()[j]);
-
-      flattenShape.push_back(mulDim(selfShape[i], selfShape[i + 1]));
+      for (int j = 0; j <= i; ++j)
+        flattenShape.push_back(outShape[j]);
 
       for (int j = i + 2, s = selfShape.size(); j < s; ++j)
         flattenShape.push_back(selfShape[j]);

--- a/test/Conversion/TorchToLinalg/broadcast.mlir
+++ b/test/Conversion/TorchToLinalg/broadcast.mlir
@@ -22,10 +22,11 @@ func.func @torch.aten.broadcast_to$simple_static(%arg0: !torch.vtensor<[4,2],f32
 
 // CHECK-LABEL:   func.func @torch.aten.broadcast_to$static_numpy_broadcast(
 // CHECK:           %[[INIT_TENSOR:.*]] = tensor.empty() : tensor<1x4x2xf32>
+// CHECK:           %[[COLLAPSE:.*]] = tensor.collapse_shape %{{.*}} {{\[\[}}0, 1], [2]] : tensor<1x1x2xf32> into tensor<1x2xf32>
 // CHECK:           %[[GENERIC:.*]] = linalg.generic
-// CHECK-SAME:        indexing_maps = [affine_map<(d0, d1, d2) -> (d0, 0, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>]
+// CHECK-SAME:        indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>]
 // CHECK-SAME:        iterator_types = ["parallel", "parallel", "parallel"]}
-// CHECK-SAME:        ins({{.*}} : tensor<1x1x2xf32>) outs({{.*}} : tensor<1x4x2xf32>) {
+// CHECK-SAME:        ins(%[[COLLAPSE]] : tensor<1x2xf32>) outs({{.*}} : tensor<1x4x2xf32>) {
 // CHECK:           ^bb0(%[[IN:.*]]: f32, %{{.*}}: f32):
 // CHECK:             linalg.yield %[[IN]] : f32
 // CHECK:           } -> tensor<1x4x2xf32>


### PR DESCRIPTION
Not all dimensions in `torch.repeat` may need to be broadcasted. Skip unsqueezing and flattening these dimensions together.