### PR TITLE
[TOSA] Handle strided AtenSlice lowering

### DIFF
--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3930,8 +3930,6 @@ FX_IMPORTER_TOSA_XFAIL_SET = {
     "SliceCopyStartGreaterThanDimSize_Module_basic",
     "SliceEndSleStartModule_basic",
     "SliceOutOfLowerBoundEndIndexModule_basic",
-    "SliceOutOfLowerBoundStartIndexModule_basic",
-    "SliceSizeTwoStepModule_basic",
     "SortIntListReverse_basic",
     "SortIntList_basic",
     "SortTensorDescending_basic",


### PR DESCRIPTION
Lower step-greater-than-one slices by reshaping to an NxKxC view, gathering rows, then restoring the original shape.