### PR TITLE
[TorchOnnxToTorch] Fix null blob pointer dereference

### DIFF
--- a/include/torch-mlir/Conversion/TorchOnnxToTorch/Utils.h
+++ b/include/torch-mlir/Conversion/TorchOnnxToTorch/Utils.h
@@ -83,8 +83,10 @@ struct onnx_list_of_constant_ints_op_binder {
 
       auto ty = cast<ShapedType>(attr.getType());
       ElementsAttr denseAttr;
-      auto ptr = attr.getRawHandle().getBlob()->getData();
-      denseAttr = DenseElementsAttr::getFromRawBuffer(ty, ptr);
+      auto blobPtr = attr.getRawHandle().getBlob();
+      if (!blobPtr)
+        return false;
+      denseAttr = DenseElementsAttr::getFromRawBuffer(ty, blobPtr->getData());
       for (auto axis : denseAttr.getValues<llvm::APInt>()) {
         bind_values.push_back(axis.getSExtValue());
       }


### PR DESCRIPTION
Check blob pointer for null before dereferencing in `onnx_list_of_constant_ints_op_binder` to prevent crashes when the blob data is missing.