### PR TITLE
[TorchToTMTenor] enable broadcasting query- and key_seq_len of attention mask

### DIFF
--- a/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
+++ b/lib/Conversion/TorchToTMTensor/TorchToTMTensor.cpp
@@ -1871,63 +1871,64 @@ public:
       mask = genericOp.getResult(0);
     }
 
-    // Broadcast the batch dimensions of the mask:
+    // Broadcast the mask to the expected attention-mask shape:
+    // [..., query_seq_len, key_seq_len].
     if (!isa<Torch::NoneType>(mask.getType())) {
       auto maskTy = cast<RankedTensorType>(mask.getType());
       int64_t rank = maskTy.getRank();
+      // Target mask shape: [..., query_seq_len, key_seq_len].
+      SmallVector<int64_t> targetMaskShape(rank);
+      SmallVector<Value> targetMaskDynDimValues(rank);
+      for (int64_t i = 0; i < rank - 2; ++i) {
+        targetMaskShape[i] = queryTy.getDimSize(i);
+        if (targetMaskShape[i] == ShapedType::kDynamic)
+          targetMaskDynDimValues[i] =
+              tensor::DimOp::create(rewriter, loc, query, i);
+      }
+
+      targetMaskShape[rank - 2] = queryTy.getDimSize(queryTy.getRank() - 2);
+      if (targetMaskShape[rank - 2] == ShapedType::kDynamic)
+        targetMaskDynDimValues[rank - 2] =
+            tensor::DimOp::create(rewriter, loc, query, queryTy.getRank() - 2);
+
+      targetMaskShape[rank - 1] = keyTy.getDimSize(keyTy.getRank() - 2);
+      if (targetMaskShape[rank - 1] == ShapedType::kDynamic)
+        targetMaskDynDimValues[rank - 1] =
+            tensor::DimOp::create(rewriter, loc, key, keyTy.getRank() - 2);
+
       bool needsBroadcast = false;
-      for (int i = 0, s = rank - 2; i < s; ++i) {
-        needsBroadcast |= maskTy.getDimSize(i) != queryTy.getDimSize(i);
+      for (int64_t i = 0; i < rank; ++i) {
+        needsBroadcast |= maskTy.getDimSize(i) != targetMaskShape[i];
       }
 
       if (needsBroadcast) {
-        SmallVector<int64_t> maskShape;
         SmallVector<Value> maskDynDims;
-
         SmallVector<AffineExpr> maskExprs;
-        for (int i = 0, s = rank - 2; i < s; ++i) {
-          maskShape.push_back(queryTy.getDimSize(i));
-
-          if (maskTy.getDimSize(i) != queryTy.getDimSize(i)) {
-            maskExprs.push_back(rewriter.getAffineConstantExpr(0));
-          } else {
-            maskExprs.push_back(rewriter.getAffineDimExpr(i));
-          }
-
-          if (queryTy.isDynamicDim(i)) {
-            maskDynDims.push_back(
-                tensor::DimOp::create(rewriter, loc, query, i));
-          }
+        for (int64_t i = 0; i < rank; ++i) {
+          bool broadcastDim = maskTy.getDimSize(i) != targetMaskShape[i];
+          maskExprs.push_back(broadcastDim ? rewriter.getAffineConstantExpr(0)
+                                           : rewriter.getAffineDimExpr(i));
+          if (targetMaskShape[i] == ShapedType::kDynamic)
+            maskDynDims.push_back(targetMaskDynDimValues[i]);
         }
-
-        maskExprs.push_back(rewriter.getAffineDimExpr(rank - 2));
-        maskExprs.push_back(rewriter.getAffineDimExpr(rank - 1));
-        maskShape.push_back(maskTy.getDimSize(rank - 2));
-        maskShape.push_back(maskTy.getDimSize(rank - 1));
-        if (maskTy.isDynamicDim(rank - 2))
-          maskDynDims.push_back(
-              tensor::DimOp::create(rewriter, loc, mask, rank - 2));
-        if (maskTy.isDynamicDim(rank - 1))
-          maskDynDims.push_back(
-              tensor::DimOp::create(rewriter, loc, mask, rank - 1));
 
         SmallVector<AffineMap> affineMaps = {
             AffineMap::get(/*dimCount=*/rank, /*symbolCount=*/0, maskExprs,
                            op.getContext()),
             rewriter.getMultiDimIdentityMap(rank)};
-        SmallVector<utils::IteratorType> findMaxIteratorTypes(
+        SmallVector<utils::IteratorType> iteratorTypes(
             rank, utils::IteratorType::parallel);
 
-        Value emptyMask = tensor::EmptyOp::create(
-            rewriter, loc, maskShape, maskTy.getElementType(), maskDynDims);
-        Value newMask =
-            linalg::GenericOp::create(
-                rewriter, loc, emptyMask.getType(), mask,
-                ValueRange({emptyMask}), affineMaps, findMaxIteratorTypes,
-                [&](OpBuilder &b, Location loc, ValueRange args) {
-                  linalg::YieldOp::create(b, loc, args[0]);
-                })
-                .getResult(0);
+        Value emptyMask =
+            tensor::EmptyOp::create(rewriter, loc, targetMaskShape,
+                                    maskTy.getElementType(), maskDynDims);
+        Value newMask = linalg::GenericOp::create(
+                            rewriter, loc, emptyMask.getType(), mask,
+                            ValueRange({emptyMask}), affineMaps, iteratorTypes,
+                            [&](OpBuilder &b, Location loc, ValueRange args) {
+                              linalg::YieldOp::create(b, loc, args[0]);
+                            })
+                            .getResult(0);
         mask = newMask;
       }
     }

--- a/test/Conversion/TorchToTMTensor/basic.mlir
+++ b/test/Conversion/TorchToTMTensor/basic.mlir
@@ -97,6 +97,65 @@ func.func @sdpa_scale_dynamic_head_dim(%query: !torch.vtensor<[1,4,8,?],f32>, %k
 
 // -----
 
+// CHECK-LABEL: @sdpa_bool_mask_key_seq_dynamic
+// CHECK: %[[MASK_IN:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[1,1,?],i1> -> tensor<1x1x?xi1>
+// CHECK: %[[KEY:.*]] = torch_c.to_builtin_tensor %arg1 : !torch.vtensor<[16,?,128],f16> -> tensor<16x?x128xf16>
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[KEY_SEQ:.*]] = tensor.dim %[[KEY]], %[[C1]] : tensor<16x?x128xf16>
+// CHECK: %[[EMPTY_MASK:.*]] = tensor.empty(%[[KEY_SEQ]]) : tensor<16x1x?xi1>
+// CHECK: %[[BCAST_MASK:.*]] = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[MASK_IN]] : tensor<1x1x?xi1>) outs(%[[EMPTY_MASK]] : tensor<16x1x?xi1>)
+// CHECK: tm_tensor.attention ins(%{{.*}}, %{{.*}}, %{{.*}}, %[[BCAST_MASK]] : tensor<16x1x128xf16>, tensor<16x?x128xf16>, tensor<16x?x128xf16>, tensor<16x1x?xi1>)
+func.func @sdpa_bool_mask_key_seq_dynamic(%query: !torch.vtensor<[16,1,128],f16>, %key: !torch.vtensor<[16,?,128],f16>, %value: !torch.vtensor<[16,?,128],f16>, %mask: !torch.vtensor<[1,1,?],i1>) -> !torch.vtensor<[16,1,128],f16> {
+  %float0 = torch.constant.float 0.000000e+00
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  %0 = torch.aten.scaled_dot_product_attention %query, %key, %value, %mask, %float0, %false, %none, %false : !torch.vtensor<[16,1,128],f16>, !torch.vtensor<[16,?,128],f16>, !torch.vtensor<[16,?,128],f16>, !torch.vtensor<[1,1,?],i1>, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[16,1,128],f16>
+  return %0 : !torch.vtensor<[16,1,128],f16>
+}
+
+// -----
+
+// CHECK-LABEL: @sdpa_bool_mask_both_seq_dynamic
+// CHECK: %[[MASK_IN:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[1,?,?],i1> -> tensor<1x?x?xi1>
+// CHECK: %[[KEY:.*]] = torch_c.to_builtin_tensor %arg1 : !torch.vtensor<[16,?,128],f16> -> tensor<16x?x128xf16>
+// CHECK: %[[QUERY:.*]] = torch_c.to_builtin_tensor %arg0 : !torch.vtensor<[16,?,128],f16> -> tensor<16x?x128xf16>
+// CHECK: %[[C1_A:.*]] = arith.constant 1 : index
+// CHECK: %[[QSEQ:.*]] = tensor.dim %[[QUERY]], %[[C1_A]] : tensor<16x?x128xf16>
+// CHECK: %[[C1_B:.*]] = arith.constant 1 : index
+// CHECK: %[[KSEQ:.*]] = tensor.dim %[[KEY]], %[[C1_B]] : tensor<16x?x128xf16>
+// CHECK: %[[EMPTY_MASK:.*]] = tensor.empty(%[[QSEQ]], %[[KSEQ]]) : tensor<16x?x?xi1>
+// CHECK: %[[BCAST_MASK:.*]] = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[MASK_IN]] : tensor<1x?x?xi1>) outs(%[[EMPTY_MASK]] : tensor<16x?x?xi1>)
+// CHECK: tm_tensor.attention ins(%{{.*}}, %{{.*}}, %{{.*}}, %[[BCAST_MASK]] : tensor<16x?x128xf16>, tensor<16x?x128xf16>, tensor<16x?x128xf16>, tensor<16x?x?xi1>)
+func.func @sdpa_bool_mask_both_seq_dynamic(%query: !torch.vtensor<[16,?,128],f16>, %key: !torch.vtensor<[16,?,128],f16>, %value: !torch.vtensor<[16,?,128],f16>, %mask: !torch.vtensor<[1,?,?],i1>) -> !torch.vtensor<[16,?,128],f16> {
+  %float0 = torch.constant.float 0.000000e+00
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  %0 = torch.aten.scaled_dot_product_attention %query, %key, %value, %mask, %float0, %false, %none, %false : !torch.vtensor<[16,?,128],f16>, !torch.vtensor<[16,?,128],f16>, !torch.vtensor<[16,?,128],f16>, !torch.vtensor<[1,?,?],i1>, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[16,?,128],f16>
+  return %0 : !torch.vtensor<[16,?,128],f16>
+}
+
+// -----
+
+// CHECK: #map = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
+// CHECK-LABEL: @sdpa_bool_mask_4d_static_ones
+// CHECK: %[[MASK_IN:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[1,1,1,1],i1> -> tensor<1x1x1x1xi1>
+// CHECK: %[[KEY:.*]] = torch_c.to_builtin_tensor %arg1 : !torch.vtensor<[1,16,?,128],f16> -> tensor<1x16x?x128xf16>
+// CHECK: %[[C2:.*]] = arith.constant 2 : index
+// CHECK: %[[KSEQ:.*]] = tensor.dim %[[KEY]], %[[C2]] : tensor<1x16x?x128xf16>
+// CHECK: %[[EMPTY_MASK:.*]] = tensor.empty(%[[KSEQ]]) : tensor<1x16x1x?xi1>
+// CHECK: %[[BCAST_MASK:.*]] = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%[[MASK_IN]] : tensor<1x1x1x1xi1>) outs(%[[EMPTY_MASK]] : tensor<1x16x1x?xi1>)
+// CHECK: %[[COLLAPSED_MASK:.*]] = tensor.collapse_shape %[[BCAST_MASK]] {{.*}} : tensor<1x16x1x?xi1> into tensor<16x1x?xi1>
+// CHECK: tm_tensor.attention ins(%{{.*}}, %{{.*}}, %{{.*}}, %[[COLLAPSED_MASK]] : tensor<16x1x128xf16>, tensor<16x?x128xf16>, tensor<16x?x128xf16>, tensor<16x1x?xi1>)
+func.func @sdpa_bool_mask_4d_static_ones(%query: !torch.vtensor<[1,16,1,128],f16>, %key: !torch.vtensor<[1,16,?,128],f16>, %value: !torch.vtensor<[1,16,?,128],f16>, %mask: !torch.vtensor<[1,1,1,1],i1>) -> !torch.vtensor<[1,16,1,128],f16> {
+  %float0 = torch.constant.float 0.000000e+00
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  %0 = torch.aten.scaled_dot_product_attention %query, %key, %value, %mask, %float0, %false, %none, %false : !torch.vtensor<[1,16,1,128],f16>, !torch.vtensor<[1,16,?,128],f16>, !torch.vtensor<[1,16,?,128],f16>, !torch.vtensor<[1,1,1,1],i1>, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[1,16,1,128],f16>
+  return %0 : !torch.vtensor<[1,16,1,128],f16>
+}
+
+// -----
+
 // CHECK-LABEL: @scatter_src_i64_index
 // CHECK: tm_tensor.scatter {dimension_map = array<i64: 0, 1, 2>} unique_indices(false) ins(%{{.*}}, %{{.*}} : tensor<?xf32>, tensor<?x3xi64>) outs(%{{.*}} : tensor<10x8x6xf32>) {
 // CHECK:      ^bb0(%arg3: f32, %arg4: f32):

--- a/test/Conversion/TorchToTMTensor/basic.mlir
+++ b/test/Conversion/TorchToTMTensor/basic.mlir
@@ -97,6 +97,8 @@ func.func @sdpa_scale_dynamic_head_dim(%query: !torch.vtensor<[1,4,8,?],f32>, %k
 
 // -----
 
+// CHECK: #map = affine_map<(d0, d1, d2) -> (0, d1, d2)>
+// CHECK: #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 // CHECK-LABEL: @sdpa_bool_mask_key_seq_dynamic
 // CHECK: %[[MASK_IN:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[1,1,?],i1> -> tensor<1x1x?xi1>
 // CHECK: %[[KEY:.*]] = torch_c.to_builtin_tensor %arg1 : !torch.vtensor<[16,?,128],f16> -> tensor<16x?x128xf16>
@@ -115,6 +117,8 @@ func.func @sdpa_bool_mask_key_seq_dynamic(%query: !torch.vtensor<[16,1,128],f16>
 
 // -----
 
+// CHECK: #map = affine_map<(d0, d1, d2) -> (0, d1, d2)>
+// CHECK: #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 // CHECK-LABEL: @sdpa_bool_mask_both_seq_dynamic
 // CHECK: %[[MASK_IN:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[1,?,?],i1> -> tensor<1x?x?xi1>
 // CHECK: %[[KEY:.*]] = torch_c.to_builtin_tensor %arg1 : !torch.vtensor<[16,?,128],f16> -> tensor<16x?x128xf16>


### PR DESCRIPTION
I ran into a problem where i would get a attention mask of shape [1,1,1,1] which would need to be broadcasted along the `key_seq_len` dimension which is not possible with the current implementation. This led to verification errors down the line. 

This change enables broadcasting the `query_seq_len` and `key_seq_len` dimension of the attention mask if required.