### PR TITLE
[Torch] Enable dtype inference for operations with list-type operands

### DIFF
--- a/lib/Dialect/Torch/Transforms/SimplifyAbstractInterpCalculationsUtils.cpp
+++ b/lib/Dialect/Torch/Transforms/SimplifyAbstractInterpCalculationsUtils.cpp
@@ -39,12 +39,14 @@ public:
                                 PatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     MLIRContext *context = op->getContext();
-    // Only unroll loops if they are contained in a shape calculate region.
+    // Only unroll loops if they are contained in a shape or dtype calculate
+    // regions.
     Region *region = op->getParentRegion();
     Operation *parentOp = region->getParentOp();
-    if (!parentOp || !isa<Torch::ShapeCalculateOp>(parentOp))
+    if (!parentOp ||
+        !isa<Torch::ShapeCalculateOp, Torch::DtypeCalculateOp>(parentOp))
       return rewriter.notifyMatchFailure(
-          op, "Loop is not contained in a shape calculation region.");
+          op, "Loop is not contained in a shape or dtype calculation regions.");
     if (!op.isForLike())
       return rewriter.notifyMatchFailure(op, "Loop is not for-like");
     int64_t maxTripCount;


### PR DESCRIPTION
The type inference task consists of two subtasks: shape inference and dtype inference. For operations such as `torch.aten.cat`, shape inference works correctly, but dtype inference fails. This commit fixes that issue.

Enable loop unrolling within `DtypeCalculateOp` regions to support dtype inference for operations with list-type operands, such as `torch.aten.cat`. This commit extends `FullyUnrollPrimLoop` pattern to also unroll loops contained in `DtypeCalculateOp` regions, enabling the simplification pass to promote dtype information through operations like torch.aten.cat.