### PR TITLE
[torch][canonicalizer] Add handling for torch.aten.cat ops with operands with shape (0,)

### DIFF
--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -4202,6 +4202,8 @@ void AtenCatOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
       if (!operandTy || !operandTy.hasSizes())
         return failure();
       int64_t adim = dim < 0 ? dim + operandTy.getSizes().size() : dim;
+      if ((int64_t) operandTy.getSizes().size() == 1 && operandTy.getSizes()[0] == 0)
+        continue;
       if (operandTy.getSizes()[adim] != 0)
         filtered.push_back(operand);
     }

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -2472,6 +2472,18 @@ func.func @torch.aten.cat$fold_zero_dim_operand() -> !torch.vtensor<[4],si32> {
 
 // -----
 
+//  CHECK-LABEL:    @torch.aten.cat$handle_zero_size_3d_tensor
+//   CHECK-SAME:      %[[ARG0:.+]]: !torch.vtensor<[2,0,3],f32>
+//        CHECK:        return %[[ARG0]] : !torch.vtensor<[2,0,3],f32>
+func.func @torch.aten.cat$handle_zero_size_3d_tensor(%arg0: !torch.vtensor<[2,0,3],f32>) -> !torch.vtensor<[2,0,3],f32> {
+  %int1 = torch.constant.int 1
+  %0 = torch.prim.ListConstruct %arg0 : (!torch.vtensor<[2,0,3],f32>) -> !torch.list<vtensor>
+  %1 = torch.aten.cat %0, %int1 : !torch.list<vtensor>, !torch.int -> !torch.vtensor<[2,0,3],f32>
+  return %1 : !torch.vtensor<[2,0,3],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.broadcast_to$fold(
 // CHECK-SAME:            %[[ARG:.*]]: !torch.vtensor<[3,4,2],f32>) -> !torch.vtensor<[3,4,2],f32> {
 // CHECK-NEXT:      return %[[ARG]] : !torch.vtensor<[3,4,2],f32>


### PR DESCRIPTION
- the torch aten.cat op has a canonicalization rule that uses an assumption that every operand has the same rank and has the same shape (expect for the concatenation dim)
- this assumption is not necessarily valid - the input tensors may be empty and have shape (0,) https://docs.pytorch.org/docs/stable/generated/torch.cat.html
- --> if the operand tensor is empty it is skipped in the canonicalization rule