### PR TITLE
[docs] Refresh cmake section for testing flags

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -173,7 +173,7 @@ cmake -GNinja -Bbuild \
 
 ###### [About MLIR debugging](https://mlir.llvm.org/getting_started/Debugging/)
 
-##### Options to run end-to-end tests
+##### Flags for enabling end-to-end tests
 
 To enable local end-to-end tests, append:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -173,7 +173,7 @@ cmake -GNinja -Bbuild \
 
 ###### [About MLIR debugging](https://mlir.llvm.org/getting_started/Debugging/)
 
-##### Flags for enabling end-to-end tests
+##### (Optional) Flags for enabling end-to-end tests
 
 To enable local end-to-end tests, append:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -178,8 +178,9 @@ cmake -GNinja -Bbuild \
 To enable local end-to-end tests, append:
 
 ```shell
+  \
   -DTORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=ON \
-  -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON \
+  -DTORCH_MLIR_ENABLE_JIT_IR_IMPORTER=ON
 ```
 
 - NOTE: The JIT IR importer depends on the native PyTorch extension features and defaults to `ON` if not changed.


### PR DESCRIPTION
- Adjust wording for optional cmake testing flags
- Make code snippet easier to copy/append to base command