### PR TITLE
Add verifier for AtenMatmul to check that 1D x 1D outputs a scaler

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -6670,6 +6670,7 @@ def Torch_AtenMatmulOp : Torch_Op<"aten.matmul", [
       printDefaultTorchOp(printer, *this, 2, 1);
     }
   }];
+  let hasVerifier = 1;
 }
 
 def Torch_AtenMvOp : Torch_Op<"aten.mv", [

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -5294,6 +5294,29 @@ LogicalResult ShapeCalculateYieldShapesOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// AtenMatmulOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult AtenMatmulOp::verify() {
+
+  auto lhsType = cast<BaseTensorType>(getSelf().getType());
+  auto rhsType = cast<BaseTensorType>(getOther().getType());
+  auto resultType = cast<BaseTensorType>(getResult().getType());
+
+  if (lhsType.hasSizes() && rhsType.hasSizes() && resultType.hasSizes()) {
+    // Get the rank
+    auto lhsRank = lhsType.getSizes().size();
+    auto rhsRank = rhsType.getSizes().size();
+    auto resultRank = resultType.getSizes().size(); 
+
+    if (lhsRank == 1 && rhsRank == 1 && resultRank != 0) {
+      return emitOpError("1D x 1D matmul should produce a scalar (rank 0)");   
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // AtenNormScalarOp
 //===----------------------------------------------------------------------===//
 

--- a/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
+++ b/projects/pt1/python/torch_mlir/jit_ir_importer/build_tools/torch_ods_gen.py
@@ -575,7 +575,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::mm : (Tensor, Tensor) -> (Tensor)")
     emit("aten::_int_mm : (Tensor, Tensor) -> (Tensor)")
     emit("aten::addmm : (Tensor, Tensor, Tensor, Scalar, Scalar) -> (Tensor)")
-    emit("aten::matmul : (Tensor, Tensor) -> (Tensor)")
+    emit("aten::matmul : (Tensor, Tensor) -> (Tensor)", has_verifier=True)
     emit("aten::mv : (Tensor, Tensor) -> (Tensor)")
     emit("aten::dot : (Tensor, Tensor) -> (Tensor)", has_canonicalizer=True)
     emit("aten::outer : (Tensor, Tensor) -> (Tensor)")

--- a/test/Dialect/Torch/invalid.mlir
+++ b/test/Dialect/Torch/invalid.mlir
@@ -403,3 +403,13 @@ func.func @torch.symbolic_int$no_shape_symbols(%arg0: !torch.vtensor<[?],f32>) -
   torch.bind_symbolic_shape %arg0, [%int0], affine_map<()[s0] -> (s0)> : !torch.vtensor<[?],f32>
   return %arg0 : !torch.vtensor<[?],f32>
 }
+
+// -----
+
+func.func @torch.matmul$1d_1d_result_not_scalar(%arg0: !torch.vtensor<[4],f32>, %arg1: !torch.vtensor<[4],f32>) 
+    -> !torch.vtensor<[1],f32> {
+  // expected-error @+1 {{1D x 1D matmul should produce a scalar (rank 0)}}
+  %0 = torch.aten.matmul %arg0, %arg1 
+      : !torch.vtensor<[4],f32>, !torch.vtensor<[4],f32> -> !torch.vtensor<[1],f32>
+  return %0 : !torch.vtensor<[1],f32>
+}


### PR DESCRIPTION
I'm adding a rank verifier for the AtenMatmul operation. The goal is to catch rank mismatches earlier in the pipeline.

#### Problem
Currently, invalid result rank error only show up during the lowering stage (e.g., when running `--convert-torch-to-linalg`) and the error (`torch.cast` error shown below) doesn't clearly point to the root cause.

#### Solution: Catching Errors Earlier
Adding a verifier to report a clear, specific error directly on the AtenMatmul op itself, before lowering even starts.

#### Case: 1D x 1D 
A critical check is for 1D × 1D Matmul. The [Pytorch Matmul doc](https://docs.pytorch.org/docs/stable/generated/torch.matmul.html) is clear that this 1D x 1D must output a scalar (rank 0). The verifier ensures this rank is correct.

#### Before and After
If we feed an invalid MLIR like this:
```
func.func @invalid_matmul_1d_1d(%arg0: !torch.vtensor<[4],f32>, %arg1: !torch.vtensor<[4],f32>) -> !torch.vtensor<[1],f32> {
  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[4],f32>, !torch.vtensor<[4],f32> -> !torch.vtensor<[1],f32>
  return %0 : !torch.vtensor<[1],f32>
}
```

**Before**: 
Run `torch-mlir-opt inpu.mlir --convert-torch-to-linalg`
Note: Error only shown during lowering.
- Error: 'tensor.cast' op operand type 'tensor<f32>' and result type 'tensor<1xf32>' are cast incompatible.

**After**: 
Run `ninja check-torch-mlir`
Note: Error shown when verifing IR 
- Verifier-reported error: "1D x 1D matmul should produce a scalar (rank 0)".

