### PR TITLE
APInt fix

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -2917,7 +2917,7 @@ LogicalResult ConvertAtenOp<ValueTensorLiteralOp>::matchAndRewrite(
       unsigned bitWidth = builtinTensorElemTy.getIntOrFloatBitWidth();
       DenseElementsAttr valueAttr =
           elements.mapValues(builtinTensorElemTy, [&](const APInt &v) {
-            return APInt(bitWidth, v.getSExtValue());
+            return APInt(bitWidth, v.getSExtValue(), /*isSigned=*/true);
           });
       rewriter.replaceOpWithNewOp<tosa::ConstOp>(op, outputTy, valueAttr);
       return success();

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -1024,6 +1024,18 @@ func.func @torch.vtensor.literal_si64$basic() -> !torch.vtensor<[1,512],si64> {
 }
 
 // -----
+
+// CHECK-LABEL: @torch.vtensor.literal_si32$basic(
+// CHECK: %[[VAL_0:.*]] = "tosa.const"() <{value = dense<-1> : tensor<1x512xi32>}> : () -> tensor<1x512xi32>
+// CHECK: %[[VAL_1:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<1x512xi32> -> !torch.vtensor<[1,512],si32>
+// CHECK: return %[[VAL_1]] : !torch.vtensor<[1,512],si32>
+func.func @torch.vtensor.literal_si32$basic() -> !torch.vtensor<[1,512],si32> {
+  %0 = torch.vtensor.literal(dense<-1> : tensor<1x512xsi32>) : !torch.vtensor<[1,512],si32>
+  return %0 : !torch.vtensor<[1,512],si32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.arange.start_step() -> !torch.vtensor<[5],si64> {
 // CHECK:           %[[VAL_0:.*]] = torch.constant.none
 // CHECK:           %[[VAL_1:.*]] = torch.constant.int 0


### PR DESCRIPTION
`ConvertAtenOp<ValueTensorLiteralOp>` triggers newly added assertions around `APInt` construction (see [llvm/llvm-project#106524](https://github.com/llvm/llvm-project/pull/106524)) when `isSigned == false` and we pass the result of `v.getSExtValue()` that doesn't fit within the specified bit-width. For example, if we build a 32-bit `APInt` using a value of `-1` (returned by `v.getSExtValue()`), that negative number is stored in a `uint64-t` representation as `0xFF FF FF FF FF FF FF FF`. Since we are treating it as unsigned, it obviously doesn't fit into 32-bits, causing the new assertion to fail.
  