### PR TITLE
fix: infer output shape directly in ConvertAtenUnflattenIntOp

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -187,7 +187,7 @@ sudo apt install clang ccache lld
     - **...run Python regression tests**, run:
 
       ```shell
-      cmake --build build --target check-torch-mlir-python
+      cmake --build build --target check-torch_mlir-python
       ```
 
 TIP: add multiple target options to stack build phases

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -720,7 +720,6 @@ public:
           reassociations[i - numSizes + 1].push_back(i);
       }
 
-      // Is there a function that already does this somewhere?
       auto sizeToOFR = [&](Value sizeVal) -> OpFoldResult {
         int64_t constantSize;
         if (matchPattern(sizeVal, m_TorchConstantInt(&constantSize))) {
@@ -742,7 +741,6 @@ public:
 
       for (int64_t j = 0, e = reassocSizes.size(); j < e; ++j) {
         int64_t constantSize;
-        // mlir::Value to int comparison...
         if (matchPattern(reassocSizes[j], m_TorchConstantInt(&constantSize)) &&
             constantSize == -1) {
           minusOneIdx = j;
@@ -782,21 +780,6 @@ public:
         }
       }
 
-      // Originally I was doing:
-      // expand = tensor::ExpandShapeOp::create(rewriter, loc, expandTy,
-      // adaptor.getSelf(), reassociations, outputShape).getResult(); But with
-      // that I was running into: error: 'tensor.expand_shape' op expected
-      // dimension 0 of collapsed type to be dynamic since one or more of the
-      // corresponding dimensions in the expanded type is dynamic %4491 =
-      // torch.aten.as_strided %4488, %4489, %4490, %int0_462 :
-      // !torch.vtensor<[2,4096,5120],f16>, !torch.list<int>, !torch.list<int>,
-      // !torch.int -> !torch.vtensor<[2,4096,2560],f16>
-      // /home/rdhar/expand-shape-bug/iree/iree-model-benchmark/sdxl/int8-model/base_ir/stable_diffusion_xl_base_1_0_scheduled_unet_bs1_64_1024x1024_i8.mlir:13071:13:
-      // note: see current operation: %17734 = "tensor.expand_shape"(%17730)
-      // <{reassociation = [[0, 1, 2]], static_output_shape = array<i64: 2, 1,
-      // 1>}> : (tensor<2xi64>) -> tensor<?x1x1xi64> So there is this really
-      // ugly code to handle the types... but it kind of defeats all the code
-      // above.
       SmallVector<int64_t> resultShape =
           decomposeMixedValues(outputShape).first;
       auto resultType =

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/reshape_like.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/reshape_like.py
@@ -1281,6 +1281,46 @@ def UnflattenIntNegativeOneSizeStaticModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(5, 12, 3))
 
 
+class UnflattenIntDynamicModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, 12], torch.float32, True),
+        ]
+    )
+    def forward(self, inputs):
+        return torch.ops.aten.unflatten(inputs, 1, [3, 4])
+
+
+@register_test_case(module_factory=lambda: UnflattenIntDynamicModule())
+def UnflattenIntDynamicModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 12))
+
+
+class UnflattenIntDynamicWithInferredSizeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, 20], torch.float32, True),
+        ]
+    )
+    def forward(self, inputs):
+        return torch.ops.aten.unflatten(inputs, 1, [4, -1])
+
+
+@register_test_case(module_factory=lambda: UnflattenIntDynamicWithInferredSizeModule())
+def UnflattenIntDynamicWithInferredSizeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 20))
+
+
 # ==============================================================================
 
 

--- a/test/Conversion/TorchToLinalg/unflatten.mlir
+++ b/test/Conversion/TorchToLinalg/unflatten.mlir
@@ -57,3 +57,18 @@ func.func @torch.aten.unflatten.int$dynamic_input(%arg0: !torch.vtensor<[?,6],f3
   %1 = torch.aten.unflatten.int %arg0, %int1, %0 : !torch.vtensor<[?,6],f32>, !torch.int, !torch.list<int> -> !torch.vtensor<[?,2,3],f32>
   return %1 : !torch.vtensor<[?,2,3],f32>
 }
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten.unflatten.int$two_dynamic_dims
+// CHECK:           torch_c.to_builtin_tensor
+// CHECK:           tensor.from_elements
+// CHECK:           tensor.reshape
+// CHECK:           torch_c.from_builtin_tensor
+func.func @torch.aten.unflatten.int$two_dynamic_dims(%arg0: !torch.vtensor<[?,12],f32>) -> !torch.vtensor<[?,?,?],f32> {
+  %int1 = torch.constant.int 1
+  %2 = torch.aten.size.int %arg0, %int1 : !torch.vtensor<[?,12],f32>, !torch.int -> !torch.int
+  %0 = torch.prim.ListConstruct %2, %2 : (!torch.int, !torch.int) -> !torch.list<int>
+  %1 = torch.aten.unflatten.int %arg0, %int1, %0 : !torch.vtensor<[?,12],f32>, !torch.int, !torch.list<int> -> !torch.vtensor<[?,?,?],f32>
+  return %1 : !torch.vtensor<[?,?,?],f32>
+}

--- a/test/Conversion/TorchToLinalg/unflatten.mlir
+++ b/test/Conversion/TorchToLinalg/unflatten.mlir
@@ -1,0 +1,59 @@
+// RUN: torch-mlir-opt <%s -convert-torch-to-linalg -split-input-file -verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL:   func.func @torch.aten.unflatten.int$static
+// CHECK:           torch_c.to_builtin_tensor
+// CHECK:           tensor.expand_shape
+// CHECK:           torch_c.from_builtin_tensor
+func.func @torch.aten.unflatten.int$static(%arg0: !torch.vtensor<[2,6,4],f32>) -> !torch.vtensor<[2,2,3,4],f32> {
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %0 = torch.prim.ListConstruct %int2, %int3 : (!torch.int, !torch.int) -> !torch.list<int>
+  %1 = torch.aten.unflatten.int %arg0, %int1, %0 : !torch.vtensor<[2,6,4],f32>, !torch.int, !torch.list<int> -> !torch.vtensor<[2,2,3,4],f32>
+  return %1 : !torch.vtensor<[2,2,3,4],f32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten.unflatten.int$negative_dim
+// CHECK:           torch_c.to_builtin_tensor
+// CHECK:           tensor.expand_shape
+// CHECK:           torch_c.from_builtin_tensor
+func.func @torch.aten.unflatten.int$negative_dim(%arg0: !torch.vtensor<[2,6,4],f32>) -> !torch.vtensor<[2,2,3,4],f32> {
+  %int-2 = torch.constant.int -2
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %0 = torch.prim.ListConstruct %int2, %int3 : (!torch.int, !torch.int) -> !torch.list<int>
+  %1 = torch.aten.unflatten.int %arg0, %int-2, %0 : !torch.vtensor<[2,6,4],f32>, !torch.int, !torch.list<int> -> !torch.vtensor<[2,2,3,4],f32>
+  return %1 : !torch.vtensor<[2,2,3,4],f32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten.unflatten.int$inferred_size
+// CHECK:           torch_c.to_builtin_tensor
+// CHECK:           tensor.expand_shape
+// CHECK:           torch_c.from_builtin_tensor
+func.func @torch.aten.unflatten.int$inferred_size(%arg0: !torch.vtensor<[3,12],f32>) -> !torch.vtensor<[3,2,6],f32> {
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int-1 = torch.constant.int -1
+  %0 = torch.prim.ListConstruct %int2, %int-1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %1 = torch.aten.unflatten.int %arg0, %int1, %0 : !torch.vtensor<[3,12],f32>, !torch.int, !torch.list<int> -> !torch.vtensor<[3,2,6],f32>
+  return %1 : !torch.vtensor<[3,2,6],f32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten.unflatten.int$dynamic_input
+// CHECK:           torch_c.to_builtin_tensor
+// CHECK:           tensor.expand_shape
+// CHECK:           torch_c.from_builtin_tensor
+func.func @torch.aten.unflatten.int$dynamic_input(%arg0: !torch.vtensor<[?,6],f32>) -> !torch.vtensor<[?,2,3],f32> {
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %0 = torch.prim.ListConstruct %int2, %int3 : (!torch.int, !torch.int) -> !torch.list<int>
+  %1 = torch.aten.unflatten.int %arg0, %int1, %0 : !torch.vtensor<[?,6],f32>, !torch.int, !torch.list<int> -> !torch.vtensor<[?,2,3],f32>
+  return %1 : !torch.vtensor<[?,2,3],f32>
+}


### PR DESCRIPTION
We are facing an error that is related to a specific unflatten case - when we have dimensions that need to be inferred, we cannot handle them at the moment. For example, input shape [128] and sizes [1, 1, 1, -1], the -1 is to infer the dimension in that slot, and we expect to get [1, 1, 1, 128]. We calculate this directly and use this to build our `ExpandShapeOp`.

Some more discussion:
- https://github.com/iree-org/iree/issues/22022#issuecomment-3330199043
- https://github.com/llvm/torch-mlir/issues/4315 and this issue is related to https://github.com/llvm/torch-mlir/pull/4269