### PR TITLE
[docs] Restructure the "Initiate Build" section in development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -189,21 +189,22 @@ former and defaults to `ON` if not changed:
 
 #### Initiate Build
 
-[Configure the build](#configure-for-building) if you haven't already done so. Then, use one of the following commands to build the project:
+1. [Configure the build](#configure-for-building) if you haven't already done so.
+1. Use one of the following commands to build the project:
 
-```shell
-# Build just torch-mlir (not all of LLVM)
-cmake --build build --target tools/torch-mlir/all
+    ```shell
+    # Build just torch-mlir (not all of LLVM)
+    cmake --build build --target tools/torch-mlir/all
 
-# Run unit tests.
-cmake --build build --target check-torch-mlir
+    # Run unit tests.
+    cmake --build build --target check-torch-mlir
 
-# Run Python regression tests.
-cmake --build build --target check-torch-mlir-python
+    # Run Python regression tests.
+    cmake --build build --target check-torch-mlir-python
 
-# Build everything (including LLVM if in-tree)
-cmake --build build
-```
+    # Build everything (including LLVM if in-tree)
+    cmake --build build
+    ```
 
 ### Setup Python Environment to export the built Python packages
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -190,30 +190,32 @@ former and defaults to `ON` if not changed:
 #### Initiate Build
 
 1. [Configure the build](#configure-for-building) if you haven't already done so.
-1. Use one of the following commands to build the project:
-    - Build everything (including LLVM if in-tree)
+1. **If you want to...**
+    - **...build _everything_** (including LLVM if configured as "in-tree"), run:
 
       ```shell
       cmake --build build
       ```
 
-    - Build just torch-mlir (not all of LLVM)
+    - **...build _just_ torch-mlir** (not all of LLVM), run:
 
       ```shell
       cmake --build build --target tools/torch-mlir/all
       ```
 
-    - Run unit tests.
+    - **...run unit tests**, run:
 
       ```shell
       cmake --build build --target check-torch-mlir
       ```
 
-    - Run Python regression tests.
+    - **...run Python regression tests**, run:
 
       ```shell
       cmake --build build --target check-torch-mlir-python
       ```
+
+TIP: add multiple target options to stack build phases
 
 ### Setup Python Environment to export the built Python packages
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -191,26 +191,29 @@ former and defaults to `ON` if not changed:
 
 1. [Configure the build](#configure-for-building) if you haven't already done so.
 1. Use one of the following commands to build the project:
+    - Build just torch-mlir (not all of LLVM)
 
-    ```shell
-    # Build just torch-mlir (not all of LLVM)
-    cmake --build build --target tools/torch-mlir/all
-    ```
+      ```shell
+      cmake --build build --target tools/torch-mlir/all
+      ```
 
-    ```shell
-    # Run unit tests.
-    cmake --build build --target check-torch-mlir
-    ```
+    - Run unit tests.
 
-    ```shell
-    # Run Python regression tests.
-    cmake --build build --target check-torch-mlir-python
-    ```
+      ```shell
+      cmake --build build --target check-torch-mlir
+      ```
 
-    ```shell
-    # Build everything (including LLVM if in-tree)
-    cmake --build build
-    ```
+    - Run Python regression tests.
+
+      ```shell
+      cmake --build build --target check-torch-mlir-python
+      ```
+
+    - Build everything (including LLVM if in-tree)
+
+      ```shell
+      cmake --build build
+      ```
 
 ### Setup Python Environment to export the built Python packages
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -189,7 +189,7 @@ former and defaults to `ON` if not changed:
 
 #### Initiate Build
 
-After either cmake run (in-tree/out-of-tree), use one of the following commands to build the project:
+[Configure the build](#configure-for-building) if you haven't already done so. Then, use one of the following commands to build the project:
 
 ```shell
 # Build just torch-mlir (not all of LLVM)

--- a/docs/development.md
+++ b/docs/development.md
@@ -195,13 +195,19 @@ former and defaults to `ON` if not changed:
     ```shell
     # Build just torch-mlir (not all of LLVM)
     cmake --build build --target tools/torch-mlir/all
+    ```
 
+    ```shell
     # Run unit tests.
     cmake --build build --target check-torch-mlir
+    ```
 
+    ```shell
     # Run Python regression tests.
     cmake --build build --target check-torch-mlir-python
+    ```
 
+    ```shell
     # Build everything (including LLVM if in-tree)
     cmake --build build
     ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -191,6 +191,12 @@ former and defaults to `ON` if not changed:
 
 1. [Configure the build](#configure-for-building) if you haven't already done so.
 1. Use one of the following commands to build the project:
+    - Build everything (including LLVM if in-tree)
+
+      ```shell
+      cmake --build build
+      ```
+
     - Build just torch-mlir (not all of LLVM)
 
       ```shell
@@ -207,12 +213,6 @@ former and defaults to `ON` if not changed:
 
       ```shell
       cmake --build build --target check-torch-mlir-python
-      ```
-
-    - Build everything (including LLVM if in-tree)
-
-      ```shell
-      cmake --build build
       ```
 
 ### Setup Python Environment to export the built Python packages


### PR DESCRIPTION
- include prerequisite
- number the steps
- put "vanilla" command first
- separate fenced code blocks to leverage GitHub's copy button