### PR TITLE
Workaround for ConversionPatternRewriter::eraseOp issue

### DIFF
--- a/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
+++ b/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
@@ -253,8 +253,7 @@ void TorchMatchSpecializedBackendOp::populateSpecializedConversions(
           auto newOp = rewriter.create<Torch::AtenScaledDotProductAttentionOp>(
               op.getLoc(), op->getResultTypes()[0], newOperands,
               op->getAttrs());
-          rewriter.replaceAllUsesWith(op.getResult(0), newOp.getResult());
-          rewriter.eraseOp(op);
+          rewriter.replaceOp(op, {newOp.getResult(), nullptr});
           return success();
         }
         return failure();


### PR DESCRIPTION
Using `ConversionPatternRewriter::replaceAllUsesWith` + `ConversionPatternRewriter::eraseOp` is not supported at the moment, and will fail an assert after integrating https://github.com/llvm/llvm-project/commit/2929a2978cc3bdb0ff12a0e5d0a9236ff221f668.

The workaround is to use `replaceOp` instead, see: https://github.com/llvm/llvm-project/pull/155244#issuecomment-3272023121