### PR TITLE
[TorchToLinalg] Fix bmm accumulator type to be inferred using input element type

### DIFF
--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -744,7 +744,7 @@ public:
     // Check the matrixs shapes are valid for mulplication.
     checkDimEqualHelper(rewriter, loc, lhsDim2, rhsDim1);
 
-    Type accumulatorDType = getDefaultAccType(rewriter, resultElementType);
+    Type accumulatorDType = getDefaultAccType(rewriter, lhsElementType);
     Value initTensor0 = createZeroInitTensor(
         rewriter, loc, ValueRange{lhsDim0, lhsDim1, rhsDim2}, accumulatorDType);
 

--- a/test/Conversion/TorchToLinalg/basic.mlir
+++ b/test/Conversion/TorchToLinalg/basic.mlir
@@ -157,6 +157,19 @@ func.func @torch.aten.matmul$generic_f16(%arg0: !torch.vtensor<[?,?,8,16],f16>, 
 
 // -----
 
+// Verify that aten.bmm(si8, si8) -> si32 uses i32 accumulator (not i64),
+// enabling downstream i8 HW intrinsics.
+// CHECK-LABEL: func.func @torch.aten.bmm$i8
+// CHECK:      linalg.batch_matmul ins(%{{.*}}, %{{.*}} : tensor<2x8x16xi8>, tensor<2x16x8xi8>) outs(%{{.*}} : tensor<2x8x8xi32>) -> tensor<2x8x8xi32>
+// CHECK-NOT:  arith.extsi
+// CHECK-NOT:  arith.trunci
+func.func @torch.aten.bmm$i8(%arg0: !torch.vtensor<[2,8,16],si8>, %arg1: !torch.vtensor<[2,16,8],si8>) -> !torch.vtensor<[2,8,8],si32> {
+  %0 = torch.aten.bmm %arg0, %arg1 : !torch.vtensor<[2,8,16],si8>, !torch.vtensor<[2,16,8],si8> -> !torch.vtensor<[2,8,8],si32>
+  return %0 : !torch.vtensor<[2,8,8],si32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @torch.aten.mm$basic_strict(
 // CHECK-NOT: assert
 func.func @torch.aten.mm$basic_strict(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,2],f32>


### PR DESCRIPTION
ConvertAtenBmmOp derived the accumulator type from the result element type using `getDefaultAccType`. For i8xi8->i32 case, it resulted in i8xi8->i64. This not only caused over-widening of accumulator but also prevented downstream passes from selecting narrow-type hardware intrinsics.

This patch fixes that by using the lhs input element type instead so that i8 inputs produce an i32 accumulator rather than i64.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>