### PR TITLE
[DUPLICATE] Add onnx GridSample support for border padding mode

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -163,9 +163,7 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             rewriter.getIntegerAttr(rewriter.getIntegerType(64), iModeInt));
 
         Value paddingMode = rewriter.create<Torch::ConstantIntOp>(
-            binder.getLoc(), rewriter.getType<Torch::IntType>(),
-            rewriter.getIntegerAttr(rewriter.getIntegerType(64),
-                                    paddingModeInt));
+            binder.getLoc(), paddingModeInt);
 
         bool alignMode = align;
         Value alignCorners = rewriter.create<Torch::ConstantBoolOp>(

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -2588,16 +2588,16 @@ public:
     };
 
     auto lambdaBorder = [&](OpBuilder &b, Location loc, Value x,
-                            Value SizeSubOne) -> Value {
+                            Value sizeSubOne) -> Value {
       Value xMaxZero = b.create<arith::MaximumFOp>(loc, x, zeroFloat);
-      return b.create<arith::MinimumFOp>(loc, xMaxZero, SizeSubOne);
+      return b.create<arith::MinimumFOp>(loc, xMaxZero, sizeSubOne);
     };
 
     auto lambdaPadding = [&](OpBuilder &b, Location loc, int64_t paddingMode,
-                             Value x, Value SizeSubOne) -> Value {
+                             Value x, Value sizeSubOne) -> Value {
       // Border
       if (paddingMode == 1) {
-        return lambdaBorder(b, loc, x, SizeSubOne);
+        return lambdaBorder(b, loc, x, sizeSubOne);
       }
 
       return x;
@@ -2609,7 +2609,10 @@ public:
     Value interMode = adaptor.getInterpolationMode();
 
     int64_t paddingModeInt;
-    matchPattern(op.getPaddingMode(), m_TorchConstantInt(&paddingModeInt));
+    if(!matchPattern(op.getPaddingMode(), m_TorchConstantInt(&paddingModeInt))) {
+      return failure();
+    }
+
 
     SmallVector<Value> dynamicSizes{};
     if (resultType.isDynamicDim(0))

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
@@ -992,6 +992,18 @@ func.func @test_grid_sampler02(%arg0: !torch.vtensor<[5,10,10,4],f32>, %arg1: !t
 
 // -----
 
+// CHECK-LABEL: @test_grid_sampler03
+// CHECK: %[[INT0:.*]] = torch.constant.int 0
+// CHECK: %[[INT1:.*]] = torch.constant.int 1
+// CHECK: %[[B0:.*]] = torch.constant.bool true
+// CHECK: %[[A0:.*]] = torch.aten.grid_sampler %arg0, %arg1, %[[INT0]], %[[INT1]], %[[B0]] : !torch.vtensor<[5,10,10,4],f32>
+func.func @test_grid_sampler03(%arg0: !torch.vtensor<[5,10,10,4],f32>, %arg1: !torch.vtensor<[5,7,8,2],f32>) -> !torch.vtensor<[?,?,?,?],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  %0 = torch.operator "onnx.GridSample" (%arg0, %arg1) {torch.onnx.align_corners = 1 : si64, torch.onnx.padding_mode = "border"} : (!torch.vtensor<[5,10,10,4],f32>, !torch.vtensor<[5,7,8,2],f32>) -> !torch.vtensor<[?,?,?,?],f32>
+  return %0 : !torch.vtensor<[?,?,?,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @test_oldest_pad
 func.func @test_oldest_pad(%arg0: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[5,4],f32> attributes {torch.onnx_meta.opset_version = 1 : si64} {
   // CHECK: %[[int0:.*]] = torch.constant.int 0

--- a/test/Conversion/TorchToLinalg/gridsampler.mlir
+++ b/test/Conversion/TorchToLinalg/gridsampler.mlir
@@ -96,6 +96,18 @@ func.func @grid_sampler3(%arg0: !torch.vtensor<[?,?,?,?],f32>, %arg1: !torch.vte
 // -----
 
 // CHECK-LABEL: func @grid_sampler4
+// CHECK: #map
+// CHECK-DAG: %[[Y49:.*]] = arith.maximumf %[[Y47:.*]], %[[CST0:.*]] : f32
+// CHECK-DAG: %[[Y50:.*]] = arith.minimumf %[[Y49:.*]], %[[Y22:.*]] : f32
+// CHECK-DAG: %[[Y51:.*]] = arith.constant 0 : i64
+// CHECK-DAG: %[[Y52:.*]] = arith.cmpi eq, %[[Y9:.*]], %[[Y51:.*]] : i64
+// CHECK-DAG: %[[Y53:.*]] = arith.select %[[Y52:.*]], %[[Y47:.*]], %[[Y50:.*]] : f32
+// CHECK-DAG: %[[Y54:.*]] = arith.maximumf %[[Y48:.*]], %[[CST0:.*]] : f32
+// CHECK-DAG: %[[Y55:.*]] = arith.minimumf %[[Y54:.*]], %[[Y23:.*]] : f32
+// CHECK-DAG: %[[Y56:.*]] = arith.constant 0 : i64
+// CHECK-DAG: %[[Y52:.*]] = arith.cmpi eq, %[[Y9:.*]], %[[Y51:.*]] : i64
+// CHECK-DAG: linalg.yield %[[Y60:.*]] : f32
+// CHECK: return %[[X12:.*]] : !torch.vtensor<[?,?,?,?],f32>
 func.func @grid_sampler4(%arg0: !torch.vtensor<[?,?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?,?,?,?],f32> {
   %false = torch.constant.bool 1
   %int0 = torch.constant.int 0


### PR DESCRIPTION
Duplicate of #3819, rebasing on latest changes
-------------
Adds support for padding_mode="border"

Clamps the grid coordinates between 0 and size - 1 like this when using this padding mode:

x_result = min(max(0, x), W - 1)
y_result = min(max(0, y), H - 1)
Added Lit tests for both TorchToLinalg and OnnxToTorch lowerings

