### PR TITLE
[CI] : Pin back ninja to older version on windows.

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -2,7 +2,8 @@
 wheel
 setuptools
 cmake
-ninja
+ninja<1.13.0; sys_platform == 'win32'
+ninja; sys_platform != 'win32'
 packaging
 
 # Workaround for what should be a torch dep


### PR DESCRIPTION
Windows build is failing https://github.com/llvm/torch-mlir/actions/runs/19180245913/job/54834980057#step:8:6030

```
LINK: command "C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\TorchMLIRAggregateCAPI.rsp /out:tools\torch-mlir\python_packages\torch_mlir\torch_mlir\_mlir_libs\TorchMLIRAggregateCAPI.dll /implib:tools\torch-mlir\python_packages\torch_mlir\torch_mlir\_mlir_libs\TorchMLIRAggregateCAPI.lib /pdb:tools\torch-mlir\python_packages\torch_mlir\torch_mlir\_mlir_libs\TorchMLIRAggregateCAPI.pdb /dll /version:0.0 /machine:x64 /INCREMENTAL:NO /DEF:tools\torch-mlir\python\CMakeFiles\TorchMLIRAggregateCAPI.dir\.\exports.def /MANIFEST:EMBED,ID=2" failed (exit code 1181) with the following output:
  LINK : fatal error LNK1181: cannot open input file 'LIRAggregateCAPI.dir\D_\a\torch-mlir\torch-mlir\externals\llvm-project\llvm\resources\windows_version_resource.rc.res'
```
   
due to the ninja issue mentioned in https://github.com/ninja-build/ninja/issues/2616

Pinning back to older ninja version on windows.