### PR TITLE
[TorchToStableHLO] Fix unsigned integer conversion in ValueTensorLiteralOp.

### DIFF
--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1771,6 +1771,8 @@ FX_IMPORTER_TOSA_CRASHING_SET = {
     #     raise TimeoutError(self.error_message)
     # TimeoutError: Timeout
     "BertModule_basic",
+    "UInt8Tensor_basic",
+    "BoolTensor_basic",
 }
 
 # Write the TOSA set as a "passing" set as it is very early in development

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/constant_alloc.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/constant_alloc.py
@@ -2102,3 +2102,46 @@ class AtenDiagEmbedNonDefault4DDiag(torch.nn.Module):
     @register_test_case(module_factory=lambda: AtenDiagEmbedNonDefault4DDiag())
     def AtenDiagEmbedNonDefault4DDiag_basic(module, tu: TestUtils):
         module.forward(tu.rand(2, 3, 4, 5))
+
+
+# ==============================================================================
+
+
+class UInt8Tensor(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+        ]
+    )
+    def forward(self):
+        x = torch.tensor([128], dtype=torch.uint8)
+        return torch.ops.aten.to(x, dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: UInt8Tensor())
+def UInt8Tensor_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class BoolTensor(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+        ]
+    )
+    def forward(self):
+        x = torch.tensor([True], dtype=torch.bool)
+        return torch.ops.aten.to(x, dtype=torch.float32)
+
+
+@register_test_case(module_factory=lambda: BoolTensor())
+def BoolTensor_basic(module, tu: TestUtils):
+    module.forward()


### PR DESCRIPTION
Previously, all integer values were sign-extended when converting tensors, which corrupted unsigned integer values. This commit fixes the conversion to zero-extend unsigned integers and sign-extend signed integers.