### PR TITLE
[Torch] Fix AtenSelectIntOp crash for signless dense attr

### DIFF
--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -2664,7 +2664,8 @@ OpFoldResult AtenSelectIntOp::fold(FoldAdaptor adaptor) {
     return nullptr;
 
   if (self.isSplat())
-    return DenseElementsAttr::get(bty, self.getSplatValue<Attribute>());
+    return DenseElementsAttr::get(bty.clone(self.getElementType()),
+                                  self.getSplatValue<Attribute>());
 
   auto dimAttr = dyn_cast_or_null<IntegerAttr>(adaptor.getDim());
   auto indexAttr = dyn_cast_or_null<IntegerAttr>(adaptor.getIndex());
@@ -2680,7 +2681,7 @@ OpFoldResult AtenSelectIntOp::fold(FoldAdaptor adaptor) {
   }
 
   auto splattr = self.getValues<Attribute>()[index];
-  return DenseElementsAttr::get(bty, splattr);
+  return DenseElementsAttr::get(bty.clone(self.getElementType()), splattr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -3106,6 +3106,16 @@ func.func @aten_select_int_fold_splat(%arg0 : !torch.int, %arg1 : !torch.int) ->
 
 // -----
 
+// CHECK-LABEL: @aten_select_signless_int_fold_splat
+func.func @aten_select_signless_int_fold_splat(%arg0 : !torch.int, %arg1 : !torch.int) -> !torch.vtensor<[1],si64> {
+  %splat = torch.vtensor.literal(dense<4> : tensor<4xi64>) : !torch.vtensor<[4],si64>
+  %select = torch.aten.select.int %splat, %arg0, %arg1 : !torch.vtensor<[4],si64>, !torch.int, !torch.int -> !torch.vtensor<[1],si64>
+  // CHECK: %[[RET:.+]] = torch.vtensor.literal(dense<4> : tensor<1xi64>) : !torch.vtensor<[1],si64>
+  // CHECK: return %[[RET]]
+  return %select : !torch.vtensor<[1],si64>
+}
+// -----
+
 // CHECK-LABEL: @aten_select_int_fold_1D
 func.func @aten_select_int_fold_1D() -> !torch.vtensor<[1],si64> {
   %index = torch.constant.int 1


### PR DESCRIPTION
Fixes folder to return a `DenseElementsAttr` with the same element type as the original attr (not the return type). This allows `TorchDialect::materializeConstant` to handle creating the correct result type.