### PR TITLE
[Torch] Add enable_gqa attr to flex_attention HOP

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -1457,7 +1457,7 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
     HasValueSemantics,
     ReadOnly
   ]> {
-  let summary = "Computes the flex_attention operation (1-1 with torch._higher_order_ops.flex_attention)";
+  let summary = "Computes the flex_attention operation";
   let description = [{
     FlexAttention operation with flexible block-sparse attention patterns.
 
@@ -1469,6 +1469,9 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
       return_lse: Bool to return log-sum-exp values
 
     Attributes:
+      enable_gqa: Bool metadata indicating lowerings should expand key/value
+        heads to query heads for grouped-query attention. This is not a
+        PyTorch HOP operand.
       score_mod_fn: Optional function symbol reference for score modification
       mask_mod_fn: Optional function symbol reference for mask modification
 
@@ -1487,6 +1490,7 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
     AnyTorchOptionalFloatType:$scale,
     Torch_BoolType:$return_lse,
     Torch_BoolType:$return_max_scores,
+    DefaultValuedOptionalAttr<BoolAttr, "false">:$enable_gqa,
     OptionalAttr<FlatSymbolRefAttr>:$score_mod_fn,
     OptionalAttr<FlatSymbolRefAttr>:$mask_mod_fn
   );

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -1469,8 +1469,10 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
       return_lse: Bool to return log-sum-exp values
 
     Attributes:
-      enable_gqa: Bool metadata indicating lowerings should expand key/value
-        heads to query heads for grouped-query attention. This is not a
+      enable_gqa: Optional bool metadata indicating lowerings should expand
+        key/value heads to query heads for grouped-query attention. When
+        omitted, lowerings may infer whether grouped-query attention expansion
+        is needed from the query/key/value head dimensions. This is not a
         PyTorch HOP operand.
       score_mod_fn: Optional function symbol reference for score modification
       mask_mod_fn: Optional function symbol reference for mask modification
@@ -1490,7 +1492,7 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
     AnyTorchOptionalFloatType:$scale,
     Torch_BoolType:$return_lse,
     Torch_BoolType:$return_max_scores,
-    DefaultValuedOptionalAttr<BoolAttr, "false">:$enable_gqa,
+    OptionalAttr<BoolAttr>:$enable_gqa,
     OptionalAttr<FlatSymbolRefAttr>:$score_mod_fn,
     OptionalAttr<FlatSymbolRefAttr>:$mask_mod_fn
   );

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -235,8 +235,9 @@ func.func @torch.hop_flex_attention (%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg
 func.func @torch.hop_flex_attention_enable_gqa(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,2,8,16],f32>, %arg2: !torch.vtensor<[2,2,8,16],f32>) -> (!torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none) {
   %float1.0 = torch.constant.float 1.000000e+00
   %false_gqa = torch.constant.bool false
-  // CHECK: torch.hop_flex_attention %arg0, %arg1, %arg2, %{{.*}}, %{{.*}}, %{{.*}}
-  // CHECK-SAME: {enable_gqa = true}
+  // CHECK: %[[GQA_FLOAT:.*]] = torch.constant.float 1.000000e+00
+  // CHECK: %[[GQA_FALSE:.*]] = torch.constant.bool false
+  // CHECK: torch.hop_flex_attention %arg0, %arg1, %arg2, %[[GQA_FLOAT]], %[[GQA_FALSE]], %[[GQA_FALSE]] {enable_gqa = true}
   %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false_gqa, %false_gqa {enable_gqa = true} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
   return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
 }

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -241,3 +241,14 @@ func.func @torch.hop_flex_attention_enable_gqa(%arg0: !torch.vtensor<[2,4,8,16],
   %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false_gqa, %false_gqa {enable_gqa = true} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
   return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
 }
+
+// CHECK-LABEL: func.func @torch.hop_flex_attention_disable_gqa
+func.func @torch.hop_flex_attention_disable_gqa(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> (!torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none) {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false_gqa = torch.constant.bool false
+  // CHECK: %[[NO_GQA_FLOAT:.*]] = torch.constant.float 1.000000e+00
+  // CHECK: %[[NO_GQA_FALSE:.*]] = torch.constant.bool false
+  // CHECK: torch.hop_flex_attention %arg0, %arg1, %arg2, %[[NO_GQA_FLOAT]], %[[NO_GQA_FALSE]], %[[NO_GQA_FALSE]] {enable_gqa = false}
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false_gqa, %false_gqa {enable_gqa = false} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
+  return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
+}

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -234,9 +234,9 @@ func.func @torch.hop_flex_attention (%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg
 // CHECK-LABEL: func.func @torch.hop_flex_attention_enable_gqa
 func.func @torch.hop_flex_attention_enable_gqa(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,2,8,16],f32>, %arg2: !torch.vtensor<[2,2,8,16],f32>) -> (!torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none) {
   %float1.0 = torch.constant.float 1.000000e+00
-  %false = torch.constant.bool false
+  %false_gqa = torch.constant.bool false
   // CHECK: torch.hop_flex_attention %arg0, %arg1, %arg2, %{{.*}}, %{{.*}}, %{{.*}}
   // CHECK-SAME: {enable_gqa = true}
-  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {enable_gqa = true} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false_gqa, %false_gqa {enable_gqa = true} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
   return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
 }

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -230,3 +230,13 @@ func.func @torch.hop_flex_attention (%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg
   %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false_0, %false_0 {mask_mod_fn = @sdpa_mask0, score_mod_fn = @sdpa_score0} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
   return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
 }
+
+// CHECK-LABEL: func.func @torch.hop_flex_attention_enable_gqa
+func.func @torch.hop_flex_attention_enable_gqa(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,2,8,16],f32>, %arg2: !torch.vtensor<[2,2,8,16],f32>) -> (!torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none) {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false = torch.constant.bool false
+  // CHECK: torch.hop_flex_attention %arg0, %arg1, %arg2, %{{.*}}, %{{.*}}, %{{.*}}
+  // CHECK-SAME: {enable_gqa = true}
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false {enable_gqa = true} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.vtensor<[2,2,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
+  return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.none, !torch.none
+}


### PR DESCRIPTION
This adds an `enable_gqa` attribute to `torch.hop_flex_attention`.

`enable_gqa` is intentionally modeled as op metadata, not as a Torch bool operand. PyTorch’s public `torch.nn.attention.flex_attention(..., enable_gqa=True)` accepts and validates the flag, but the internal `flex_attention_hop` call does not receive it as part of the HOP argument list:

https://github.com/pytorch/pytorch/blob/6b63b49b1337dc80bc7c76d4c56a31737120b222/torch/_higher_order_ops/flex_attention.py#L98-L109

Adding it as an operand would therefore make the torch-mlir op diverge from the actual PyTorch HOP ABI.


This is, ultimately, still a hack for downstream lowerings to actually emit `flex_attention` with the `enable_gqa`, but the current ABI is the enforcer. 