### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows

### DIFF
--- a/.github/workflows/bazelBuildAndTest.yml
+++ b/.github/workflows/bazelBuildAndTest.yml
@@ -18,6 +18,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
 
 jobs:
   ubuntu-build:

--- a/.github/workflows/oneshotSnapshotPackage.yml
+++ b/.github/workflows/oneshotSnapshotPackage.yml
@@ -4,6 +4,9 @@ name: Release oneshot snapshot package
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release_snapshot_package:
     name: "Tag snapshot release"

--- a/.github/workflows/pre-commit-all.yml
+++ b/.github/workflows/pre-commit-all.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main, post-commit-test]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,9 @@ name: pre-commit
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `RollPyTorch.yml`, `merge-rollpytorch.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.