### PR TITLE
Bump the manylinux image used by build_linux_packages.sh

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -41,7 +41,7 @@ repo_root="$(cd "$this_dir"/../../ && pwd)"
 arch="$(uname -m)"
 echo "Running on Arch: ${arch}"
 # This needs to be a manylinux image so we can ship pip packages
-TM_RELEASE_DOCKER_IMAGE="${TM_RELEASE_DOCKER_IMAGE:-quay.io/pypa/manylinux2014_${arch}}"
+TM_RELEASE_DOCKER_IMAGE="${TM_RELEASE_DOCKER_IMAGE:-quay.io/pypa/manylinux_2_28_${arch}}"
 # This assumes an Ubuntu LTS like image. You can build your own with
 # ./build_tools/docker/Dockerfile
 TM_CI_DOCKER_IMAGE="${TM_CI_DOCKER_IMAGE:-powderluv/torch-mlir-ci:latest}"


### PR DESCRIPTION
Our current manylinux image ships GCC 10, which has recently started
failing to compile torch-mlir, see failing CI job:
  * https://github.com/llvm/torch-mlir-release/actions/runs/19329445043/job/55288631613).

While there may be narrower fixes, the image we use is also quite dated,
so updating it is a reasonable path.
