### PR TITLE
[TorchOnnxToTorch] Fix ReduceProd reshape for keepdims=0

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -2415,37 +2415,13 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
               axis, trueVal, noneVal);
         }
 
-        // Derived the final shape of the tensor after prod loop of each axis.
-        SmallVector<int64_t> dataReduceProdSize;
-        auto dataSize = dataTy.getSizes();
-        auto resultTypeSizes = resultType.getSizes();
-        if (!keepDims) {
-          // Handle the keepDimsBool == False case:
-          // 2 point algorithm to derive the static shape after prod loop.
-          int j = 0;
-          for (int i = 0; i < rank; i++) {
-            if (resultTypeSizes.size() && dataSize[i] == resultTypeSizes[j]) {
-              dataReduceProdSize.push_back(resultTypeSizes[i]);
-              j++;
-              continue;
-            }
-            dataReduceProdSize.push_back(1);
-          }
-        }
-
-        // Handle the keepDimsBool == False case:
-        // Reshape the prod loop result to the final result shape.
-        SmallVector<Value> dataReduceProdShape;
-        for (auto dim : dataReduceProdSize)
-          dataReduceProdShape.push_back(Torch::ConstantIntOp::create(
-              rewriter, binder.getLoc(), rewriter.getI64IntegerAttr(dim)));
-        Value dataReduceProdShapeList = Torch::PrimListConstructOp::create(
-            rewriter, binder.getLoc(),
-            rewriter.getType<Torch::ListType>(
-                rewriter.getType<Torch::IntType>()),
-            dataReduceProdShape);
+        // keepDims == true returned early from the loop above; here keepDims
+        // is false and the reduced dims have been dropped from resultType, so
+        // reshape the intermediate directly to the result shape.
+        Value shapeList =
+            createConstantIntList(binder, rewriter, resultType.getSizes());
         rewriter.replaceOpWithNewOp<Torch::AtenReshapeOp>(
-            binder.op, resultType, dataReduceProd, dataReduceProdShapeList);
+            binder.op, resultType, dataReduceProd, shapeList);
         return success();
       });
   patterns.onOp(

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -1672,6 +1672,19 @@ func.func @test_reduce_prod_keepdims_random(%arg0: !torch.vtensor<[3,2,2],f32>, 
 
 // -----
 
+// CHECK-LABEL: func.func @test_reduce_prod_axes_attr_no_keepdims
+func.func @test_reduce_prod_axes_attr_no_keepdims(%arg0: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3],f32> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 13 : si64} {
+  // CHECK: %[[PROD:.*]] = torch.aten.prod.dim_int %arg0, %{{.*}}, %{{.*}}, %{{.*}} : !torch.vtensor<[3,4],f32>, !torch.int, !torch.bool, !torch.none -> !torch.vtensor<[?,?],f32>
+  // CHECK: %[[C3:.*]] = torch.constant.int 3
+  // CHECK: %[[SHAPE:.*]] = torch.prim.ListConstruct %[[C3]] : (!torch.int) -> !torch.list<int>
+  // CHECK: %[[RESHAPE:.*]] = torch.aten.reshape %[[PROD]], %[[SHAPE]] : !torch.vtensor<[?,?],f32>, !torch.list<int> -> !torch.vtensor<[3],f32>
+  // CHECK: return %[[RESHAPE]] : !torch.vtensor<[3],f32>
+  %0 = torch.operator "onnx.ReduceProd"(%arg0) {torch.onnx.axes = [1 : si64], torch.onnx.keepdims = 0 : si64} : (!torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3],f32>
+  return %0 : !torch.vtensor<[3],f32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @test_sinh
 func.func @test_sinh_example(%arg0: !torch.vtensor<[3],f32>) -> !torch.vtensor<[3],f32> attributes {torch.onnx_meta.ir_version = 4 : si64, torch.onnx_meta.opset_version = 9 : si64} {
   // CHECK: torch.aten.sinh %arg0 : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>


### PR DESCRIPTION
The reduced dims have already been dropped from resultType, so the reshape target is just resultType.getSizes().



Fixes https://github.com/iree-org/iree/issues/24181