### PR TITLE
[OnnxToTorch] Preserve element types in MatMulInteger when zero-points are absent

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -563,24 +563,34 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             binder.tensorResultType(resultType))
           return failure();
 
-        if (binder.tensorOperandAtIndex(lhsZp, 2)) {
-          lhsZp = Torch::ConstantIntOp::create(
-              rewriter, binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+        auto lhsZpMissing = binder.tensorOperandAtIndex(lhsZp, 2);
+        auto rhsZpMissing = binder.tensorOperandAtIndex(rhsZp, 3);
+
+        // When both zero-points are absent (symmetric quantization, zp=0),
+        // keep the native element types for the matmul operands.
+        if (lhsZpMissing && rhsZpMissing) {
+          rewriter.replaceOpWithNewOp<Torch::AtenMatmulOp>(
+              binder.op, resultType, lhs, rhs);
+          return success();
         }
 
-        if (binder.tensorOperandAtIndex(rhsZp, 3)) {
-          rhsZp = Torch::ConstantIntOp::create(
-              rewriter, binder.getLoc(), rewriter.getType<Torch::IntType>(),
-              rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
-        }
-
-        // This op is lowered as follows:
+        // This op is lowered as follows if at least one zero-point is provided:
         // lhs = lhs.to(dtype=torch.int32)
         // rhs = rhs.to(dtype=torch.int32)
         // lhs = lhs - lhsZp
         // rhs = rhs - rhsZp
         // res = torch.mm(lhs, rhs)
+        if (lhsZpMissing) {
+          lhsZp = Torch::ConstantIntOp::create(
+              rewriter, binder.getLoc(), rewriter.getType<Torch::IntType>(),
+              rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+        }
+
+        if (rhsZpMissing) {
+          rhsZp = Torch::ConstantIntOp::create(
+              rewriter, binder.getLoc(), rewriter.getType<Torch::IntType>(),
+              rewriter.getIntegerAttr(rewriter.getIntegerType(64), 0));
+        }
 
         // Converting lhs and rhs tensor to `si32` type.
         lhs = Torch::convertTensorToDtype(

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
@@ -620,6 +620,31 @@ func.func @test_matmulinteger_non_scalar_rhsZp(%arg0: !torch.vtensor<[?,?],ui8>,
 
 // -----
 
+// CHECK-LABEL: @test_matmulinteger_no_zero_points
+func.func @test_matmulinteger_no_zero_points(%arg0: !torch.vtensor<[4,3],si8>, %arg1: !torch.vtensor<[3,2],si8>) -> !torch.vtensor<[4,2],si32> attributes {torch.onnx_meta.ir_version = 5 : si64, torch.onnx_meta.opset_version = 10 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  // When zero-points are absent, operands stay in their native dtype (i8xi8 -> i32 in this case)
+  // CHECK-NOT: torch.aten.to.dtype
+  // CHECK-NOT: torch.aten.sub
+  // CHECK: %[[MM:.+]] = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[4,3],si8>, !torch.vtensor<[3,2],si8> -> !torch.vtensor<[4,2],si32>
+  // CHECK: return %[[MM]] : !torch.vtensor<[4,2],si32>
+  %0 = torch.operator "onnx.MatMulInteger"(%arg0, %arg1) : (!torch.vtensor<[4,3],si8>, !torch.vtensor<[3,2],si8>) -> !torch.vtensor<[4,2],si32>
+  return %0 : !torch.vtensor<[4,2],si32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_matmulinteger_no_zero_points_batched
+func.func @test_matmulinteger_no_zero_points_batched(%arg0: !torch.vtensor<[2,4096,640],si8>, %arg1: !torch.vtensor<[2,640,640],si8>) -> !torch.vtensor<[2,4096,640],si32> attributes {torch.onnx_meta.ir_version = 5 : si64, torch.onnx_meta.opset_version = 10 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  // CHECK-NOT: torch.aten.to.dtype
+  // CHECK-NOT: torch.aten.sub
+  // CHECK: %[[MM:.+]] = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[2,4096,640],si8>, !torch.vtensor<[2,640,640],si8> -> !torch.vtensor<[2,4096,640],si32>
+  // CHECK: return %[[MM]] : !torch.vtensor<[2,4096,640],si32>
+  %0 = torch.operator "onnx.MatMulInteger"(%arg0, %arg1) : (!torch.vtensor<[2,4096,640],si8>, !torch.vtensor<[2,640,640],si8>) -> !torch.vtensor<[2,4096,640],si32>
+  return %0 : !torch.vtensor<[2,4096,640],si32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @test_mul
   func.func @test_mul(%arg0: !torch.vtensor<[3,4,5],f32>, %arg1: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],f32> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 14 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
     // CHECK: torch.aten.mul.Tensor %arg0, %arg1 : !torch.vtensor<[3,4,5],f32>, !torch.vtensor<[3,4,5],f32> -> !torch.vtensor<[3,4,5],f32>


### PR DESCRIPTION
The MatMulInteger lowering unconditionally widens operands to i32 before creating aten.matmul, even when no zero-point operands were provided (symmetric quantization, zp=0). This destroyed the narrow element type information early in the pipeline, preventing downstream passes from selecting appropriate hardware intrinsics (e.g. i8 MAC instructions) that depend on seeing the original element types.

When both zero-point operands are absent, skip the i32 widening and zero-point subtraction entirely and emit aten.matmul with the original (i8/u8) operands. The existing i32 path is preserved when at least one zero-point is provided, since subtracting a non-zero zero-point from an i8 (or any low bit-width) value requires a wider type to avoid overflow.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>