### PR TITLE
[TorchToLinalg] Improve OnnxVariantRotaryEmbeddingOp lowering

### DIFF
--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -4073,8 +4073,8 @@ private:
           {static_cast<int64_t>(finalDimVals.size())}, rewriter.getI64Type());
       Value shapeValue = tensor::FromElementsOp::create(
           rewriter, loc, shapeType, finalDimVals);
-      result = tensor::ReshapeOp::create(rewriter, loc, resultType,
-                                         rotaryEmbedding, shapeValue);
+      result = tensor::ReshapeOp::create(rewriter, loc, resultType, result,
+                                         shapeValue);
     }
 
     rewriter.replaceOpWithNewOp<tensor::CastOp>(op, resultType, result);


### PR DESCRIPTION
Extend OnnxVariantRotaryEmbeddingOp lowering to handle rank-3 input (batch, seq, hidden) in addition to rank-4, support dynamic batch and sequence dimensions, and apply an optional scale multiplier. Rank-3 inputs are reshaped to rank-4 for the linalg.generic computation and reshaped back afterward.