### PR TITLE
[TorchToTosa] Support flattened index_put updates in TOSA lowering

### DIFF
--- a/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
@@ -448,7 +448,7 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
   auto indicesType = dyn_cast<RankedTensorType>(indicesValue.getType());
   auto fillValuesType = dyn_cast<RankedTensorType>(fillValues.getType());
 
-  if (!resultType || !paramsType || !indicesType)
+  if (!resultType || !paramsType || !indicesType || !fillValuesType)
     return std::nullopt;
 
   // N: number of batches
@@ -522,7 +522,7 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
   //    !torch.vtensor<[1,4],si64>
   // Detail algorithm visualization:
 
-  int N = 1, W = 1, K = 1, fillK = 1, C = 1, ND = 1;
+  int N = 1, W = 1, K = 1, C = 1, ND = 1;
 
   int paramsRank = paramsType.getShape().size();   // 2
   int indicesRank = indicesType.getShape().size(); // 2
@@ -564,6 +564,7 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
 
   // int N = 1, W = 3, K = 4, fillk = 3, C = 1, ND = 2;
   SmallVector<int64_t, 3> tosaInputValuesShape({N, K, C});     // {1,4,1}
+  SmallVector<int64_t, 3> tosaFillValuesShape({N, W, C});      // {1,3,1}
   SmallVector<int64_t, 2> tosaIndicesShape({N, W});            // {1,3}
   SmallVector<int64_t, 2> indicesMatrixShape({W, ND});         // {3,2}
   SmallVector<int64_t, 2> indicesMatrixReducesumShape({W, 1}); // {3,1}
@@ -576,7 +577,16 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
   //    reshape(1) tile(3)  reshape(1,3)   reshape(1,3,1)
   //  [] -> [0] -> [0,0,0] -> [[0,0,0]] -> [[[0], [0], [0]]]
   //    reshape to [1] and then tile to W * C update values.
-  if (fillValuesType.getRank() == 0) {
+  if (fillValuesType.getRank() == 0 && C == 0) {
+    auto emptyFillValues = getZerosLikeTensor(
+        rewriter, op,
+        GetTypeFromTensorShape(tosaFillValuesShape,
+                               fillValuesType.getElementType()));
+    if (!emptyFillValues)
+      return std::nullopt;
+    fillValues = *emptyFillValues;
+    fillValuesType = dyn_cast<RankedTensorType>(fillValues.getType());
+  } else if (fillValuesType.getRank() == 0) {
     // [] -> [0]
     SmallVector<int64_t, 1> oneShape({1}); // {1}
     auto tosaFillValuesOneReshapeOp = tosa::CreateOpAndInfer<tosa::ReshapeOp>(
@@ -607,33 +617,17 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
   }
 
   // TOSA scatter update values are shaped [N, W, C], where W is the
-  // number of flattened scatter indices.  fillK validates that fillValues
-  // contains exactly one C-sized update for each flattened index.
+  // number of flattened scatter indices.
   int64_t fillNumElements = 1;
   for (int64_t dim : fillValuesType.getShape()) {
     fillNumElements *= dim;
   }
-  if (C == 0) {
-    if (fillNumElements != 0) {
-      (void)rewriter.notifyMatchFailure(
-          op, "zero-channel scatter update must have zero elements");
-      return std::nullopt;
-    }
-    fillK = W;
-  } else {
-    if (fillNumElements % C != 0) {
-      (void)rewriter.notifyMatchFailure(
-          op, "scatter update element count must be divisible by channels");
-      return std::nullopt;
-    }
-    fillK = fillNumElements / C;
-    if (fillK != W) {
-      (void)rewriter.notifyMatchFailure(
-          op, "scatter update count must match flattened indices");
-      return std::nullopt;
-    }
+  if (fillNumElements != W * C) {
+    (void)rewriter.notifyMatchFailure(
+        op, "scatter update element count must match flattened indices and "
+            "channels");
+    return std::nullopt;
   }
-  SmallVector<int64_t, 3> tosaFillValuesShape({N, W, C}); // {1,3,1}
 
   // Reshape/Flatten fillValues to 3d tensor
   // [[0,0,0]] -> [[[0], [0], [0]]]

--- a/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
@@ -603,9 +603,13 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
 
   // fillK: range of each index, total number of fillInput(could be scatter)
   // after flattened k = 1*1*3 = 3
-  for (int i = 0; i < ND; i++) {
-    fillK *= fillValuesType.getShape()[i];
+  int64_t fillNumElements = 1;
+  for (int64_t dim : fillValuesType.getShape()) {
+    fillNumElements *= dim;
   }
+  if (fillNumElements % C != 0)
+    return std::nullopt;
+  fillK = fillNumElements / C;
   SmallVector<int64_t, 3> tosaFillValuesShape({N, fillK, C}); // {1,3,1}
 
   // Reshape/Flatten fillValues to 3d tensor

--- a/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
@@ -553,7 +553,13 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
   // input(chould be scatter) C = product(params.shape[ND:] ND = 2, paramsRank,
   // C = 1
   for (int i = ND; i < paramsRank; i++) {
-    C *= paramsType.getShape()[i];
+    int64_t dim = paramsType.getShape()[i];
+    if (dim < 0) {
+      (void)rewriter.notifyMatchFailure(
+          op, "scatter channel dimensions must be static");
+      return std::nullopt;
+    }
+    C *= dim;
   }
 
   // int N = 1, W = 3, K = 4, fillk = 3, C = 1, ND = 2;
@@ -569,18 +575,17 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
   // 2. !torch.vtensor<[],si64>
   //    reshape(1) tile(3)  reshape(1,3)   reshape(1,3,1)
   //  [] -> [0] -> [0,0,0] -> [[0,0,0]] -> [[[0], [0], [0]]]
-  //    reshape to [1] and then tile to same number of indicesValue.shape[0],
-  //    [1,1,1]
+  //    reshape to [1] and then tile to W * C update values.
   if (fillValuesType.getRank() == 0) {
     // [] -> [0]
-    SmallVector<int64_t, 1> oneShape({1}); // {3,1}
+    SmallVector<int64_t, 1> oneShape({1}); // {1}
     auto tosaFillValuesOneReshapeOp = tosa::CreateOpAndInfer<tosa::ReshapeOp>(
         rewriter, op->getLoc(),
         GetTypeFromTensorShape(oneShape, fillValuesType.getElementType()),
         fillValues, tosa::getTosaConstShape(rewriter, op->getLoc(), oneShape));
 
     // [0] -> [0,0,0]
-    SmallVector<int64_t, 1> tileShape({W}); // {3}
+    SmallVector<int64_t, 1> tileShape({W * C}); // {3}
     auto tileOpMultiples =
         tosa::getTosaConstShape(rewriter, op->getLoc(), tileShape);
     auto tosaFillValuesTileOp = tosa::CreateOpAndInfer<tosa::TileOp>(
@@ -589,7 +594,7 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
         tosaFillValuesOneReshapeOp.getResult(), tileOpMultiples);
 
     // [0,0,0] -> [[0,0,0]]
-    SmallVector<int64_t, 2> newTosaFillValuesShape({N, W}); // {1,3}
+    SmallVector<int64_t, 2> newTosaFillValuesShape({N, W * C}); // {1,3}
     auto newTosaFillValuesReshapeOp = tosa::CreateOpAndInfer<tosa::ReshapeOp>(
         rewriter, op->getLoc(),
         GetTypeFromTensorShape(newTosaFillValuesShape,
@@ -601,16 +606,34 @@ std::optional<Value> convertScatterNdOp(PatternRewriter &rewriter,
     fillValuesType = dyn_cast<RankedTensorType>(fillValues.getType());
   }
 
-  // fillK: range of each index, total number of fillInput(could be scatter)
-  // after flattened k = 1*1*3 = 3
+  // TOSA scatter update values are shaped [N, W, C], where W is the
+  // number of flattened scatter indices.  fillK validates that fillValues
+  // contains exactly one C-sized update for each flattened index.
   int64_t fillNumElements = 1;
   for (int64_t dim : fillValuesType.getShape()) {
     fillNumElements *= dim;
   }
-  if (fillNumElements % C != 0)
-    return std::nullopt;
-  fillK = fillNumElements / C;
-  SmallVector<int64_t, 3> tosaFillValuesShape({N, fillK, C}); // {1,3,1}
+  if (C == 0) {
+    if (fillNumElements != 0) {
+      (void)rewriter.notifyMatchFailure(
+          op, "zero-channel scatter update must have zero elements");
+      return std::nullopt;
+    }
+    fillK = W;
+  } else {
+    if (fillNumElements % C != 0) {
+      (void)rewriter.notifyMatchFailure(
+          op, "scatter update element count must be divisible by channels");
+      return std::nullopt;
+    }
+    fillK = fillNumElements / C;
+    if (fillK != W) {
+      (void)rewriter.notifyMatchFailure(
+          op, "scatter update count must match flattened indices");
+      return std::nullopt;
+    }
+  }
+  SmallVector<int64_t, 3> tosaFillValuesShape({N, W, C}); // {1,3,1}
 
   // Reshape/Flatten fillValues to 3d tensor
   // [[0,0,0]] -> [[[0], [0], [0]]]

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3825,7 +3825,6 @@ FX_IMPORTER_TOSA_XFAIL_SET = {
     "IndexPutImpl1DFloatAccumulateModule_basic",
     "IndexPutImpl1DIntAccumulateModule_basic",
     "IndexPutImpl2DFloatAccumulateModule_basic",
-    "IndexPutImpl2DImplicitModule_basic",
     "IndexPutImpl2DIndexModule_basic",
     "IndexPutImpl2DNoneIndexStaticModule_basic",
     "IndexPutImpl3DFloatAccumulateModule_basic",

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -2658,6 +2658,27 @@ func.func @torch.aten.scatter.src$basic(%arg0: !torch.vtensor<[10,8,6],f32>, %ar
 
 // -----
 
+// CHECK-LABEL:   func.func @torch.aten.index_put.hacked_twin$c_gt_1_update(
+// CHECK-SAME:                                                               %[[VAL_0:.*]]: !torch.vtensor<[4,4],f32>,
+// CHECK-SAME:                                                               %[[VAL_1:.*]]: !torch.vtensor<[2],si64>,
+// CHECK-SAME:                                                               %[[VAL_2:.*]]: !torch.vtensor<[2,4],f32>) -> !torch.vtensor<[4,4],f32> {
+// CHECK:           %[[UPDATES_BUILTIN:.*]] = torch_c.to_builtin_tensor %[[VAL_2]] : !torch.vtensor<[2,4],f32> -> tensor<2x4xf32>
+// CHECK:           %[[INPUT_BUILTIN:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[4,4],f32> -> tensor<4x4xf32>
+// CHECK:           %[[INDEX_BUILTIN:.*]] = torch_c.to_builtin_tensor %[[VAL_1]] : !torch.vtensor<[2],si64> -> tensor<2xi64>
+// CHECK:           %[[UPDATES_SHAPE:.*]] = tosa.const_shape  {values = dense<[1, 2, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[UPDATES:.*]] = tosa.reshape %[[UPDATES_BUILTIN]], %[[UPDATES_SHAPE]] : (tensor<2x4xf32>, !tosa.shape<3>) -> tensor<1x2x4xf32>
+// CHECK:           %[[INPUT_SHAPE:.*]] = tosa.const_shape  {values = dense<[1, 4, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[INPUT:.*]] = tosa.reshape %[[INPUT_BUILTIN]], %[[INPUT_SHAPE]] : (tensor<4x4xf32>, !tosa.shape<3>) -> tensor<1x4x4xf32>
+// CHECK:           %{{.*}} = tosa.scatter %[[INPUT]], %{{.*}}, %[[UPDATES]] : (tensor<1x4x4xf32>, tensor<1x2xi32>, tensor<1x2x4xf32>) -> tensor<1x4x4xf32>
+func.func @torch.aten.index_put.hacked_twin$c_gt_1_update(%arg0: !torch.vtensor<[4,4],f32>, %arg1: !torch.vtensor<[2],si64>, %arg2: !torch.vtensor<[2,4],f32>) -> !torch.vtensor<[4,4],f32> {
+  %false = torch.constant.bool false
+  %0 = torch.prim.ListConstruct %arg1 : (!torch.vtensor<[2],si64>) -> !torch.list<vtensor>
+  %1 = torch.aten.index_put.hacked_twin %arg0, %0, %arg2, %false : !torch.vtensor<[4,4],f32>, !torch.list<vtensor>, !torch.vtensor<[2,4],f32>, !torch.bool -> !torch.vtensor<[4,4],f32>
+  return %1 : !torch.vtensor<[4,4],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.slice_scatter$basic(
 // CHECK-SAME:                                              %[[VAL_0:.*]]: !torch.vtensor<[6,8],f32>,
 // CHECK-SAME:                                              %[[VAL_1:.*]]: !torch.vtensor<[6,1],f32>) -> !torch.vtensor<[6,8],f32> {

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -2746,6 +2746,26 @@ func.func @torch.aten.diag_embed$basic(%arg0: !torch.vtensor<[2,3,4],f32>) -> !t
 
 // -----
 
+// CHECK-LABEL:   func.func @torch.aten.index_put_hacked_twin_flattened_updates(
+// CHECK:           %[[SCATTER:.*]] = tosa.scatter
+// CHECK-SAME:        (tensor<1x6x1xf32>, tensor<1x6xi32>, tensor<1x6x1xf32>) -> tensor<1x6x1xf32>
+// CHECK:           %[[RESHAPE:.*]] = tosa.reshape %[[SCATTER]]
+// CHECK-SAME:        (tensor<1x6x1xf32>, !tosa.shape<3>) -> tensor<1x2x3xf32>
+// CHECK:           torch_c.from_builtin_tensor %[[RESHAPE]] : tensor<1x2x3xf32> -> !torch.vtensor<[1,2,3],f32>
+func.func @torch.aten.index_put_hacked_twin_flattened_updates(
+    %arg0: !torch.vtensor<[1,2,3],f32>,
+    %arg1: !torch.vtensor<[6],si64>,
+    %arg2: !torch.vtensor<[6],si64>,
+    %arg3: !torch.vtensor<[6],si64>,
+    %arg4: !torch.vtensor<[6],f32>) -> !torch.vtensor<[1,2,3],f32> {
+  %indices = torch.prim.ListConstruct %arg1, %arg2, %arg3 : (!torch.vtensor<[6],si64>, !torch.vtensor<[6],si64>, !torch.vtensor<[6],si64>) -> !torch.list<vtensor>
+  %false = torch.constant.bool false
+  %0 = torch.aten.index_put.hacked_twin %arg0, %indices, %arg4, %false : !torch.vtensor<[1,2,3],f32>, !torch.list<vtensor>, !torch.vtensor<[6],f32>, !torch.bool -> !torch.vtensor<[1,2,3],f32>
+  return %0 : !torch.vtensor<[1,2,3],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.index.Tensor_hacked_twin(
 // CHECK-SAME:                                                   %[[VAL_0:.*]]: !torch.vtensor<[2,4,2],si64>,
 // CHECK-SAME:                                                   %[[VAL_1:.*]]: !torch.vtensor<[],si64>) -> !torch.vtensor<[4,2],si64> {


### PR DESCRIPTION
Fixes TOSA lowering for index_put/scatter updates when the update tensor is already flattened.

Previously, fillK was computed from only the first ND dimensions of fillValues, which assumes updates still follow the indexed tensor shape. Flattened updates break that assumption and can produce invalid reshape/scatter shapes.

The fix derives fillK from the total number of update elements with a divisibility check. This supports both shaped and flattened updates while preserving the existing {N, fillK, C} scatter form. A regression test was added for flattened torch.aten.index_put.hacked_twin updates.