### PR TITLE
[tosa][NFC] fix ArrayRef lifetime issue for indexShap

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -4228,6 +4228,8 @@ LogicalResult ConvertAtenOp<AtenIndexSelectOp>::matchAndRewrite(
   auto inputShape = inputType.getShape();
   int inputRank = inputType.getRank();
 
+  // indexShape is reference. storing actual data in SmallVector to avoid
+  // use-after-free
   SmallVector<int64_t> indexShapeTorchCompatible{};
   if (indexType.getRank() == 0) {
     indexShapeTorchCompatible = makeShapeTorchCompatible({1});

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -4219,7 +4219,7 @@ LogicalResult ConvertAtenOp<AtenIndexSelectOp>::matchAndRewrite(
 
   auto index = adaptor.getIndex();
   auto indexType = dyn_cast<RankedTensorType>(index.getType());
-  auto indexShape = indexType.getShape();
+  ArrayRef<int64_t> indexShape = indexType.getShape();
 
   if (!indexType)
     return rewriter.notifyMatchFailure(
@@ -4228,8 +4228,10 @@ LogicalResult ConvertAtenOp<AtenIndexSelectOp>::matchAndRewrite(
   auto inputShape = inputType.getShape();
   int inputRank = inputType.getRank();
 
+  SmallVector<int64_t> indexShapeTorchCompatible{};
   if (indexType.getRank() == 0) {
-    indexShape = makeShapeTorchCompatible({1});
+    indexShapeTorchCompatible = makeShapeTorchCompatible({1});
+    indexShape = indexShapeTorchCompatible;
     index = rewriter.create<tosa::ReshapeOp>(
         op->getLoc(),
         RankedTensorType::get(indexShape, indexType.getElementType()), index,


### PR DESCRIPTION
clang report warning for object lifetime issue
indexShape is ArrayRef and makeShapeTorchCompatible will return
SmallVector. The Vector will be destroyed before using indexShap.
```bash
torch-mlir/lib/Conversion/TorchToTosa/TorchToTosa.cpp:4232:18: warning: object backing the pointer indexShape will be destroyed at the end of the full-expression [-Wdangling-assignment-gsl]
 4232 |     indexShape = makeShapeTorchCompatible({1});
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```