### PR TITLE
Update torch versions in requirement files

### DIFF
--- a/pytorch-requirements.txt
+++ b/pytorch-requirements.txt
@@ -1,3 +1,3 @@
 -f https://download.pytorch.org/whl/nightly/cpu/torch/
 --pre
-torch==2.10.0.dev20251016
+torch==2.10.0.dev20251213

--- a/torchvision-requirements.txt
+++ b/torchvision-requirements.txt
@@ -1,3 +1,3 @@
 -f https://download.pytorch.org/whl/nightly/cpu/torchvision/
 --pre
-torchvision==0.25.0.dev20251016
+torchvision==0.25.0.dev20251213


### PR DESCRIPTION
The existing torch versions pinned in top-level requirement files are no longer available.
This patch updates them to a relatively recent release of torch.