### PR TITLE
[Torch] Support mask mod arguments in flex_attention HOP

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -1467,6 +1467,12 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
       value: Value tensor [B, H, N, Ev]
       scale: Optional float for scaling attention scores (None means 1/sqrt(head_dim))
       return_lse: Bool to return log-sum-exp values
+      return_max_scores: Bool to return max score values
+
+    Variadic Args:
+      mask_mod_other_buffers: Additional values passed to mask_mod_fn after
+        (batch, head, token_q, token_kv). These make PyTorch mask_mod closure
+        captures from traced/exported HOP graphs explicit in MLIR.
 
     Attributes:
       enable_gqa: Optional bool metadata indicating lowerings should expand
@@ -1492,6 +1498,7 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
     AnyTorchOptionalFloatType:$scale,
     Torch_BoolType:$return_lse,
     Torch_BoolType:$return_max_scores,
+    Variadic<AnyTorchType>:$mask_mod_other_buffers,
     OptionalAttr<BoolAttr>:$enable_gqa,
     OptionalAttr<FlatSymbolRefAttr>:$score_mod_fn,
     OptionalAttr<FlatSymbolRefAttr>:$mask_mod_fn
@@ -1503,14 +1510,14 @@ def Torch_HigherOrderFlexAttentionOp : Torch_Op<"hop_flex_attention", [
     AnyTorchOptionalTensorType:$max_scores
   );
 
-  let hasCustomAssemblyFormat = 1;
-  let extraClassDefinition = [{
-    ParseResult HigherOrderFlexAttentionOp::parse(OpAsmParser &parser, OperationState &result) {
-      return parseDefaultTorchOp(parser, result, 6, 3);
-    }
-    void HigherOrderFlexAttentionOp::print(OpAsmPrinter &printer) {
-      printDefaultTorchOp(printer, *this, 6, 3);
-    }
+  let assemblyFormat = [{
+    $query `,` $key `,` $value `,` $scale `,` $return_lse `,`
+    $return_max_scores
+    (`,` `mask_mod_other_buffers` `(` $mask_mod_other_buffers^ `)`)? attr-dict `:`
+    type($query) `,` type($key) `,` type($value) `,` type($scale) `,`
+    type($return_lse) `,` type($return_max_scores)
+    (`,` `mask_mod_other_buffers` `(` type($mask_mod_other_buffers)^ `)`)? `->` type($output) `,`
+    type($logsumexp) `,` type($max_scores)
   }];
   let hasVerifier = 1;
 }

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -18,6 +18,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectResourceBlobManager.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Support/LLVM.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
@@ -259,6 +260,29 @@ LogicalResult HigherOrderFlexAttentionOp::verify() {
   }
   if (!isa<Torch::BoolType>(getReturnMaxScores().getType())) {
     return emitError() << "expected return_max_scores to be a bool type";
+  }
+  if (!getMaskModOtherBuffers().empty() && !getMaskModFnAttr()) {
+    return emitError()
+           << "expected mask_mod_fn when mask_mod_other_buffers are provided";
+  }
+  if (auto maskModFnAttr = getMaskModFnAttr()) {
+    auto maskModFn =
+        SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(*this, maskModFnAttr);
+    if (!maskModFn) {
+      return emitError() << "'@" << maskModFnAttr.getValue()
+                         << "' does not reference a valid function";
+    }
+    size_t numMaskModOtherBuffers = getMaskModOtherBuffers().size();
+    unsigned expectedNumInputs = 4 + numMaskModOtherBuffers;
+    unsigned actualNumInputs = maskModFn.getFunctionType().getNumInputs();
+    if (actualNumInputs != expectedNumInputs) {
+      return emitError() << "expected mask_mod_fn to take "
+                         << expectedNumInputs
+                         << " arguments (batch, head, token_q, token_kv plus "
+                         << numMaskModOtherBuffers
+                         << " mask_mod_other_buffers), but got "
+                         << actualNumInputs;
+    }
   }
 
   auto queryType = dyn_cast<ValueTensorType>(query.getType());

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -266,8 +266,8 @@ LogicalResult HigherOrderFlexAttentionOp::verify() {
            << "expected mask_mod_fn when mask_mod_other_buffers are provided";
   }
   if (auto maskModFnAttr = getMaskModFnAttr()) {
-    auto maskModFn =
-        SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(*this, maskModFnAttr);
+    auto maskModFn = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+        *this, maskModFnAttr);
     if (!maskModFn) {
       return emitError() << "'@" << maskModFnAttr.getValue()
                          << "' does not reference a valid function";
@@ -276,8 +276,7 @@ LogicalResult HigherOrderFlexAttentionOp::verify() {
     unsigned expectedNumInputs = 4 + numMaskModOtherBuffers;
     unsigned actualNumInputs = maskModFn.getFunctionType().getNumInputs();
     if (actualNumInputs != expectedNumInputs) {
-      return emitError() << "expected mask_mod_fn to take "
-                         << expectedNumInputs
+      return emitError() << "expected mask_mod_fn to take " << expectedNumInputs
                          << " arguments (batch, head, token_q, token_kv plus "
                          << numMaskModOtherBuffers
                          << " mask_mod_other_buffers), but got "

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -1925,19 +1925,22 @@ class GraphNodeImporter:
     ):
         """Imports the torch._higher_order_ops.flex_attention HOP.
 
-        Args format: (query, key, value, score_mod, block_mask, scale, kernel_options, ...)
+        HOP args are:
+        (query, key, value, score_mod, block_mask, scale, kernel_options,
+         score_mod_other_buffers, mask_mod_other_buffers)
+
         - query, key, value: Attention input tensors
         - score_mod: Optional submodule/callable for score modification (imported as function)
         - block_mask: Optional BlockMask tuple containing mask_mod function and runtime tensors
         - scale: Optional float for attention score scaling
         - kernel_options: Optional Dict of performance tuning options:
             - return_lse: Boolean for whether to return the log-sum-exp tensor
+        - mask_mod_other_buffers: Optional values captured by the mask_mod
+            function and made explicit as op operands
 
         This creates a call to hop_flex_attention with function symbol references for
         score_mod and mask_mod.
         """
-        # flex_attention HOP args from PyTorch:
-        # (query, key, value, score_mod, block_mask, scale, kernel_options, ...)
         (
             query_arg,
             key_arg,
@@ -1947,6 +1950,34 @@ class GraphNodeImporter:
             scale_arg,
             kernel_options,
         ) = node.args[:7]
+        score_mod_other_buffers_arg = node.args[7] if len(node.args) > 7 else ()
+        mask_mod_other_buffers_arg = node.args[8] if len(node.args) > 8 else ()
+        if len(node.args) > 9:
+            raise NotImplementedError(
+                f"Unexpected flex_attention HOP argument count: {len(node.args)}"
+            )
+
+        def _normalize_other_buffers(arg, arg_name):
+            if arg is None:
+                return ()
+            if not isinstance(arg, tuple):
+                raise NotImplementedError(
+                    f"Expected {arg_name} to be a tuple, got {type(arg).__name__}"
+                )
+            return arg
+
+        score_mod_other_buffers = _normalize_other_buffers(
+            score_mod_other_buffers_arg, "score_mod_other_buffers"
+        )
+        if score_mod_other_buffers:
+            raise NotImplementedError(
+                "score_mod captured buffers are not supported by the "
+                "torch-mlir flex_attention importer"
+            )
+
+        mask_mod_other_buffers = _normalize_other_buffers(
+            mask_mod_other_buffers_arg, "mask_mod_other_buffers"
+        )
 
         # Import Q, K, V tensors
         query = self._import_argument(loc, query_arg, None)
@@ -2027,10 +2058,15 @@ class GraphNodeImporter:
                 self._cc.torch_bool_type,
             ).result
 
+        mask_mod_other_buffer_values = [
+            self._import_argument(loc, arg, None) for arg in mask_mod_other_buffers
+        ]
+
         # Build operands for aten.flex_attention.
-        # Op expects exactly 6 operands: query, key, value, scale, return_lse, return_max_scores.
+        # Op expects 6 fixed operands followed by mask_mod_other_buffers:
+        # query, key, value, scale, return_lse, return_max_scores,
+        # *mask_mod_other_buffers.
         # Note: score_mod_fn and mask_mod_fn go as ATTRIBUTES, not operands.
-        # Note: block_mask tensors are handled by mask_mod_fn, not passed as operands.
 
         flat_operands = [
             query,
@@ -2039,7 +2075,7 @@ class GraphNodeImporter:
             scale,
             return_lse,
             return_max_scores,
-        ]
+        ] + mask_mod_other_buffer_values
 
         # Build attributes with function references
         # Only include attributes if they're not None (OptionalAttr in TableGen)

--- a/test/Dialect/Torch/invalid.mlir
+++ b/test/Dialect/Torch/invalid.mlir
@@ -403,3 +403,28 @@ func.func @torch.symbolic_int$no_shape_symbols(%arg0: !torch.vtensor<[?],f32>) -
   torch.bind_symbolic_shape %arg0, [%int0], affine_map<()[s0] -> (s0)> : !torch.vtensor<[?],f32>
   return %arg0 : !torch.vtensor<[?],f32>
 }
+
+// -----
+
+func.func @torch.hop_flex_attention$mask_buffers_without_mask_fn(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>, %arg3: !torch.vtensor<[2,4,8,8],i1>) -> !torch.vtensor<[2,4,8,16],f32> {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false = torch.constant.bool false
+  // expected-error @+1 {{expected mask_mod_fn when mask_mod_other_buffers are provided}}
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false, mask_mod_other_buffers(%arg3) : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool, mask_mod_other_buffers(!torch.vtensor<[2,4,8,8],i1>) -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  return %output : !torch.vtensor<[2,4,8,16],f32>
+}
+
+// -----
+
+func.func private @sdpa_mask0(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>) -> !torch.vtensor<[],i1> {
+  %0 = torch.aten.ge.Tensor %arg2, %arg3 : !torch.vtensor<[],si32>, !torch.vtensor<[],si32> -> !torch.vtensor<[],i1>
+  return %0 : !torch.vtensor<[],i1>
+}
+
+func.func @torch.hop_flex_attention$mask_fn_wrong_arity(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>, %arg3: !torch.vtensor<[2,4,8,8],i1>) -> !torch.vtensor<[2,4,8,16],f32> {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false = torch.constant.bool false
+  // expected-error @+1 {{expected mask_mod_fn to take 5 arguments (batch, head, token_q, token_kv plus 1 mask_mod_other_buffers), but got 4}}
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false, %false, mask_mod_other_buffers(%arg3) {mask_mod_fn = @sdpa_mask0} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool, mask_mod_other_buffers(!torch.vtensor<[2,4,8,8],i1>) -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  return %output : !torch.vtensor<[2,4,8,16],f32>
+}

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -217,6 +217,11 @@ func.func private @sdpa_mask0(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vten
   return %0 : !torch.vtensor<[],i1>
 }
 
+func.func private @sdpa_mask_with_arg(%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>, %arg4: !torch.vtensor<[2,4,8,8],i1>) -> !torch.vtensor<[],i1> {
+  %0 = torch.aten.ge.Tensor %arg2, %arg3 : !torch.vtensor<[],si32>, !torch.vtensor<[],si32> -> !torch.vtensor<[],i1>
+  return %0 : !torch.vtensor<[],i1>
+}
+
 // CHECK-LABEL: func.func @torch.hop_flex_attention
 func.func @torch.hop_flex_attention (%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>) -> (!torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>) {
   %float1.0 = torch.constant.float 1.000000e+00
@@ -228,6 +233,20 @@ func.func @torch.hop_flex_attention (%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg
   // CHECK-SAME: : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool
   // CHECK-SAME: -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>
   %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false_0, %false_0 {mask_mod_fn = @sdpa_mask0, score_mod_fn = @sdpa_score0} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+}
+
+// CHECK-LABEL: func.func @torch.hop_flex_attention_mask_mod_other_buffers
+func.func @torch.hop_flex_attention_mask_mod_other_buffers(%arg0: !torch.vtensor<[2,4,8,16],f32>, %arg1: !torch.vtensor<[2,4,8,16],f32>, %arg2: !torch.vtensor<[2,4,8,16],f32>, %arg3: !torch.vtensor<[2,4,8,8],i1>) -> (!torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>) {
+  %float1.0 = torch.constant.float 1.000000e+00
+  %false_0 = torch.constant.bool false
+  // CHECK: %[[MASK_FLOAT:.*]] = torch.constant.float 1.000000e+00
+  // CHECK: %[[MASK_FALSE:.*]] = torch.constant.bool false
+  // CHECK: torch.hop_flex_attention %arg0, %arg1, %arg2, %[[MASK_FLOAT]], %[[MASK_FALSE]], %[[MASK_FALSE]], mask_mod_other_buffers(%arg3)
+  // CHECK-SAME: {mask_mod_fn = @sdpa_mask_with_arg, score_mod_fn = @sdpa_score0}
+  // CHECK-SAME: : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool, mask_mod_other_buffers(!torch.vtensor<[2,4,8,8],i1>)
+  // CHECK-SAME: -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
+  %output, %logsumexp, %maxscore = torch.hop_flex_attention %arg0, %arg1, %arg2, %float1.0, %false_0, %false_0, mask_mod_other_buffers(%arg3) {mask_mod_fn = @sdpa_mask_with_arg, score_mod_fn = @sdpa_score0} : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8,16],f32>, !torch.float, !torch.bool, !torch.bool, mask_mod_other_buffers(!torch.vtensor<[2,4,8,8],i1>) -> !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
   return %output, %logsumexp, %maxscore : !torch.vtensor<[2,4,8,16],f32>, !torch.vtensor<[2,4,8],f32>, !torch.vtensor<[2,4,8],f32>
 }
 

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -437,6 +437,164 @@ def test_flex_attention_noblock_return_lse():
 
 
 @run
+# CHECK-LABEL: test_flex_attention_mask_mod_other_buffer
+# Check that helper functions are emitted first.
+# CHECK: func.func private @[[SCORE_FN:sdpa_score[0-9]+]](%arg0: !torch.vtensor<[],f32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>, %arg4: !torch.vtensor<[],si32>) -> !torch.vtensor<[],f32>
+# CHECK: func.func private @[[MASK_FN:sdpa_mask[0-9]+]](%arg0: !torch.vtensor<[],si32>, %arg1: !torch.vtensor<[],si32>, %arg2: !torch.vtensor<[],si32>, %arg3: !torch.vtensor<[],si32>, %arg4: !torch.vtensor<[4,8,1024,1024],i1>) -> !torch.vtensor<[],i1>
+# Then check the main function.
+# CHECK: func.func @test_flex_attention_mask_mod_other_buffer(%arg0: !torch.vtensor<[4,8,1024,64],f32>, %arg1: !torch.vtensor<[4,8,1024,64],f32>, %arg2: !torch.vtensor<[4,8,1024,64],f32>, %arg3: !torch.vtensor<[4,8,1024,1024],i1>)
+# CHECK-SAME: -> !torch.vtensor<[4,8,1024,64],f32>
+# Validate flex_attention op with a trailing mask_mod_other_buffers operand:
+# CHECK: %[[SCALE:.*]] = torch.constant.float 1.000000e+00
+# CHECK: %[[RETURN_LSE:.*]] = torch.constant.bool false
+# CHECK: %[[RETURN_MAX:.*]] = torch.constant.bool false
+# CHECK: %[[OUTPUT:.*]], %[[LOGSUMEXP:.*]], %[[MAX_SCORES:.*]] = torch.hop_flex_attention %arg0, %arg1, %arg2, %[[SCALE]], %[[RETURN_LSE]], %[[RETURN_MAX]], mask_mod_other_buffers(%arg3) {mask_mod_fn = @[[MASK_FN]], score_mod_fn = @[[SCORE_FN]]}
+# CHECK-SAME: : !torch.vtensor<[4,8,1024,64],f32>, !torch.vtensor<[4,8,1024,64],f32>, !torch.vtensor<[4,8,1024,64],f32>, !torch.float, !torch.bool, !torch.bool, mask_mod_other_buffers(!torch.vtensor<[4,8,1024,1024],i1>)
+# CHECK-SAME: -> !torch.vtensor<[4,8,1024,64],f32>, !torch.vtensor<[4,8,1024],f32>, !torch.vtensor<[4,8,1024],f32>
+# CHECK: return %[[OUTPUT]]
+def test_flex_attention_mask_mod_other_buffer():
+    from torch._higher_order_ops.flex_attention import (
+        flex_attention as flex_attention_hop,
+    )
+    from torch._subclasses.fake_tensor import FakeTensor
+    from torch.nn.attention.flex_attention import BlockMask, _LARGE_SPARSE_BLOCK_SIZE
+    from torch import Tensor
+
+    def _create_empty_block_mask(query: Tensor, key: Tensor, mask_mod):
+        device = query.device
+        return BlockMask.from_kv_blocks(
+            kv_num_blocks=torch.ones([1, 1, 1], dtype=torch.int32, device=device),
+            kv_indices=torch.zeros([1, 1, 1, 1], dtype=torch.int32, device=device),
+            BLOCK_SIZE=_LARGE_SPARSE_BLOCK_SIZE,
+            mask_mod=mask_mod,
+            seq_lengths=(query.shape[-2], key.shape[-2]),
+        )
+
+    def relative_position_bias(
+        score: Tensor,
+        batch: Tensor,
+        head: Tensor,
+        token_q: Tensor,
+        token_kv: Tensor,
+    ) -> Tensor:
+        return torch.tanh(score)
+
+    def explicit_mask(
+        batch: Tensor,
+        head: Tensor,
+        token_q: Tensor,
+        token_kv: Tensor,
+        attn_mask: Tensor,
+    ) -> Tensor:
+        return attn_mask[batch, head, token_q, token_kv]
+
+    class FlexAttention(torch.nn.Module):
+        def __init__(self, block_mask):
+            super().__init__()
+            self.block_mask = block_mask
+
+        def forward(self, q, k, v, attn_mask):
+            output, _, _ = flex_attention_hop(
+                q,
+                k,
+                v,
+                relative_position_bias,
+                self.block_mask.as_tuple(),
+                1.0,
+                {},
+                (),
+                (attn_mask,),
+            )
+            assert isinstance(output, FakeTensor)
+            return output
+
+    B, Hq, Hkv, L, S, E, Ev = 4, 8, 8, 1024, 1024, 64, 64
+    q = torch.ones(B, Hq, L, E)
+    k = torch.ones(B, Hkv, S, E)
+    v = torch.ones(B, Hkv, S, Ev)
+    attn_mask = torch.ones(B, Hq, L, S, dtype=torch.bool)
+    m = fx.export_and_import(
+        FlexAttention(_create_empty_block_mask(q, k, explicit_mask)),
+        q,
+        k,
+        v,
+        attn_mask,
+        func_name="test_flex_attention_mask_mod_other_buffer",
+    )
+    print(m)
+
+
+@run
+# CHECK-LABEL: test_flex_attention_score_mod_other_buffer_unsupported
+# CHECK: score_mod captured buffers are not supported by the torch-mlir flex_attention importer
+def test_flex_attention_score_mod_other_buffer_unsupported():
+    from torch._higher_order_ops.flex_attention import (
+        flex_attention as flex_attention_hop,
+    )
+    from torch._subclasses.fake_tensor import FakeTensor
+    from torch.nn.attention.flex_attention import BlockMask, _LARGE_SPARSE_BLOCK_SIZE
+    from torch import Tensor
+
+    def _create_empty_block_mask(query: Tensor, key: Tensor):
+        device = query.device
+        return BlockMask.from_kv_blocks(
+            kv_num_blocks=torch.ones([1, 1, 1], dtype=torch.int32, device=device),
+            kv_indices=torch.zeros([1, 1, 1, 1], dtype=torch.int32, device=device),
+            BLOCK_SIZE=_LARGE_SPARSE_BLOCK_SIZE,
+            seq_lengths=(query.shape[-2], key.shape[-2]),
+        )
+
+    def relative_position_bias(
+        score: Tensor,
+        batch: Tensor,
+        head: Tensor,
+        token_q: Tensor,
+        token_kv: Tensor,
+        bias: Tensor,
+    ) -> Tensor:
+        return score + bias
+
+    class FlexAttention(torch.nn.Module):
+        def __init__(self, block_mask):
+            super().__init__()
+            self.block_mask = block_mask
+
+        def forward(self, q, k, v, bias):
+            output, _, _ = flex_attention_hop(
+                q,
+                k,
+                v,
+                relative_position_bias,
+                self.block_mask.as_tuple(),
+                1.0,
+                {},
+                (bias,),
+                (),
+            )
+            assert isinstance(output, FakeTensor)
+            return output
+
+    B, Hq, Hkv, L, S, E, Ev = 4, 8, 8, 1024, 1024, 64, 64
+    q = torch.ones(B, Hq, L, E)
+    k = torch.ones(B, Hkv, S, E)
+    v = torch.ones(B, Hkv, S, Ev)
+    bias = torch.ones(())
+    try:
+        fx.export_and_import(
+            FlexAttention(_create_empty_block_mask(q, k)),
+            q,
+            k,
+            v,
+            bias,
+            func_name="test_flex_attention_score_mod_other_buffer_unsupported",
+        )
+    except NotImplementedError as e:
+        print(e)
+    else:
+        raise AssertionError("expected score_mod captured buffers to be unsupported")
+
+
+@run
 # CHECK-LABEL: test_stack_trace
 # CHECK: #loc[[LOC1:.+]] = loc(
 # CHECK: %{{.+}} = torch.aten.add.Tensor {{.+}} loc(#loc[[LOC1]])


### PR DESCRIPTION
In traced/exported FX graphs, Dynamo represents mask_mod closure captures for the flex_attention HOP as the final mask_mod_other_buffers argument. torch.hop_flex_attention only modelled the mask function symbol, so those captures could not be represented in Torch IR.

This adds trailing variadic `mask_mod_other_buffers` operands to `torch.hop_flex_attention` and prints them with explicit `mask_mod_other_buffers(...)` syntax. The FX importer forwards only exported `mask_mod_other_buffers` values into those operands. `score_mod_other_buffers` are named and rejected with an explicit unsupported error instead of being silently dropped.

