### PR TITLE
[TorchToTosa] Lower MXFP8 aten._scaled_mm to TOSA

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -32,6 +32,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/MathExtras.h"
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <numeric>
 #include <optional>
@@ -122,6 +123,17 @@ static bool isSupportedBlockedScaledMmScaleElementType(Type type) {
   return isa<Float8E8M0FNUType>(type);
 }
 
+// TOSA matmul_t_block_scaled uses 128x32 data blocks and one E8M0 scale for
+// each 32-wide slice. The swizzled PyTorch/NVIDIA storage packs each 128x4
+// scale block as a 32x16 byte tile.
+// https://www.mlplatform.org/tosa/tosa_spec_1_0_1.html#_matmul_t_block_scaled
+static constexpr int64_t kTosaBlockedScaleRowBlock = 128;
+static constexpr int64_t kTosaBlockedScaleColBlock = 4;
+static constexpr int64_t kTosaBlockedScaleSwizzleTileRows = 32;
+static constexpr int64_t kTosaBlockedScaleSwizzleTileCols = 16;
+static constexpr int64_t kTosaBlockedScaleSwizzleTileSize =
+    kTosaBlockedScaleSwizzleTileRows * kTosaBlockedScaleSwizzleTileCols;
+
 static SmallVector<int64_t> getTensorShape(RankedTensorType tensorTy) {
   return SmallVector<int64_t>(tensorTy.getShape().begin(),
                               tensorTy.getShape().end());
@@ -139,7 +151,7 @@ static Value reshapeTensor(Value input, ArrayRef<int64_t> shape, Type elementTy,
 static std::optional<Value>
 createScaledMmZeroTensor(ConversionPatternRewriter &rewriter, Location loc,
                          Type elementType) {
-  if (!isa<Float8E4M3FNType, Float8E5M2Type, Float8E8M0FNUType>(elementType))
+  if (!isa<Float8E4M3FNType, Float8E5M2Type>(elementType))
     return tosa::createZeroPointTensor(rewriter, loc, elementType,
                                        /*zeroPoint=*/0);
 
@@ -343,30 +355,17 @@ static FailureOr<Value> createScaledMmMatmulTBlockScaledResult(
   return castScaledMmResultToType(*resultWithBiasOr, resultTy, rewriter);
 }
 
-static FailureOr<Value> reshapeFlatBlockedScaleForTosa(
-    Value scale, RankedTensorType scaleTy, int64_t rows, int64_t scaleCols,
-    ConversionPatternRewriter &rewriter, Location loc) {
-  if (!scaleTy.hasStaticShape())
-    return failure();
-
+static FailureOr<Value>
+reshapeFlatBlockedScale(Value scale, RankedTensorType scaleTy, int64_t rows,
+                        int64_t scaleCols, ConversionPatternRewriter &rewriter,
+                        Location loc) {
   SmallVector<int64_t> scaleShape = {1, rows, scaleCols};
   auto reshapedTy = RankedTensorType::get(scaleShape, scaleTy.getElementType());
-  int64_t rowBlocks = llvm::divideCeil(rows, int64_t{128});
-  int64_t colBlocks = llvm::divideCeil(scaleCols, int64_t{4});
-  SmallVector<int64_t> paddedScaleShape = {1, rowBlocks * 128, colBlocks * 4};
-
-  if (scaleTy.getRank() == 2) {
-    if (scaleTy.getDimSize(0) != paddedScaleShape[1] ||
-        scaleTy.getDimSize(1) != paddedScaleShape[2])
-      return failure();
-  } else {
-    if (scaleTy.getRank() != 1)
-      return failure();
-
-    int64_t numel = scaleTy.getDimSize(0);
-    if (numel != paddedScaleShape[1] * paddedScaleShape[2])
-      return failure();
-  }
+  int64_t rowBlocks = llvm::divideCeil(rows, kTosaBlockedScaleRowBlock);
+  int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
+  SmallVector<int64_t> paddedScaleShape = {
+      1, rowBlocks * kTosaBlockedScaleRowBlock,
+      colBlocks * kTosaBlockedScaleColBlock};
 
   auto paddedScaleTy =
       RankedTensorType::get(paddedScaleShape, scaleTy.getElementType());
@@ -403,6 +402,28 @@ static FailureOr<ArrayRef<char>> getDenseConstantRawByteData(Value value) {
   return failure();
 }
 
+static SmallVector<char> expandRawByteData(ArrayRef<char> rawData,
+                                           int64_t numElements) {
+  if (rawData.size() == 1 && numElements > 1)
+    return SmallVector<char>(numElements, rawData.front());
+  return SmallVector<char>(rawData.begin(), rawData.end());
+}
+
+static FailureOr<SmallVector<char>>
+getDenseConstantRawByteData(Value value, int64_t numElements) {
+  FailureOr<ArrayRef<char>> rawData = getDenseConstantRawByteData(value);
+  if (failed(rawData))
+    return failure();
+  return expandRawByteData(*rawData, numElements);
+}
+
+// PyTorch accepts blocked scales in two encodings:
+//   FlatPadded: a runtime value already padded to ceil(rows, 128) x
+//     ceil(K / 32, 4), either rank-2 or flattened. Lowering reshapes it and
+//     slices away padding that is outside the true M/N extent.
+//   SwizzledConstant: a compile-time constant stored as 32x16 byte tiles. This
+//     is reordered at compile time into the compact [1, rows, K / 32] TOSA
+//     layout because TOSA does not model the swizzled storage format.
 enum class BlockedScaleLayout {
   Invalid,
   FlatPadded,
@@ -411,19 +432,19 @@ enum class BlockedScaleLayout {
 
 struct BlockedScaleClassification {
   BlockedScaleLayout layout = BlockedScaleLayout::Invalid;
-  ArrayRef<char> rawSwizzledData = {};
+  SmallVector<char> rawSwizzledData = {};
 };
 
-static BlockedScaleLayout
-classifyFlatBlockedScaleForTosa(RankedTensorType scaleTy, int64_t rows,
-                                int64_t scaleCols) {
+static BlockedScaleLayout classifyFlatBlockedScale(RankedTensorType scaleTy,
+                                                   int64_t rows,
+                                                   int64_t scaleCols) {
   if (!scaleTy.hasStaticShape())
     return BlockedScaleLayout::Invalid;
 
-  int64_t rowBlocks = llvm::divideCeil(rows, int64_t{128});
-  int64_t colBlocks = llvm::divideCeil(scaleCols, int64_t{4});
-  int64_t paddedRows = rowBlocks * 128;
-  int64_t paddedCols = colBlocks * 4;
+  int64_t rowBlocks = llvm::divideCeil(rows, kTosaBlockedScaleRowBlock);
+  int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
+  int64_t paddedRows = rowBlocks * kTosaBlockedScaleRowBlock;
+  int64_t paddedCols = colBlocks * kTosaBlockedScaleColBlock;
 
   if (scaleTy.getRank() == 2)
     return scaleTy.getDimSize(0) == paddedRows &&
@@ -439,53 +460,55 @@ classifyFlatBlockedScaleForTosa(RankedTensorType scaleTy, int64_t rows,
              : BlockedScaleLayout::Invalid;
 }
 
-static bool hasSwizzledBlockedScaleShapeForTosa(RankedTensorType scaleTy,
-                                                int64_t rows,
-                                                int64_t scaleCols) {
+static bool hasSwizzledBlockedScaleShape(RankedTensorType scaleTy, int64_t rows,
+                                         int64_t scaleCols) {
   if (!scaleTy.hasStaticShape() || scaleTy.getRank() != 2)
     return false;
 
-  int64_t rowBlocks = llvm::divideCeil(rows, int64_t{128});
-  int64_t colBlocks = llvm::divideCeil(scaleCols, int64_t{4});
-  return scaleTy.getDimSize(0) == rowBlocks * colBlocks * 32 &&
-         scaleTy.getDimSize(1) == 16;
+  int64_t rowBlocks = llvm::divideCeil(rows, kTosaBlockedScaleRowBlock);
+  int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
+  return scaleTy.getDimSize(0) ==
+             rowBlocks * colBlocks * kTosaBlockedScaleSwizzleTileRows &&
+         scaleTy.getDimSize(1) == kTosaBlockedScaleSwizzleTileCols;
 }
 
-static FailureOr<ArrayRef<char>>
-getSwizzledBlockedScaleRawDataForTosa(Value scale, RankedTensorType scaleTy,
-                                      int64_t rows, int64_t scaleCols) {
-  if (!hasSwizzledBlockedScaleShapeForTosa(scaleTy, rows, scaleCols))
+static FailureOr<SmallVector<char>>
+getSwizzledBlockedScaleRawData(Value scale, RankedTensorType scaleTy,
+                               int64_t rows, int64_t scaleCols) {
+  if (!hasSwizzledBlockedScaleShape(scaleTy, rows, scaleCols))
     return failure();
 
-  FailureOr<ArrayRef<char>> rawData = getDenseConstantRawByteData(scale);
+  FailureOr<SmallVector<char>> rawData =
+      getDenseConstantRawByteData(scale, scaleTy.getNumElements());
   if (failed(rawData) ||
       static_cast<int64_t>(rawData->size()) != scaleTy.getNumElements())
     return failure();
   return *rawData;
 }
 
-static BlockedScaleClassification
-classifyBlockedScaleForTosa(Value scale, RankedTensorType scaleTy, int64_t rows,
-                            int64_t scaleCols) {
+static BlockedScaleClassification classifyBlockedScale(Value scale,
+                                                       RankedTensorType scaleTy,
+                                                       int64_t rows,
+                                                       int64_t scaleCols) {
   BlockedScaleLayout flatLayout =
-      classifyFlatBlockedScaleForTosa(scaleTy, rows, scaleCols);
+      classifyFlatBlockedScale(scaleTy, rows, scaleCols);
   if (flatLayout != BlockedScaleLayout::Invalid)
     return {flatLayout, {}};
 
-  FailureOr<ArrayRef<char>> rawData =
-      getSwizzledBlockedScaleRawDataForTosa(scale, scaleTy, rows, scaleCols);
+  FailureOr<SmallVector<char>> rawData =
+      getSwizzledBlockedScaleRawData(scale, scaleTy, rows, scaleCols);
   if (failed(rawData))
     return {};
-  return {BlockedScaleLayout::SwizzledConstant, *rawData};
+  return {BlockedScaleLayout::SwizzledConstant, std::move(*rawData)};
 }
 
-static FailureOr<Value> reorderSwizzledBlockedScaleConstantForTosa(
+static FailureOr<Value> reorderSwizzledBlockedScaleConstant(
     Value scale, RankedTensorType scaleTy, int64_t rows, int64_t scaleCols,
     ArrayRef<char> rawData, ConversionPatternRewriter &rewriter, Location loc) {
-  if (!hasSwizzledBlockedScaleShapeForTosa(scaleTy, rows, scaleCols))
+  if (!hasSwizzledBlockedScaleShape(scaleTy, rows, scaleCols))
     return failure();
 
-  int64_t colBlocks = llvm::divideCeil(scaleCols, int64_t{4});
+  int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
 
   // E8M0 scale values are layout-reordered byte payloads here, not numerically
   // transformed. The swizzled storage is [rowBlocks * colBlocks * 32, 16],
@@ -497,17 +520,21 @@ static FailureOr<Value> reorderSwizzledBlockedScaleConstantForTosa(
 
   SmallVector<char> compactData(rows * scaleCols);
   for (int64_t row = 0; row < rows; ++row) {
-    int64_t rowBlock = row / 128;
-    int64_t rowInBlock = row % 128;
+    int64_t rowBlock = row / kTosaBlockedScaleRowBlock;
+    int64_t rowInBlock = row % kTosaBlockedScaleRowBlock;
     for (int64_t col = 0; col < scaleCols; ++col) {
-      int64_t colBlock = col / 4;
-      int64_t colInBlock = col % 4;
+      int64_t colBlock = col / kTosaBlockedScaleColBlock;
+      int64_t colInBlock = col % kTosaBlockedScaleColBlock;
       int64_t block = rowBlock * colBlocks + colBlock;
       // Within each 32x16 tile, rows are grouped by row % 32 and columns by
       // four-row sub-blocks, so compact [row, col] maps to:
       //   tileBase + (row % 32) * 16 + (row / 32) * 4 + (col % 4).
-      int64_t srcIndex = block * 512 + (rowInBlock % 32) * 16 +
-                         (rowInBlock / 32) * 4 + colInBlock;
+      int64_t srcIndex = block * kTosaBlockedScaleSwizzleTileSize +
+                         (rowInBlock % kTosaBlockedScaleSwizzleTileRows) *
+                             kTosaBlockedScaleSwizzleTileCols +
+                         (rowInBlock / kTosaBlockedScaleSwizzleTileRows) *
+                             kTosaBlockedScaleColBlock +
+                         colInBlock;
       compactData[row * scaleCols + col] = rawData[srcIndex];
     }
   }
@@ -520,49 +547,44 @@ static FailureOr<Value> reorderSwizzledBlockedScaleConstantForTosa(
 }
 
 static FailureOr<Value>
-getBlockedScaleForTosa(Value scale, RankedTensorType scaleTy, int64_t rows,
-                       int64_t scaleCols,
-                       BlockedScaleClassification classification,
-                       ConversionPatternRewriter &rewriter, Location loc) {
+getBlockedScale(Value scale, RankedTensorType scaleTy, int64_t rows,
+                int64_t scaleCols, BlockedScaleClassification classification,
+                ConversionPatternRewriter &rewriter, Location loc) {
   switch (classification.layout) {
   case BlockedScaleLayout::FlatPadded:
-    return reshapeFlatBlockedScaleForTosa(scale, scaleTy, rows, scaleCols,
-                                          rewriter, loc);
+    assert(classifyFlatBlockedScale(scaleTy, rows, scaleCols) ==
+               BlockedScaleLayout::FlatPadded &&
+           "blocked scale classification must validate flat padded layout");
+    return reshapeFlatBlockedScale(scale, scaleTy, rows, scaleCols, rewriter,
+                                   loc);
   case BlockedScaleLayout::SwizzledConstant:
-    return reorderSwizzledBlockedScaleConstantForTosa(
-        scale, scaleTy, rows, scaleCols, classification.rawSwizzledData,
-        rewriter, loc);
+    return reorderSwizzledBlockedScaleConstant(scale, scaleTy, rows, scaleCols,
+                                               classification.rawSwizzledData,
+                                               rewriter, loc);
   case BlockedScaleLayout::Invalid:
     return failure();
   }
   llvm_unreachable("unhandled blocked scale layout");
 }
 
-static Value getBlockedRhsForTosa(Value rhs, RankedTensorType rhsTy, int64_t k,
-                                  int64_t n,
-                                  ConversionPatternRewriter &rewriter,
-                                  Location loc) {
-  // TOSA matmul_t_block_scaled expects RHS as [batch, N, K].
-  auto rhsTransposedTy = RankedTensorType::get({n, k}, rhsTy.getElementType());
-  rhs = tosa::TransposeOp::create(rewriter, loc, rhsTransposedTy, rhs,
-                                  rewriter.getDenseI32ArrayAttr({1, 0}))
-            .getResult();
-  auto rhsBlockedTy = RankedTensorType::get({1, n, k}, rhsTy.getElementType());
-  return tosa::ReshapeOp::create(
-             rewriter, loc, rhsBlockedTy, rhs,
-             tosa::getTosaConstShape(rewriter, loc, {1, n, k}))
-      .getResult();
-}
+static Value addBatchDimForBlockedMatmul(Value value, RankedTensorType valueTy,
+                                         int64_t outer, int64_t inner,
+                                         bool transpose,
+                                         ConversionPatternRewriter &rewriter,
+                                         Location loc) {
+  if (transpose) {
+    auto transposedTy =
+        RankedTensorType::get({outer, inner}, valueTy.getElementType());
+    value = tosa::TransposeOp::create(rewriter, loc, transposedTy, value,
+                                      rewriter.getDenseI32ArrayAttr({1, 0}))
+                .getResult();
+  }
 
-static Value getBlockedLhsForTosa(Value lhs, RankedTensorType lhsTy, int64_t m,
-                                  int64_t k,
-                                  ConversionPatternRewriter &rewriter,
-                                  Location loc) {
-  // Keep this legalization tied to aten._scaled_mm's rank-2 contract.
-  auto lhsBlockedTy = RankedTensorType::get({1, m, k}, lhsTy.getElementType());
+  auto rhsBlockedTy =
+      RankedTensorType::get({1, outer, inner}, valueTy.getElementType());
   return tosa::ReshapeOp::create(
-             rewriter, loc, lhsBlockedTy, lhs,
-             tosa::getTosaConstShape(rewriter, loc, {1, m, k}))
+             rewriter, loc, rhsBlockedTy, value,
+             tosa::getTosaConstShape(rewriter, loc, {1, outer, inner}))
       .getResult();
 }
 
@@ -571,6 +593,21 @@ static LogicalResult rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
     RankedTensorType lhsTy, RankedTensorType rhsTy, RankedTensorType scaleATy,
     RankedTensorType scaleBTy, RankedTensorType resultTy,
     ConversionPatternRewriter &rewriter, Location loc) {
+  Type lhsElemTy = lhsTy.getElementType();
+  Type rhsElemTy = rhsTy.getElementType();
+  if (!isSupportedScaledMmDataElementType(rhsElemTy))
+    return rewriter.notifyMatchFailure(
+        op, "aten._scaled_mm expects FP8 rhs input for blocked scales");
+
+  if (!isSupportedScaledMmDataElementType(lhsElemTy))
+    return rewriter.notifyMatchFailure(
+        op, "aten._scaled_mm expects FP8 lhs input for blocked scales");
+
+  if (lhsElemTy != rhsElemTy)
+    return rewriter.notifyMatchFailure(
+        op, "aten._scaled_mm requires matching lhs/rhs element types for "
+            "blocked scales");
+
   if (lhsTy.getRank() != 2 || rhsTy.getRank() != 2 || resultTy.getRank() != 2)
     return rewriter.notifyMatchFailure(
         op, "aten._scaled_mm expects rank-2 tensors for flat blocked scales");
@@ -595,21 +632,24 @@ static LogicalResult rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
 
   int64_t scaleCols = k / 32;
   BlockedScaleClassification scaleAClassification =
-      classifyBlockedScaleForTosa(scaleA, scaleATy, m, scaleCols);
+      classifyBlockedScale(scaleA, scaleATy, m, scaleCols);
   BlockedScaleClassification scaleBClassification =
-      classifyBlockedScaleForTosa(scaleB, scaleBTy, n, scaleCols);
+      classifyBlockedScale(scaleB, scaleBTy, n, scaleCols);
   if (scaleAClassification.layout == BlockedScaleLayout::Invalid ||
       scaleBClassification.layout == BlockedScaleLayout::Invalid)
     return rewriter.notifyMatchFailure(
         op, "failed to validate aten._scaled_mm flat blocked scales");
 
-  lhs = getBlockedLhsForTosa(lhs, lhsTy, m, k, rewriter, loc);
-  rhs = getBlockedRhsForTosa(rhs, rhsTy, k, n, rewriter, loc);
+  lhs = addBatchDimForBlockedMatmul(lhs, lhsTy, m, k, /*transpose=*/false,
+                                    rewriter, loc);
+  // TOSA matmul_t_block_scaled expects RHS as [batch, N, K].
+  rhs = addBatchDimForBlockedMatmul(rhs, rhsTy, n, k, /*transpose=*/true,
+                                    rewriter, loc);
 
-  auto scaleAOr = getBlockedScaleForTosa(scaleA, scaleATy, m, scaleCols,
-                                         scaleAClassification, rewriter, loc);
-  auto scaleBOr = getBlockedScaleForTosa(scaleB, scaleBTy, n, scaleCols,
-                                         scaleBClassification, rewriter, loc);
+  auto scaleAOr = getBlockedScale(scaleA, scaleATy, m, scaleCols,
+                                  scaleAClassification, rewriter, loc);
+  auto scaleBOr = getBlockedScale(scaleB, scaleBTy, n, scaleCols,
+                                  scaleBClassification, rewriter, loc);
   if (failed(scaleAOr) || failed(scaleBOr))
     return rewriter.notifyMatchFailure(
         op, "failed to reshape aten._scaled_mm flat blocked scales");
@@ -3266,19 +3306,6 @@ public:
           op, lhs, rhs, scaleA, scaleB, bias, lhsTy, rhsTy, scaleATy, scaleBTy,
           resultTy, *batchedScaleShapes, m, k, n, rewriter, loc);
     }
-
-    if (!isSupportedScaledMmDataElementType(rhsElemTy))
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm expects FP8 rhs input for blocked scales");
-
-    if (!isSupportedScaledMmDataElementType(lhsElemTy))
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm expects FP8 lhs input for blocked scales");
-
-    if (lhsElemTy != rhsElemTy)
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm requires matching lhs/rhs element types for "
-              "blocked scales");
 
     return rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
         op, lhs, rhs, scaleA, scaleB, bias, lhsTy, rhsTy, scaleATy, scaleBTy,

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -588,7 +588,7 @@ static Value addBatchDimForBlockedMatmul(Value value, RankedTensorType valueTy,
       .getResult();
 }
 
-static LogicalResult rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
+static LogicalResult rewriteBlockedScaledMmToMatmulTBlockScaledOp(
     Operation *op, Value lhs, Value rhs, Value scaleA, Value scaleB, Value bias,
     RankedTensorType lhsTy, RankedTensorType rhsTy, RankedTensorType scaleATy,
     RankedTensorType scaleBTy, RankedTensorType resultTy,
@@ -610,7 +610,7 @@ static LogicalResult rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
 
   if (lhsTy.getRank() != 2 || rhsTy.getRank() != 2 || resultTy.getRank() != 2)
     return rewriter.notifyMatchFailure(
-        op, "aten._scaled_mm expects rank-2 tensors for flat blocked scales");
+        op, "aten._scaled_mm expects rank-2 tensors for blocked scales");
 
   int64_t m = lhsTy.getDimSize(0);
   int64_t k = lhsTy.getDimSize(1);
@@ -638,7 +638,7 @@ static LogicalResult rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
   if (scaleAClassification.layout == BlockedScaleLayout::Invalid ||
       scaleBClassification.layout == BlockedScaleLayout::Invalid)
     return rewriter.notifyMatchFailure(
-        op, "failed to validate aten._scaled_mm flat blocked scales");
+        op, "failed to validate aten._scaled_mm blocked scales");
 
   lhs = addBatchDimForBlockedMatmul(lhs, lhsTy, m, k, /*transpose=*/false,
                                     rewriter, loc);
@@ -652,7 +652,7 @@ static LogicalResult rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
                                   scaleBClassification, rewriter, loc);
   if (failed(scaleAOr) || failed(scaleBOr))
     return rewriter.notifyMatchFailure(
-        op, "failed to reshape aten._scaled_mm flat blocked scales");
+        op, "failed to reshape aten._scaled_mm blocked scales");
 
   auto blockedResultTy =
       RankedTensorType::get({1, m, n}, resultTy.getElementType());
@@ -3307,7 +3307,7 @@ public:
           resultTy, *batchedScaleShapes, m, k, n, rewriter, loc);
     }
 
-    return rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
+    return rewriteBlockedScaledMmToMatmulTBlockScaledOp(
         op, lhs, rhs, scaleA, scaleB, bias, lhsTy, rhsTy, scaleATy, scaleBTy,
         resultTy, rewriter, loc);
   }

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -118,6 +118,10 @@ static bool isSupportedStaticScaledMmResultElementType(Type type) {
   return type.isF32() || type.isF16() || type.isBF16();
 }
 
+static bool isSupportedBlockedScaledMmScaleElementType(Type type) {
+  return isa<Float8E8M0FNUType>(type);
+}
+
 static SmallVector<int64_t> getTensorShape(RankedTensorType tensorTy) {
   return SmallVector<int64_t>(tensorTy.getShape().begin(),
                               tensorTy.getShape().end());
@@ -129,6 +133,21 @@ static Value reshapeTensor(Value input, ArrayRef<int64_t> shape, Type elementTy,
       RankedTensorType::get(makeShapeLLVMCompatible(shape), elementTy);
   return tosa::ReshapeOp::create(rewriter, loc, resultTy, input,
                                  tosa::getTosaConstShape(rewriter, loc, shape))
+      .getResult();
+}
+
+static std::optional<Value>
+createScaledMmZeroTensor(ConversionPatternRewriter &rewriter, Location loc,
+                         Type elementType) {
+  if (!isa<Float8E4M3FNType, Float8E5M2Type, Float8E8M0FNUType>(elementType))
+    return tosa::createZeroPointTensor(rewriter, loc, elementType,
+                                       /*zeroPoint=*/0);
+
+  auto zeroPointType = RankedTensorType::get({1}, elementType);
+  std::array<char, 1> rawZero = {0};
+  auto zeroPointAttr =
+      DenseElementsAttr::getFromRawBuffer(zeroPointType, rawZero);
+  return tosa::ConstOp::create(rewriter, loc, zeroPointType, zeroPointAttr)
       .getResult();
 }
 
@@ -219,8 +238,7 @@ insertZerosAlongAxis(Value input, int axis, int64_t stride,
   // Torch IR does not convey quantization params via tensor element types, so
   // we use a literal zero here. Quantized frontends will insert the necessary
   // rescale ops before we hit this lowering.
-  auto padValueOr =
-      tosa::createZeroPointTensor(rewriter, loc, elementType, /*zeroPoint=*/0);
+  auto padValueOr = createScaledMmZeroTensor(rewriter, loc, elementType);
   if (!padValueOr.has_value())
     return failure();
   Value padValue = *padValueOr;
@@ -296,11 +314,320 @@ addBiasToScaledMmAccumulator(Value accumulator, Value bias, int64_t n,
   auto biasAccumulatorTy =
       RankedTensorType::get(biasTy.getShape(), accumulatorTy.getElementType());
   bias = tosa::tosaCastTensorToType(rewriter, bias, biasAccumulatorTy).value();
-  bias = reshapeTensor(bias, {1, n}, accumulatorTy.getElementType(), rewriter,
-                       loc);
+  SmallVector<int64_t> biasShape(accumulatorTy.getRank(), 1);
+  biasShape.back() = n;
+  bias = reshapeTensor(bias, biasShape, accumulatorTy.getElementType(),
+                       rewriter, loc);
   return tosa::AddOp::create(rewriter, loc, accumulator.getType(), accumulator,
                              bias)
       .getResult();
+}
+
+static FailureOr<Value> createScaledMmMatmulTBlockScaledResult(
+    Operation *op, Value lhs, Value rhs, Value scaleA, Value scaleB, Value bias,
+    RankedTensorType resultTy, ConversionPatternRewriter &rewriter,
+    Location loc) {
+  auto f32Ty = rewriter.getF32Type();
+  auto blockedMatmulTy = RankedTensorType::get(resultTy.getShape(), f32Ty);
+  Value blockedMatmul = tosa::MatmulTBlockScaledOp::create(
+                            rewriter, loc, blockedMatmulTy, lhs, scaleA, rhs,
+                            scaleB, tosa::BlockSize::BLOCK_SIZE_32)
+                            .getResult();
+  int64_t n = resultTy.getDimSize(resultTy.getRank() - 1);
+  auto resultWithBiasOr =
+      addBiasToScaledMmAccumulator(blockedMatmul, bias, n, rewriter, loc);
+  if (failed(resultWithBiasOr))
+    return rewriter.notifyMatchFailure(op,
+                                       "Failed to add bias to aten._scaled_mm "
+                                       "accumulator");
+  return castScaledMmResultToType(*resultWithBiasOr, resultTy, rewriter);
+}
+
+static FailureOr<Value> reshapeFlatBlockedScaleForTosa(
+    Value scale, RankedTensorType scaleTy, int64_t rows, int64_t scaleCols,
+    ConversionPatternRewriter &rewriter, Location loc) {
+  if (!scaleTy.hasStaticShape())
+    return failure();
+
+  SmallVector<int64_t> scaleShape = {1, rows, scaleCols};
+  auto reshapedTy = RankedTensorType::get(scaleShape, scaleTy.getElementType());
+  int64_t rowBlocks = llvm::divideCeil(rows, int64_t{128});
+  int64_t colBlocks = llvm::divideCeil(scaleCols, int64_t{4});
+  SmallVector<int64_t> paddedScaleShape = {1, rowBlocks * 128, colBlocks * 4};
+
+  if (scaleTy.getRank() == 2) {
+    if (scaleTy.getDimSize(0) != paddedScaleShape[1] ||
+        scaleTy.getDimSize(1) != paddedScaleShape[2])
+      return failure();
+  } else {
+    if (scaleTy.getRank() != 1)
+      return failure();
+
+    int64_t numel = scaleTy.getDimSize(0);
+    if (numel != paddedScaleShape[1] * paddedScaleShape[2])
+      return failure();
+  }
+
+  auto paddedScaleTy =
+      RankedTensorType::get(paddedScaleShape, scaleTy.getElementType());
+  Value paddedScale =
+      tosa::ReshapeOp::create(
+          rewriter, loc, paddedScaleTy, scale,
+          tosa::getTosaConstShape(rewriter, loc, paddedScaleShape))
+          .getResult();
+  if (paddedScaleShape == scaleShape)
+    return paddedScale;
+  return tosa::SliceOp::create(
+             rewriter, loc, reshapedTy, paddedScale,
+             tosa::getTosaConstShape(rewriter, loc, {0, 0, 0}),
+             tosa::getTosaConstShape(rewriter, loc, scaleShape))
+      .getResult();
+}
+
+static FailureOr<ArrayRef<char>> getDenseConstantRawByteData(Value value) {
+  auto constOp = value.getDefiningOp<tosa::ConstOp>();
+  if (!constOp)
+    return failure();
+
+  ElementsAttr attr = constOp.getValues();
+  if (auto denseAttr = dyn_cast<DenseElementsAttr>(attr))
+    return denseAttr.getRawData();
+
+  if (auto resourceAttr = dyn_cast<DenseResourceElementsAttr>(attr)) {
+    auto *blob = resourceAttr.getRawHandle().getBlob();
+    if (!blob)
+      return failure();
+    return blob->getData();
+  }
+
+  return failure();
+}
+
+enum class BlockedScaleLayout {
+  Invalid,
+  FlatPadded,
+  SwizzledConstant,
+};
+
+struct BlockedScaleClassification {
+  BlockedScaleLayout layout = BlockedScaleLayout::Invalid;
+  ArrayRef<char> rawSwizzledData = {};
+};
+
+static BlockedScaleLayout
+classifyFlatBlockedScaleForTosa(RankedTensorType scaleTy, int64_t rows,
+                                int64_t scaleCols) {
+  if (!scaleTy.hasStaticShape())
+    return BlockedScaleLayout::Invalid;
+
+  int64_t rowBlocks = llvm::divideCeil(rows, int64_t{128});
+  int64_t colBlocks = llvm::divideCeil(scaleCols, int64_t{4});
+  int64_t paddedRows = rowBlocks * 128;
+  int64_t paddedCols = colBlocks * 4;
+
+  if (scaleTy.getRank() == 2)
+    return scaleTy.getDimSize(0) == paddedRows &&
+                   scaleTy.getDimSize(1) == paddedCols
+               ? BlockedScaleLayout::FlatPadded
+               : BlockedScaleLayout::Invalid;
+
+  if (scaleTy.getRank() != 1)
+    return BlockedScaleLayout::Invalid;
+
+  return scaleTy.getDimSize(0) == paddedRows * paddedCols
+             ? BlockedScaleLayout::FlatPadded
+             : BlockedScaleLayout::Invalid;
+}
+
+static bool hasSwizzledBlockedScaleShapeForTosa(RankedTensorType scaleTy,
+                                                int64_t rows,
+                                                int64_t scaleCols) {
+  if (!scaleTy.hasStaticShape() || scaleTy.getRank() != 2)
+    return false;
+
+  int64_t rowBlocks = llvm::divideCeil(rows, int64_t{128});
+  int64_t colBlocks = llvm::divideCeil(scaleCols, int64_t{4});
+  return scaleTy.getDimSize(0) == rowBlocks * colBlocks * 32 &&
+         scaleTy.getDimSize(1) == 16;
+}
+
+static FailureOr<ArrayRef<char>>
+getSwizzledBlockedScaleRawDataForTosa(Value scale, RankedTensorType scaleTy,
+                                      int64_t rows, int64_t scaleCols) {
+  if (!hasSwizzledBlockedScaleShapeForTosa(scaleTy, rows, scaleCols))
+    return failure();
+
+  FailureOr<ArrayRef<char>> rawData = getDenseConstantRawByteData(scale);
+  if (failed(rawData) ||
+      static_cast<int64_t>(rawData->size()) != scaleTy.getNumElements())
+    return failure();
+  return *rawData;
+}
+
+static BlockedScaleClassification
+classifyBlockedScaleForTosa(Value scale, RankedTensorType scaleTy, int64_t rows,
+                            int64_t scaleCols) {
+  BlockedScaleLayout flatLayout =
+      classifyFlatBlockedScaleForTosa(scaleTy, rows, scaleCols);
+  if (flatLayout != BlockedScaleLayout::Invalid)
+    return {flatLayout, {}};
+
+  FailureOr<ArrayRef<char>> rawData =
+      getSwizzledBlockedScaleRawDataForTosa(scale, scaleTy, rows, scaleCols);
+  if (failed(rawData))
+    return {};
+  return {BlockedScaleLayout::SwizzledConstant, *rawData};
+}
+
+static FailureOr<Value> reorderSwizzledBlockedScaleConstantForTosa(
+    Value scale, RankedTensorType scaleTy, int64_t rows, int64_t scaleCols,
+    ArrayRef<char> rawData, ConversionPatternRewriter &rewriter, Location loc) {
+  if (!hasSwizzledBlockedScaleShapeForTosa(scaleTy, rows, scaleCols))
+    return failure();
+
+  int64_t colBlocks = llvm::divideCeil(scaleCols, int64_t{4});
+
+  // E8M0 scale values are layout-reordered byte payloads here, not numerically
+  // transformed. The swizzled storage is [rowBlocks * colBlocks * 32, 16],
+  // where each 32x16 tile stores one 128-row by 4-column padded scale block.
+  // For constants with this exact layout, reorder the raw bytes at compile time
+  // into TOSA's compact [1, rows, K/32] scale layout.
+  if (static_cast<int64_t>(rawData.size()) != scaleTy.getNumElements())
+    return failure();
+
+  SmallVector<char> compactData(rows * scaleCols);
+  for (int64_t row = 0; row < rows; ++row) {
+    int64_t rowBlock = row / 128;
+    int64_t rowInBlock = row % 128;
+    for (int64_t col = 0; col < scaleCols; ++col) {
+      int64_t colBlock = col / 4;
+      int64_t colInBlock = col % 4;
+      int64_t block = rowBlock * colBlocks + colBlock;
+      // Within each 32x16 tile, rows are grouped by row % 32 and columns by
+      // four-row sub-blocks, so compact [row, col] maps to:
+      //   tileBase + (row % 32) * 16 + (row / 32) * 4 + (col % 4).
+      int64_t srcIndex = block * 512 + (rowInBlock % 32) * 16 +
+                         (rowInBlock / 32) * 4 + colInBlock;
+      compactData[row * scaleCols + col] = rawData[srcIndex];
+    }
+  }
+
+  SmallVector<int64_t> compactShape = {1, rows, scaleCols};
+  auto compactTy =
+      RankedTensorType::get(compactShape, scaleTy.getElementType());
+  auto attr = DenseElementsAttr::getFromRawBuffer(compactTy, compactData);
+  return tosa::ConstOp::create(rewriter, loc, compactTy, attr).getResult();
+}
+
+static FailureOr<Value>
+getBlockedScaleForTosa(Value scale, RankedTensorType scaleTy, int64_t rows,
+                       int64_t scaleCols,
+                       BlockedScaleClassification classification,
+                       ConversionPatternRewriter &rewriter, Location loc) {
+  switch (classification.layout) {
+  case BlockedScaleLayout::FlatPadded:
+    return reshapeFlatBlockedScaleForTosa(scale, scaleTy, rows, scaleCols,
+                                          rewriter, loc);
+  case BlockedScaleLayout::SwizzledConstant:
+    return reorderSwizzledBlockedScaleConstantForTosa(
+        scale, scaleTy, rows, scaleCols, classification.rawSwizzledData,
+        rewriter, loc);
+  case BlockedScaleLayout::Invalid:
+    return failure();
+  }
+  llvm_unreachable("unhandled blocked scale layout");
+}
+
+static Value getBlockedRhsForTosa(Value rhs, RankedTensorType rhsTy, int64_t k,
+                                  int64_t n,
+                                  ConversionPatternRewriter &rewriter,
+                                  Location loc) {
+  // TOSA matmul_t_block_scaled expects RHS as [batch, N, K].
+  auto rhsTransposedTy = RankedTensorType::get({n, k}, rhsTy.getElementType());
+  rhs = tosa::TransposeOp::create(rewriter, loc, rhsTransposedTy, rhs,
+                                  rewriter.getDenseI32ArrayAttr({1, 0}))
+            .getResult();
+  auto rhsBlockedTy = RankedTensorType::get({1, n, k}, rhsTy.getElementType());
+  return tosa::ReshapeOp::create(
+             rewriter, loc, rhsBlockedTy, rhs,
+             tosa::getTosaConstShape(rewriter, loc, {1, n, k}))
+      .getResult();
+}
+
+static Value getBlockedLhsForTosa(Value lhs, RankedTensorType lhsTy, int64_t m,
+                                  int64_t k,
+                                  ConversionPatternRewriter &rewriter,
+                                  Location loc) {
+  // Keep this legalization tied to aten._scaled_mm's rank-2 contract.
+  auto lhsBlockedTy = RankedTensorType::get({1, m, k}, lhsTy.getElementType());
+  return tosa::ReshapeOp::create(
+             rewriter, loc, lhsBlockedTy, lhs,
+             tosa::getTosaConstShape(rewriter, loc, {1, m, k}))
+      .getResult();
+}
+
+static LogicalResult rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
+    Operation *op, Value lhs, Value rhs, Value scaleA, Value scaleB, Value bias,
+    RankedTensorType lhsTy, RankedTensorType rhsTy, RankedTensorType scaleATy,
+    RankedTensorType scaleBTy, RankedTensorType resultTy,
+    ConversionPatternRewriter &rewriter, Location loc) {
+  if (lhsTy.getRank() != 2 || rhsTy.getRank() != 2 || resultTy.getRank() != 2)
+    return rewriter.notifyMatchFailure(
+        op, "aten._scaled_mm expects rank-2 tensors for flat blocked scales");
+
+  int64_t m = lhsTy.getDimSize(0);
+  int64_t k = lhsTy.getDimSize(1);
+  int64_t rhsK = rhsTy.getDimSize(0);
+  int64_t n = rhsTy.getDimSize(1);
+  if (k != rhsK)
+    return rewriter.notifyMatchFailure(
+        op, "aten._scaled_mm requires inner dimensions of lhs/rhs to match");
+  if (k % 32 != 0)
+    return rewriter.notifyMatchFailure(
+        op, "aten._scaled_mm expects blocked-scale K to be divisible by 32");
+  if (resultTy.getDimSize(0) != m || resultTy.getDimSize(1) != n)
+    return rewriter.notifyMatchFailure(
+        op, "aten._scaled_mm expects blocked result shape [M, N]");
+  if (!isValidScaledMmBias(bias, n))
+    return rewriter.notifyMatchFailure(
+        op, "aten._scaled_mm expects bias to be a rank-1 tensor with N "
+            "elements");
+
+  int64_t scaleCols = k / 32;
+  BlockedScaleClassification scaleAClassification =
+      classifyBlockedScaleForTosa(scaleA, scaleATy, m, scaleCols);
+  BlockedScaleClassification scaleBClassification =
+      classifyBlockedScaleForTosa(scaleB, scaleBTy, n, scaleCols);
+  if (scaleAClassification.layout == BlockedScaleLayout::Invalid ||
+      scaleBClassification.layout == BlockedScaleLayout::Invalid)
+    return rewriter.notifyMatchFailure(
+        op, "failed to validate aten._scaled_mm flat blocked scales");
+
+  lhs = getBlockedLhsForTosa(lhs, lhsTy, m, k, rewriter, loc);
+  rhs = getBlockedRhsForTosa(rhs, rhsTy, k, n, rewriter, loc);
+
+  auto scaleAOr = getBlockedScaleForTosa(scaleA, scaleATy, m, scaleCols,
+                                         scaleAClassification, rewriter, loc);
+  auto scaleBOr = getBlockedScaleForTosa(scaleB, scaleBTy, n, scaleCols,
+                                         scaleBClassification, rewriter, loc);
+  if (failed(scaleAOr) || failed(scaleBOr))
+    return rewriter.notifyMatchFailure(
+        op, "failed to reshape aten._scaled_mm flat blocked scales");
+
+  auto blockedResultTy =
+      RankedTensorType::get({1, m, n}, resultTy.getElementType());
+  auto blockedResultOr = createScaledMmMatmulTBlockScaledResult(
+      op, lhs, rhs, *scaleAOr, *scaleBOr, bias, blockedResultTy, rewriter, loc);
+  if (failed(blockedResultOr))
+    return failure();
+
+  Value result =
+      tosa::ReshapeOp::create(
+          rewriter, loc, resultTy, *blockedResultOr,
+          tosa::getTosaConstShape(rewriter, loc, getTensorShape(resultTy)))
+          .getResult();
+  rewriter.replaceOp(op, {result});
+  return success();
 }
 
 static LogicalResult rewriteScaledMmToMatMulOp(
@@ -329,9 +656,9 @@ static LogicalResult rewriteScaledMmToMatMulOp(
   scaleB = reshapeTensor(scaleB, batchedScaleBShapeVec, f32Ty, rewriter, loc);
 
   auto zeroPointAOr =
-      tosa::createZeroPointTensor(rewriter, loc, lhsTy.getElementType(), 0);
+      createScaledMmZeroTensor(rewriter, loc, lhsTy.getElementType());
   auto zeroPointBOr =
-      tosa::createZeroPointTensor(rewriter, loc, rhsTy.getElementType(), 0);
+      createScaledMmZeroTensor(rewriter, loc, rhsTy.getElementType());
   if (!zeroPointAOr || !zeroPointBOr)
     return rewriter.notifyMatchFailure(
         op, "failed to materialize FP8 zero point for matmul");
@@ -2872,59 +3199,90 @@ public:
     auto lhsElemTy = lhsTy.getElementType();
     auto rhsElemTy = rhsTy.getElementType();
 
-    if (!isSupportedScaledMmDataElementType(lhsElemTy) ||
-        !isSupportedScaledMmDataElementType(rhsElemTy))
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm only supports FP8 input types");
+    auto isBlockedScale = [](RankedTensorType ty) {
+      return (ty.getRank() == 1 || ty.getRank() == 2) && ty.hasStaticShape() &&
+             isSupportedBlockedScaledMmScaleElementType(ty.getElementType());
+    };
+    bool useStaticFp8Scales =
+        isSupportedStaticScaledMmScaleElementType(scaleATy.getElementType()) &&
+        isSupportedStaticScaledMmScaleElementType(scaleBTy.getElementType());
+    bool useBlockedScales =
+        isBlockedScale(scaleATy) && isBlockedScale(scaleBTy);
 
-    if (lhsElemTy != rhsElemTy)
+    if (!useStaticFp8Scales && !useBlockedScales)
       return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm expects matching lhs/rhs FP8 input types");
-
-    if (!isSupportedStaticScaledMmScaleElementType(scaleATy.getElementType()) ||
-        !isSupportedStaticScaledMmScaleElementType(scaleBTy.getElementType()))
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm expects fp32 static FP8 scales");
+          op, "aten._scaled_mm expects fp32 static FP8 scales or "
+              "float8_e8m0fnu blocked scales");
 
     if (!isSupportedStaticScaledMmResultElementType(resultTy.getElementType()))
       return rewriter.notifyMatchFailure(
           op, "aten._scaled_mm expects f32, f16 or bf16 result type for "
-              "static FP8 scales");
+              "FP8/MXFP8 scales");
 
     Location loc = op.getLoc();
 
-    if (lhsTy.getRank() != 2 || rhsTy.getRank() != 2 || resultTy.getRank() != 2)
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm expects rank-2 input and result tensors for "
-              "static FP8 scales");
+    if (useStaticFp8Scales) {
+      if (!isSupportedScaledMmDataElementType(lhsElemTy) ||
+          !isSupportedScaledMmDataElementType(rhsElemTy))
+        return rewriter.notifyMatchFailure(
+            op, "aten._scaled_mm expects FP8 input types for static scales");
 
-    int64_t m = lhsTy.getShape()[0];
-    int64_t k = lhsTy.getShape()[1];
-    int64_t rhsK = rhsTy.getShape()[0];
-    int64_t n = rhsTy.getShape()[1];
-    if (k != rhsK)
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm requires inner dimensions of lhs/rhs to match");
-    if (resultTy.getShape()[0] != m || resultTy.getShape()[1] != n)
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm expects static FP8 result shape [M, N]");
+      if (lhsElemTy != rhsElemTy)
+        return rewriter.notifyMatchFailure(
+            op, "aten._scaled_mm expects matching lhs/rhs FP8 input types");
 
-    std::optional<StaticScaledMmScaleShapes> batchedScaleShapes =
-        getStaticScaledMmTensorwiseOrRowwiseBatchedScaleShapes(scaleATy,
-                                                               scaleBTy, m, n);
-    if (!batchedScaleShapes)
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm expects static FP8 scales to be fp32 "
-              "tensorwise scales or rowwise [M,1]/[1,N] scale layouts");
+      if (lhsTy.getRank() != 2 || rhsTy.getRank() != 2 ||
+          resultTy.getRank() != 2)
+        return rewriter.notifyMatchFailure(
+            op, "aten._scaled_mm expects rank-2 input and result tensors for "
+                "static FP8 scales");
 
-    if (!isValidScaledMmBias(bias, n))
-      return rewriter.notifyMatchFailure(
-          op, "aten._scaled_mm expects bias to be a rank-1 tensor with N "
-              "elements");
+      int64_t m = lhsTy.getShape()[0];
+      int64_t k = lhsTy.getShape()[1];
+      int64_t rhsK = rhsTy.getShape()[0];
+      int64_t n = rhsTy.getShape()[1];
+      if (k != rhsK)
+        return rewriter.notifyMatchFailure(
+            op,
+            "aten._scaled_mm requires inner dimensions of lhs/rhs to match");
+      if (resultTy.getShape()[0] != m || resultTy.getShape()[1] != n)
+        return rewriter.notifyMatchFailure(
+            op, "aten._scaled_mm expects static FP8 result shape [M, N]");
 
-    return rewriteScaledMmToMatMulOp(
+      std::optional<StaticScaledMmScaleShapes> batchedScaleShapes =
+          getStaticScaledMmTensorwiseOrRowwiseBatchedScaleShapes(
+              scaleATy, scaleBTy, m, n);
+      if (!batchedScaleShapes)
+        return rewriter.notifyMatchFailure(
+            op, "aten._scaled_mm expects static FP8 scales to be fp32 "
+                "tensorwise scales or rowwise [M,1]/[1,N] scale layouts");
+
+      if (!isValidScaledMmBias(bias, n))
+        return rewriter.notifyMatchFailure(
+            op, "aten._scaled_mm expects bias to be a rank-1 tensor with N "
+                "elements");
+
+      return rewriteScaledMmToMatMulOp(
+          op, lhs, rhs, scaleA, scaleB, bias, lhsTy, rhsTy, scaleATy, scaleBTy,
+          resultTy, *batchedScaleShapes, m, k, n, rewriter, loc);
+    }
+
+    if (!isSupportedScaledMmDataElementType(rhsElemTy))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm expects FP8 rhs input for blocked scales");
+
+    if (!isSupportedScaledMmDataElementType(lhsElemTy))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm expects FP8 lhs input for blocked scales");
+
+    if (lhsElemTy != rhsElemTy)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm requires matching lhs/rhs element types for "
+              "blocked scales");
+
+    return rewriteFlatBlockedScaledMmToMatmulTBlockScaledOp(
         op, lhs, rhs, scaleA, scaleB, bias, lhsTy, rhsTy, scaleATy, scaleBTy,
-        resultTy, *batchedScaleShapes, m, k, n, rewriter, loc);
+        resultTy, rewriter, loc);
   }
 };
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -426,6 +426,7 @@ FX_IMPORTER_XFAIL_SET = {
     "AtenIntBoolOpModule_basic",
     "AtenIntMM_basic",
     "AtenNonzero1DDynamicModule_basic",  # no lowering for torch.aten.sym_constrain_range_for_size
+    "AtenScaledMmBlockScaledFp8Module_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
@@ -662,6 +663,7 @@ FX_IMPORTER_STABLEHLO_XFAIL_SET = {
     "AtenMmQuint8_basic",
     "AtenRealView128Module_basic",
     "AtenRealView64Module_basic",
+    "AtenScaledMmBlockScaledFp8Module_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
@@ -2912,6 +2914,7 @@ ONNX_XFAIL_SET = {
     "AtenMmQMixedSigni8_basic",
     "AtenMmQint8_basic",
     "AtenMmQuint8_basic",
+    "AtenScaledMmBlockScaledFp8Module_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
@@ -3639,6 +3642,7 @@ FX_IMPORTER_TOSA_XFAIL_SET = {
     "Aten_AssertScalar_basic",
     # These import through FX and lower to TOSA, but the TOSA execution backend
     # cannot currently load FP8 tensor element types in the lowered matmul path.
+    "AtenScaledMmBlockScaledFp8Module_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -427,6 +427,7 @@ FX_IMPORTER_XFAIL_SET = {
     "AtenIntMM_basic",
     "AtenNonzero1DDynamicModule_basic",  # no lowering for torch.aten.sym_constrain_range_for_size
     "AtenScaledMmBlockScaledFp8Module_basic",
+    "AtenScaledMmBlockScaledFp8SwizzledModule_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
@@ -664,6 +665,7 @@ FX_IMPORTER_STABLEHLO_XFAIL_SET = {
     "AtenRealView128Module_basic",
     "AtenRealView64Module_basic",
     "AtenScaledMmBlockScaledFp8Module_basic",
+    "AtenScaledMmBlockScaledFp8SwizzledModule_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
@@ -2915,6 +2917,7 @@ ONNX_XFAIL_SET = {
     "AtenMmQint8_basic",
     "AtenMmQuint8_basic",
     "AtenScaledMmBlockScaledFp8Module_basic",
+    "AtenScaledMmBlockScaledFp8SwizzledModule_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
@@ -3643,6 +3646,7 @@ FX_IMPORTER_TOSA_XFAIL_SET = {
     # These import through FX and lower to TOSA, but the TOSA execution backend
     # cannot currently load FP8 tensor element types in the lowered matmul path.
     "AtenScaledMmBlockScaledFp8Module_basic",
+    "AtenScaledMmBlockScaledFp8SwizzledModule_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3643,8 +3643,11 @@ FX_IMPORTER_TOSA_XFAIL_SET = {
     "AtenSymConstrainRangeForSize_basic",
     "AtenSymConstrainRange_basic",
     "Aten_AssertScalar_basic",
-    # These import through FX and lower to TOSA, but the TOSA execution backend
-    # cannot currently load FP8 tensor element types in the lowered matmul path.
+    # These import through FX and lower to TOSA. To enable them end-to-end, the
+    # TOSA execution backend needs support for loading the FP8 input tensors and
+    # float8_e8m0fnu blocked-scale tensors used by matmul_t_block_scaled. The
+    # e2e framework also needs a non-CPU reference path because PyTorch CPU does
+    # not execute blocked-scale _scaled_mm.
     "AtenScaledMmBlockScaledFp8Module_basic",
     "AtenScaledMmBlockScaledFp8SwizzledModule_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -198,6 +198,41 @@ def AtenScaledMmBlockScaledFp8Module_basic(module, tu: TestUtils):
     )
 
 
+class AtenScaledMmBlockScaledFp8SwizzledModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer(
+            "scale_lhs", torch.ones(32, 16, dtype=torch.float8_e8m0fnu)
+        )
+        self.register_buffer(
+            "scale_rhs", torch.ones(32, 16, dtype=torch.float8_e8m0fnu)
+        )
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([3, 32], torch.float32, True),
+            ([32, 64], torch.float32, True),
+        ]
+    )
+    def forward(self, lhs, rhs):
+        lhs_fp8 = lhs.to(torch.float8_e4m3fn)
+        rhs_fp8 = rhs.to(torch.float8_e4m3fn)
+        return torch._scaled_mm(
+            lhs_fp8,
+            rhs_fp8,
+            self.scale_lhs,
+            self.scale_rhs,
+            out_dtype=torch.bfloat16,
+        )
+
+
+@register_test_case(module_factory=lambda: AtenScaledMmBlockScaledFp8SwizzledModule())
+def AtenScaledMmBlockScaledFp8SwizzledModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 32), tu.rand(32, 64))
+
+
 # ==============================================================================
 
 

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -162,6 +162,45 @@ def AtenScaledMmPerTensorE5M2Module_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class AtenScaledMmBlockScaledFp8Module(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([3, 32], torch.float32, True),
+            ([32, 64], torch.float32, True),
+            ([512], torch.float8_e8m0fnu, True),
+            ([512], torch.float8_e8m0fnu, True),
+        ]
+    )
+    def forward(self, lhs, rhs, scale_lhs, scale_rhs):
+        lhs_fp8 = lhs.to(torch.float8_e4m3fn)
+        rhs_fp8 = rhs.to(torch.float8_e4m3fn)
+        return torch._scaled_mm(
+            lhs_fp8,
+            rhs_fp8,
+            scale_lhs,
+            scale_rhs,
+            out_dtype=torch.bfloat16,
+        )
+
+
+@register_test_case(module_factory=lambda: AtenScaledMmBlockScaledFp8Module())
+def AtenScaledMmBlockScaledFp8Module_basic(module, tu: TestUtils):
+    module.forward(
+        tu.rand(3, 32),
+        tu.rand(32, 64),
+        torch.ones(512, dtype=torch.float8_e8m0fnu),
+        torch.ones(512, dtype=torch.float8_e8m0fnu),
+    )
+
+
+# ==============================================================================
+
+
 class MatmulVecMat(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -5308,6 +5308,46 @@ func.func @torch.aten._scaled_mm$block_scaled_fp8_swizzled_constant_scales(%arg0
 }
 
 // -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_swizzled_splat_constant_scales(
+// CHECK:           %[[SCALE_A_3D:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x3x1xf8E8M0FNU>}>
+// CHECK:           %[[SCALE_B_3D:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x64x1xf8E8M0FNU>}>
+// CHECK:           tosa.matmul_t_block_scaled %{{.*}}, %[[SCALE_A_3D]], %{{.*}}, %[[SCALE_B_3D]] {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf8E4M3FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x64x32xf8E4M3FN>, tensor<1x64x1xf8E8M0FNU>) -> tensor<1x3x64xf32>
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_swizzled_splat_constant_scales(%arg0: !torch.vtensor<[3,32],f8E4M3FN>, %arg1: !torch.vtensor<[32,64],f8E4M3FN>) -> !torch.vtensor<[3,64],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.vtensor.literal(dense<0x00> : tensor<32x16xf8E8M0FNU>) : !torch.vtensor<[32,16],f8E8M0FNU>
+  %scale_b = torch.vtensor.literal(dense<0x00> : tensor<32x16xf8E8M0FNU>) : !torch.vtensor<[32,16],f8E8M0FNU>
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %scale_a, %scale_b, %none, %none, %int15, %false : !torch.vtensor<[3,32],f8E4M3FN>, !torch.vtensor<[32,64],f8E4M3FN>, !torch.vtensor<[32,16],f8E8M0FNU>, !torch.vtensor<[32,16],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[3,64],bf16>
+  return %0 : !torch.vtensor<[3,64],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_swizzled_resource_scales(
+// CHECK:           %[[SCALE_A_3D:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x3x1xf8E8M0FNU>}>
+// CHECK:           %[[SCALE_B_3D:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x64x1xf8E8M0FNU>}>
+// CHECK:           tosa.matmul_t_block_scaled %{{.*}}, %[[SCALE_A_3D]], %{{.*}}, %[[SCALE_B_3D]] {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf8E4M3FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x64x32xf8E4M3FN>, tensor<1x64x1xf8E8M0FNU>) -> tensor<1x3x64xf32>
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_swizzled_resource_scales(%arg0: !torch.vtensor<[3,32],f8E4M3FN>, %arg1: !torch.vtensor<[32,64],f8E4M3FN>) -> !torch.vtensor<[3,64],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.vtensor.literal(dense_resource<mxfp8_swizzled_scale_resource> : tensor<32x16xf8E8M0FNU>) : !torch.vtensor<[32,16],f8E8M0FNU>
+  %scale_b = torch.vtensor.literal(dense_resource<mxfp8_swizzled_scale_resource> : tensor<32x16xf8E8M0FNU>) : !torch.vtensor<[32,16],f8E8M0FNU>
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %scale_a, %scale_b, %none, %none, %int15, %false : !torch.vtensor<[3,32],f8E4M3FN>, !torch.vtensor<[32,64],f8E4M3FN>, !torch.vtensor<[32,16],f8E8M0FNU>, !torch.vtensor<[32,16],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[3,64],bf16>
+  return %0 : !torch.vtensor<[3,64],bf16>
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      mxfp8_swizzled_scale_resource: "0x08000000000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF"
+    }
+  }
+#-}
+
+// -----
 module {
   // scale_result is verifier-valid as a scalar, but this TOSA lowering does
   // not yet model the extra output scaling semantics.

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -5129,6 +5129,285 @@ func.func @torch.aten._scaled_mm$per_row_scales_rectangular(%arg0: !torch.vtenso
 }
 
 // -----
+
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_flat(
+// CHECK-SAME:      %arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-DAG:       %[[SCALE_A:.*]] = torch_c.to_builtin_tensor %arg2 : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK:           %[[LHS:.*]] = tosa.reshape %{{.*}} : (tensor<128x128xf8E4M3FN>, !tosa.shape<3>) -> tensor<1x128x128xf8E4M3FN>
+// CHECK:           %[[RHS_2D:.*]] = tosa.transpose %{{.*}} {perms = array<i32: 1, 0>} : (tensor<128x128xf8E4M3FN>) -> tensor<128x128xf8E4M3FN>
+// CHECK:           %[[RHS:.*]] = tosa.reshape %[[RHS_2D]], %{{.*}} : (tensor<128x128xf8E4M3FN>, !tosa.shape<3>) -> tensor<1x128x128xf8E4M3FN>
+// CHECK:           %[[SCALE_A_3D:.*]] = tosa.reshape %[[SCALE_A]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_3D:.*]] = tosa.reshape %[[SCALE_B]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A_3D]], %[[RHS]], %[[SCALE_B_3D]] {block_size = BLOCK_SIZE_32} : (tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>, tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK:           tosa.cast %[[MATMUL]] : (tensor<1x128x128xf32>) -> tensor<1x128x128xbf16>
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_flat(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_use_fast_accum(
+// CHECK-SAME:      %arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>, tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK:           tosa.cast %[[MATMUL]] : (tensor<1x128x128xf32>) -> tensor<1x128x128xbf16>
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_use_fast_accum(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %true = torch.constant.bool true
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %true : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_bias(
+// CHECK-SAME:      %arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>, %arg4: !torch.vtensor<[128],bf16>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-DAG:       %[[BIAS:.*]] = torch_c.to_builtin_tensor %arg4 : !torch.vtensor<[128],bf16> -> tensor<128xbf16>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>, tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK:           %[[BIAS_F32:.*]] = tosa.cast %[[BIAS]] : (tensor<128xbf16>) -> tensor<128xf32>
+// CHECK:           %[[BIAS_3D:.*]] = tosa.reshape %[[BIAS_F32]], %{{.*}} : (tensor<128xf32>, !tosa.shape<3>) -> tensor<1x1x128xf32>
+// CHECK:           %[[WITH_BIAS:.*]] = tosa.add %[[MATMUL]], %[[BIAS_3D]] : (tensor<1x128x128xf32>, tensor<1x1x128xf32>) -> tensor<1x128x128xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[WITH_BIAS]] : (tensor<1x128x128xf32>) -> tensor<1x128x128xbf16>
+// CHECK:           tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x128x128xbf16>, !tosa.shape<2>) -> tensor<128x128xbf16>
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_bias(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>, %arg4: !torch.vtensor<[128],bf16>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %arg4, %none, %int15, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[128],bf16>, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_f16_result(
+// CHECK-SAME:      %arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],f16> {
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>, tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[MATMUL]] : (tensor<1x128x128xf32>) -> tensor<1x128x128xf16>
+// CHECK:           tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x128x128xf16>, !tosa.shape<2>) -> tensor<128x128xf16>
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_f16_result(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],f16> {
+  %false = torch.constant.bool false
+  %int6 = torch.constant.int 6
+  %none = torch.constant.none
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int6, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],f16>
+  return %0 : !torch.vtensor<[128,128],f16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_f32_result(
+// CHECK-SAME:      %arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],f32> {
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>, tensor<1x128x128xf8E4M3FN>, tensor<1x128x4xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK-NOT:       tosa.cast %[[MATMUL]]
+// CHECK:           tosa.reshape %[[MATMUL]], %{{.*}} : (tensor<1x128x128xf32>, !tosa.shape<2>) -> tensor<128x128xf32>
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_f32_result(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],f32> {
+  %false = torch.constant.bool false
+  %int6 = torch.constant.int 6
+  %none = torch.constant.none
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int6, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],f32>
+  return %0 : !torch.vtensor<[128,128],f32>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_e5m2(
+// CHECK-SAME:      %arg0: !torch.vtensor<[128,128],f8E5M2>, %arg1: !torch.vtensor<[128,128],f8E5M2>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x128x128xf8E5M2>, tensor<1x128x4xf8E8M0FNU>, tensor<1x128x128xf8E5M2>, tensor<1x128x4xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK:           tosa.cast %[[MATMUL]] : (tensor<1x128x128xf32>) -> tensor<1x128x128xbf16>
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_e5m2(%arg0: !torch.vtensor<[128,128],f8E5M2>, %arg1: !torch.vtensor<[128,128],f8E5M2>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,128],f8E5M2>, !torch.vtensor<[128,128],f8E5M2>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_rank2_padded_scales(
+// CHECK-SAME:      %arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[128,4],f8E8M0FNU>, %arg3: !torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-DAG:       %[[SCALE_A:.*]] = torch_c.to_builtin_tensor %arg2 : !torch.vtensor<[128,4],f8E8M0FNU> -> tensor<128x4xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[128,4],f8E8M0FNU> -> tensor<128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_3D:.*]] = tosa.reshape %[[SCALE_A]], %{{.*}} : (tensor<128x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_3D:.*]] = tosa.reshape %[[SCALE_B]], %{{.*}} : (tensor<128x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           tosa.matmul_t_block_scaled %{{.*}}, %[[SCALE_A_3D]], %{{.*}}, %[[SCALE_B_3D]] {block_size = BLOCK_SIZE_32}
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_rank2_padded_scales(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[128,4],f8E8M0FNU>, %arg3: !torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,4],f8E8M0FNU>, !torch.vtensor<[128,4],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_flat_ragged_scales(
+// CHECK-SAME:      %arg0: !torch.vtensor<[130,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,80],f8E4M3FN>, %arg2: !torch.vtensor<[1024],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[130,80],bf16> {
+// CHECK-DAG:       %[[SCALE_A:.*]] = torch_c.to_builtin_tensor %arg2 : !torch.vtensor<[1024],f8E8M0FNU> -> tensor<1024xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_PADDED:.*]] = tosa.reshape %[[SCALE_A]], %{{.*}} : (tensor<1024xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x256x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_3D:.*]] = tosa.slice %[[SCALE_A_PADDED]], %{{.*}}, %{{.*}} : (tensor<1x256x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x130x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_PADDED:.*]] = tosa.reshape %[[SCALE_B]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_3D:.*]] = tosa.slice %[[SCALE_B_PADDED]], %{{.*}}, %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x80x4xf8E8M0FNU>
+// CHECK:           tosa.matmul_t_block_scaled %{{.*}}, %[[SCALE_A_3D]], %{{.*}}, %[[SCALE_B_3D]] {block_size = BLOCK_SIZE_32}
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_flat_ragged_scales(%arg0: !torch.vtensor<[130,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,80],f8E4M3FN>, %arg2: !torch.vtensor<[1024],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[130,80],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[130,128],f8E4M3FN>, !torch.vtensor<[128,80],f8E4M3FN>, !torch.vtensor<[1024],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[130,80],bf16>
+  return %0 : !torch.vtensor<[130,80],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_rank2_padded_ragged_scales(
+// CHECK-SAME:      %arg0: !torch.vtensor<[130,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,80],f8E4M3FN>, %arg2: !torch.vtensor<[256,4],f8E8M0FNU>, %arg3: !torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.vtensor<[130,80],bf16> {
+// CHECK-DAG:       %[[SCALE_A:.*]] = torch_c.to_builtin_tensor %arg2 : !torch.vtensor<[256,4],f8E8M0FNU> -> tensor<256x4xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[128,4],f8E8M0FNU> -> tensor<128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_PADDED:.*]] = tosa.reshape %[[SCALE_A]], %{{.*}} : (tensor<256x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x256x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_3D:.*]] = tosa.slice %[[SCALE_A_PADDED]], %{{.*}}, %{{.*}} : (tensor<1x256x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x130x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_PADDED:.*]] = tosa.reshape %[[SCALE_B]], %{{.*}} : (tensor<128x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_3D:.*]] = tosa.slice %[[SCALE_B_PADDED]], %{{.*}}, %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x80x4xf8E8M0FNU>
+// CHECK:           tosa.matmul_t_block_scaled %{{.*}}, %[[SCALE_A_3D]], %{{.*}}, %[[SCALE_B_3D]] {block_size = BLOCK_SIZE_32}
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_rank2_padded_ragged_scales(%arg0: !torch.vtensor<[130,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,80],f8E4M3FN>, %arg2: !torch.vtensor<[256,4],f8E8M0FNU>, %arg3: !torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.vtensor<[130,80],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[130,128],f8E4M3FN>, !torch.vtensor<[128,80],f8E4M3FN>, !torch.vtensor<[256,4],f8E8M0FNU>, !torch.vtensor<[128,4],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[130,80],bf16>
+  return %0 : !torch.vtensor<[130,80],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm$block_scaled_fp8_swizzled_constant_scales(
+// CHECK-SAME:      %arg0: !torch.vtensor<[3,32],f8E4M3FN>, %arg1: !torch.vtensor<[32,64],f8E4M3FN>) -> !torch.vtensor<[3,64],bf16> {
+// CHECK-DAG:       %[[LHS_2D:.*]] = torch_c.to_builtin_tensor %arg0 : !torch.vtensor<[3,32],f8E4M3FN> -> tensor<3x32xf8E4M3FN>
+// CHECK-DAG:       %[[RHS_2D:.*]] = torch_c.to_builtin_tensor %arg1 : !torch.vtensor<[32,64],f8E4M3FN> -> tensor<32x64xf8E4M3FN>
+// CHECK:           %[[LHS:.*]] = tosa.reshape %[[LHS_2D]], %{{.*}} : (tensor<3x32xf8E4M3FN>, !tosa.shape<3>) -> tensor<1x3x32xf8E4M3FN>
+// CHECK:           %[[RHS_TRANSPOSED:.*]] = tosa.transpose %[[RHS_2D]] {perms = array<i32: 1, 0>} : (tensor<32x64xf8E4M3FN>) -> tensor<64x32xf8E4M3FN>
+// CHECK:           %[[RHS:.*]] = tosa.reshape %[[RHS_TRANSPOSED]], %{{.*}} : (tensor<64x32xf8E4M3FN>, !tosa.shape<3>) -> tensor<1x64x32xf8E4M3FN>
+// CHECK:           %[[SCALE_A_3D:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x3x1xf8E8M0FNU>}>
+// CHECK:           %[[SCALE_B_3D:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x64x1xf8E8M0FNU>}>
+// CHECK:           tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A_3D]], %[[RHS]], %[[SCALE_B_3D]] {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf8E4M3FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x64x32xf8E4M3FN>, tensor<1x64x1xf8E8M0FNU>) -> tensor<1x3x64xf32>
+// CHECK-NOT:       torch.aten._scaled_mm
+func.func @torch.aten._scaled_mm$block_scaled_fp8_swizzled_constant_scales(%arg0: !torch.vtensor<[3,32],f8E4M3FN>, %arg1: !torch.vtensor<[32,64],f8E4M3FN>) -> !torch.vtensor<[3,64],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  // Non-splat payloads exercise compile-time byte reordering from the swizzled
+  // 32x16 scale layout into the compact TOSA [1, rows, K/32] scale layout.
+  %scale_a = torch.vtensor.literal(dense<"0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF"> : tensor<32x16xf8E8M0FNU>) : !torch.vtensor<[32,16],f8E8M0FNU>
+  %scale_b = torch.vtensor.literal(dense<"0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF"> : tensor<32x16xf8E8M0FNU>) : !torch.vtensor<[32,16],f8E8M0FNU>
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %scale_a, %scale_b, %none, %none, %int15, %false : !torch.vtensor<[3,32],f8E4M3FN>, !torch.vtensor<[32,64],f8E4M3FN>, !torch.vtensor<[32,16],f8E8M0FNU>, !torch.vtensor<[32,16],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[3,64],bf16>
+  return %0 : !torch.vtensor<[3,64],bf16>
+}
+
+// -----
+module {
+  // scale_result is verifier-valid as a scalar, but this TOSA lowering does
+  // not yet model the extra output scaling semantics.
+  func.func @torch.aten._scaled_mm$block_scaled_fp8_scale_result_rejected(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>, %arg4: !torch.vtensor<[],f32>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %arg4, %int15, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.vtensor<[],f32>, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // The Torch verifier accepts this padded blockwise scale metadata because it
+  // follows PyTorch's ceil-div K blocking. TOSA block-scaled matmul currently
+  // requires an exact 32-wide contracting block, so conversion rejects it.
+  func.func @torch.aten._scaled_mm$block_scaled_fp8_k_not_divisible_by_32_rejected(%arg0: !torch.vtensor<[128,48],f8E4M3FN>, %arg1: !torch.vtensor<[48,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,48],f8E4M3FN>, !torch.vtensor<[48,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // Block-scaled FP4 imports through Torch, but this TOSA lowering is currently
+  // scoped to MXFP8 data with E8M0 scales.
+  func.func @torch.aten._scaled_mm$block_scaled_fp4_rejected(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // Mixed FP8 data dtypes are verifier-valid, but this lowering requires
+  // matching MXFP8 lhs/rhs element types for TOSA block-scaled matmul.
+  func.func @torch.aten._scaled_mm$block_scaled_mixed_fp8_rejected(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E5M2>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E5M2>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // Rank-2 E8M0 scale tensors that are neither padded blockwise scale layouts
+  // nor constant swizzled payloads must not be silently accepted.
+  func.func @torch.aten._scaled_mm$block_scaled_fp8_ambiguous_rank2_scale_rejected(%arg0: !torch.vtensor<[130,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,80],f8E4M3FN>, %arg2: !torch.vtensor<[2,512],f8E8M0FNU>, %arg3: !torch.vtensor<[1,512],f8E8M0FNU>) -> !torch.vtensor<[130,80],bf16> {
+    %false = torch.constant.bool false
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[130,128],f8E4M3FN>, !torch.vtensor<[128,80],f8E4M3FN>, !torch.vtensor<[2,512],f8E8M0FNU>, !torch.vtensor<[1,512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[130,80],bf16>
+    return %0 : !torch.vtensor<[130,80],bf16>
+  }
+}
+
+// -----
+module {
+  // The [32,16] shape is only accepted for swizzled constant payloads. Runtime
+  // values with this shape are ambiguous and cannot be safely byte-reordered.
+  func.func @torch.aten._scaled_mm$block_scaled_fp8_non_constant_swizzled_scale_rejected(%arg0: !torch.vtensor<[3,32],f8E4M3FN>, %arg1: !torch.vtensor<[32,64],f8E4M3FN>, %arg2: !torch.vtensor<[32,16],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,64],bf16> {
+    %false = torch.constant.bool false
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[3,32],f8E4M3FN>, !torch.vtensor<[32,64],f8E4M3FN>, !torch.vtensor<[32,16],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[3,64],bf16>
+    return %0 : !torch.vtensor<[3,64],bf16>
+  }
+}
+
+// -----
+module {
+  // This has the same numel as the accepted swizzled [32,16] constant layout,
+  // but the shape is ambiguous and must not be byte-reordered as swizzled data.
+  func.func @torch.aten._scaled_mm$block_scaled_fp8_ambiguous_constant_rank2_scale_rejected(%arg0: !torch.vtensor<[3,32],f8E4M3FN>, %arg1: !torch.vtensor<[32,64],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,64],bf16> {
+    %false = torch.constant.bool false
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    %scale_a = torch.vtensor.literal(dense<"0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF"> : tensor<2x256xf8E8M0FNU>) : !torch.vtensor<[2,256],f8E8M0FNU>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm %arg0, %arg1, %scale_a, %arg2, %none, %none, %int15, %false : !torch.vtensor<[3,32],f8E4M3FN>, !torch.vtensor<[32,64],f8E4M3FN>, !torch.vtensor<[2,256],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[3,64],bf16>
+    return %0 : !torch.vtensor<[3,64],bf16>
+  }
+}
+
+// -----
 module {
   // Paired with the positive rectangular rowwise case above: this f32 block
   // scale recipe is verifier-valid, but outside the tensorwise/rowwise support
@@ -5140,6 +5419,20 @@ module {
     // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
     %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,256],f8E4M3FN>, !torch.vtensor<[256,256],f8E4M3FN>, !torch.vtensor<[128,2],f32>, !torch.vtensor<[2,2],f32>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,256],bf16>
     return %0 : !torch.vtensor<[128,256],bf16>
+  }
+}
+
+// -----
+module {
+  // Same early bias validation as static FP8, but through the E8M0 blocked-scale
+  // path. The bias dtype and numel are otherwise valid.
+  func.func @torch.aten._scaled_mm$block_scaled_fp8_non_vector_bias_rejected(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>, %arg4: !torch.vtensor<[1,128],bf16>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %arg4, %none, %int15, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[1,128],bf16>, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
   }
 }
 

--- a/test/Dialect/Torch/invalid.mlir
+++ b/test/Dialect/Torch/invalid.mlir
@@ -421,6 +421,21 @@ func.func @torch.aten._scaled_mm$invalid_blockwise_scale_numel(
 
 // -----
 
+func.func @torch.aten._scaled_mm$invalid_self_dtype(
+    %arg0: !torch.vtensor<[128,128],f32>,
+    %arg1: !torch.vtensor<[128,128],f8E4M3FN>,
+    %arg2: !torch.vtensor<[512],f8E8M0FNU>,
+    %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  // expected-error @+1 {{'torch.aten._scaled_mm' op expected self to have an FP8 or FP4 dtype}}
+  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,128],f32>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+
 func.func @torch.aten._scaled_mm$invalid_mat2_non_contracting_dim(
     %arg0: !torch.vtensor<[128,128],f8E4M3FN>,
     %arg1: !torch.vtensor<[128,127],f8E4M3FN>,


### PR DESCRIPTION
Adds TorchToTosa legalization for block-scaled FP8 aten._scaled_mm with float8_e8m0fnu scale tensors.

Stacked on #4558 and #4559. Until those land and this branch is rebased, the GitHub diff will include the earlier stack commits as well. The review focus for this PR is the third commit: MXFP8/block-scaled TorchToTosa lowering.