### PR TITLE
[Torch] Fix crash in getScalarIntValue

### DIFF
--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -2679,6 +2679,24 @@ func.func @torch.aten.ScalarImplicit$canonicalize_literal_0d() -> !torch.number 
     return %1 : !torch.number
 }
 
+// CHECK-LABEL:   func.func @torch.aten.ScalarImplicit$dense_resource() -> !torch.number {
+// CHECK:             %int42 = torch.constant.int 42
+// CHECK:             %[[VAL_0:.*]] = torch.derefine %int42 : !torch.int to !torch.number
+// CHECK:             return %[[VAL_0]] : !torch.number
+func.func @torch.aten.ScalarImplicit$dense_resource() -> !torch.number {
+    %0 = torch.vtensor.literal(dense_resource<blob_si64> : tensor<si64>) : !torch.vtensor<[],si64>
+    %1 = torch.aten.ScalarImplicit %0 : !torch.vtensor<[],si64> -> !torch.number
+    return %1 : !torch.number
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      blob_si64: "0x080000002a00000000000000"
+    }
+  }
+#-}
+
 // -----
 
 // CHECK-LABEL:   func.func @torch.aten.ScalarImplicit$canonicalize_literal_0d_float() -> !torch.number {


### PR DESCRIPTION
Fix crash in `getScalarIntValue()` due to unhandled `DenseResourceElementsAttr`.