### PR TITLE
[CI] : Copy llvm python requirements.txt to bazel workdir.

### DIFF
--- a/utils/bazel/docker/Dockerfile
+++ b/utils/bazel/docker/Dockerfile
@@ -32,6 +32,7 @@ COPY build-requirements.txt /opt/app/build-requirements.txt
 COPY test-requirements.txt  /opt/app/test-requirements.txt
 COPY torchvision-requirements.txt  /opt/app/torchvision-requirements.txt
 COPY pytorch-requirements.txt /opt/app/pytorch-requirements.txt
+COPY externals/llvm-project/mlir/python/requirements.txt /opt/app/externals/llvm-project/mlir/python/requirements.txt
 WORKDIR /opt/app
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install --upgrade --ignore-installed -r requirements.txt


### PR DESCRIPTION
This only fixes the failure in https://github.com/llvm/torch-mlir/actions/runs/17864459407/job/50803266616#step:6:1273, however, `bazel` builds have been failing for a long time due to https://github.com/llvm/torch-mlir/actions/runs/17758450172/job/50465645001#step:8:2688. 