### PR TITLE
[TorchToStableHLO] fix: NLLLoss conversion error

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -11025,7 +11025,7 @@ public:
     auto unequalCond =
         AtenNeScalarOp::create(rewriter, loc, condType, target, ignoreIndex);
     auto zeroTensorType =
-        ValueTensorType::get(ctx, {}, rewriter.getIntegerType(64, true));
+        ValueTensorType::get(ctx, SmallVector<int64_t>({1}), rewriter.getIntegerType(64, true));
     Value zeroTensor =
         PrimNumToTensorScalarOp::create(rewriter, loc, zeroTensorType, zero);
     auto safeTarget = AtenWhereSelfOp::create(rewriter, loc, target.getType(),

--- a/test/Conversion/TorchToStablehlo/nll_loss.mlir
+++ b/test/Conversion/TorchToStablehlo/nll_loss.mlir
@@ -1,0 +1,14 @@
+// RUN: torch-mlir-opt <%s --torchdynamo-export-to-torch-backend-pipeline --torch-backend-to-stablehlo-backend-pipeline -split-input-file -verify-diagnostics | FileCheck %s
+
+module {
+  func.func @main(%arg0: !torch.vtensor<[3,5],bf16>, %arg1: !torch.vtensor<[3],si64>, %arg2: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+    // CHECK: %[[CST_0:.*]] = stablehlo.constant dense<0> : tensor<1xi64>
+    %int1 = torch.constant.int 1
+    %int-100 = torch.constant.int -100
+    // CHECK: %[[VAL_1:.*]] = stablehlo.convert %[[CST_0]] : (tensor<1xi64>) -> tensor<1xbf16>
+    // CHECK: %[[VAL_2:.*]] = stablehlo.broadcast_in_dim %[[VAL_1]], dims = [0] : (tensor<1xbf16>) -> tensor<3xbf16>
+    // CHECK: %{{.*}} = stablehlo.select %{{.*}}, %{{.*}}, %[[VAL_2]] : tensor<3xi1>, tensor<3xbf16>
+    %output, %total_weight = torch.aten.nll_loss_forward %arg0, %arg1, %arg2, %int1, %int-100 : !torch.vtensor<[3,5],bf16>, !torch.vtensor<[3],si64>, !torch.vtensor<[5],f32>, !torch.int, !torch.int -> !torch.vtensor<[],f32>, !torch.vtensor<[],f32>
+    return %output : !torch.vtensor<[],f32>
+  }
+}


### PR DESCRIPTION
Pytorch NLLLoss had a conversion error issue to StableHLO.  
The conversion was blocked by error: `Assertion isa<To>(Val) && "cast<Ty>() argument of incompatible type!"'` failed. because torch-mlir's NllLoss decomposition creates `torch.prim.NumToTensor.Scalar %int0 : !torch.int -> !torch.vtensor<*,si64>`.
This is problematic because StableHLO lowering doesn't know how to handle a tensor `!torch.vtensor<*,si64>` of empty shape.
Fixed by modifying the code to produce `!torch.vtensor<[1],si64>.`
