### PR TITLE
[Bug] fix: Near-infinite loop for SliceScatter lowering

### DIFF
--- a/lib/Conversion/TorchToStablehlo/GatherScatter.cpp
+++ b/lib/Conversion/TorchToStablehlo/GatherScatter.cpp
@@ -661,6 +661,8 @@ LogicalResult ConvertAtenOp<AtenSliceScatterOp>::matchAndRewrite(
     return op->emitError(
         "unimplemented: not support dynamic dimSize when end smaller than 0.");
   }
+  // Python allows users to set the range end to be larger than dimsize.
+  end = end > dimSize ? dimSize : end;
   end = end >= 0 ? end : dimSize + end;
 
   int64_t size = 0;


### PR DESCRIPTION
Issue: User may set the range end of slice_scatter to a very large value because a large end index in Python is automatically converted to the maximum length of a range. However, such a value caused large loop iterations in Torch-MLIR.  
Solution: Added a bounds check during SliceScatterOp lowering.