### PR TITLE
Bump LLVM to llvm/llvm-project@0f3ca6bb9ca5

### DIFF
--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -2346,7 +2346,7 @@ Value getDFTMatmulCoeff(OpBuilder b, Location loc,
   // scale = 2 * pi / N
   double scale = 2 * llvm::numbers::pi / matrixType.getDimSize(0);
 
-  SmallVector<std::complex<APFloat>> values;
+  SmallVector<mlir::Complex<APFloat>> values;
   for (auto i : llvm::seq<unsigned>(0, matrixType.getDimSize(0))) {
     for (auto j : llvm::seq<unsigned>(0, matrixType.getDimSize(1))) {
       double v = scale * i * j;
@@ -2361,7 +2361,7 @@ Value getDFTMatmulCoeff(OpBuilder b, Location loc,
       imag.convert(floatType.getFloatSemantics(), APFloat::rmNearestTiesToEven,
                    &unused);
 
-      values.push_back(std::complex<APFloat>(real, imag));
+      values.push_back(mlir::Complex<APFloat>(real, imag));
     }
   }
   return arith::ConstantOp::create(b, loc, matrixType,


### PR DESCRIPTION
## Summary

Bump `externals/llvm-project` to `0f3ca6bb9ca514518c55fc02855a6083312ddfe2` and migrate to the new MLIR complex element type API.

LLVM commit [`0ff5c32c2821`](https://github.com/llvm/llvm-project/commit/0ff5c32c2821) ("[mlir] Use custom mlir::Complex type for non-float complex numbers", #191821) changed `DenseElementsAttr::get` complex overloads to take `ArrayRef<mlir::Complex<T>>` instead of `ArrayRef<std::complex<T>>`. For `T = APFloat`, `mlir::Complex<T>` resolves to `NonFloatComplex<T>` because `APFloat` does not satisfy `std::is_floating_point_v`, so the existing call site in `TorchToLinalg/Linear.cpp` (FFT DFT matmul coefficient) no longer compiles.

This PR:
- Bumps `externals/llvm-project` to `0f3ca6bb9ca514518c55fc02855a6083312ddfe2`.
- Replaces `std::complex<APFloat>` with `mlir::Complex<APFloat>` for the `SmallVector` element type and the per-element constructor in `getDFTMatmulCoeff`.

## Test plan
- [ ] Local build against the new LLVM succeeds.
- [ ] torch-mlir CI passes (or surfaces any other API breaks between the previous pin and `0f3ca6bb9ca5`).