### PR TITLE
[TorchToTMTensor] Accept 1/sqrt(headDim) scale for SDPA

### DIFF
--- a/test/Conversion/TorchToTMTensor/basic.mlir
+++ b/test/Conversion/TorchToTMTensor/basic.mlir
@@ -2,6 +2,91 @@
 
 // -----
 
+// CHECK-LABEL: @sdpa_scale_none
+// CHECK: tm_tensor.attention
+func.func @sdpa_scale_none(%query: !torch.vtensor<[1,4,8,64],f32>, %key: !torch.vtensor<[1,4,8,64],f32>, %value: !torch.vtensor<[1,4,8,64],f32>) -> !torch.vtensor<[1,4,8,64],f32> {
+  %float0 = torch.constant.float 0.000000e+00
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  %0 = torch.aten.scaled_dot_product_attention %query, %key, %value, %none, %float0, %false, %none, %false : !torch.vtensor<[1,4,8,64],f32>, !torch.vtensor<[1,4,8,64],f32>, !torch.vtensor<[1,4,8,64],f32>, !torch.none, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[1,4,8,64],f32>
+  return %0 : !torch.vtensor<[1,4,8,64],f32>
+}
+
+// -----
+
+// Test scale = 1/sqrt(64) = 0.125 which is the default PyTorch scale for headDim=64
+// CHECK-LABEL: @sdpa_scale_rsqrt_head_dim
+// CHECK: tm_tensor.attention
+func.func @sdpa_scale_rsqrt_head_dim(%query: !torch.vtensor<[1,4,8,64],f32>, %key: !torch.vtensor<[1,4,8,64],f32>, %value: !torch.vtensor<[1,4,8,64],f32>) -> !torch.vtensor<[1,4,8,64],f32> {
+  %float0 = torch.constant.float 0.000000e+00
+  // 1/sqrt(64) = 1/8 = 0.125
+  %scale = torch.constant.float 1.250000e-01
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  %0 = torch.aten.scaled_dot_product_attention %query, %key, %value, %none, %float0, %false, %scale, %false : !torch.vtensor<[1,4,8,64],f32>, !torch.vtensor<[1,4,8,64],f32>, !torch.vtensor<[1,4,8,64],f32>, !torch.none, !torch.float, !torch.bool, !torch.float, !torch.bool -> !torch.vtensor<[1,4,8,64],f32>
+  return %0 : !torch.vtensor<[1,4,8,64],f32>
+}
+
+// -----
+
+// Test scale = 1/sqrt(128) ≈ 0.0883883 for headDim=128
+// CHECK-LABEL: @sdpa_scale_rsqrt_head_dim_128
+// CHECK: tm_tensor.attention
+func.func @sdpa_scale_rsqrt_head_dim_128(%query: !torch.vtensor<[1,4,8,128],f32>, %key: !torch.vtensor<[1,4,8,128],f32>, %value: !torch.vtensor<[1,4,8,128],f32>) -> !torch.vtensor<[1,4,8,128],f32> {
+  %float0 = torch.constant.float 0.000000e+00
+  // 1/sqrt(128) ≈ 0.0883883476483184
+  %scale = torch.constant.float 0.0883883476483184
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  %0 = torch.aten.scaled_dot_product_attention %query, %key, %value, %none, %float0, %false, %scale, %false : !torch.vtensor<[1,4,8,128],f32>, !torch.vtensor<[1,4,8,128],f32>, !torch.vtensor<[1,4,8,128],f32>, !torch.none, !torch.float, !torch.bool, !torch.float, !torch.bool -> !torch.vtensor<[1,4,8,128],f32>
+  return %0 : !torch.vtensor<[1,4,8,128],f32>
+}
+
+// -----
+
+// Test that an invalid scale (not 1/sqrt(headDim)) is rejected
+func.func @sdpa_scale_invalid(%query: !torch.vtensor<[1,4,8,64],f32>, %key: !torch.vtensor<[1,4,8,64],f32>, %value: !torch.vtensor<[1,4,8,64],f32>) -> !torch.vtensor<[1,4,8,64],f32> {
+  %float0 = torch.constant.float 0.000000e+00
+  // 0.5 is not 1/sqrt(64)=0.125
+  %scale = torch.constant.float 5.000000e-01
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.scaled_dot_product_attention'}}
+  %0 = torch.aten.scaled_dot_product_attention %query, %key, %value, %none, %float0, %false, %scale, %false : !torch.vtensor<[1,4,8,64],f32>, !torch.vtensor<[1,4,8,64],f32>, !torch.vtensor<[1,4,8,64],f32>, !torch.none, !torch.float, !torch.bool, !torch.float, !torch.bool -> !torch.vtensor<[1,4,8,64],f32>
+  return %0 : !torch.vtensor<[1,4,8,64],f32>
+}
+
+// -----
+
+// Test that a scale just over 1e-6 relative error from 1/sqrt(headDim) is rejected.
+// For headDim=64: expected = 0.125, we use 0.12500025 which is 2e-6 relative error.
+func.func @sdpa_scale_just_outside_tolerance(%query: !torch.vtensor<[1,4,8,64],f32>, %key: !torch.vtensor<[1,4,8,64],f32>, %value: !torch.vtensor<[1,4,8,64],f32>) -> !torch.vtensor<[1,4,8,64],f32> {
+  %float0 = torch.constant.float 0.000000e+00
+  // 0.12500025 = 0.125 * (1 + 2e-6), which is 2e-6 relative error (> 1e-6 tolerance)
+  %scale = torch.constant.float 0.12500025
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.scaled_dot_product_attention'}}
+  %0 = torch.aten.scaled_dot_product_attention %query, %key, %value, %none, %float0, %false, %scale, %false : !torch.vtensor<[1,4,8,64],f32>, !torch.vtensor<[1,4,8,64],f32>, !torch.vtensor<[1,4,8,64],f32>, !torch.none, !torch.float, !torch.bool, !torch.float, !torch.bool -> !torch.vtensor<[1,4,8,64],f32>
+  return %0 : !torch.vtensor<[1,4,8,64],f32>
+}
+
+// -----
+
+// Test that any scale with dynamic head dimension is rejected
+// (we cannot verify scale matches 1/sqrt(headDim) without knowing headDim)
+func.func @sdpa_scale_dynamic_head_dim(%query: !torch.vtensor<[1,4,8,?],f32>, %key: !torch.vtensor<[1,4,8,?],f32>, %value: !torch.vtensor<[1,4,8,?],f32>) -> !torch.vtensor<[1,4,8,?],f32> {
+  %float0 = torch.constant.float 0.000000e+00
+  %scale = torch.constant.float 1.250000e-01
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.scaled_dot_product_attention'}}
+  %0 = torch.aten.scaled_dot_product_attention %query, %key, %value, %none, %float0, %false, %scale, %false : !torch.vtensor<[1,4,8,?],f32>, !torch.vtensor<[1,4,8,?],f32>, !torch.vtensor<[1,4,8,?],f32>, !torch.none, !torch.float, !torch.bool, !torch.float, !torch.bool -> !torch.vtensor<[1,4,8,?],f32>
+  return %0 : !torch.vtensor<[1,4,8,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL: @scatter_src_i64_index
 // CHECK: tm_tensor.scatter {dimension_map = array<i64: 0, 1, 2>} unique_indices(false) ins(%{{.*}}, %{{.*}} : tensor<?xf32>, tensor<?x3xi64>) outs(%{{.*}} : tensor<10x8x6xf32>) {
 // CHECK:      ^bb0(%arg3: f32, %arg4: f32):


### PR DESCRIPTION
This PR improves the scaled_dot_product_attention conversion in TorchToTMTensor to accept explicit scale values that match PyTorch's default 1/sqrt(headDim), not just scale=None, see https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html.

Breaking change: Support for scale=1.0 is removed. This was likely incorrect as it's not the default as was mentioned — also, for example, IREE's downstream AttentionOpConversion always applies 1/sqrt(headDim) scaling internally, so accepting scale=1.0 would silently produce wrong results (the output would be scaled by 1/sqrt(headDim) when the user expected no scaling): https://github.com/iree-org/iree/blob/f4b596d5b2a8813948f6dab18a36403e768eb5e1/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp#L174.

Note that this change accepts scale values that match 1/sqrt(headDim) within a relative tolerance of 1e-6 (~10x float32 machine epsilon), which handles:
- Different computation orders producing slightly different values
- Float64 → float32 → float64 round-trips through serialization
