### PR TITLE
Add support for Quantization/Dequantization

### DIFF
--- a/lib/Conversion/TorchToStablehlo/CMakeLists.txt
+++ b/lib/Conversion/TorchToStablehlo/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_conversion_library(TorchMLIRTorchToStablehlo
   Reduction.cpp
   Rng.cpp
   Pooling.cpp
+  Uncategorized.cpp
   Utils.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/TorchToStablehlo/PopulatePatterns.h
+++ b/lib/Conversion/TorchToStablehlo/PopulatePatterns.h
@@ -67,6 +67,10 @@ void populateRngOpPatternsAndLegality(TypeConverter &typeConverter,
                                       ConversionTarget &target,
                                       const TorchToStablehloOptions &options);
 
+void populateUncategorizedPatternsAndLegality(
+    TypeConverter &typeConverter, RewritePatternSet &patterns,
+    ConversionTarget &target, const TorchToStablehloOptions &options);
+
 } // namespace torch_to_stablehlo
 } // namespace torch
 } // namespace mlir

--- a/lib/Conversion/TorchToStablehlo/TorchToStablehlo.cpp
+++ b/lib/Conversion/TorchToStablehlo/TorchToStablehlo.cpp
@@ -13,6 +13,7 @@
 #include "PopulatePatterns.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Quant/IR/Quant.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "stablehlo/dialect/ChloOps.h"
 #include "stablehlo/dialect/StablehloOps.h"
@@ -40,6 +41,7 @@ public:
     registry.insert<tensor::TensorDialect>();
     registry.insert<shape::ShapeDialect>();
     registry.insert<arith::ArithDialect>();
+    registry.insert<quant::QuantDialect>();
     TorchConversion::getBackendTypeConversionDependentDialects(registry);
   }
   void runOnOperation() override {
@@ -47,7 +49,7 @@ public:
     ConversionTarget target(*context);
     target.addLegalDialect<chlo::ChloDialect, stablehlo::StablehloDialect,
                            tensor::TensorDialect, arith::ArithDialect,
-                           shape::ShapeDialect>();
+                           shape::ShapeDialect, quant::QuantDialect>();
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
@@ -71,6 +73,8 @@ public:
     torch_to_stablehlo::populatePoolingOpPatternsAndLegality(
         typeConverter, patterns, target, options);
     torch_to_stablehlo::populateRngOpPatternsAndLegality(
+        typeConverter, patterns, target, options);
+    torch_to_stablehlo::populateUncategorizedPatternsAndLegality(
         typeConverter, patterns, target, options);
 
     if (failed(applyPartialConversion(getOperation(), target,

--- a/lib/Conversion/TorchToStablehlo/Uncategorized.cpp
+++ b/lib/Conversion/TorchToStablehlo/Uncategorized.cpp
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/TorchToStablehlo/TorchToStablehlo.h"
+
+#include "../PassDetail.h"
+#include "PopulatePatterns.h"
+#include "Utils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Quant/IR/QuantTypes.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "stablehlo/dialect/ChloOps.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "torch-mlir/Conversion/TorchToStablehlo/StablehloLegalizeUtils.h"
+#include "torch-mlir/Conversion/Utils/Utils.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
+#include "torch-mlir/Dialect/Torch/Utils/TorchUpstream.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include <cmath>
+#include <numeric>
+#include <type_traits>
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+using namespace mlir::torch::torch_to_stablehlo;
+
+// AtenQuantizePerTensorOp
+// torch-mlir uses AtenQuantizePerTensorOp and AtenIntReprOp for per tensor
+// quantization. These two ops are processed and converted together to
+// stablehlo.uniform_quantize op.
+namespace {
+class ConvertAtenQuantizePerTensorOp
+    : public OpConversionPattern<AtenQuantizePerTensorOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(AtenQuantizePerTensorOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto *zeroPoint = op.getZeroPoint().getDefiningOp();
+    if (!zeroPoint || !isa<ConstantIntOp>(zeroPoint)) {
+      return failure();
+    }
+    auto zeroPointConstantOp = mlir::cast<ConstantIntOp>(zeroPoint);
+    auto zeroPointValue = zeroPointConstantOp.getValueAttr().getInt();
+
+    auto scale = op.getScale().getDefiningOp();
+    if (!scale || !isa<ConstantFloatOp>(scale)) {
+      return failure();
+    }
+
+    auto scaleConstantOp = mlir::cast<ConstantFloatOp>(scale);
+    auto scaleValue =
+        scaleConstantOp.getValueAttr().getValue().convertToDouble();
+
+    auto users = op.getResult().getUsers();
+    auto opUser = *op.getResult().user_begin();
+    if (!(std::distance(users.begin(), users.end()) == 1) ||
+        !isa<AtenIntReprOp>(opUser)) {
+      return failure();
+    }
+
+    auto inputElemType =
+        mlir::cast<RankedTensorType>(
+            getTypeConverter()->convertType(op.getOperands().front().getType()))
+            .getElementType();
+
+    mlir::Type dtype =
+        cast<ValueTensorType>(op->getResult(0).getType()).getDtype();
+    int32_t bitWidth = 0;
+    int32_t flags = quant::QuantizationFlags::FlagValue::Signed;
+    if (isa<QUInt8Type>(dtype)) {
+      bitWidth = 8;
+      flags = 0;
+    } else if (isa<QInt8Type>(dtype)) {
+      bitWidth = 8;
+    } else if (isa<QInt16Type>(dtype)) {
+      bitWidth = 16;
+    } else if (isa<QInt32Type>(dtype)) {
+      bitWidth = 32;
+    } else {
+      return failure();
+    }
+    auto storageType = IntegerType::get(getContext(), bitWidth);
+
+    // Minimum and maximum values for unsigned integer.
+    int64_t minValue = 0;
+    int64_t maxValue = (1LL << bitWidth) - 1;
+    // Update the minimum and maximum for signed integer.
+    if (flags) {
+      // For signed integers (2's complement representation)
+      minValue = -(1LL << (bitWidth - 1));
+      maxValue = (1LL << (bitWidth - 1)) - 1;
+    }
+
+    auto qty = quant::UniformQuantizedType::get(
+        flags, storageType, inputElemType, scaleValue, zeroPointValue, minValue,
+        maxValue);
+
+    RankedTensorType outputType = cast<RankedTensorType>(
+        getTypeConverter()->convertType(op->getResult(0).getType()));
+    mlir::TensorType new_type = outputType.clone(qty);
+
+    stablehlo::UniformQuantizeOp qunatize =
+        rewriter.replaceOpWithNewOp<stablehlo::UniformQuantizeOp>(
+            opUser, new_type, adaptor.getOperands().front());
+
+    opUser->getResults().front().replaceAllUsesWith(
+        qunatize->getResults().front());
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+} // namespace
+
+// Aten_MakePerTensorQuantizedTensorOp
+// torch-mlir uses Aten_MakePerTensorQuantizedTensorOp and AtenDequantizeSelfOp
+// in pair to represent per channel dequantization. These two ops are converted
+// together to stablehlo.uniform_dequantize op
+namespace {
+class ConvertAten_MakePerTensorQuantizedTensorOp
+    : public OpConversionPattern<Aten_MakePerTensorQuantizedTensorOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(Aten_MakePerTensorQuantizedTensorOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto opUser = *op.getResult().user_begin();
+    auto users = op.getResult().getUsers();
+    if (!(std::distance(users.begin(), users.end()) == 1) ||
+        !isa<AtenDequantizeSelfOp>(opUser)) {
+      return failure();
+    }
+    // [TODO] verify that zeroPoint and Scale matches with the input operand
+    // type.
+    RankedTensorType outputType = cast<RankedTensorType>(
+        getTypeConverter()->convertType(opUser->getResult(0).getType()));
+
+    rewriter.replaceOpWithNewOp<stablehlo::UniformDequantizeOp>(
+        opUser, outputType, adaptor.getOperands().front());
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+} // namespace
+
+void mlir::torch::torch_to_stablehlo::populateUncategorizedPatternsAndLegality(
+    TypeConverter &typeConverter, RewritePatternSet &patterns,
+    ConversionTarget &target, const TorchToStablehloOptions &options) {
+  MLIRContext *context = patterns.getContext();
+
+  target.addIllegalOp<AtenQuantizePerTensorOp>();
+  target.addIllegalOp<AtenIntReprOp>();
+  patterns.add<ConvertAtenQuantizePerTensorOp>(typeConverter, context);
+  target.addIllegalOp<Aten_MakePerTensorQuantizedTensorOp>();
+  target.addIllegalOp<AtenDequantizeSelfOp>();
+  patterns.add<ConvertAten_MakePerTensorQuantizedTensorOp>(typeConverter,
+                                                           context);
+}

--- a/test/Conversion/TorchToStablehlo/quantization.mlir
+++ b/test/Conversion/TorchToStablehlo/quantization.mlir
@@ -16,3 +16,23 @@ func.func @test_quantization_per_tensor(%arg0: !torch.vtensor<[2,4,4],f32>) -> !
   %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[2,4,4],!torch.qint8> -> !torch.vtensor<[2,4,4],f32>
   return %3 : !torch.vtensor<[2,4,4],f32>
 }
+
+// -----
+
+// CHECK-LABEL: test_quantization_per_channel
+func.func @test_quantization_per_channel(%arg0: !torch.vtensor<[4,3,7,7],f32>) -> !torch.vtensor<[4,3,7,7],f32> {
+  // CHECK: %[[ARG0:.+]] = torch_c.to_builtin_tensor %arg0 : !torch.vtensor<[4,3,7,7],f32> -> tensor<4x3x7x7xf32>
+  %0 = torch.vtensor.literal(dense<[4.000000e-01, 1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<4xf32>) : !torch.vtensor<[4],f32>
+  %1 = torch.vtensor.literal(dense<[4, 1, 2, 3]> : tensor<4xsi8>) : !torch.vtensor<[4],si8>
+  %int12 = torch.constant.int 12
+  %int1 = torch.constant.int 1
+  // CHECK: %[[QUANT:.+]] = stablehlo.uniform_quantize %[[ARG0]]
+  // CHECK-SAME: (tensor<4x3x7x7xf32>) -> tensor<4x3x7x7x!quant.uniform<i8:f32:1, {0.4{{.*}}:4,0.1{{.*}}:1,0.2{{.*}}:2,0.3{{.*}}:3}>>
+  %2 = torch.aten.quantize_per_channel %arg0, %0, %1, %int1, %int12 : !torch.vtensor<[4,3,7,7],f32>, !torch.vtensor<[4],f32>, !torch.vtensor<[4],si8>, !torch.int, !torch.int -> !torch.vtensor<[4,3,7,7],!torch.qint8>
+  %3 = torch.aten.int_repr %2 : !torch.vtensor<[4,3,7,7],!torch.qint8> -> !torch.vtensor<[4,3,7,7],si8>
+  // CHECK: %[[DEQ:.+]] = stablehlo.uniform_dequantize %[[QUANT]]
+  // CHECK-SAME: (tensor<4x3x7x7x!quant.uniform<i8:f32:1, {0.4{{.*}}:4,0.1{{.*}}:1,0.2{{.*}}:2,0.3{{.*}}:3}>>) -> tensor<4x3x7x7xf32>
+  %4 = torch.aten._make_per_channel_quantized_tensor %3, %0, %1, %int1 : !torch.vtensor<[4,3,7,7],si8>, !torch.vtensor<[4],f32>, !torch.vtensor<[4],si8>, !torch.int -> !torch.vtensor<[4,3,7,7],!torch.qint8>
+  %5 = torch.aten.dequantize.self %4 : !torch.vtensor<[4,3,7,7],!torch.qint8> -> !torch.vtensor<[4,3,7,7],f32>
+  return %5 : !torch.vtensor<[4,3,7,7],f32>
+}

--- a/test/Conversion/TorchToStablehlo/quantization.mlir
+++ b/test/Conversion/TorchToStablehlo/quantization.mlir
@@ -1,0 +1,18 @@
+// RUN: torch-mlir-opt <%s -convert-torch-to-stablehlo -split-input-file -verify-diagnostics | FileCheck %s
+
+
+// CHECK-LABEL: test_quantization_per_tensor
+func.func @test_quantization_per_tensor(%arg0: !torch.vtensor<[2,4,4],f32>) -> !torch.vtensor<[2,4,4],f32> {
+  // CHECK: %[[ARG0:.+]] = torch_c.to_builtin_tensor %arg0 : !torch.vtensor<[2,4,4],f32> -> tensor<2x4x4xf32>
+  %int12 = torch.constant.int 12
+  %float1.000000e-01 = torch.constant.float 0.1
+  %zero = torch.constant.int 0
+  // CHECK: %[[QUANT:.+]] = stablehlo.uniform_quantize %[[ARG0]]
+  // CHECK-SAME: (tensor<2x4x4xf32>) -> tensor<2x4x4x!quant.uniform<i8:f32, 1.000000e-01>>
+  %0 = torch.aten.quantize_per_tensor %arg0, %float1.000000e-01, %zero, %int12 : !torch.vtensor<[2,4,4],f32>, !torch.float, !torch.int, !torch.int -> !torch.vtensor<[2,4,4],!torch.qint8>
+  %1 = torch.aten.int_repr %0 : !torch.vtensor<[2,4,4],!torch.qint8> -> !torch.vtensor<[2,4,4],si8>
+  // CHECK: %[[DEQ:.+]] = stablehlo.uniform_dequantize %[[QUANT]]
+  %2 = torch.aten._make_per_tensor_quantized_tensor %1, %float1.000000e-01, %zero : !torch.vtensor<[2,4,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[2,4,4],!torch.qint8>
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[2,4,4],!torch.qint8> -> !torch.vtensor<[2,4,4],f32>
+  return %3 : !torch.vtensor<[2,4,4],f32>
+}


### PR DESCRIPTION
The following changes have been introduced in the PR

1. Onnx to torch-mlir conversion for per channel quantization/dequantization.
2. Torch-mlir to stablehlo conversion for per tensor quantization/dequantization.
3. Torch-mlir to stablehlo conversion for per channel quantization/dequantization. 