### PR TITLE
[TorchOnnxToTorch] Add block_size support for onnx.DequantizeLinear

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
@@ -2350,12 +2350,173 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         Value zeropoint = operands[2];
 
         auto operandTy = cast<Torch::ValueTensorType>(operand.getType());
+        auto typedOperand = cast<TypedValue<Torch::ValueTensorType>>(operand);
         auto scaleTy = dyn_cast<Torch::ValueTensorType>(scale.getType());
         if (!scaleTy || !scaleTy.hasSizes())
           return rewriter.notifyMatchFailure(binder.op, "requires known rank");
         if (!resultType.hasDtype())
           return rewriter.notifyMatchFailure(binder.op,
                                              "requires known result dtype");
+
+        // Check for block quantization (block_size > 0).
+        // Note: block quantization with 2 operands (no zero_point) is not
+        // yet supported because the handler requires exactly 3 operands
+        // (tensorOperands(operands, 3) above). When needed, add a
+        // 2-operand path that uses a zero constant for zero_point.
+        int64_t blockSize = 0;
+        (void)binder.s64IntegerAttr(blockSize, "block_size", 0);
+        if (blockSize > 0) {
+          if (!operandTy.hasSizes())
+            return rewriter.notifyMatchFailure(
+                binder.op, "block quantization requires known operand rank");
+
+          int64_t axis = 1;
+          (void)binder.s64IntegerAttr(axis, "axis", 1);
+
+          auto operandSizes = operandTy.getSizes();
+          int64_t rank = operandSizes.size();
+          if (axis < 0)
+            axis += rank;
+          if (axis < 0 || axis >= rank)
+            return rewriter.notifyMatchFailure(
+                binder.op, "axis out of range for operand rank");
+
+          int64_t K = operandSizes[axis];
+          if (K == Torch::kUnknownSize)
+            return rewriter.notifyMatchFailure(
+                binder.op,
+                "block quantization requires static size on quantized axis");
+          if (K % blockSize != 0)
+            return rewriter.notifyMatchFailure(
+                binder.op, "axis size not divisible by block_size");
+          int64_t G = K / blockSize;
+
+          auto zpTy = cast<Torch::ValueTensorType>(zeropoint.getType());
+          if (!zpTy.hasSizes())
+            return rewriter.notifyMatchFailure(
+                binder.op, "block quantization requires known zero_point rank");
+
+          // Build reshaped sizes: [..., G, blockSize, ...]
+          SmallVector<int64_t> reshapedSizes(operandSizes);
+          reshapedSizes[axis] = G;
+          reshapedSizes.insert(reshapedSizes.begin() + axis + 1, blockSize);
+
+          // Helper to build a dim value: use aten.size.int for dynamic dims,
+          // constant for static dims. Reads sizes from the tensor type itself.
+          auto getDimValue = [&](TypedValue<Torch::ValueTensorType> tensor,
+                                 int64_t dimIdx) -> Value {
+            auto sizes = tensor.getType().getSizes();
+            if (sizes[dimIdx] != Torch::kUnknownSize)
+              return Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(sizes[dimIdx]));
+            Value dimConst = Torch::ConstantIntOp::create(
+                rewriter, loc, rewriter.getI64IntegerAttr(dimIdx));
+            return Torch::AtenSizeIntOp::create(
+                rewriter, loc, rewriter.getType<Torch::IntType>(), tensor,
+                dimConst);
+          };
+
+          // Build reshape dim list, using size.int for dynamic dims.
+          SmallVector<Value> reshapeDimValues;
+          for (int64_t i = 0; i < (int64_t)reshapedSizes.size(); ++i) {
+            if (i < axis) {
+              reshapeDimValues.push_back(getDimValue(typedOperand, i));
+            } else if (i == axis) {
+              reshapeDimValues.push_back(Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(G)));
+            } else if (i == axis + 1) {
+              reshapeDimValues.push_back(Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(blockSize)));
+            } else {
+              // Dims after the inserted blockSize dim: original index is i-1.
+              reshapeDimValues.push_back(getDimValue(typedOperand, i - 1));
+            }
+          }
+          Value reshapeDimsList = Torch::PrimListConstructOp::create(
+              rewriter, loc,
+              Torch::ListType::get(
+                  Torch::IntType::get(binder.op->getContext())),
+              reshapeDimValues);
+
+          // Block dequantization: y = (x - zero_point) * scale
+          // where each block of `blockSize` elements along `axis` shares
+          // one scale and zero_point value.
+          //
+          // Running example: x:[4,8] ui8, scale:[4,2] f32, zp:[4,2] ui8,
+          //                  axis=1, block_size=4, G=2
+
+          // Step 1: Reshape x: [4,8] -> [4,2,4] (split axis into G groups
+          // of blockSize).
+          auto reshapedTy = operandTy.getWithSizesAndDtype(
+              reshapedSizes, operandTy.getOptionalDtype());
+          Value reshaped = Torch::AtenReshapeOp::create(
+              rewriter, loc, reshapedTy, operand, reshapeDimsList);
+
+          // Step 2: Cast x to output dtype: [4,2,4] ui8 -> [4,2,4] f32.
+          Value none = Torch::ConstantNoneOp::create(rewriter, loc);
+          Value cstFalse = Torch::ConstantBoolOp::create(rewriter, loc, false);
+          auto outScalarTy = Torch::getScalarTypeForType(resultType.getDtype());
+          Value outDtypeConst = Torch::ConstantIntOp::create(
+              rewriter, loc, rewriter.getType<Torch::IntType>(),
+              rewriter.getIntegerAttr(rewriter.getIntegerType(64),
+                                      static_cast<int64_t>(outScalarTy)));
+          auto reshapedCastTy = operandTy.getWithSizesAndDtype(
+              reshapedSizes, resultType.getDtype());
+          Value castedX = Torch::AtenToDtypeOp::create(
+              rewriter, loc, reshapedCastTy, reshaped, outDtypeConst,
+              /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
+              /*memory_format=*/none);
+
+          // Step 3: Unsqueeze zero_point and cast: [4,2] ui8 -> [4,2,1] f32.
+          // The inserted dim=1 broadcasts against blockSize in step 4.
+          Value cstAxisP1 = Torch::ConstantIntOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(axis + 1));
+          SmallVector<int64_t> zpUnsqSizes(zpTy.getSizes());
+          zpUnsqSizes.insert(zpUnsqSizes.begin() + axis + 1, 1);
+          auto zpUnsqTy =
+              zpTy.getWithSizesAndDtype(zpUnsqSizes, zpTy.getOptionalDtype());
+          Value zpUnsq = Torch::AtenUnsqueezeOp::create(rewriter, loc, zpUnsqTy,
+                                                        zeropoint, cstAxisP1);
+          auto zpCastTy =
+              zpTy.getWithSizesAndDtype(zpUnsqSizes, resultType.getDtype());
+          Value zpCasted = Torch::AtenToDtypeOp::create(
+              rewriter, loc, zpCastTy, zpUnsq, outDtypeConst,
+              /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
+              /*memory_format=*/none);
+
+          // Step 4: Sub x - zero_point: [4,2,4] - [4,2,1] -> [4,2,4]
+          // (broadcasts zp along block dim).
+          Value one = Torch::ConstantFloatOp::create(
+              rewriter, loc, rewriter.getF64FloatAttr(1.0));
+          Value diff = Torch::AtenSubTensorOp::create(
+              rewriter, loc, reshapedCastTy, castedX, zpCasted, one);
+
+          // Step 5: Unsqueeze scale: [4,2] f32 -> [4,2,1] f32.
+          SmallVector<int64_t> scaleUnsqSizes(scaleTy.getSizes());
+          scaleUnsqSizes.insert(scaleUnsqSizes.begin() + axis + 1, 1);
+          auto scaleUnsqTy = scaleTy.getWithSizesAndDtype(
+              scaleUnsqSizes, scaleTy.getOptionalDtype());
+          Value scaleUnsq = Torch::AtenUnsqueezeOp::create(
+              rewriter, loc, scaleUnsqTy, scale, cstAxisP1);
+
+          // Step 6: Mul diff * scale: [4,2,4] * [4,2,1] -> [4,2,4]
+          // (broadcasts scale along block dim).
+          Value scaled = Torch::AtenMulTensorOp::create(
+              rewriter, loc, reshapedCastTy, diff, scaleUnsq);
+
+          // Step 7: Reshape back: [4,2,4] -> [4,8].
+          SmallVector<Value> origDimValues;
+          for (int64_t i = 0; i < rank; ++i)
+            origDimValues.push_back(getDimValue(typedOperand, i));
+          Value origDimsList = Torch::PrimListConstructOp::create(
+              rewriter, loc,
+              Torch::ListType::get(
+                  Torch::IntType::get(binder.op->getContext())),
+              origDimValues);
+          rewriter.replaceOpWithNewOp<Torch::AtenReshapeOp>(
+              binder.op, resultType, scaled, origDimsList);
+          return success();
+        }
 
         int64_t scaleRank = scaleTy.getSizes().size();
         if (scaleRank > 1)

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_a_to_f.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_a_to_f.mlir
@@ -829,6 +829,180 @@ func.func @test_dequantizelinear_per_channel_si8(%arg0: !torch.vtensor<[64,3,3,3
 
 // -----
 
+// Block quantization: 3D, axis=2, ui8→f16
+// CHECK-LABEL: @test_dequantizelinear_blocked_ui8
+func.func @test_dequantizelinear_blocked_ui8(%arg0: !torch.vtensor<[60,2816,2048],ui8>, %arg1: !torch.vtensor<[60,2816,16],f16>, %arg2: !torch.vtensor<[60,2816,16],ui8>) -> !torch.vtensor<[60,2816,2048],f16> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
+  // CHECK-DAG: %[[CST60:.*]] = torch.constant.int 60
+  // CHECK-DAG: %[[CST2816:.*]] = torch.constant.int 2816
+  // CHECK-DAG: %[[CST16:.*]] = torch.constant.int 16
+  // CHECK-DAG: %[[CST128:.*]] = torch.constant.int 128
+  // CHECK: %[[SHAPE:.*]] = torch.prim.ListConstruct %[[CST60]], %[[CST2816]], %[[CST16]], %[[CST128]]
+  // CHECK: %[[RESHAPED:.*]] = torch.aten.reshape %arg0, %[[SHAPE]]
+  // CHECK: %[[CASTED:.*]] = torch.aten.to.dtype %[[RESHAPED]],
+  // CHECK-SAME: -> !torch.vtensor<[60,2816,16,128],f16>
+  // CHECK: %[[AXIS:.*]] = torch.constant.int 3
+  // CHECK: %[[ZP_USQ:.*]] = torch.aten.unsqueeze %arg2, %[[AXIS]]
+  // CHECK: %[[ZP_CAST:.*]] = torch.aten.to.dtype %[[ZP_USQ]],
+  // CHECK-SAME: -> !torch.vtensor<[60,2816,16,1],f16>
+  // CHECK: %[[DIFF:.*]] = torch.aten.sub.Tensor %[[CASTED]], %[[ZP_CAST]],
+  // CHECK: %[[S_USQ:.*]] = torch.aten.unsqueeze %arg1, %[[AXIS]]
+  // CHECK: %[[SCALED:.*]] = torch.aten.mul.Tensor %[[DIFF]], %[[S_USQ]]
+  // CHECK-DAG: %[[CST2048:.*]] = torch.constant.int 2048
+  // CHECK: %[[OUT_SHAPE:.*]] = torch.prim.ListConstruct
+  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[SCALED]], %[[OUT_SHAPE]]
+  // CHECK-SAME: -> !torch.vtensor<[60,2816,2048],f16>
+  // CHECK: return %[[RESULT]]
+  %0 = torch.operator "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {torch.onnx.axis = 2 : si64, torch.onnx.block_size = 128 : si64} : (!torch.vtensor<[60,2816,2048],ui8>, !torch.vtensor<[60,2816,16],f16>, !torch.vtensor<[60,2816,16],ui8>) -> !torch.vtensor<[60,2816,2048],f16>
+  return %0 : !torch.vtensor<[60,2816,2048],f16>
+}
+
+// -----
+
+// Block quantization: 2D, default axis=1, ui8→f32 (typical weight matrix)
+// CHECK-LABEL: @test_dequantizelinear_blocked_2d
+func.func @test_dequantizelinear_blocked_2d(%arg0: !torch.vtensor<[4,1024],ui8>, %arg1: !torch.vtensor<[4,8],f32>, %arg2: !torch.vtensor<[4,8],ui8>) -> !torch.vtensor<[4,1024],f32> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
+  // CHECK-DAG: %[[CST4:.*]] = torch.constant.int 4
+  // CHECK-DAG: %[[CST8:.*]] = torch.constant.int 8
+  // CHECK-DAG: %[[CST128:.*]] = torch.constant.int 128
+  // CHECK: %[[SHAPE:.*]] = torch.prim.ListConstruct %[[CST4]], %[[CST8]], %[[CST128]]
+  // CHECK: %[[RESHAPED:.*]] = torch.aten.reshape %arg0, %[[SHAPE]]
+  // CHECK: %[[CASTED:.*]] = torch.aten.to.dtype %[[RESHAPED]],
+  // CHECK-SAME: -> !torch.vtensor<[4,8,128],f32>
+  // CHECK: %[[AXIS:.*]] = torch.constant.int 2
+  // CHECK: %[[ZP_USQ:.*]] = torch.aten.unsqueeze %arg2, %[[AXIS]]
+  // CHECK: %[[ZP_CAST:.*]] = torch.aten.to.dtype %[[ZP_USQ]],
+  // CHECK-SAME: -> !torch.vtensor<[4,8,1],f32>
+  // CHECK: %[[DIFF:.*]] = torch.aten.sub.Tensor %[[CASTED]], %[[ZP_CAST]],
+  // CHECK: %[[S_USQ:.*]] = torch.aten.unsqueeze %arg1, %[[AXIS]]
+  // CHECK: %[[SCALED:.*]] = torch.aten.mul.Tensor %[[DIFF]], %[[S_USQ]]
+  // CHECK-DAG: %[[CST1024:.*]] = torch.constant.int 1024
+  // CHECK: %[[OUT_SHAPE:.*]] = torch.prim.ListConstruct
+  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[SCALED]], %[[OUT_SHAPE]]
+  // CHECK-SAME: -> !torch.vtensor<[4,1024],f32>
+  // CHECK: return %[[RESULT]]
+  %0 = torch.operator "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {torch.onnx.axis = 1 : si64, torch.onnx.block_size = 128 : si64} : (!torch.vtensor<[4,1024],ui8>, !torch.vtensor<[4,8],f32>, !torch.vtensor<[4,8],ui8>) -> !torch.vtensor<[4,1024],f32>
+  return %0 : !torch.vtensor<[4,1024],f32>
+}
+
+// -----
+
+// Block quantization: axis=0 (quantizing along first dim)
+// CHECK-LABEL: @test_dequantizelinear_blocked_axis0
+func.func @test_dequantizelinear_blocked_axis0(%arg0: !torch.vtensor<[256,64],ui8>, %arg1: !torch.vtensor<[4,64],f16>, %arg2: !torch.vtensor<[4,64],ui8>) -> !torch.vtensor<[256,64],f16> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
+  // CHECK-DAG: %[[CST4:.*]] = torch.constant.int 4
+  // CHECK-DAG: %[[CST64_0:.*]] = torch.constant.int 64
+  // CHECK-DAG: %[[CST64_1:.*]] = torch.constant.int 64
+  // CHECK: %[[SHAPE:.*]] = torch.prim.ListConstruct %[[CST4]], %[[CST64_0]], %[[CST64_1]]
+  // CHECK: %[[RESHAPED:.*]] = torch.aten.reshape %arg0, %[[SHAPE]]
+  // CHECK: %[[CASTED:.*]] = torch.aten.to.dtype %[[RESHAPED]],
+  // CHECK-SAME: -> !torch.vtensor<[4,64,64],f16>
+  // CHECK: %[[AXIS:.*]] = torch.constant.int 1
+  // CHECK: %[[ZP_USQ:.*]] = torch.aten.unsqueeze %arg2, %[[AXIS]]
+  // CHECK: %[[ZP_CAST:.*]] = torch.aten.to.dtype %[[ZP_USQ]],
+  // CHECK-SAME: -> !torch.vtensor<[4,1,64],f16>
+  // CHECK: %[[DIFF:.*]] = torch.aten.sub.Tensor %[[CASTED]], %[[ZP_CAST]],
+  // CHECK: %[[S_USQ:.*]] = torch.aten.unsqueeze %arg1, %[[AXIS]]
+  // CHECK: %[[SCALED:.*]] = torch.aten.mul.Tensor %[[DIFF]], %[[S_USQ]]
+  // CHECK-DAG: %[[CST256:.*]] = torch.constant.int 256
+  // CHECK: %[[OUT_SHAPE:.*]] = torch.prim.ListConstruct
+  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[SCALED]], %[[OUT_SHAPE]]
+  // CHECK-SAME: -> !torch.vtensor<[256,64],f16>
+  // CHECK: return %[[RESULT]]
+  %0 = torch.operator "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {torch.onnx.axis = 0 : si64, torch.onnx.block_size = 64 : si64} : (!torch.vtensor<[256,64],ui8>, !torch.vtensor<[4,64],f16>, !torch.vtensor<[4,64],ui8>) -> !torch.vtensor<[256,64],f16>
+  return %0 : !torch.vtensor<[256,64],f16>
+}
+
+// -----
+
+// Block quantization: negative axis (-1 = last dim)
+// CHECK-LABEL: @test_dequantizelinear_blocked_neg_axis
+func.func @test_dequantizelinear_blocked_neg_axis(%arg0: !torch.vtensor<[4,512],ui8>, %arg1: !torch.vtensor<[4,4],f16>, %arg2: !torch.vtensor<[4,4],ui8>) -> !torch.vtensor<[4,512],f16> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
+  // CHECK-DAG: %[[CST4_0:.*]] = torch.constant.int 4
+  // CHECK-DAG: %[[CST4_1:.*]] = torch.constant.int 4
+  // CHECK-DAG: %[[CST128:.*]] = torch.constant.int 128
+  // CHECK: %[[SHAPE:.*]] = torch.prim.ListConstruct %[[CST4_0]], %[[CST4_1]], %[[CST128]]
+  // CHECK: %[[RESHAPED:.*]] = torch.aten.reshape %arg0, %[[SHAPE]]
+  // CHECK: %[[CASTED:.*]] = torch.aten.to.dtype %[[RESHAPED]],
+  // CHECK-SAME: -> !torch.vtensor<[4,4,128],f16>
+  // CHECK: %[[DIFF:.*]] = torch.aten.sub.Tensor
+  // CHECK: %[[SCALED:.*]] = torch.aten.mul.Tensor
+  // CHECK-DAG: %[[CST512:.*]] = torch.constant.int 512
+  // CHECK: %[[OUT_SHAPE:.*]] = torch.prim.ListConstruct
+  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[SCALED]], %[[OUT_SHAPE]]
+  // CHECK-SAME: -> !torch.vtensor<[4,512],f16>
+  // CHECK: return %[[RESULT]]
+  %0 = torch.operator "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {torch.onnx.axis = -1 : si64, torch.onnx.block_size = 128 : si64} : (!torch.vtensor<[4,512],ui8>, !torch.vtensor<[4,4],f16>, !torch.vtensor<[4,4],ui8>) -> !torch.vtensor<[4,512],f16>
+  return %0 : !torch.vtensor<[4,512],f16>
+}
+
+// -----
+
+// Block quantization: dynamic batch dimension (exercises aten.size.int path)
+// CHECK-LABEL: @test_dequantizelinear_blocked_dynamic_batch
+func.func @test_dequantizelinear_blocked_dynamic_batch(%arg0: !torch.vtensor<[?,2048],ui8>, %arg1: !torch.vtensor<[?,16],f16>, %arg2: !torch.vtensor<[?,16],ui8>) -> !torch.vtensor<[?,2048],f16> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
+  // CHECK-DAG: %[[DIM0:.*]] = torch.aten.size.int %arg0,
+  // CHECK-DAG: %[[CST16:.*]] = torch.constant.int 16
+  // CHECK-DAG: %[[CST128:.*]] = torch.constant.int 128
+  // CHECK: %[[SHAPE:.*]] = torch.prim.ListConstruct %[[DIM0]], %[[CST16]], %[[CST128]]
+  // CHECK: %[[RESHAPED:.*]] = torch.aten.reshape %arg0, %[[SHAPE]]
+  // CHECK: %[[CASTED:.*]] = torch.aten.to.dtype %[[RESHAPED]],
+  // CHECK-SAME: -> !torch.vtensor<[?,16,128],f16>
+  // CHECK: %[[DIFF:.*]] = torch.aten.sub.Tensor
+  // CHECK: %[[SCALED:.*]] = torch.aten.mul.Tensor
+  // CHECK-DAG: %[[OUT_DIM0:.*]] = torch.aten.size.int %arg0,
+  // CHECK-DAG: %[[CST2048:.*]] = torch.constant.int 2048
+  // CHECK: %[[OUT_SHAPE:.*]] = torch.prim.ListConstruct %[[OUT_DIM0]], %[[CST2048]]
+  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[SCALED]], %[[OUT_SHAPE]]
+  // CHECK-SAME: -> !torch.vtensor<[?,2048],f16>
+  // CHECK: return %[[RESULT]]
+  %0 = torch.operator "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {torch.onnx.axis = 1 : si64, torch.onnx.block_size = 128 : si64} : (!torch.vtensor<[?,2048],ui8>, !torch.vtensor<[?,16],f16>, !torch.vtensor<[?,16],ui8>) -> !torch.vtensor<[?,2048],f16>
+  return %0 : !torch.vtensor<[?,2048],f16>
+}
+
+// -----
+
+// Block quantization: 4D tensor (convolution weight pattern)
+// CHECK-LABEL: @test_dequantizelinear_blocked_4d
+func.func @test_dequantizelinear_blocked_4d(%arg0: !torch.vtensor<[64,128,3,3],ui8>, %arg1: !torch.vtensor<[64,4,3,3],f32>, %arg2: !torch.vtensor<[64,4,3,3],ui8>) -> !torch.vtensor<[64,128,3,3],f32> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
+  // CHECK-DAG: %[[CST64:.*]] = torch.constant.int 64
+  // CHECK-DAG: %[[CST4:.*]] = torch.constant.int 4
+  // CHECK-DAG: %[[CST32:.*]] = torch.constant.int 32
+  // CHECK-DAG: %[[CST3_0:.*]] = torch.constant.int 3
+  // CHECK-DAG: %[[CST3_1:.*]] = torch.constant.int 3
+  // CHECK: %[[SHAPE:.*]] = torch.prim.ListConstruct %[[CST64]], %[[CST4]], %[[CST32]], %[[CST3_0]], %[[CST3_1]]
+  // CHECK: %[[RESHAPED:.*]] = torch.aten.reshape %arg0, %[[SHAPE]]
+  // CHECK: %[[CASTED:.*]] = torch.aten.to.dtype %[[RESHAPED]],
+  // CHECK-SAME: -> !torch.vtensor<[64,4,32,3,3],f32>
+  // CHECK: %[[DIFF:.*]] = torch.aten.sub.Tensor
+  // CHECK: %[[SCALED:.*]] = torch.aten.mul.Tensor
+  // CHECK-DAG: %[[CST128:.*]] = torch.constant.int 128
+  // CHECK: %[[OUT_SHAPE:.*]] = torch.prim.ListConstruct
+  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[SCALED]], %[[OUT_SHAPE]]
+  // CHECK-SAME: -> !torch.vtensor<[64,128,3,3],f32>
+  // CHECK: return %[[RESULT]]
+  %0 = torch.operator "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {torch.onnx.axis = 1 : si64, torch.onnx.block_size = 32 : si64} : (!torch.vtensor<[64,128,3,3],ui8>, !torch.vtensor<[64,4,3,3],f32>, !torch.vtensor<[64,4,3,3],ui8>) -> !torch.vtensor<[64,128,3,3],f32>
+  return %0 : !torch.vtensor<[64,128,3,3],f32>
+}
+
+// -----
+
+// Block quantization: signed int8 input (si8→f32)
+// CHECK-LABEL: @test_dequantizelinear_blocked_si8
+func.func @test_dequantizelinear_blocked_si8(%arg0: !torch.vtensor<[8,256],si8>, %arg1: !torch.vtensor<[8,4],f32>, %arg2: !torch.vtensor<[8,4],si8>) -> !torch.vtensor<[8,256],f32> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 21 : si64} {
+  // CHECK: %[[RESHAPED:.*]] = torch.aten.reshape
+  // CHECK: %[[CASTED:.*]] = torch.aten.to.dtype %[[RESHAPED]],
+  // CHECK-SAME: -> !torch.vtensor<[8,4,64],f32>
+  // CHECK: %[[DIFF:.*]] = torch.aten.sub.Tensor
+  // CHECK: %[[SCALED:.*]] = torch.aten.mul.Tensor
+  // CHECK: %[[RESULT:.*]] = torch.aten.reshape %[[SCALED]],
+  // CHECK-SAME: -> !torch.vtensor<[8,256],f32>
+  // CHECK: return %[[RESULT]]
+  %0 = torch.operator "onnx.DequantizeLinear"(%arg0, %arg1, %arg2) {torch.onnx.axis = 1 : si64, torch.onnx.block_size = 64 : si64} : (!torch.vtensor<[8,256],si8>, !torch.vtensor<[8,4],f32>, !torch.vtensor<[8,4],si8>) -> !torch.vtensor<[8,256],f32>
+  return %0 : !torch.vtensor<[8,256],f32>
+}
+
+// -----
+
 // CHECK-LABEL: @test_div_bcast
 func.func @test_div_bcast(%arg0: !torch.vtensor<[3,4,5],f32>, %arg1: !torch.vtensor<[5],f32>) -> !torch.vtensor<[3,4,5],f32> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 14 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
   // CHECK: torch.aten.div.Tensor %arg0, %arg1 : !torch.vtensor<[3,4,5],f32>, !torch.vtensor<[5],f32> -> !torch.vtensor<[3,4,5],f32>


### PR DESCRIPTION
Lower block-quantized DequantizeLinear (opset 21+) to reshape → cast → sub(zero_point) → mul(scale) → reshape.