### PR TITLE
[Torch] Fold `aten.to.dtype` on splat constants.

### DIFF
--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/type_conversion.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/type_conversion.py
@@ -370,3 +370,179 @@ class PrimsConvertElementTypeModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: PrimsConvertElementTypeModule())
 def PrimsConvertElementTypeModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 5))
+
+
+# ==============================================================================
+
+
+class ToDtypeConstIntFromDoubleModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const = torch.tensor([1.1], dtype=torch.float64)
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.ops.aten.to(
+            self.const,
+            dtype=torch.int64,
+        )
+
+
+@register_test_case(module_factory=lambda: ToDtypeConstIntFromDoubleModule())
+def ToDtypeConstIntFromDoubleModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class ToDtypeConstInt32FromInt64Module(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const = torch.tensor([2147483648], dtype=torch.int64)
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.ops.aten.to(
+            self.const,
+            dtype=torch.int32,
+        )
+
+
+@register_test_case(module_factory=lambda: ToDtypeConstInt32FromInt64Module())
+def ToDtypeConstInt32FromInt64Module_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class ToDtypeConstFloat16FromFloat64Module(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const = torch.tensor([1.2345], dtype=torch.float64)
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.ops.aten.to(
+            self.const,
+            dtype=torch.float16,
+        )
+
+
+@register_test_case(module_factory=lambda: ToDtypeConstFloat16FromFloat64Module())
+def ToDtypeConstFloat16FromFloat64Module_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class ToDtypeConstBFloat16FromFloat32Module(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const = torch.tensor([-0.5101], dtype=torch.float32)
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.ops.aten.to(
+            self.const,
+            dtype=torch.float16,
+        )
+
+
+@register_test_case(module_factory=lambda: ToDtypeConstBFloat16FromFloat32Module())
+def ToDtypeConstBFloat16FromFloat32Module_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class ToDtypeConstBoolFromInt32ZeroModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const = torch.tensor([0], dtype=torch.int32)
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.ops.aten.to(
+            self.const,
+            dtype=torch.bool,
+        )
+
+
+@register_test_case(module_factory=lambda: ToDtypeConstBoolFromInt32ZeroModule())
+def ToDtypeConstBoolFromInt32ZeroModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class ToDtypeConstBoolFromInt32NonZeroIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const = torch.tensor([32], dtype=torch.int32)
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.ops.aten.to(
+            self.const,
+            dtype=torch.bool,
+        )
+
+
+@register_test_case(module_factory=lambda: ToDtypeConstBoolFromInt32NonZeroIntModule())
+def ToDtypeConstBoolFromInt32NonZeroIntModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class ToDtypeConstBoolFromFloat32NonZeroNanModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const = torch.tensor([float("nan")], dtype=torch.float32)
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.ops.aten.to(
+            self.const,
+            dtype=torch.bool,
+        )
+
+
+@register_test_case(
+    module_factory=lambda: ToDtypeConstBoolFromFloat32NonZeroNanModule()
+)
+def ToDtypeConstBoolFromFloat32NonZeroNanModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class ToDtypeConstFloat32FromBoolModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const = torch.tensor([True], dtype=torch.bool)
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.ops.aten.to(
+            self.const,
+            dtype=torch.float32,
+        )
+
+
+@register_test_case(module_factory=lambda: ToDtypeConstFloat32FromBoolModule())
+def ToDtypeConstFloat32FromBoolModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class ToDtypeConstInt32FromBoolModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.const = torch.tensor([True], dtype=torch.bool)
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.ops.aten.to(
+            self.const,
+            dtype=torch.int32,
+        )
+
+
+@register_test_case(module_factory=lambda: ToDtypeConstInt32FromBoolModule())
+def ToDtypeConstInt32FromBoolModule_basic(module, tu: TestUtils):
+    module.forward()

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -159,21 +159,15 @@ func.func @torch.aten.fmod_int(%arg0: !torch.vtensor<[?],si32>, %arg1: !torch.vt
 
 // CHECK:   func.func @torch.aten.fmod_float(%[[ARG0:.+]]: !torch.vtensor<[?],f16>, %[[ARG1:.+]]: !torch.vtensor<[1],f16>) -> !torch.vtensor<[?],f16> {
 // CHECK:     %[[FLOAT1:.+]] = torch.constant.float 1.000000e+00
-// CHECK:     %[[V0:.+]] = torch.vtensor.literal(dense<-1> : tensor<si64>) : !torch.vtensor<[],si64>
-// CHECK:     %[[V1:.+]] = torch.vtensor.literal(dense<0> : tensor<si64>) : !torch.vtensor<[],si64>
-// CHECK:     %[[NONE:.+]] = torch.constant.none
-// CHECK:     %[[FALSE:.+]] = torch.constant.bool false
-// CHECK:     %[[INT5:.+]] = torch.constant.int 5
-// CHECK:     %[[V2:.+]] = torch.vtensor.literal(dense<1> : tensor<si64>) : !torch.vtensor<[],si64>
+// CHECK:     %[[V0:.+]] = torch.vtensor.literal(dense<-1.0{{.*}}> : tensor<f16>) : !torch.vtensor<[],f16>
+// CHECK:     %[[V1:.+]] = torch.vtensor.literal(dense<0.0{{.*}}> : tensor<f16>) : !torch.vtensor<[],f16>
+// CHECK:     %[[V2:.+]] = torch.vtensor.literal(dense<1.0{{.*}}> : tensor<f16>) : !torch.vtensor<[],f16>
 // CHECK:     %[[INT0:.+]] = torch.constant.int 0
 // CHECK:     %[[V3:.+]] = torch.aten.div.Tensor %[[ARG0]], %[[ARG1]] : !torch.vtensor<[?],f16>, !torch.vtensor<[1],f16> -> !torch.vtensor<[?],f16>
 // CHECK:     %[[V4:.+]] = torch.aten.gt.Scalar %[[V3]], %[[INT0]] : !torch.vtensor<[?],f16>, !torch.int -> !torch.vtensor<[?],i1>
 // CHECK:     %[[V5:.+]] = torch.aten.lt.Scalar %[[V3]], %[[INT0]] : !torch.vtensor<[?],f16>, !torch.int -> !torch.vtensor<[?],i1>
-// CHECK:     %[[V6:.+]] = torch.aten.to.dtype %[[V2]], %[[INT5]], %[[FALSE]], %[[FALSE]], %[[NONE]] : !torch.vtensor<[],si64>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[],f16>
-// CHECK:     %[[V7:.+]] = torch.aten.to.dtype %[[V1]], %[[INT5]], %[[FALSE]], %[[FALSE]], %[[NONE]] : !torch.vtensor<[],si64>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[],f16>
-// CHECK:     %[[V8:.+]] = torch.aten.where.self %[[V4]], %[[V6]], %[[V7]] : !torch.vtensor<[?],i1>, !torch.vtensor<[],f16>, !torch.vtensor<[],f16> -> !torch.vtensor<[?],f16>
-// CHECK:     %[[V9:.+]] = torch.aten.to.dtype %[[V0]], %[[INT5]], %[[FALSE]], %[[FALSE]], %[[NONE]] : !torch.vtensor<[],si64>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[],f16>
-// CHECK:     %[[V10:.+]] = torch.aten.where.self %[[V5]], %[[V9]], %[[V8]] : !torch.vtensor<[?],i1>, !torch.vtensor<[],f16>, !torch.vtensor<[?],f16> -> !torch.vtensor<[?],f16>
+// CHECK:     %[[V8:.+]] = torch.aten.where.self %[[V4]], %[[V2]], %[[V1]] : !torch.vtensor<[?],i1>, !torch.vtensor<[],f16>, !torch.vtensor<[],f16> -> !torch.vtensor<[?],f16>
+// CHECK:     %[[V10:.+]] = torch.aten.where.self %[[V5]], %[[V0]], %[[V8]] : !torch.vtensor<[?],i1>, !torch.vtensor<[],f16>, !torch.vtensor<[?],f16> -> !torch.vtensor<[?],f16>
 // CHECK:     %[[V11:.+]] = torch.aten.abs %[[V3]] : !torch.vtensor<[?],f16> -> !torch.vtensor<[?],f16>
 // CHECK:     %[[V12:.+]] = torch.aten.floor %[[V11]] : !torch.vtensor<[?],f16> -> !torch.vtensor<[?],f16>
 // CHECK:     %[[V13:.+]] = torch.aten.mul.Tensor %[[V10]], %[[V12]] : !torch.vtensor<[?],f16>, !torch.vtensor<[?],f16> -> !torch.vtensor<[?],f16>


### PR DESCRIPTION
This commit teaches `AtenToDtypeOp::fold` to constant-fold dtype conversions when the operand is a splat `DenseElementsAttr`.

Folding is done according to torch's rounding behavior, i.e.
  * Bool: 0 and -0.0 → false; nonzero/NaN/±Inf → true.
  * Float → Int: round toward zero.
  * Int → Float: sign-aware, rmNearestTiesToEven.
  * Float ↔ Float: use builtin `mlir::FloatType::getFloatSemantics()`.
  * Int ↔ Int: use `zextOrTrunc` / `sextOrTrunc` based on source signedness.

Folding is only performed when `non_blocking == false`, `copy == false`, and `memory_format` is None.