### PR TITLE
Update shape_inference.cpp for randn.generator

### DIFF
--- a/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
+++ b/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
@@ -470,12 +470,10 @@ compute_shape_randn(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype,
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
 
-std::vector<torch::lazy::Shape>
-compute_shape_randn(at::IntArrayRef size, ::std::optional<at::Generator> generator, 
-                    ::std::optional<at::ScalarType> dtype,
-                    ::std::optional<at::Layout> layout,
-                    ::std::optional<at::Device> device,
-                    ::std::optional<bool> pin_memory) {
+std::vector<torch::lazy::Shape> compute_shape_randn(
+    at::IntArrayRef size, ::std::optional<at::Generator> generator,
+    ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout,
+    ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }

--- a/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
+++ b/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
@@ -475,7 +475,7 @@ compute_shape_randn(at::IntArrayRef size, ::std::optional<at::Generator> generat
                     ::std::optional<at::ScalarType> dtype,
                     ::std::optional<at::Layout> layout,
                     ::std::optional<at::Device> device,
--                    ::std::optional<bool> pin_memory) {
+                    ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }

--- a/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
+++ b/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
@@ -475,7 +475,7 @@ compute_shape_randn(at::IntArrayRef size, ::std::optional<at::Generator> generat
                     ::std::optional<at::ScalarType> dtype,
                     ::std::optional<at::Layout> layout,
                     ::std::optional<at::Device> device,
-                    ::std::optional<bool> pin_memory) {
+-                    ::std::optional<bool> pin_memory) {
   return {
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }

--- a/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
+++ b/projects/ltc/csrc/base_lazy_backend/shape_inference.cpp
@@ -470,6 +470,16 @@ compute_shape_randn(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype,
       Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
 }
 
+std::vector<torch::lazy::Shape>
+compute_shape_randn(at::IntArrayRef size, ::std::optional<at::Generator> generator, 
+                    ::std::optional<at::ScalarType> dtype,
+                    ::std::optional<at::Layout> layout,
+                    ::std::optional<at::Device> device,
+                    ::std::optional<bool> pin_memory) {
+  return {
+      Shape(dtype.value_or(at::get_default_dtype_as_scalartype()), size.vec())};
+}
+
 std::vector<torch::lazy::Shape> compute_shape_randint(
     int64_t high, at::IntArrayRef size, ::std::optional<at::ScalarType> dtype,
     ::std::optional<at::Layout> layout, ::std::optional<at::Device> device,


### PR DESCRIPTION
PR adds support for `aten.randn.generator`, the generator object (if passed) will not affect shape inference.