### PR TITLE
[fx_importer] Fix scalar overload selection for symbolic args

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -454,6 +454,16 @@ def is_builtin_function_or_method(obj: Any) -> bool:
     return isinstance(obj, (BuiltinMethodType, BuiltinFunctionType))
 
 
+def is_scalar_arg(arg: NodeArgument) -> bool:
+    """Check whether an arg is, or carries a meta val of, a literal or symbolic scalar."""
+    if isinstance(arg, (float, int)) or is_symbolic(arg):
+        return True
+    if isinstance(arg, torch_fx.Node):
+        val = arg.meta.get("val")
+        return isinstance(val, (float, int)) or is_symbolic(val)
+    return False
+
+
 # TODO: switch back to `slots=True` when py3.9 support is dropped
 @dataclass(frozen=True)
 class InputInfo:
@@ -2068,9 +2078,7 @@ class GraphNodeImporter:
         mlir_op_name = _get_mlir_op_name_for_schema(schema)
 
         # Intervening to use Scalar ops due to incorrect ops from AOT-autograd with scalar arguments.
-        if mlir_op_name in TENSOR_SCALAR_OP_CONVERTER and (
-            isinstance(node.args[1], float) or isinstance(node.args[1], int)
-        ):
+        if mlir_op_name in TENSOR_SCALAR_OP_CONVERTER and is_scalar_arg(node.args[1]):
             mlir_op_name = TENSOR_SCALAR_OP_CONVERTER[mlir_op_name]
             # we are dynamically changing which op is emitted here due to an issue in
             # torch dynamo where it emits the Tensor variant of ops even when processing

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -116,6 +116,38 @@ def test_import_frozen_exported_program_with_dynamic_shapes():
 
 
 @run
+# CHECK-LABEL: test_dynamic_shape_symfloat_mul_uses_scalar_overload
+# CHECK:     func.func @test_net(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[?,10],f32>) -> !torch.vtensor<[?,10],f32>
+# CHECK:     torch.aten.mul.Scalar {{.*}} : !torch.vtensor<[?,10],f32>, !torch.float -> !torch.vtensor<[?,10],f32>
+def test_dynamic_shape_symfloat_mul_uses_scalar_overload():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            # When exported with dynamic_shapes, n will be a symbolic int, and
+            # the right hand side of the multiplication will be a symbolic float.
+            n = x.shape[0]
+            return x * (n / (n - 1))
+
+    # Sample input
+    x = torch.randn(8, 10)
+
+    dim_0 = Dim("dim_0", min=2, max=64)
+    dynamic_shapes = {"x": {0: dim_0}}
+
+    m = fx.export_and_import(
+        Basic(),
+        x,
+        dynamic_shapes=dynamic_shapes,
+        func_name="test_net",
+        strict=True,
+    )
+    print(m)
+    m.operation.verify()
+
+
+@run
 # CHECK-LABEL: test_broadcast_with_dynamic_shapes
 # CHECK:     func.func @test_net(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[1,2],f32>, %[[ARG1:[a-zA-Z0-9]+]]: !torch.vtensor<[?],f32>) -> !torch.vtensor<[?,2],f32>
 # CHECK:     %[[S0:.*]] = torch.symbolic_int "{{[a-z0-9]+}}" {min_val = {{[0-9]+}}, max_val = {{[0-9]+}}} : !torch.int


### PR DESCRIPTION
Fixes scalar overload selection in the `fx_importer` when the scalar operand is a symbolic value instead of a Python literal.

The importer already rewrites some incorrectly-exported Tensor overloads to Scalar overloads when operand 1 is a Python float or int. But in the case of dynamic shapes, the scalar can be a node whose value is a `torch.SymFloat` or `torch.SymInt`. In this case, the importer is emitting invalid IR that fails verification, for example:

 ```mlir
%2 = torch.aten.mul.Tensor %arg0, %1 : !torch.vtensor<[?,10],f32>, !torch.float -> !torch.vtensor<[?,10],f32>
 ```

This fails verification because the op expects operand 1 to be a tensor, not a float. The fix is to generalize the existing scalar-argument detection to also recognize operands whose value is a scalar symbolic type. 

With this fix, the importer now produces this valid IR instead:
 ```mlir
%2 = torch.aten.mul.Scalar %arg0, %1 : !torch.vtensor<[?,10],f32>, !torch.float -> !torch.vtensor<[?,10],f32>
 ```