### PR TITLE
docs: Fix incorrect python package path in development.md

### DIFF
--- a/build_tools/write_env_file.sh
+++ b/build_tools/write_env_file.sh
@@ -13,7 +13,7 @@ portable_realpath() {
 
 td="$(portable_realpath "$(dirname "$0")"/..)"
 build_dir="$(portable_realpath "${TORCH_MLIR_BUILD_DIR:-$td/build}")"
-python_packages_dir="$build_dir/tools/torch-mlir/python_packages"
+python_packages_dir="$build_dir/python_packages"
 
 write_env_file() {
   echo "Updating $build_dir/.env file"

--- a/docs/development.md
+++ b/docs/development.md
@@ -197,7 +197,7 @@ TIP: add multiple target options to stack build phases
 #### Linux and macOS
 
 ```shell
-export PYTHONPATH=`pwd`/build/tools/torch-mlir/python_packages/torch_mlir:`pwd`/test/python/fx_importer
+export PYTHONPATH=`pwd`/build/python_packages/torch_mlir:`pwd`/test/python/fx_importer
 ```
 
 #### Windows PowerShell


### PR DESCRIPTION
The documentation for setting the PYTHONPATH in development.md points to an incorrect directory. The python package is now located at `build/python_packages/torch-mlir` instead of `build/tools/torch-mlir/python_packages/torch_mlir`.

This commit corrects the path to help new users correctly set up their environment.