### PR TITLE
fix: unknown target 'check-torch-mlir-python'

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,6 @@ add_lit_testsuite(check-torch-mlir "Running the torch-mlir regression tests"
         )
 set_target_properties(check-torch-mlir PROPERTIES FOLDER "Tests")
 
-add_lit_testsuites(TORCH_MLIR ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TORCH_MLIR_TEST_DEPENDS})
+add_lit_testsuites(TORCH-MLIR ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TORCH_MLIR_TEST_DEPENDS})
 
 add_subdirectory(CAPI)


### PR DESCRIPTION
When looking through `development.md`, running `cmake --build build --target check-torch-mlir-python` like instructed gives the error
```
ninja: error: unknown target 'check-torch-mlir-python', did you mean 'check-torch_mlir-python'?
```
One option is of course to change the docs, but the underscore seems inconsistent with the other targets, i.e. `cmake --build build --target check-torch-mlir` works just fine.
Another note is that in `projects/pt1/python/test/CMakeLists.txt`, there actually is this target defined with the hyphen:
```
add_lit_testsuite(check-torch-mlir-python "Running the torch-mlir Python regression tests"
  ${CMAKE_CURRENT_BINARY_DIR}
  DEPENDS ${TEST_DEPENDS}
  )
set_target_properties(check-torch-mlir-python PROPERTIES FOLDER "Tests")
```
So it seems that somehow it is being overriden - making the one line change like I do here in the project name parameter seems to resolve this. But I'm not sure if that's the best solution. Looking for a review and some feedback here on the right approach to fix this.