### PR TITLE
[TorchToLinalg] Fix bmm accumulator for mixed-precision inputs

### DIFF
--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -724,11 +724,13 @@ public:
         // type.
         lhs = torch_to_linalg::convertTensorToElementType(rewriter, loc, lhs,
                                                           resultElementType);
+        lhsElementType = resultElementType;
       } else {
         // True if the rhs element type is not equal to the result' element
         // type.
         rhs = torch_to_linalg::convertTensorToElementType(rewriter, loc, rhs,
                                                           resultElementType);
+        rhsElementType = resultElementType;
       }
     }
 

--- a/test/Conversion/TorchToLinalg/basic.mlir
+++ b/test/Conversion/TorchToLinalg/basic.mlir
@@ -170,6 +170,15 @@ func.func @torch.aten.bmm$i8(%arg0: !torch.vtensor<[2,8,16],si8>, %arg1: !torch.
 
 // -----
 
+// CHECK-LABEL: func.func @torch.aten.bmm$mixed_si4_f16
+// CHECK:      linalg.batch_matmul ins(%{{.*}}, %{{.*}} : tensor<1x4x8xf16>, tensor<1x8x4xf16>) outs(%{{.*}} : tensor<1x4x4xf32>) -> tensor<1x4x4xf32>
+func.func @torch.aten.bmm$mixed_si4_f16(%arg0: !torch.vtensor<[1,4,8],si4>, %arg1: !torch.vtensor<[1,8,4],f16>) -> !torch.vtensor<[1,4,4],f16> {
+  %0 = torch.aten.bmm %arg0, %arg1 : !torch.vtensor<[1,4,8],si4>, !torch.vtensor<[1,8,4],f16> -> !torch.vtensor<[1,4,4],f16>
+  return %0 : !torch.vtensor<[1,4,4],f16>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @torch.aten.mm$basic_strict(
 // CHECK-NOT: assert
 func.func @torch.aten.mm$basic_strict(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,2],f32>


### PR DESCRIPTION
Mixed-precision bmm promotes the narrower operand to the result type, but `lhsElementType` was captured before promotion. After #4532 derived the accumulator from `lhsElementType`, `si4 x f16 -> f16` got an i4 accumulator and the f16 dot products overflowed. This change updates `lhsElementType` / `rhsElementType` after promotion.

Fusilli CI: https://github.com/iree-org/fusilli/actions/runs/24565196026/job/71823481663