### PR TITLE
Add negative PY_BUILTIN_TO_TORCH_OP

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -284,6 +284,7 @@ PY_BUILTIN_TO_TORCH_OP = {
     "mod": torch.ops.aten.fmod,
     "eq": torch.ops.aten.eq,
     "floordiv": torch.ops.aten.floordiv,
+    "neg": torch.ops.aten.neg,
 }
 
 # torch with cuda has a __version__ that looks like  "2.1.0+cu113",


### PR DESCRIPTION
Adds support for negative PY_BUILTIN ops that can now be mapped to torch.ops.aten.neg