### PR TITLE
Fix warning on parentheses around ‘&&’ within ‘||’

### DIFF
--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -4107,9 +4107,8 @@ OpFoldResult AtenSliceTensorOp::fold(FoldAdaptor adaptor) {
     limit = limit < 0 ? limit + inType.getSizes()[dimInt] : limit;
     limit = limit < 0 ? -1 : limit;
     limit = std::min(limit, inType.getSizes()[dimInt]);
-    assert((stride > 0 && begin < limit) ||
-           (stride < 0 && begin > limit) &&
-               "aten.slice.Tensor iteration args are statically invalid.");
+    assert(((stride > 0 && begin < limit) || (stride < 0 && begin > limit)) &&
+           "aten.slice.Tensor iteration args are statically invalid.");
 
     int64_t inputRank = inType.getSizes().size();
     llvm::SmallVector<int64_t> inputStrides(inputRank, 1);


### PR DESCRIPTION
Fixes the following warning when compiling with gcc 11.4:
```
torch-mlir/lib/Dialect/Torch/IR/TorchOps.cpp:4111:42: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
 4111 |            (stride < 0 && begin > limit) &&
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
 4112 |                "aten.slice.Tensor iteration args are statically invalid.");
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```