### PR TITLE
[TorchOnnxToTorch] Remove creation of torch view/reshape ops

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/ComMicrosoftDomain.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/ComMicrosoftDomain.cpp
@@ -480,8 +480,6 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
         Value cstSequenceLength =
             rewriter.createOrFold<Torch::AtenSizeIntOp>(loc, query, cstOneDim);
 
-        Value cstHiddenSize = Torch::ConstantIntOp::create(
-            rewriter, loc, rewriter.getI64IntegerAttr(hiddenSize));
         Value cstHeadSize = Torch::ConstantIntOp::create(
             rewriter, loc, rewriter.getI64IntegerAttr(headSize));
         Value cstNumHeads = Torch::ConstantIntOp::create(
@@ -495,8 +493,6 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
             rewriter, loc, rewriter.getI64IntegerAttr(0));
         Value cstIntOne = Torch::ConstantIntOp::create(
             rewriter, loc, rewriter.getI64IntegerAttr(1));
-        Value cstIntMinusOne = Torch::ConstantIntOp::create(
-            rewriter, loc, rewriter.getI64IntegerAttr(-1));
         Value cstDim1 = Torch::ConstantIntOp::create(
             rewriter, loc, rewriter.getI64IntegerAttr(1));
         Value cstDim2 = Torch::ConstantIntOp::create(
@@ -528,19 +524,18 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
         // A direct reshape would incorrectly interleave heads and sequence
         // positions.
 
-        // Reshaping query: [batch, seq, hidden] -> [batch, seq, num_heads,
+        // Unflatten query: [batch, seq, hidden] -> [batch, seq, num_heads,
         // head_size]
         SmallVector<int64_t> queryIntermediateSizesInt{
             batchSize, sequenceLength, numHeads, headSize};
-        Value queryIntermediateSizesList = Torch::PrimListConstructOp::create(
+        Value unflattenSizesList = Torch::PrimListConstructOp::create(
             rewriter, loc, intListType,
-            llvm::SmallVector<Value>{cstBatchSize, cstSequenceLength,
-                                     cstNumHeads, cstHeadSize});
-        Value qIntermediate = Torch::AtenReshapeOp::create(
+            llvm::SmallVector<Value>{cstNumHeads, cstHeadSize});
+        Value qIntermediate = Torch::AtenUnflattenIntOp::create(
             rewriter, loc,
             queryType.getWithSizesAndDtype(queryIntermediateSizesInt,
                                            queryType.getOptionalDtype()),
-            query, queryIntermediateSizesList);
+            query, /*dim=*/cstDim2, unflattenSizesList);
 
         // Transpose query: [batch, seq, num_heads, head_size] -> [batch,
         // num_heads, seq, head_size]
@@ -552,21 +547,20 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
                                            queryType.getOptionalDtype()),
             qIntermediate, cstDim1, cstDim2);
 
-        // Reshaping key: [batch, seq, kv_hidden] -> [batch, seq, kv_num_heads,
+        // Unflatten key: [batch, seq, kv_hidden] -> [batch, seq, kv_num_heads,
         // head_size]
         SmallVector<int64_t> kvIntermediateSizesInt{batchSize, sequenceLength,
                                                     kvNumHeads, headSize};
-        Value kvIntermediateSizesList = Torch::PrimListConstructOp::create(
+        Value kvUnflattenSizesList = Torch::PrimListConstructOp::create(
             rewriter, loc, intListType,
-            llvm::SmallVector<Value>{cstBatchSize, cstSequenceLength,
-                                     cstKVNumHeads, cstHeadSize});
+            llvm::SmallVector<Value>{cstKVNumHeads, cstHeadSize});
         Torch::ValueTensorType keyType =
             cast<Torch::ValueTensorType>(key.getType());
-        Value kIntermediate = Torch::AtenReshapeOp::create(
+        Value kIntermediate = Torch::AtenUnflattenIntOp::create(
             rewriter, loc,
             keyType.getWithSizesAndDtype(kvIntermediateSizesInt,
                                          keyType.getOptionalDtype()),
-            key, kvIntermediateSizesList);
+            key, /*dim=*/cstDim2, kvUnflattenSizesList);
 
         // Transpose key: [batch, seq, kv_num_heads, head_size] -> [batch,
         // kv_num_heads, seq, head_size]
@@ -578,15 +572,15 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
                                          keyType.getOptionalDtype()),
             kIntermediate, cstDim1, cstDim2);
 
-        // Reshaping value: [batch, seq, kv_hidden] -> [batch, seq,
+        // Unflatten value: [batch, seq, kv_hidden] -> [batch, seq,
         // kv_num_heads, head_size]
         Torch::ValueTensorType valueType =
             cast<Torch::ValueTensorType>(value.getType());
-        Value vIntermediate = Torch::AtenReshapeOp::create(
+        Value vIntermediate = Torch::AtenUnflattenIntOp::create(
             rewriter, loc,
             valueType.getWithSizesAndDtype(kvIntermediateSizesInt,
                                            valueType.getOptionalDtype()),
-            value, kvIntermediateSizesList);
+            value, /*dim=*/cstDim2, kvUnflattenSizesList);
 
         // Transpose value: [batch, seq, kv_num_heads, head_size] -> [batch,
         // kv_num_heads, seq, head_size]
@@ -649,15 +643,12 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
               rewriter, loc, positionIdsType, initPosIds,
               /*repeats=*/repeatValuesList);
 
-          // Reshape past_seqlens to [batch, 1] for broadcasting
-          Value viewSizeList = Torch::PrimListConstructOp::create(
-              rewriter, loc, intListType,
-              llvm::SmallVector<Value>{cstIntMinusOne, cstIntOne});
+          // Unsqueeze past_seqlens: [batch] -> [batch, 1] for broadcasting
           Torch::ValueTensorType seqLensViewType = Torch::ValueTensorType::get(
               context, llvm::SmallVector<int64_t>{batchSize, 1},
               IntegerType::get(context, 64, IntegerType::Signed));
-          pastSeqLens = Torch::AtenViewOp::create(
-              rewriter, loc, seqLensViewType, pastSeqLens, viewSizeList);
+          pastSeqLens = Torch::AtenUnsqueezeOp::create(
+              rewriter, loc, seqLensViewType, pastSeqLens, cstDim1);
 
           // Add past_seqlens to get final position IDs
           positionIds = Torch::AtenAddTensorOp::create(
@@ -719,29 +710,43 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
             rewriter, loc, qRangeType, cstSequenceLength, cstInt64Dtype,
             /*layout=*/cstNone, /*device=*/cstNone, /*pin_memory=*/cstNone);
 
-        // pastLen -> [B, 1, 1, 1] for 4D scatter index broadcasting
-        Value scatterViewList = Torch::PrimListConstructOp::create(
-            rewriter, loc, intListType,
-            SmallVector<Value>{cstIntMinusOne, cstIntOne, cstIntOne,
-                               cstIntOne});
-        SmallVector<int64_t> pastLenView4dSizes{batchSize, 1, 1, 1};
+        // pastLen -> [B, 1, 1, 1] via unsqueeze chain for 4D scatter index
+        // broadcasting
+        auto intSiType = rewriter.getIntegerType(64, /*isSigned=*/true);
+        Value cstDim3 = Torch::ConstantIntOp::create(
+            rewriter, loc, rewriter.getI64IntegerAttr(3));
+        // [batch] -> [batch, 1]
+        Torch::ValueTensorType pastLenUnsq1Type = Torch::ValueTensorType::get(
+            context, SmallVector<int64_t>{batchSize, 1}, intSiType);
+        Value pastLenUnsq1 = Torch::AtenUnsqueezeOp::create(
+            rewriter, loc, pastLenUnsq1Type, pastLen, cstDim1);
+        // [batch, 1] -> [batch, 1, 1]
+        Torch::ValueTensorType pastLenUnsq2Type = Torch::ValueTensorType::get(
+            context, SmallVector<int64_t>{batchSize, 1, 1}, intSiType);
+        Value pastLenUnsq2 = Torch::AtenUnsqueezeOp::create(
+            rewriter, loc, pastLenUnsq2Type, pastLenUnsq1, cstDim2);
+        // [batch, 1, 1] -> [batch, 1, 1, 1]
         Torch::ValueTensorType pastLenView4dType = Torch::ValueTensorType::get(
-            context, pastLenView4dSizes,
-            rewriter.getIntegerType(64, /*isSigned=*/true));
-        Value pastLenView4d = Torch::AtenViewOp::create(
-            rewriter, loc, pastLenView4dType, pastLen, scatterViewList);
+            context, SmallVector<int64_t>{batchSize, 1, 1, 1}, intSiType);
+        Value pastLenView4d = Torch::AtenUnsqueezeOp::create(
+            rewriter, loc, pastLenView4dType, pastLenUnsq2, cstDim3);
 
-        // qRange -> [1, 1, seq, 1] for scatter
-        Value scatterQViewList = Torch::PrimListConstructOp::create(
-            rewriter, loc, intListType,
-            SmallVector<Value>{cstIntOne, cstIntOne, cstIntMinusOne,
-                               cstIntOne});
-        SmallVector<int64_t> scatterQViewSizes{1, 1, sequenceLength, 1};
+        // qRange -> [1, 1, seq, 1] via unsqueeze chain for scatter
+        // [seq] -> [1, seq]
+        Torch::ValueTensorType qUnsq0Type = Torch::ValueTensorType::get(
+            context, SmallVector<int64_t>{1, sequenceLength}, intSiType);
+        Value qUnsq0 = Torch::AtenUnsqueezeOp::create(rewriter, loc, qUnsq0Type,
+                                                      qRange, cstIntZero);
+        // [1, seq] -> [1, 1, seq]
+        Torch::ValueTensorType qUnsq1Type = Torch::ValueTensorType::get(
+            context, SmallVector<int64_t>{1, 1, sequenceLength}, intSiType);
+        Value qUnsq1 = Torch::AtenUnsqueezeOp::create(rewriter, loc, qUnsq1Type,
+                                                      qUnsq0, cstIntZero);
+        // [1, 1, seq] -> [1, 1, seq, 1]
         Torch::ValueTensorType scatterQViewType = Torch::ValueTensorType::get(
-            context, scatterQViewSizes,
-            rewriter.getIntegerType(64, /*isSigned=*/true));
-        Value scatterQRangeView = Torch::AtenViewOp::create(
-            rewriter, loc, scatterQViewType, qRange, scatterQViewList);
+            context, SmallVector<int64_t>{1, 1, sequenceLength, 1}, intSiType);
+        Value scatterQRangeView = Torch::AtenUnsqueezeOp::create(
+            rewriter, loc, scatterQViewType, qUnsq1, cstDim3);
 
         // scatterIdxBase = pastLen[B,1,1,1] + qRange[1,1,seq,1]
         //               -> [B, 1, seq, 1]
@@ -810,39 +815,43 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
             // qRange: [seqLen] -> [1, seqLen, 1]  (reuses qRange from above)
             // kRange: [kvSeqLen] -> [1, 1, kvSeqLen]
 
-            // pastLen -> [batch, 1, 1]
-            Value seqlensViewList = Torch::PrimListConstructOp::create(
-                rewriter, loc, intListType,
-                SmallVector<Value>{cstIntMinusOne, cstIntOne, cstIntOne});
-            SmallVector<int64_t> seqlensViewSizes{batchSize, 1, 1};
+            // pastLen -> [batch, 1, 1] via unsqueeze chain
+            // [batch] -> [batch, 1]
+            Torch::ValueTensorType pastLenMaskUnsq1Type =
+                Torch::ValueTensorType::get(
+                    context, SmallVector<int64_t>{batchSize, 1}, intSiType);
+            Value pastLenMaskUnsq1 = Torch::AtenUnsqueezeOp::create(
+                rewriter, loc, pastLenMaskUnsq1Type, pastLen, cstDim1);
+            // [batch, 1] -> [batch, 1, 1]
             Torch::ValueTensorType seqlensViewType =
                 Torch::ValueTensorType::get(
-                    context, seqlensViewSizes,
-                    rewriter.getIntegerType(64, /*isSigned=*/true));
-            Value pastLenView = Torch::AtenViewOp::create(
-                rewriter, loc, seqlensViewType, pastLen, seqlensViewList);
+                    context, SmallVector<int64_t>{batchSize, 1, 1}, intSiType);
+            Value pastLenView = Torch::AtenUnsqueezeOp::create(
+                rewriter, loc, seqlensViewType, pastLenMaskUnsq1, cstDim2);
 
-            // qRange -> [1, seqLen, 1]
-            Value qViewList = Torch::PrimListConstructOp::create(
-                rewriter, loc, intListType,
-                SmallVector<Value>{cstIntOne, cstIntMinusOne, cstIntOne});
-            SmallVector<int64_t> qViewSizes{1, sequenceLength, 1};
+            // qRange -> [1, seqLen, 1] via unsqueeze chain
+            // [seqLen] -> [1, seqLen]
+            Torch::ValueTensorType qMaskUnsq0Type = Torch::ValueTensorType::get(
+                context, SmallVector<int64_t>{1, sequenceLength}, intSiType);
+            Value qMaskUnsq0 = Torch::AtenUnsqueezeOp::create(
+                rewriter, loc, qMaskUnsq0Type, qRange, cstIntZero);
+            // [1, seqLen] -> [1, seqLen, 1]
             Torch::ValueTensorType qViewType = Torch::ValueTensorType::get(
-                context, qViewSizes,
-                rewriter.getIntegerType(64, /*isSigned=*/true));
-            Value qRangeView = Torch::AtenViewOp::create(
-                rewriter, loc, qViewType, qRange, qViewList);
+                context, SmallVector<int64_t>{1, sequenceLength, 1}, intSiType);
+            Value qRangeView = Torch::AtenUnsqueezeOp::create(
+                rewriter, loc, qViewType, qMaskUnsq0, cstDim2);
 
-            // kRange -> [1, 1, kvSeqLen]
-            Value kViewList = Torch::PrimListConstructOp::create(
-                rewriter, loc, intListType,
-                SmallVector<Value>{cstIntOne, cstIntOne, cstIntMinusOne});
-            SmallVector<int64_t> kViewSizes{1, 1, kvSeqLen};
+            // kRange -> [1, 1, kvSeqLen] via unsqueeze chain
+            // [kvSeqLen] -> [1, kvSeqLen]
+            Torch::ValueTensorType kUnsq0Type = Torch::ValueTensorType::get(
+                context, SmallVector<int64_t>{1, kvSeqLen}, intSiType);
+            Value kUnsq0 = Torch::AtenUnsqueezeOp::create(
+                rewriter, loc, kUnsq0Type, kRange, cstIntZero);
+            // [1, kvSeqLen] -> [1, 1, kvSeqLen]
             Torch::ValueTensorType kViewType = Torch::ValueTensorType::get(
-                context, kViewSizes,
-                rewriter.getIntegerType(64, /*isSigned=*/true));
-            Value kRangeView = Torch::AtenViewOp::create(
-                rewriter, loc, kViewType, kRange, kViewList);
+                context, SmallVector<int64_t>{1, 1, kvSeqLen}, intSiType);
+            Value kRangeView = Torch::AtenUnsqueezeOp::create(
+                rewriter, loc, kViewType, kUnsq0, cstIntZero);
 
             // Causal mask: k <= pastLen + q
             // pastLenView[batch,1,1] + qRangeView[1,seqLen,1]
@@ -866,20 +875,16 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
             Value causalMask = Torch::AtenLeTensorOp::create(
                 rewriter, loc, maskBoolType, kRangeView, pastLenPlusQ);
 
-            // Reshape to [batch, 1, seqLen, kvSeqLen] for SDPA.
+            // Unsqueeze to [batch, 1, seqLen, kvSeqLen] for SDPA.
             // Pass the boolean mask directly — downstream backends (e.g.
             // IREE's iree_linalg_ext.attention) handle bool-to-float
             // conversion internally.
-            Value maskReshapeSizeList = Torch::PrimListConstructOp::create(
-                rewriter, loc, intListType,
-                SmallVector<Value>{cstBatchSize, cstIntOne, cstSequenceLength,
-                                   kvSeqLenVal});
             SmallVector<int64_t> attnMaskSizes{batchSize, 1, sequenceLength,
                                                kvSeqLen};
             Torch::ValueTensorType attnMaskType = Torch::ValueTensorType::get(
                 context, attnMaskSizes, rewriter.getI1Type());
-            attnMask = Torch::AtenReshapeOp::create(
-                rewriter, loc, attnMaskType, causalMask, maskReshapeSizeList);
+            attnMask = Torch::AtenUnsqueezeOp::create(
+                rewriter, loc, attnMaskType, causalMask, cstDim1);
           }
         }
 
@@ -919,14 +924,9 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
                                           attnType.getOptionalDtype()),
             attention, cstDim1, cstDim2);
 
-        // Reshape: [batch, seq, num_heads, head_size] -> [batch, seq, hidden]
-        Value attentionResultSizesList = Torch::PrimListConstructOp::create(
-            rewriter, loc, intListType,
-            llvm::SmallVector<Value>{cstBatchSize, cstSequenceLength,
-                                     cstHiddenSize});
-        attention = Torch::AtenReshapeOp::create(rewriter, loc, resultTypes[0],
-                                                 attnTransposed,
-                                                 attentionResultSizesList);
+        // Flatten: [batch, seq, num_heads, head_size] -> [batch, seq, hidden]
+        attention = Torch::AtenFlattenUsingIntsOp::create(
+            rewriter, loc, resultTypes[0], attnTransposed, cstDim2, cstDim3);
 
         rewriter.replaceOp(binder.op, {attention, presentKey, presentValue});
         return success();

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
@@ -2503,21 +2503,21 @@ func.func @test_mwm(%arg0: !torch.vtensor<[],si64>, %arg1: !torch.vtensor<[],si6
 
 // CHECK-LABEL: func.func @test_group_query_attention
 func.func @test_group_query_attention(%arg0: !torch.vtensor<[1,1,16],f32>, %arg1: !torch.vtensor<[1,1,16],f32>, %arg2: !torch.vtensor<[1,1,16],f32>) -> (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,1,8],f32>, !torch.vtensor<[1,2,1,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
-  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.reshape %arg0, {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
+  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.unflatten.int %arg0, {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int %[[Q_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.reshape %arg1, {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
+  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.unflatten.int %arg1, {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int %[[K_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.reshape %arg2, {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
+  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.unflatten.int %arg2, {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int %[[V_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,1,1],i1>
-  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,1],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.unsqueeze %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,1],i1>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
-  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,1,16],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.flatten.using_ints %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,1,16],f32>
   %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<0> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
@@ -2534,20 +2534,20 @@ func.func @test_group_query_attention_dynamic_seq(%arg0: !torch.vtensor<[1,?,16]
   // CHECK: %[[PAST_KEY:.+]] = torch.vtensor.literal(dense<> : tensor<1x2x0x8xf32>) : !torch.vtensor<[1,2,0,8],f32>
   // CHECK: %[[PAST_VALUE:.+]] = torch.vtensor.literal(dense<> : tensor<1x2x0x8xf32>) : !torch.vtensor<[1,2,0,8],f32>
   // CHECK: %[[SEQ_LEN:.+]] = torch.aten.size.int %arg0, {{.*}} : !torch.vtensor<[1,?,16],f32>, !torch.int -> !torch.int
-  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.reshape %arg0, {{.*}} -> !torch.vtensor<[1,?,2,8],f32>
+  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.unflatten.int %arg0, {{.*}} -> !torch.vtensor<[1,?,2,8],f32>
   // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int %[[Q_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
-  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.reshape %arg1, {{.*}} -> !torch.vtensor<[1,?,2,8],f32>
+  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.unflatten.int %arg1, {{.*}} -> !torch.vtensor<[1,?,2,8],f32>
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int %[[K_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
-  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.reshape %arg2, {{.*}} -> !torch.vtensor<[1,?,2,8],f32>
+  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.unflatten.int %arg2, {{.*}} -> !torch.vtensor<[1,?,2,8],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int %[[V_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
   // CHECK: %[[PAD_KEY:.+]] = torch.aten.constant_pad_nd %[[PAST_KEY]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
   // CHECK: %[[PAD_VALUE:.+]] = torch.aten.constant_pad_nd %[[PAST_VALUE]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
   // CHECK: %[[PRESENT_KEY:.+]] = torch.aten.scatter.src %[[PAD_KEY]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
   // CHECK: %[[PRESENT_VALUE:.+]] = torch.aten.scatter.src %[[PAD_VALUE]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
-  // CHECK: %[[MASK:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[1,1,?,?],i1>
+  // CHECK: %[[MASK:.+]] = torch.aten.unsqueeze {{.*}} -> !torch.vtensor<[1,1,?,?],i1>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[PRESENT_KEY]], %[[PRESENT_VALUE]], %[[MASK]], {{.*}} -> !torch.vtensor<[1,2,?,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[1,?,2,8],f32>
-  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,?,16],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.flatten.using_ints %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,?,16],f32>
   %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<0> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
@@ -2563,20 +2563,20 @@ func.func @test_group_query_attention_dynamic_seq(%arg0: !torch.vtensor<[1,?,16]
 func.func @test_group_query_attention_dynamic_batch_seq(%arg0: !torch.vtensor<[?,?,16],f32>, %arg1: !torch.vtensor<[?,?,16],f32>, %arg2: !torch.vtensor<[?,?,16],f32>, %past_key: !torch.vtensor<[?,2,0,8],f32>, %past_value: !torch.vtensor<[?,2,0,8],f32>, %seqlens_k: !torch.vtensor<[?],si32>, %total_seq_length: !torch.vtensor<[?],si32>) -> (!torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,2,?,8],f32>, !torch.vtensor<[?,2,?,8],f32>) attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 22 : si64, torch.onnx_meta.producer_name = "", torch.onnx_meta.producer_version = ""} {
   // CHECK: %[[BATCH:.+]] = torch.aten.size.int %arg0, {{.*}} : !torch.vtensor<[?,?,16],f32>, !torch.int -> !torch.int
   // CHECK: %[[SEQ_LEN:.+]] = torch.aten.size.int %arg0, {{.*}} : !torch.vtensor<[?,?,16],f32>, !torch.int -> !torch.int
-  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.reshape %arg0, {{.*}} -> !torch.vtensor<[?,?,2,8],f32>
+  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.unflatten.int %arg0, {{.*}} -> !torch.vtensor<[?,?,2,8],f32>
   // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int %[[Q_RESHAPE]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
-  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.reshape %arg1, {{.*}} -> !torch.vtensor<[?,?,2,8],f32>
+  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.unflatten.int %arg1, {{.*}} -> !torch.vtensor<[?,?,2,8],f32>
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int %[[K_RESHAPE]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
-  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.reshape %arg2, {{.*}} -> !torch.vtensor<[?,?,2,8],f32>
+  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.unflatten.int %arg2, {{.*}} -> !torch.vtensor<[?,?,2,8],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int %[[V_RESHAPE]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
   // CHECK: %[[PAD_KEY:.+]] = torch.aten.constant_pad_nd %arg3, {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
   // CHECK: %[[PAD_VALUE:.+]] = torch.aten.constant_pad_nd %arg4, {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
   // CHECK: %[[PRESENT_KEY:.+]] = torch.aten.scatter.src %[[PAD_KEY]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
   // CHECK: %[[PRESENT_VALUE:.+]] = torch.aten.scatter.src %[[PAD_VALUE]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
-  // CHECK: %[[MASK:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[?,1,?,?],i1>
+  // CHECK: %[[MASK:.+]] = torch.aten.unsqueeze {{.*}} -> !torch.vtensor<[?,1,?,?],i1>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[PRESENT_KEY]], %[[PRESENT_VALUE]], %[[MASK]], {{.*}} -> !torch.vtensor<[?,2,?,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[?,?,2,8],f32>
-  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[?,?,16],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.flatten.using_ints %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[?,?,16],f32>
   %4:3 = torch.operator "onnx.GroupQueryAttention"(%arg0, %arg1, %arg2, %past_key, %past_value, %seqlens_k, %total_seq_length) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,2,0,8],f32>, !torch.vtensor<[?,2,0,8],f32>, !torch.vtensor<[?],si32>, !torch.vtensor<[?],si32>) -> (!torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,2,?,8],f32>, !torch.vtensor<[?,2,?,8],f32>)
   return %4#0, %4#1, %4#2 : !torch.vtensor<[?,?,16],f32>, !torch.vtensor<[?,2,?,8],f32>, !torch.vtensor<[?,2,?,8],f32>
 }
@@ -2595,10 +2595,10 @@ func.func @test_group_query_attention_with_rotary_embedding(%query: !torch.vtens
   // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_ROTARY]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,1,1],i1>
-  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,1],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.unsqueeze %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,1],i1>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_ROTARY]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
-  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,1,16],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.flatten.using_ints %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,1,16],f32>
   %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<0> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
@@ -2619,11 +2619,11 @@ func.func @test_group_query_attention_packed_qkv_rotary(%packed_qkv: !torch.vten
   // CHECK: %[[Q_SLICE:.+]] = torch.aten.slice.Tensor %arg0, {{.*}} -> !torch.vtensor<[1,1,32],f32>
   // CHECK: %[[K_SLICE:.+]] = torch.aten.slice.Tensor %arg0, {{.*}} -> !torch.vtensor<[1,1,16],f32>
   // CHECK: %[[V_SLICE:.+]] = torch.aten.slice.Tensor %arg0, {{.*}} -> !torch.vtensor<[1,1,16],f32>
-  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.reshape %[[Q_SLICE]], {{.*}} -> !torch.vtensor<[1,1,4,8],f32>
+  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.unflatten.int %[[Q_SLICE]], {{.*}} -> !torch.vtensor<[1,1,4,8],f32>
   // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int %[[Q_RESHAPE]], {{.*}} -> !torch.vtensor<[1,4,1,8],f32>
-  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.reshape %[[K_SLICE]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
+  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.unflatten.int %[[K_SLICE]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int %[[K_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.reshape %[[V_SLICE]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
+  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.unflatten.int %[[V_SLICE]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int %[[V_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[Q_ROTARY:.+]] = torch.onnx.rotary_embedding %[[Q_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,4,1,8],f32>
   // CHECK: %[[K_ROTARY:.+]] = torch.onnx.rotary_embedding %[[K_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
@@ -2646,11 +2646,11 @@ func.func @test_group_query_attention_packed_qkv_dynamic(%packed_qkv: !torch.vte
   // CHECK: %[[Q_SLICE:.+]] = torch.aten.slice.Tensor %arg0, {{.*}} -> !torch.vtensor<[?,?,4096],f32>
   // CHECK: %[[K_SLICE:.+]] = torch.aten.slice.Tensor %arg0, {{.*}} -> !torch.vtensor<[?,?,1024],f32>
   // CHECK: %[[V_SLICE:.+]] = torch.aten.slice.Tensor %arg0, {{.*}} -> !torch.vtensor<[?,?,1024],f32>
-  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.reshape %[[Q_SLICE]], {{.*}} -> !torch.vtensor<[?,?,32,128],f32>
+  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.unflatten.int %[[Q_SLICE]], {{.*}} -> !torch.vtensor<[?,?,32,128],f32>
   // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int %[[Q_RESHAPE]], {{.*}} -> !torch.vtensor<[?,32,?,128],f32>
-  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.reshape %[[K_SLICE]], {{.*}} -> !torch.vtensor<[?,?,8,128],f32>
+  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.unflatten.int %[[K_SLICE]], {{.*}} -> !torch.vtensor<[?,?,8,128],f32>
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int %[[K_RESHAPE]], {{.*}} -> !torch.vtensor<[?,8,?,128],f32>
-  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.reshape %[[V_SLICE]], {{.*}} -> !torch.vtensor<[?,?,8,128],f32>
+  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.unflatten.int %[[V_SLICE]], {{.*}} -> !torch.vtensor<[?,?,8,128],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int %[[V_RESHAPE]], {{.*}} -> !torch.vtensor<[?,8,?,128],f32>
   // CHECK: %[[Q_ROTARY:.+]] = torch.onnx.rotary_embedding %[[Q_TRANSPOSE]], {{.*}} -> !torch.vtensor<[?,32,?,128],f32>
   // CHECK: %[[K_ROTARY:.+]] = torch.onnx.rotary_embedding %[[K_TRANSPOSE]], {{.*}} -> !torch.vtensor<[?,8,?,128],f32>
@@ -2672,11 +2672,11 @@ func.func @test_group_query_attention_packed_qkv_no_rotary(%packed_qkv: !torch.v
   // CHECK: %[[Q_SLICE:.+]] = torch.aten.slice.Tensor %arg0, {{.*}} -> !torch.vtensor<[1,1,32],f32>
   // CHECK: %[[K_SLICE:.+]] = torch.aten.slice.Tensor %arg0, {{.*}} -> !torch.vtensor<[1,1,16],f32>
   // CHECK: %[[V_SLICE:.+]] = torch.aten.slice.Tensor %arg0, {{.*}} -> !torch.vtensor<[1,1,16],f32>
-  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.reshape %[[Q_SLICE]], {{.*}} -> !torch.vtensor<[1,1,4,8],f32>
+  // CHECK: %[[Q_RESHAPE:.+]] = torch.aten.unflatten.int %[[Q_SLICE]], {{.*}} -> !torch.vtensor<[1,1,4,8],f32>
   // CHECK: %[[Q_TRANSPOSE:.+]] = torch.aten.transpose.int %[[Q_RESHAPE]], {{.*}} -> !torch.vtensor<[1,4,1,8],f32>
-  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.reshape %[[K_SLICE]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
+  // CHECK: %[[K_RESHAPE:.+]] = torch.aten.unflatten.int %[[K_SLICE]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[K_TRANSPOSE:.+]] = torch.aten.transpose.int %[[K_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.reshape %[[V_SLICE]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
+  // CHECK: %[[V_RESHAPE:.+]] = torch.aten.unflatten.int %[[V_SLICE]], {{.*}} -> !torch.vtensor<[1,1,2,8],f32>
   // CHECK: %[[V_TRANSPOSE:.+]] = torch.aten.transpose.int %[[V_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK-NOT: torch.onnx.rotary_embedding
   // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd %arg1, {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
@@ -2706,7 +2706,7 @@ func.func @test_group_query_attention_gqa_rotary(%query: !torch.vtensor<[1,1,32]
   // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_ROTARY]], %[[K_SCATTER]], %[[V_SCATTER]], {{.*}} -> !torch.vtensor<[1,4,1,8],f32>
   // CHECK: %[[OUT_TRANSPOSE:.+]] = torch.aten.transpose.int %[[OUTPUT]], {{.*}} -> !torch.vtensor<[1,1,4,8],f32>
-  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,1,32],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.flatten.using_ints %[[OUT_TRANSPOSE]], {{.*}} -> !torch.vtensor<[1,1,32],f32>
   %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf32>} : () -> !torch.vtensor<[1,2,0,8],f32>
   %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<0> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
@@ -2727,8 +2727,8 @@ func.func @test_group_query_attention_kv_cache(%query: !torch.vtensor<[1,1,16],f
   // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd %arg3, {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
   // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd %arg4, {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
   // CHECK: %[[Q_RANGE:.+]] = torch.aten.arange {{.*}} -> !torch.vtensor<[1],si64>
-  // CHECK: %[[PAST_VIEW:.+]] = torch.aten.view {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
-  // CHECK: %[[Q_RANGE_4D:.+]] = torch.aten.view %[[Q_RANGE]], {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
+  // CHECK: %[[PAST_VIEW:.+]] = torch.aten.unsqueeze {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
+  // CHECK: %[[Q_RANGE_4D:.+]] = torch.aten.unsqueeze {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
   // CHECK: %[[IDX_BASE:.+]] = torch.aten.add.Tensor %[[PAST_VIEW]], %[[Q_RANGE_4D]], {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
   // CHECK: %[[SCATTER_IDX:.+]] = torch.aten.expand %[[IDX_BASE]], {{.*}} -> !torch.vtensor<[1,2,1,8],si64>
   // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]],
@@ -2738,9 +2738,9 @@ func.func @test_group_query_attention_kv_cache(%query: !torch.vtensor<[1,1,16],f
   // CHECK-SAME: %[[SCATTER_IDX]], %[[V_TRANSPOSE]] :
   // CHECK-SAME: -> !torch.vtensor<[1,2,5,8],f32>
   // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,1,5],i1>
-  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,5],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.unsqueeze %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,5],i1>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f32>
-  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[1,1,16],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.flatten.using_ints {{.*}} -> !torch.vtensor<[1,1,16],f32>
   %seqlens_k = torch.operator "onnx.Constant"() {torch.onnx.value = dense<4> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<5> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %0:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,4,8],f32>, !torch.vtensor<[1,2,4,8],f32>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>) -> (!torch.vtensor<[1,1,16],f32>, !torch.vtensor<[1,2,5,8],f32>, !torch.vtensor<[1,2,5,8],f32>)
@@ -2760,7 +2760,7 @@ func.func @test_group_query_attention_seqlens_k_mask(%query: !torch.vtensor<[1,4
   // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
   // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
   // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,4,7],i1>
-  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,4,7],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.unsqueeze %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,4,7],i1>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
   %seqlens_k = torch.operator "onnx.Constant"() {torch.onnx.value = dense<6> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<7> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
@@ -2781,9 +2781,9 @@ func.func @test_group_query_attention_prefill_mask_shape(%query: !torch.vtensor<
   // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
   // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,5,8],f32>
   // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,2,5],i1>
-  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,2,5],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.unsqueeze %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,2,5],i1>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,2,8],f32>
-  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[1,2,16],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.flatten.using_ints {{.*}} -> !torch.vtensor<[1,2,16],f32>
   %seqlens_k = torch.operator "onnx.Constant"() {torch.onnx.value = dense<4> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<5> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %0:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>) -> (!torch.vtensor<[1,2,16],f32>, !torch.vtensor<[1,2,5,8],f32>, !torch.vtensor<[1,2,5,8],f32>)
@@ -2806,7 +2806,7 @@ func.func @test_group_query_attention_position_ids(%query: !torch.vtensor<[1,4,1
   // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_ROTARY]] : {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
   // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,7,8],f32>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_ROTARY]], %[[K_SCATTER]], %[[V_SCATTER]], {{.*}} -> !torch.vtensor<[1,2,4,8],f32>
-  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.reshape {{.*}} -> !torch.vtensor<[1,4,16],f32>
+  // CHECK: %[[OUT_RESHAPE:.+]] = torch.aten.flatten.using_ints {{.*}} -> !torch.vtensor<[1,4,16],f32>
   %seqlens_k = torch.operator "onnx.Constant"() {torch.onnx.value = dense<6> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<7> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %0:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len, %cos_cache, %sin_cache) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64, torch.onnx.do_rotary = 1 : si64} : (!torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1,2,3,8],f32>, !torch.vtensor<[1],si32>, !torch.vtensor<[1],si32>, !torch.vtensor<[2,4],f32>, !torch.vtensor<[2,4],f32>) -> (!torch.vtensor<[1,4,16],f32>, !torch.vtensor<[1,2,7,8],f32>, !torch.vtensor<[1,2,7,8],f32>)
@@ -2826,7 +2826,7 @@ func.func @test_group_query_attention_f16(%arg0: !torch.vtensor<[1,1,16],f16>, %
   // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]], {{.*}}, %[[K_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
   // CHECK: %[[V_SCATTER:.+]] = torch.aten.scatter.src %[[V_PAD]], {{.*}}, %[[V_TRANSPOSE]] : {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
   // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[1,1,1],i1>
-  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,1],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.unsqueeze %[[MASK]], {{.*}} -> !torch.vtensor<[1,1,1,1],i1>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[1,2,1,8],f16>
   %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf16>} : () -> !torch.vtensor<[1,2,0,8],f16>
   %1 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<> : tensor<1x2x0x8xf16>} : () -> !torch.vtensor<[1,2,0,8],f16>
@@ -2848,8 +2848,8 @@ func.func @test_group_query_attention_variable_seqlens_k(%query: !torch.vtensor<
   // CHECK: %[[K_PAD:.+]] = torch.aten.constant_pad_nd %arg3, {{.*}} -> !torch.vtensor<[2,2,5,8],f32>
   // CHECK: %[[V_PAD:.+]] = torch.aten.constant_pad_nd %arg4, {{.*}} -> !torch.vtensor<[2,2,5,8],f32>
   // CHECK: %[[Q_RANGE:.+]] = torch.aten.arange {{.*}} -> !torch.vtensor<[1],si64>
-  // CHECK: %[[PAST_VIEW:.+]] = torch.aten.view {{.*}} -> !torch.vtensor<[2,1,1,1],si64>
-  // CHECK: %[[Q_RANGE_4D:.+]] = torch.aten.view %[[Q_RANGE]], {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
+  // CHECK: %[[PAST_VIEW:.+]] = torch.aten.unsqueeze {{.*}} -> !torch.vtensor<[2,1,1,1],si64>
+  // CHECK: %[[Q_RANGE_4D:.+]] = torch.aten.unsqueeze {{.*}} -> !torch.vtensor<[1,1,1,1],si64>
   // CHECK: %[[IDX_BASE:.+]] = torch.aten.add.Tensor %[[PAST_VIEW]], %[[Q_RANGE_4D]], {{.*}} -> !torch.vtensor<[2,1,1,1],si64>
   // CHECK: %[[SCATTER_IDX:.+]] = torch.aten.expand %[[IDX_BASE]], {{.*}} -> !torch.vtensor<[2,2,1,8],si64>
   // CHECK: %[[K_SCATTER:.+]] = torch.aten.scatter.src %[[K_PAD]],
@@ -2859,7 +2859,7 @@ func.func @test_group_query_attention_variable_seqlens_k(%query: !torch.vtensor<
   // CHECK-SAME: %[[SCATTER_IDX]], %[[V_TRANSPOSE]] :
   // CHECK-SAME: -> !torch.vtensor<[2,2,5,8],f32>
   // CHECK: %[[MASK:.+]] = torch.aten.le.Tensor {{.*}} -> !torch.vtensor<[2,1,5],i1>
-  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.reshape %[[MASK]], {{.*}} -> !torch.vtensor<[2,1,1,5],i1>
+  // CHECK: %[[MASK_RESHAPE:.+]] = torch.aten.unsqueeze %[[MASK]], {{.*}} -> !torch.vtensor<[2,1,1,5],i1>
   // CHECK: %[[OUTPUT:.+]] = torch.aten.scaled_dot_product_attention %[[Q_TRANSPOSE]], %[[K_SCATTER]], %[[V_SCATTER]], %[[MASK_RESHAPE]], {{.*}} -> !torch.vtensor<[2,2,1,8],f32>
   %total_seq_len = torch.operator "onnx.Constant"() {torch.onnx.value = dense<5> : tensor<1xsi32>} : () -> !torch.vtensor<[1],si32>
   %0:3 = torch.operator "onnx.GroupQueryAttention"(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len) {torch.onnx.kv_num_heads = 2 : si64, torch.onnx.num_heads = 2 : si64} : (!torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,2,4,8],f32>, !torch.vtensor<[2,2,4,8],f32>, !torch.vtensor<[2],si32>, !torch.vtensor<[1],si32>) -> (!torch.vtensor<[2,1,16],f32>, !torch.vtensor<[2,2,5,8],f32>, !torch.vtensor<[2,2,5,8],f32>)


### PR DESCRIPTION
Replace view and reshape ops with ops that lower to `tensor.expand_shape` and `tensor.collapse_shape` instead of `tensor.reshape`:
- reshape for Q/K/V head splitting -> aten.unflatten.int
- reshape for final head merging -> aten.flatten.using_ints
- view/reshape for dim expansion -> aten.unsqueeze