### PR TITLE
[torch ops] Fix permute op handling for negative dim indices

### DIFF
--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -5600,9 +5600,9 @@ LogicalResult AtenPermuteOp::verify() {
       continue;
     }
 
-    // if 'from' is the unkwown index, continue.
-    if (from == -1) {
-      continue;
+    // normalize negative index
+    if (from < 0) {
+      from = from + outRank;
     }
 
     if (!isValidDim(from, outRank)) {

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -897,6 +897,42 @@ def Permute0RankModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class PermuteAllNegativeIndicesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([None, ([-1, -1, -1], torch.float32, True)])
+    def forward(self, x):
+        return x.permute(-3, -1, -2)
+
+
+@register_test_case(module_factory=lambda: PermuteAllNegativeIndicesModule())
+def PermuteAllNegativeIndicesModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4))
+
+
+# ==============================================================================
+
+
+class PermuteMixedIndices4DModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([None, ([-1, -1, -1, -1], torch.float32, True)])
+    def forward(self, x):
+        return x.permute(0, 3, -2, 1)
+
+
+@register_test_case(module_factory=lambda: PermuteMixedIndices4DModule())
+def PermuteMixedIndices4DModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4, 5))
+
+
+# ==============================================================================
+
+
 class TransposeIntNegDimsModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -182,6 +182,15 @@ func.func @prim_list_construct$valid_shape_subtype(%arg0: !torch.vtensor<[1,53,5
 }
 
 // Check that verification passes with '-1' as a permutation index.
+// CHECK-LABEL:   func.func @torch.permute$negative_index_valid(
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: !torch.vtensor<[1,2,3],f32>) -> !torch.vtensor<[1,2,3],f32> {
+// CHECK:           %[[VAL_1:.*]] = torch.constant.int -1
+// CHECK:           %[[VAL_2:.*]] = torch.constant.int 0
+// CHECK:           %[[VAL_3:.*]] = torch.constant.int 1
+// CHECK:           %[[VAL_4:.*]] = torch.prim.ListConstruct %[[VAL_2]], %[[VAL_3]], %[[VAL_1]] : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[VAL_5:.*]] = torch.aten.permute %[[VAL_0]], %[[VAL_4]] : !torch.vtensor<[1,2,3],f32>, !torch.list<int> -> !torch.vtensor<[1,2,3],f32>
+// CHECK:           return %[[VAL_5]] : !torch.vtensor<[1,2,3],f32>
+// CHECK:         }
 func.func @torch.permute$negative_index_valid (%arg0: !torch.vtensor<[1,2,3],f32>) -> !torch.vtensor<[1,2,3],f32> {
   %intm1 = torch.constant.int -1
   %int0 = torch.constant.int 0
@@ -190,6 +199,62 @@ func.func @torch.permute$negative_index_valid (%arg0: !torch.vtensor<[1,2,3],f32
   %3 = torch.aten.permute %arg0, %perm : !torch.vtensor<[1,2,3],f32>, !torch.list<int> -> !torch.vtensor<[1,2,3],f32>
   return %3 : !torch.vtensor<[1,2,3],f32>
 }
+
+// Check that verification passes with native (non-negative) permutation indices.
+// CHECK-LABEL:   func.func @torch.permute$native_index_valid(
+// CHECK-SAME:                                                %[[VAL_0:.*]]: !torch.vtensor<[2,3,4],f32>) -> !torch.vtensor<[4,2,3],f32> {
+// CHECK:           %[[VAL_1:.*]] = torch.constant.int 0
+// CHECK:           %[[VAL_2:.*]] = torch.constant.int 1
+// CHECK:           %[[VAL_3:.*]] = torch.constant.int 2
+// CHECK:           %[[VAL_4:.*]] = torch.prim.ListConstruct %[[VAL_3]], %[[VAL_1]], %[[VAL_2]] : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[VAL_5:.*]] = torch.aten.permute %[[VAL_0]], %[[VAL_4]] : !torch.vtensor<[2,3,4],f32>, !torch.list<int> -> !torch.vtensor<[4,2,3],f32>
+// CHECK:           return %[[VAL_5]] : !torch.vtensor<[4,2,3],f32>
+// CHECK:         }
+func.func @torch.permute$native_index_valid (%arg0: !torch.vtensor<[2,3,4],f32>) -> !torch.vtensor<[4,2,3],f32> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %perm = torch.prim.ListConstruct %int2, %int0, %int1 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.permute %arg0, %perm : !torch.vtensor<[2,3,4],f32>, !torch.list<int> -> !torch.vtensor<[4,2,3],f32>
+  return %0 : !torch.vtensor<[4,2,3],f32>
+}
+
+// Check that verification passes with native indices forming a transpose.
+// CHECK-LABEL:   func.func @torch.permute$native_index_transpose(
+// CHECK-SAME:                                                    %[[VAL_0:.*]]: !torch.vtensor<[5,7],f32>) -> !torch.vtensor<[7,5],f32> {
+// CHECK:           %[[VAL_1:.*]] = torch.constant.int 0
+// CHECK:           %[[VAL_2:.*]] = torch.constant.int 1
+// CHECK:           %[[VAL_3:.*]] = torch.prim.ListConstruct %[[VAL_2]], %[[VAL_1]] : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[VAL_4:.*]] = torch.aten.permute %[[VAL_0]], %[[VAL_3]] : !torch.vtensor<[5,7],f32>, !torch.list<int> -> !torch.vtensor<[7,5],f32>
+// CHECK:           return %[[VAL_4]] : !torch.vtensor<[7,5],f32>
+// CHECK:         }
+func.func @torch.permute$native_index_transpose (%arg0: !torch.vtensor<[5,7],f32>) -> !torch.vtensor<[7,5],f32> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %perm = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.permute %arg0, %perm : !torch.vtensor<[5,7],f32>, !torch.list<int> -> !torch.vtensor<[7,5],f32>
+  return %0 : !torch.vtensor<[7,5],f32>
+}
+
+// Check that verification passes with all negative indices (-3, -2, -1).
+// CHECK-LABEL:   func.func @torch.permute$all_negative_indices(
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: !torch.vtensor<[2,3,4],f32>) -> !torch.vtensor<[4,3,2],f32> {
+// CHECK:           %[[VAL_1:.*]] = torch.constant.int -1
+// CHECK:           %[[VAL_2:.*]] = torch.constant.int -2
+// CHECK:           %[[VAL_3:.*]] = torch.constant.int -3
+// CHECK:           %[[VAL_4:.*]] = torch.prim.ListConstruct %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK:           %[[VAL_5:.*]] = torch.aten.permute %[[VAL_0]], %[[VAL_4]] : !torch.vtensor<[2,3,4],f32>, !torch.list<int> -> !torch.vtensor<[4,3,2],f32>
+// CHECK:           return %[[VAL_5]] : !torch.vtensor<[4,3,2],f32>
+// CHECK:         }
+func.func @torch.permute$all_negative_indices (%arg0: !torch.vtensor<[2,3,4],f32>) -> !torch.vtensor<[4,3,2],f32> {
+  %intm1 = torch.constant.int -1
+  %intm2 = torch.constant.int -2
+  %intm3 = torch.constant.int -3
+  %perm = torch.prim.ListConstruct %intm1, %intm2, %intm3 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.permute %arg0, %perm : !torch.vtensor<[2,3,4],f32>, !torch.list<int> -> !torch.vtensor<[4,3,2],f32>
+  return %0 : !torch.vtensor<[4,3,2],f32>
+}
+
 
 // Check fake quantize ops
 func.func @torch.aten.fake_quantize_per_channel_affine (%arg0: !torch.vtensor<[3,3],f32>, %arg1: !torch.vtensor<[3],f32>, %arg2: !torch.vtensor<[3],si32>) -> !torch.vtensor<[3,3],f32> {


### PR DESCRIPTION
- currently the torch permute op implementation assumes that a dimension index of -1 denotes an unknown dimension
- the actual implementation of torch.permute treats negative indices as relative to the rank (i.e., for x < 0 the index is rank + x)
- --> all negative indices are normalized in the permute op implementation