### PR TITLE
Fix torch.operator names

### DIFF
--- a/projects/jit_ir_common/csrc/jit_ir_importer/torch_to_mlir_utils.cpp
+++ b/projects/jit_ir_common/csrc/jit_ir_importer/torch_to_mlir_utils.cpp
@@ -541,5 +541,5 @@ torch_mlir::createOperationFromSchema(MlirBlock appendToBlock, MlirLocation loc,
   return createMlirOperationAtEnd(
       appendToBlock, "torch.operator", loc, resultTypes, operands,
       toMlirNamedAttribute(
-          "name", mlirStringAttrGet(context, toMlirStringRef(opNameSuffix))));
+          "name", mlirStringAttrGet(context, toMlirStringRef(opName))));
 }


### PR DESCRIPTION
This implements the fix suggested by @heshuju in  https://github.com/llvm/torch-mlir/issues/4108.

It fixes an issue that was blocking the LLVM integrate in IREE. https://github.com/iree-org/iree/actions/runs/15626565095/job/44156258415?pr=21092