### PR TITLE
[TorchOnnxToTorch] Add pad+scatter KV cache and mask to GQA 

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/ComMicrosoftDomain.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/ComMicrosoftDomain.cpp
@@ -290,6 +290,7 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
         // `do_rotary` attribute. If it's false, then the input operands can be
         // 7 but if it's true then the operands has to be 9 including cos_cache
         // and sin_cache for rotary_embedding.
+        // TODO: Add support for packed_qkv.
         if (!((operands.size() == 9) || (!doRotary && operands.size() == 7)))
           return rewriter.notifyMatchFailure(
               binder.op, "Unimplemented:  excepted input operands to be either "
@@ -321,8 +322,6 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
           return rewriter.notifyMatchFailure(
               binder.op, "Unimplemented: softcap attribute is not supported, "
                          "hence it should have default value equal to 0.0");
-
-        // TODO: Add support for packed_qkv.
 
         Location loc = binder.getLoc();
         MLIRContext *context = binder.op->getContext();
@@ -562,19 +561,224 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
               /*scale=*/cstFloatOne);
         }
 
-        // Do attention.
-        Value cstEnableGQA = Torch::ConstantBoolOp::create(rewriter, loc, true);
+        // Build present_key/present_value by padding past with zeros, then
+        // scattering current K/V into the correct per-batch position.
+        //
+        // Why pad instead of cat? With cat(past, current), the current token
+        // ends up at position past_seq_len. With variable seqlens_k, ORT places
+        // the current token at seqlens_k[b] and leaves position past_seq_len as
+        // zero/uninitialized. Using cat+scatter leaves a stale copy of the
+        // current token at past_seq_len which doesn't match ORT's output.
+        // Padding with zeros then scattering avoids this.
+        //
+        // constant_pad_nd pads innermost dims first: [0, 0, 0, seq_len]
+        //   dim 3 (head_size): [0, 0]  -- no padding
+        //   dim 2 (seq):       [0, seq_len] -- extend by seq_len on the right
         Value cstFloatZero = Torch::ConstantFloatOp::create(
             rewriter, loc, rewriter.getType<Torch::FloatType>(),
             rewriter.getF64FloatAttr(0.0));
+        Value padList = Torch::PrimListConstructOp::create(
+            rewriter, loc, intListType,
+            SmallVector<Value>{cstIntZero, cstIntZero, cstIntZero,
+                               cstSequenceLength});
+        Value presentKey = Torch::AtenConstantPadNdOp::create(
+            rewriter, loc, resultTypes[1], pastKey, padList, cstFloatZero);
+        Value presentValue = Torch::AtenConstantPadNdOp::create(
+            rewriter, loc, resultTypes[2], pastValue, padList, cstFloatZero);
+
+        // Scatter current K/V into the padded buffer at position pastLen[b]+q.
+        // pastLen = seqlens_k + 1 - seq_len
+        Value totalSeqForScatter = Torch::AtenAddScalarOp::create(
+            rewriter, loc, seqlensK.getType(), seqlensK, cstIntOne, cstIntOne);
+        Value pastLen = Torch::AtenSubScalarOp::create(
+            rewriter, loc, totalSeqForScatter.getType(), totalSeqForScatter,
+            cstSequenceLength, cstIntOne);
+
+        // qRange: [0, 1, ..., seqLen-1] — shared by scatter and mask.
+        Torch::ValueTensorType qRangeType = Torch::ValueTensorType::get(
+            context, {sequenceLength},
+            rewriter.getIntegerType(64, /*isSigned=*/true));
+        Value qRange = Torch::AtenArangeOp::create(
+            rewriter, loc, qRangeType, cstSequenceLength, cstInt64Dtype,
+            /*layout=*/cstNone, /*device=*/cstNone, /*pin_memory=*/cstNone);
+
+        // pastLen -> [B, 1, 1, 1] for 4D scatter index broadcasting
+        Value scatterViewList = Torch::PrimListConstructOp::create(
+            rewriter, loc, intListType,
+            SmallVector<Value>{cstIntMinusOne, cstIntOne, cstIntOne,
+                               cstIntOne});
+        SmallVector<int64_t> pastLenView4dSizes{batchSize, 1, 1, 1};
+        Torch::ValueTensorType pastLenView4dType = Torch::ValueTensorType::get(
+            context, pastLenView4dSizes,
+            rewriter.getIntegerType(64, /*isSigned=*/true));
+        Value pastLenView4d = Torch::AtenViewOp::create(
+            rewriter, loc, pastLenView4dType, pastLen, scatterViewList);
+
+        // qRange -> [1, 1, seq, 1] for scatter
+        Value scatterQViewList = Torch::PrimListConstructOp::create(
+            rewriter, loc, intListType,
+            SmallVector<Value>{cstIntOne, cstIntOne, cstIntMinusOne,
+                               cstIntOne});
+        SmallVector<int64_t> scatterQViewSizes{1, 1, sequenceLength, 1};
+        Torch::ValueTensorType scatterQViewType = Torch::ValueTensorType::get(
+            context, scatterQViewSizes,
+            rewriter.getIntegerType(64, /*isSigned=*/true));
+        Value scatterQRangeView = Torch::AtenViewOp::create(
+            rewriter, loc, scatterQViewType, qRange, scatterQViewList);
+
+        // scatterIdxBase = pastLen[B,1,1,1] + qRange[1,1,seq,1]
+        //               -> [B, 1, seq, 1]
+        SmallVector<int64_t> scatterIdxBaseSizes{batchSize, 1, sequenceLength,
+                                                 1};
+        Torch::ValueTensorType scatterIdxBaseType = Torch::ValueTensorType::get(
+            context, scatterIdxBaseSizes,
+            rewriter.getIntegerType(64, /*isSigned=*/true));
+        Value scatterIdxBase = Torch::AtenAddTensorOp::create(
+            rewriter, loc, scatterIdxBaseType, pastLenView4d, scatterQRangeView,
+            cstIntOne);
+
+        // Expand to [B, kv_heads, seq, head_size] to match current K/V shape
+        SmallVector<int64_t> scatterExpandSizes{batchSize, kvNumHeads,
+                                                sequenceLength, headSize};
+        Torch::ValueTensorType scatterIdxType = Torch::ValueTensorType::get(
+            context, scatterExpandSizes,
+            rewriter.getIntegerType(64, /*isSigned=*/true));
+        Value scatterExpandSizeList = Torch::PrimListConstructOp::create(
+            rewriter, loc, intListType,
+            SmallVector<Value>{cstBatchSize, cstKVNumHeads, cstSequenceLength,
+                               cstHeadSize});
+        Value scatterIdx = Torch::AtenExpandOp::create(
+            rewriter, loc, scatterIdxType, scatterIdxBase,
+            scatterExpandSizeList, /*implicit=*/cstFalse);
+
+        // Scatter current K/V into buffer at position pastLen[b] + q
+        presentKey = Torch::AtenScatterSrcOp::create(
+            rewriter, loc, resultTypes[1], presentKey, cstDim2, scatterIdx,
+            kRotary);
+        presentValue = Torch::AtenScatterSrcOp::create(
+            rewriter, loc, resultTypes[2], presentValue, cstDim2, scatterIdx,
+            vInput);
+
+        // Generate causal attention mask.
+        // With scatter, KV layout matches ORT: current at pastLen[b].
+        // Simple boolean mask: k <= pastLen[b] + q
+        // Mask shape: [batch, 1, seqLen, kvSeqLen] (i1).
+        Value attnMask = cstNone;
+
+        // Get the KV sequence length from presentKey shape
+        Torch::ValueTensorType presentKeyType =
+            cast<Torch::ValueTensorType>(presentKey.getType());
+        if (presentKeyType.hasSizes() &&
+            presentKeyType.getSizes().size() == 4) {
+          int64_t kvSeqLen = presentKeyType.getSizes()[2];
+
+          // Only generate mask if KV sequence length is dynamic or > 0
+          // For dynamic shapes or non-trivial sequences, we need to mask
+          if (kvSeqLen == Torch::kUnknownSize || kvSeqLen > 0) {
+            // Get KV sequence dimension size
+            Value kvSeqLenVal = Torch::AtenSizeIntOp::create(
+                rewriter, loc, rewriter.getType<Torch::IntType>(), presentKey,
+                cstDim2);
+
+            // kRange: [0, 1, 2, ..., kvSeqLen-1] shape [kvSeqLen]
+            Torch::ValueTensorType kRangeType = Torch::ValueTensorType::get(
+                context, {kvSeqLen},
+                rewriter.getIntegerType(64, /*isSigned=*/true));
+            Value kRange = Torch::AtenArangeOp::create(
+                rewriter, loc, kRangeType, kvSeqLenVal, cstInt64Dtype,
+                /*layout=*/cstNone, /*device=*/cstNone, /*pin_memory=*/cstNone);
+
+            // Reshape for broadcasting:
+            // pastLen: [batch] -> [batch, 1, 1]
+            // qRange: [seqLen] -> [1, seqLen, 1]  (reuses qRange from above)
+            // kRange: [kvSeqLen] -> [1, 1, kvSeqLen]
+
+            // pastLen -> [batch, 1, 1]
+            Value seqlensViewList = Torch::PrimListConstructOp::create(
+                rewriter, loc, intListType,
+                SmallVector<Value>{cstIntMinusOne, cstIntOne, cstIntOne});
+            SmallVector<int64_t> seqlensViewSizes{batchSize, 1, 1};
+            Torch::ValueTensorType seqlensViewType =
+                Torch::ValueTensorType::get(
+                    context, seqlensViewSizes,
+                    rewriter.getIntegerType(64, /*isSigned=*/true));
+            Value pastLenView = Torch::AtenViewOp::create(
+                rewriter, loc, seqlensViewType, pastLen, seqlensViewList);
+
+            // qRange -> [1, seqLen, 1]
+            Value qViewList = Torch::PrimListConstructOp::create(
+                rewriter, loc, intListType,
+                SmallVector<Value>{cstIntOne, cstIntMinusOne, cstIntOne});
+            SmallVector<int64_t> qViewSizes{1, sequenceLength, 1};
+            Torch::ValueTensorType qViewType = Torch::ValueTensorType::get(
+                context, qViewSizes,
+                rewriter.getIntegerType(64, /*isSigned=*/true));
+            Value qRangeView = Torch::AtenViewOp::create(
+                rewriter, loc, qViewType, qRange, qViewList);
+
+            // kRange -> [1, 1, kvSeqLen]
+            Value kViewList = Torch::PrimListConstructOp::create(
+                rewriter, loc, intListType,
+                SmallVector<Value>{cstIntOne, cstIntOne, cstIntMinusOne});
+            SmallVector<int64_t> kViewSizes{1, 1, kvSeqLen};
+            Torch::ValueTensorType kViewType = Torch::ValueTensorType::get(
+                context, kViewSizes,
+                rewriter.getIntegerType(64, /*isSigned=*/true));
+            Value kRangeView = Torch::AtenViewOp::create(
+                rewriter, loc, kViewType, kRange, kViewList);
+
+            // Causal mask: k <= pastLen + q
+            // pastLenView[batch,1,1] + qRangeView[1,seqLen,1]
+            // -> [batch, seqLen, 1]
+            SmallVector<int64_t> pastLenPlusQSizes{batchSize, sequenceLength,
+                                                   1};
+            Torch::ValueTensorType pastLenPlusQType =
+                Torch::ValueTensorType::get(
+                    context, pastLenPlusQSizes,
+                    rewriter.getIntegerType(64, /*isSigned=*/true));
+            Value pastLenPlusQ = Torch::AtenAddTensorOp::create(
+                rewriter, loc, pastLenPlusQType, pastLenView, qRangeView,
+                cstIntOne);
+
+            // kRangeView[1,1,kvSeqLen] <= pastLenPlusQ[batch,seqLen,1]
+            // -> [batch, seqLen, kvSeqLen]
+            SmallVector<int64_t> maskBoolSizes{batchSize, sequenceLength,
+                                               kvSeqLen};
+            Torch::ValueTensorType maskBoolType = Torch::ValueTensorType::get(
+                context, maskBoolSizes, rewriter.getI1Type());
+            Value causalMask = Torch::AtenLeTensorOp::create(
+                rewriter, loc, maskBoolType, kRangeView, pastLenPlusQ);
+
+            // Reshape to [batch, 1, seqLen, kvSeqLen] for SDPA.
+            // Pass the boolean mask directly — downstream backends (e.g.
+            // IREE's iree_linalg_ext.attention) handle bool-to-float
+            // conversion internally.
+            Value maskReshapeSizeList = Torch::PrimListConstructOp::create(
+                rewriter, loc, intListType,
+                SmallVector<Value>{cstBatchSize, cstIntOne, cstSequenceLength,
+                                   kvSeqLenVal});
+            SmallVector<int64_t> attnMaskSizes{batchSize, 1, sequenceLength,
+                                               kvSeqLen};
+            Torch::ValueTensorType attnMaskType = Torch::ValueTensorType::get(
+                context, attnMaskSizes, rewriter.getI1Type());
+            attnMask = Torch::AtenReshapeOp::create(
+                rewriter, loc, attnMaskType, causalMask, maskReshapeSizeList);
+          }
+        }
+
+        // Do attention with full KV cache (past + current) and mask.
+        Value cstEnableGQA = Torch::ConstantBoolOp::create(rewriter, loc, true);
         Value cstScale = cstNone;
         if (scale != 0.0f)
           cstScale = Torch::ConstantFloatOp::create(
               rewriter, loc, rewriter.getType<Torch::FloatType>(),
               rewriter.getF64FloatAttr(scale));
+
+        // Use presentKey/presentValue (full KV cache) for attention, not just
+        // the current token's K/V. This is essential for proper KV caching.
         Value attention = Torch::AtenScaledDotProductAttentionOp::create(
-            rewriter, loc, qRotary.getType(), qRotary, kRotary, vInput,
-            /*attn_mask=*/cstNone,
+            rewriter, loc, qRotary.getType(), qRotary, presentKey, presentValue,
+            /*attn_mask=*/attnMask,
             /*dropout_p=*/cstFloatZero, /*is_causal=*/cstFalse, cstScale,
             cstEnableGQA);
 
@@ -606,40 +810,6 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
         attention = Torch::AtenReshapeOp::create(rewriter, loc, resultTypes[0],
                                                  attnTransposed,
                                                  attentionResultSizesList);
-
-        // Compute 2nd and 3rd result: present_key, present_value.
-        // present_key = torch.cat([past_key, key], dim=2) or past_key
-        // present_value = torch.cat([past_value, value], dim=2) or past_value
-        Value presentKey = pastKey, presentValue = pastValue;
-        if (!llvm::equal(
-                cast<Torch::ValueTensorType>(pastKey.getType()).getSizes(),
-                cast<Torch::ValueTensorType>(resultTypes[1]).getSizes())) {
-          Value cstConcatDim = Torch::ConstantIntOp::create(
-              rewriter, loc, rewriter.getI64IntegerAttr(2));
-          Type kvListElemType = keyType.getWithSizesAndDtype(
-              /*optionalSizes=*/std::nullopt,
-              /*optionalDtype=*/nullptr);
-          Type kvListType = Torch::ListType::get(kvListElemType);
-          Value keyList = Torch::PrimListConstructOp::create(
-              rewriter, loc, kvListType, SmallVector<Value>{pastKey, kRotary});
-          presentKey = Torch::AtenCatOp::create(rewriter, loc, resultTypes[1],
-                                                keyList, cstConcatDim);
-        }
-
-        if (!llvm::equal(
-                cast<Torch::ValueTensorType>(pastValue.getType()).getSizes(),
-                cast<Torch::ValueTensorType>(resultTypes[2]).getSizes())) {
-          Value cstConcatDim = Torch::ConstantIntOp::create(
-              rewriter, loc, rewriter.getI64IntegerAttr(2));
-          Type kvListElemType = keyType.getWithSizesAndDtype(
-              /*optionalSizes=*/std::nullopt,
-              /*optionalDtype=*/nullptr);
-          Type kvListType = Torch::ListType::get(kvListElemType);
-          Value valueList = Torch::PrimListConstructOp::create(
-              rewriter, loc, kvListType, SmallVector<Value>{pastValue, vInput});
-          presentValue = Torch::AtenCatOp::create(rewriter, loc, resultTypes[2],
-                                                  valueList, cstConcatDim);
-        }
 
         rewriter.replaceOp(binder.op, {attention, presentKey, presentValue});
         return success();

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
@@ -2503,21 +2503,21 @@ func.func @test_mwm(%arg0: !torch.vtensor<[],si64>, %arg1: !torch.vtensor<[],si6
 
 // CHECK-LABEL: func.func @test_group_query_attention
 func.func @test_group_query_attention(%arg0: !torch.vtensor<[1,1,16],f32>, %arg1: !torch.vtensor<[1,1,16],f32>, %arg2: !torch.vtensor<[1,1,16],f32>) -> (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,1,8],f32>, !torch.vtensor<[1,2,1,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
-  // Reshape + transpose for Q, K, V: [batch, seq, hidden] -> [batch, seq, heads, head_size] -> [batch, heads, seq, head_size]
   // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.reshape %arg0, {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int %[[Q_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[K_RESHAPE:.+]] = torch.aten.reshape %arg1, {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int %[[K_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[V_RESHAPE:.+]] = torch.aten.reshape %arg2, {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int %[[V_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // SDPA with no attention mask (cat-based KV cache, no causal mask needed for empty past)
-  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_TRANSPOSE]], %[[V_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // Transpose + reshape for output: [batch, heads, seq, head_size] -> [batch, seq, heads, head_size] -> [batch, seq, hidden]
+  // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,1,1],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,1],i1>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,1,16],f32>
-  // KV cache via cat: presentKey = cat(pastKey, currentKey)
-  // CHECK: %[[PRESENT_KEY:.+]] = torch.aten.cat {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // CHECK: %[[PRESENT_VALUE:.+]] = torch.aten.cat {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<0> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
@@ -2540,13 +2540,14 @@ func.func @test_group_query_attention_dynamic_seq(%arg0: !torch.vtensor<[1,?,16]
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int %[[K_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
   // CHECK: %[[V_RESHAPE:.+]] = torch.aten.reshape %arg2, {{.*}} -> !torch.vtensor<[1,?,2,8],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int %[[V_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
-  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_TRANSPOSE]], %[[V_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
+  // CHECK: %[[PAD_KEY:.+]] = torch.aten.constant_pad_nd %[[PAST_KEY]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
+  // CHECK: %[[PAD_VALUE:.+]] = torch.aten.constant_pad_nd %[[PAST_VALUE]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
+  // CHECK: %[[PRESENT_KEY:.+]] = torch.aten.scatter.src %[[PAD_KEY]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
+  // CHECK: %[[PRESENT_VALUE:.+]] = torch.aten.scatter.src %[[PAD_VALUE]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
+  // CHECK: %[[MASK:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[1,1,?,?],i1>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[PRESENT_KEY]], %[[PRESENT_VALUE]], %[[MASK]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[1,?,2,8],f32>
   // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,?,16],f32>
-  // CHECK: %[[KEY_LIST:.+]] = torch.prim.ListConstruct %[[PAST_KEY]], %[[K_TRANSPOSE]] : (!torch.vtensor<[1,2,0,8],f32>, !torch.vtensor<[1,2,?,8],f32>) -> !torch.list<vtensor>
-  // CHECK: %[[PRESENT_KEY:.+]] = torch.aten.cat %[[KEY_LIST]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
-  // CHECK: %[[VALUE_LIST:.+]] = torch.prim.ListConstruct %[[PAST_VALUE]], %[[V_TRANSPOSE]] : (!torch.vtensor<[1,2,0,8],f32>, !torch.vtensor<[1,2,?,8],f32>) -> !torch.list<vtensor>
-  // CHECK: %[[PRESENT_VALUE:.+]] = torch.aten.cat %[[VALUE_LIST]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
   %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<0> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
@@ -2568,13 +2569,14 @@ func.func @test_group_query_attention_dynamic_batch_seq(%arg0: !torch.vtensor<[?
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int %[[K_RESHAPE]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
   // CHECK: %[[V_RESHAPE:.+]] = torch.aten.reshape %arg2, {{.*}} -> !torch.vtensor<[?,?,2,8],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int %[[V_RESHAPE]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
-  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_TRANSPOSE]], %[[V_TRANSPOSE]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
+  // CHECK: %[[PAD_KEY:.+]] = torch.aten.constant_pad_nd %arg3, {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
+  // CHECK: %[[PAD_VALUE:.+]] = torch.aten.constant_pad_nd %arg4, {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
+  // CHECK: %[[PRESENT_KEY:.+]] = torch.aten.scatter.src %[[PAD_KEY]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
+  // CHECK: %[[PRESENT_VALUE:.+]] = torch.aten.scatter.src %[[PAD_VALUE]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
+  // CHECK: %[[MASK:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[?,1,?,?],i1>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[PRESENT_KEY]], %[[PRESENT_VALUE]], %[[MASK]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[?,?,2,8],f32>
   // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[?,?,16],f32>
-  // CHECK: %[[KEY_LIST:.+]] = torch.prim.ListConstruct %arg3, %[[K_TRANSPOSE]] : (!torch.vtensor<[?,2,0,8],f32>, !torch.vtensor<[?,2,?,8],f32>) -> !torch.list<vtensor>
-  // CHECK: %[[PRESENT_KEY:.+]] = torch.aten.cat %[[KEY_LIST]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
-  // CHECK: %[[VALUE_LIST:.+]] = torch.prim.ListConstruct %arg4, %[[V_TRANSPOSE]] : (!torch.vtensor<[?,2,0,8],f32>, !torch.vtensor<[?,2,?,8],f32>) -> !torch.list<vtensor>
-  // CHECK: %[[PRESENT_VALUE:.+]] = torch.aten.cat %[[VALUE_LIST]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
   %4:3 = torch.operator "onnx.GroupQueryAttention"(%arg0, %arg1, %arg2, %past_key, %past_value, %seqlens_k, %total_seq_length) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,2,0,8],f32>, !torch.vtensor<[?,2,0,8],f32>, !torch.vtensor<[?],si32>, !torch.vtensor<[?],si32>) -> (!torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,2,?,8],f32>, !torch.vtensor<[?,2,?,8],f32>)
   return %4#0, %4#1, %4#2 : !torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,2,?,8],f32>, !torch.vtensor<[?,2,?,8],f32>
 }
@@ -2583,22 +2585,20 @@ func.func @test_group_query_attention_dynamic_batch_seq(%arg0: !torch.vtensor<[?
 
 // CHECK-LABEL: func.func @test_group_query_attention_with_rotary_embedding
 func.func @test_group_query_attention_with_rotary_embedding(%query: !torch.vtensor<[1,1,16],f32>, %key: !torch.vtensor<[1,1,16],f32>, %value: !torch.vtensor<[1,1,16],f32>, %cos_cache: !torch.vtensor<[2,4],f32>, %sin_cache: !torch.vtensor<[2,4],f32>) -> (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,1,8],f32>, !torch.vtensor<[1,2,1,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
-  // Reshape + transpose for Q, K, V
   // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // Simplified rotary position IDs: arange + repeat + past_seqlens offset
-  // CHECK: %[[POS_IDS:.+]] = torch.aten.add.Tensor {{.*}} -> !torch.vtensor<[1,1],si64>
-  // CHECK: %[[Q_ROTARY:.+]] = torch.onnx.rotary_embedding %[[Q_TRANSPOSE]], %[[POS_IDS]], %arg3, %arg4, {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // CHECK: %[[K_ROTARY:.+]] = torch.onnx.rotary_embedding %[[K_TRANSPOSE]], %[[POS_IDS]], %arg3, %arg4, {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // SDPA with no attention mask
-  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_ROTARY]], %[[K_ROTARY]], %[[V_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // Transpose + reshape for output
+  // CHECK: %[[Q_ROTARY:.+]] = torch.onnx.rotary_embedding %[[Q_TRANSPOSE]], {{.*}} %arg3, %arg4, {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[K_ROTARY:.+]] = torch.onnx.rotary_embedding %[[K_TRANSPOSE]], {{.*}} %arg3, %arg4, {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_ROTARY]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,1,1],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,1],i1>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_ROTARY]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,1,16],f32>
-  // KV cache via cat
-  // CHECK: %[[PRESENT_KEY:.+]] = torch.aten.cat {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // CHECK: %[[PRESENT_VALUE:.+]] = torch.aten.cat {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<0> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
@@ -2607,31 +2607,178 @@ func.func @test_group_query_attention_with_rotary_embedding(%query: !torch.vtens
   %4:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %0, %1, %2, %3, %cos_cache, %sin_cache) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64, torch.onnx.do_rotary = 1 : si64} : (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,0,8],f32>, !torch.vtensor<[1,2,0,8],f32>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>, !torch.vtensor<[2,4],f32>, !torch.vtensor<[2,4],f32>) -> (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,1,8],f32>, !torch.vtensor<[1,2,1,8],f32>)
   return %4#0, %4#1, %4#2 : !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,1,8],f32>, !torch.vtensor<[1,2,1,8],f32>
 }
-
 // -----
 
 // Test GQA with num_heads != kv_num_heads and rotary embedding
-// num_heads=4, kv_num_heads=2 - key rotary must use kv_num_heads, not num_heads
 // CHECK-LABEL: func.func @test_group_query_attention_gqa_rotary
 func.func @test_group_query_attention_gqa_rotary(%query: !torch.vtensor<[1,1,32],f32>, %key: !torch.vtensor<[1,1,16],f32>, %value: !torch.vtensor<[1,1,16],f32>, %cos_cache: !torch.vtensor<[2,4],f32>, %sin_cache: !torch.vtensor<[2,4],f32>) -> (!torch.vtensor<[1,1,32],f32>, !torch.vtensor<[1,2,1,8],f32>, !torch.vtensor<[1,2,1,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
-  // Q reshaped with num_heads=4: [1,1,32] -> [1,1,4,8] -> [1,4,1,8]
   // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,4,1,8],f32>
-  // K reshaped with kv_num_heads=2: [1,1,16] -> [1,1,2,8] -> [1,2,1,8]
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // Rotary uses correct shapes: Q gets [1,4,1,8], K gets [1,2,1,8]
+  // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[Q_ROTARY:.+]] = torch.onnx.rotary_embedding %[[Q_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,4,1,8],f32>
   // CHECK: %[[K_ROTARY:.+]] = torch.onnx.rotary_embedding %[[K_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // SDPA: Q[1,4,1,8] x K[1,2,1,8] -> [1,4,1,8] (GQA broadcasting)
-  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_ROTARY]], %[[K_ROTARY]], {{.*}} -> !torch.vtensor<[1,4,1,8],f32>
-  // Output: [1,4,1,8] -> [1,1,4,8] -> [1,1,32]
+  // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_ROTARY]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_ROTARY]], %[[K_SCATTER]], %[[V_SCATTER]], {{.*}} -> !torch.vtensor<[1,4,1,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[1,1,4,8],f32>
   // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,1,32],f32>
-  // KV cache via cat
-  // CHECK: torch.aten.cat {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<0> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %3 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<1> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %4:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %0, %1, %2, %3, %cos_cache, %sin_cache) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 4 : si64, torch.onnx.do_rotary = 1 : si64} : (!torch.vtensor<[1,1,32],f32>, !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,0,8],f32>, !torch.vtensor<[1,2,0,8],f32>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>, !torch.vtensor<[2,4],f32>, !torch.vtensor<[2,4],f32>) -> (!torch.vtensor<[1,1,32],f32>, !torch.vtensor<[1,2,1,8],f32>, !torch.vtensor<[1,2,1,8],f32>)
   return %4#0, %4#1, %4#2 : !torch.vtensor<[1,1,32],f32>, !torch.vtensor<[1,2,1,8],f32>, !torch.vtensor<[1,2,1,8],f32>
+}
+
+// -----
+
+// Test GQA with non-zero past KV cache
+// CHECK-LABEL: func.func @test_group_query_attention_kv_cache
+func.func @test_group_query_attention_kv_cache(%query: !torch.vtensor<[1,1,16],f32>, %key: !torch.vtensor<[1,1,16],f32>, %value: !torch.vtensor<[1,1,16],f32>, %past_key: !torch.vtensor<[1,2,4,8],f32>, %past_value: !torch.vtensor<[1,2,4,8],f32>) -> (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,5,8],f32>, !torch.vtensor<[1,2,5,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %[[SEQLENS_K:.+]] = torch.aten.to.dtype {{.*}} -> !torch.vtensor<[1],si64>
+  // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd %arg3, {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
+  // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd %arg4, {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
+  // CHECK: %[[Q_RANGE:.+]] = torch.aten.arange {{.*}} -> !torch.vtensor<[1],si64>
+  // CHECK: %[[PAST_VIEW:.+]] = torch.aten.view {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
+  // CHECK: %[[Q_RANGE_4D:.+]] = torch.aten.view %[[Q_RANGE]], {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
+  // CHECK: %[[IDX_BASE:.+]] = torch.aten.add.Tensor %[[PAST_VIEW]], %[[Q_RANGE_4D]], {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
+  // CHECK: %[[SCATTER_IDX:.+]] = torch.aten.expand %[[IDX_BASE]], {{.*}} -> !torch.vtensor<[1,2,1,8],si64>
+  // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]],
+  // CHECK-SAME: %[[SCATTER_IDX]], %[[K_TRANSPOSE]] :
+  // CHECK-SAME: -> !torch.vtensor<[1,2,5,8],f32>
+  // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]],
+  // CHECK-SAME: %[[SCATTER_IDX]], %[[V_TRANSPOSE]] :
+  // CHECK-SAME: -> !torch.vtensor<[1,2,5,8],f32>
+  // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,1,5],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,5],i1>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[1,1,16],f32>
+  %seqlens_k = torch.operator "onnx.Constant"() {torch.onnx.value = dense<4> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<5> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %0:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,4,8],f32>, !torch.vtensor<[1,2,4,8],f32>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>) -> (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,5,8],f32>, !torch.vtensor<[1,2,5,8],f32>)
+  return %0#0, %0#1, %0#2 : !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,5,8],f32>, !torch.vtensor<[1,2,5,8],f32>
+}
+
+// -----
+
+// Test GQA causal mask shape with multi-token sequence
+// CHECK-LABEL: func.func @test_group_query_attention_seqlens_k_mask
+func.func @test_group_query_attention_seqlens_k_mask(%query: !torch.vtensor<[1,4,16],f32>, %key: !torch.vtensor<[1,4,16],f32>, %value: !torch.vtensor<[1,4,16],f32>, %past_key: !torch.vtensor<[1,2,3,8],f32>, %past_value: !torch.vtensor<[1,2,3,8],f32>) -> (!torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,7,8],f32>, !torch.vtensor<[1,2,7,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd %arg3, {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
+  // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd %arg4, {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
+  // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
+  // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
+  // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,4,7],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,4,7],i1>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  %seqlens_k = torch.operator "onnx.Constant"() {torch.onnx.value = dense<6> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<7> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %0:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>) -> (!torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,7,8],f32>, !torch.vtensor<[1,2,7,8],f32>)
+  return %0#0, %0#1, %0#2 : !torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,7,8],f32>, !torch.vtensor<[1,2,7,8],f32>
+}
+
+// -----
+
+// Test GQA with multi-token prefill (seqLen=2)
+// CHECK-LABEL: func.func @test_group_query_attention_prefill_mask_shape
+func.func @test_group_query_attention_prefill_mask_shape(%query: !torch.vtensor<[1,2,16],f32>, %key: !torch.vtensor<[1,2,16],f32>, %value: !torch.vtensor<[1,2,16],f32>, %past_key: !torch.vtensor<[1,2,3,8],f32>, %past_value: !torch.vtensor<[1,2,3,8],f32>) -> (!torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,5,8],f32>, !torch.vtensor<[1,2,5,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,2,8],f32>
+  // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,2,8],f32>
+  // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,2,8],f32>
+  // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd %arg3, {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
+  // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd %arg4, {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
+  // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
+  // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
+  // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,2,5],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,2,5],i1>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,2,8],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[1,2,16],f32>
+  %seqlens_k = torch.operator "onnx.Constant"() {torch.onnx.value = dense<4> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<5> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %0:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>) -> (!torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,5,8],f32>, !torch.vtensor<[1,2,5,8],f32>)
+  return %0#0, %0#1, %0#2 : !torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,5,8],f32>, !torch.vtensor<[1,2,5,8],f32>
+}
+
+// -----
+
+// Test GQA position ID calculation with rotary embeddings
+// CHECK-LABEL: func.func @test_group_query_attention_position_ids
+func.func @test_group_query_attention_position_ids(%query: !torch.vtensor<[1,4,16],f32>, %key: !torch.vtensor<[1,4,16],f32>, %value: !torch.vtensor<[1,4,16],f32>, %past_key: !torch.vtensor<[1,2,3,8],f32>, %past_value: !torch.vtensor<[1,2,3,8],f32>, %cos_cache: !torch.vtensor<[2,4],f32>, %sin_cache: !torch.vtensor<[2,4],f32>) -> (!torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,7,8],f32>, !torch.vtensor<[1,2,7,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  // CHECK: %[[POS_IDS:.+]] = torch.aten.add.Tensor {{.*}} -> !torch.vtensor<[1,4],si64>
+  // CHECK: %[[Q_ROTARY:.+]] = torch.onnx.rotary_embedding %[[Q_TRANSPOSE]], %[[POS_IDS]], {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  // CHECK: %[[K_ROTARY:.+]] = torch.onnx.rotary_embedding %[[K_TRANSPOSE]], %[[POS_IDS]], {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd %arg3, {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
+  // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd %arg4, {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
+  // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_ROTARY]] : {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
+  // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_ROTARY]], %[[K_SCATTER]], %[[V_SCATTER]], {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[1,4,16],f32>
+  %seqlens_k = torch.operator "onnx.Constant"() {torch.onnx.value = dense<6> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<7> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %0:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len, %cos_cache, %sin_cache) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64, torch.onnx.do_rotary = 1 : si64} : (!torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>, !torch.vtensor<[2,4],f32>, !torch.vtensor<[2,4],f32>) -> (!torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,7,8],f32>, !torch.vtensor<[1,2,7,8],f32>)
+  return %0#0, %0#1, %0#2 : !torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,7,8],f32>, !torch.vtensor<[1,2,7,8],f32>
+}
+
+// -----
+
+// Test GQA with f16 inputs
+// CHECK-LABEL: func.func @test_group_query_attention_f16
+func.func @test_group_query_attention_f16(%arg0: !torch.vtensor<[1,1,16],f16>, %arg1: !torch.vtensor<[1,1,16],f16>, %arg2: !torch.vtensor<[1,1,16],f16>) -> (!torch.vtensor<[1,1,16],f16>, !torch.vtensor<[1,2,1,8],f16>, !torch.vtensor<[1,2,1,8],f16>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
+  // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
+  // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
+  // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
+  // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
+  // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
+  // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
+  // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,1,1],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,1],i1>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
+  %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf16>} : () -> !torch.vtensor<[1,2,0,8],f16>
+  %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf16>} : () -> !torch.vtensor<[1,2,0,8],f16>
+  %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<0> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %3 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<1> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %4:3 = torch.operator "onnx.GroupQueryAttention"(%arg0, %arg1, %arg2, %0, %1, %2, %3) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[1,1,16],f16>, !torch.vtensor<[1,1,16],f16>, !torch.vtensor<[1,1,16],f16>, !torch.vtensor<[1,2,0,8],f16>, !torch.vtensor<[1,2,0,8],f16>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>) -> (!torch.vtensor<[1,1,16],f16>, !torch.vtensor<[1,2,1,8],f16>, !torch.vtensor<[1,2,1,8],f16>)
+  return %4#0, %4#1, %4#2 : !torch.vtensor<[1,1,16],f16>, !torch.vtensor<[1,2,1,8],f16>, !torch.vtensor<[1,2,1,8],f16>
+}
+
+// -----
+
+// Test GQA with variable seqlens_k across batch (batch=2)
+// CHECK-LABEL: func.func @test_group_query_attention_variable_seqlens_k
+func.func @test_group_query_attention_variable_seqlens_k(%query: !torch.vtensor<[2,1,16],f32>, %key: !torch.vtensor<[2,1,16],f32>, %value: !torch.vtensor<[2,1,16],f32>, %past_key: !torch.vtensor<[2,2,4,8],f32>, %past_value: !torch.vtensor<[2,2,4,8],f32>, %seqlens_k: !torch.vtensor<[2],si32>) -> (!torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,2,5,8],f32>, !torch.vtensor<[2,2,5,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %[[SEQLENS_K:.+]] = torch.aten.to.dtype %arg5, {{.*}} -> !torch.vtensor<[2],si64>
+  // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[2,2,1,8],f32>
+  // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[2,2,1,8],f32>
+  // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int {{.*}} -> !torch.vtensor<[2,2,1,8],f32>
+  // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd %arg3, {{.*}} -> !torch.vtensor<[2,2,5,8],f32>
+  // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd %arg4, {{.*}} -> !torch.vtensor<[2,2,5,8],f32>
+  // CHECK: %[[Q_RANGE:.+]] = torch.aten.arange {{.*}} -> !torch.vtensor<[1],si64>
+  // CHECK: %[[PAST_VIEW:.+]] = torch.aten.view {{.*}} -> !torch.vtensor<[2,1,1,1],si64>
+  // CHECK: %[[Q_RANGE_4D:.+]] = torch.aten.view %[[Q_RANGE]], {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
+  // CHECK: %[[IDX_BASE:.+]] = torch.aten.add.Tensor %[[PAST_VIEW]], %[[Q_RANGE_4D]], {{.*}} -> !torch.vtensor<[2,1,1,1],si64>
+  // CHECK: %[[SCATTER_IDX:.+]] = torch.aten.expand %[[IDX_BASE]], {{.*}} -> !torch.vtensor<[2,2,1,8],si64>
+  // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]],
+  // CHECK-SAME: %[[SCATTER_IDX]], %[[K_TRANSPOSE]] :
+  // CHECK-SAME: -> !torch.vtensor<[2,2,5,8],f32>
+  // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]],
+  // CHECK-SAME: %[[SCATTER_IDX]], %[[V_TRANSPOSE]] :
+  // CHECK-SAME: -> !torch.vtensor<[2,2,5,8],f32>
+  // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[2,1,5],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[2,1,1,5],i1>
+  // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[2,2,1,8],f32>
+  %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<5> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
+  %0:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,2,4,8],f32>, !torch.vtensor<[2,2,4,8],f32>, !torch.vtensor<[2],si32>, !torch.vtensor<[1],si32>) -> (!torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,2,5,8],f32>, !torch.vtensor<[2,2,5,8],f32>)
+  return %0#0, %0#1, %0#2 : !torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,2,5,8],f32>, !torch.vtensor<[2,2,5,8],f32>
 }

--- a/test/Conversion/TorchToTMTensor/basic.mlir
+++ b/test/Conversion/TorchToTMTensor/basic.mlir
@@ -129,3 +129,16 @@ func.func @scatter_src_i32_index(%arg0: !torch.vtensor<[10,8,6],f32>, %arg1: !to
   %0 = torch.aten.scatter.src %arg0, %int0, %arg1, %arg2 : !torch.vtensor<[10,8,6],f32>, !torch.int, !torch.vtensor<[2,4,3],si32>, !torch.vtensor<[5,8,6],f32> -> !torch.vtensor<[10,8,6],f32>
   return %0 : !torch.vtensor<[10,8,6],f32>
 }
+
+// -----
+
+// CHECK-LABEL: @scatter_src_dim2
+// CHECK: tm_tensor.scatter {dimension_map = array<i64: 0, 1, 2, 3>} unique_indices(false) ins(%{{.*}}, %{{.*}} : tensor<?xf32>, tensor<?x4xi64>) outs(%{{.*}} : tensor<2x2x5x8xf32>) {
+// CHECK:      ^bb0(%arg3: f32, %arg4: f32):
+// CHECK:        tm_tensor.yield %arg3 : f32
+// CHECK:      } -> tensor<2x2x5x8xf32>
+func.func @scatter_src_dim2(%arg0: !torch.vtensor<[2,2,5,8],f32>, %arg1: !torch.vtensor<[2,2,1,8],si64>, %arg2: !torch.vtensor<[2,2,1,8],f32>) -> !torch.vtensor<[2,2,5,8],f32> {
+  %int2 = torch.constant.int 2
+  %0 = torch.aten.scatter.src %arg0, %int2, %arg1, %arg2 : !torch.vtensor<[2,2,5,8],f32>, !torch.int, !torch.vtensor<[2,2,1,8],si64>, !torch.vtensor<[2,2,1,8],f32> -> !torch.vtensor<[2,2,5,8],f32>
+  return %0 : !torch.vtensor<[2,2,5,8],f32>
+}


### PR DESCRIPTION
Replace cat-based KV cache with pad+scatter for correct shared-buffer semantics. With cat(past, current), the current token always lands at past_seq_len, but ORT's GQA places it at `seqlens_k[b]` per batch element. Pad with zeros then scatter to match. Add causal attention mask: `k <= pastLen[b] + q`, reshaped to `[batch, 1, seq, kv_seq]` and passed as a boolean mask to SDPA.
