### PR TITLE
[TOSA] Fix conv2d.padding decomposition to emit 2D padding for aten.convolution

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -2380,8 +2380,12 @@ LogicalResult ConvertAtenOp<AtenConvolutionOp>::matchAndRewrite(
   // padding {height, width}. The PyTorch OFM computation uses 2*pad in each
   // spatial direction, implying the same top=bottom=height and left=right=width
   // values for TOSA.
-  SmallVector<int64_t> padding(
-      {padding_2d[0], padding_2d[0], padding_2d[1], padding_2d[1]});
+
+  int64_t padH = padding_2d[0];
+  // When padding is 'Valid', Torch produces 1D padding with only one value.
+  int64_t padW = (padding_2d.size() > 1) ? padding_2d[1] : padding_2d[0];
+
+  SmallVector<int64_t> padding({padH, padH, padW, padW});
 
   SmallVector<int64_t, 2> dilation;
   if (!matchPattern(adaptor.getDilation(), m_TorchListOfConstantInts(dilation)))


### PR DESCRIPTION
`torch.nn.Conv2d` with `padding = 'valid'` generates a `torch.ops.aten.conv2d.padding` op in ExportedProgram, which is later decomposed to  `torch.ops.aten.convolution.default` with a single padding value of `[0]` after running `ep.run_decompositions()`.

This causes a compiler failure in `torch-to-tosa` because the code expects padding to have two elements.

Here is the print of the `ExportedProgram`

```
>>> print(prog)
ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, p_0_weight: "f32[1, 1, 1, 1]", p_0_bias: "f32[1]", input: "f32[1, 1, 5, 5]"):
            input_1 = input             
            conv2d: "f32[1, 1, 5, 5]" = torch.ops.aten.conv2d.padding(input_1, p_0_weight, p_0_bias);  input_1 = p_0_weight = p_0_bias = None
            return (conv2d,)
```
```            
>>> prog_decomposed = prog.run_decompositions()
>>> print(prog_decomposed)
ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, p_0_weight: "f32[1, 1, 1, 1]", p_0_bias: "f32[1]", input: "f32[1, 1, 5, 5]"):
            input_1 = input
            convolution: "f32[1, 1, 5, 5]" = torch.ops.aten.convolution.default(input_1, p_0_weight, p_0_bias, [1, 1], [0], [1, 1], False, [0], 1);  input_1 = p_0_weight = p_0_bias = None
            return (convolution,)
```            
 
Note: A previous, correct decomposition for a similar issue exists and is locked down by e2e tests (refer to relevant context like #3883). This fix aligns the conv2d.padding decomposition with that correct behavior.

Since locking this specific decomposition down with end-to-end (e2e) tests was problematic, a dedicated LIT test has been added to the test suite to ensure this specific padding regression cannot reoccur.
 