### PR TITLE
[TorchOnnx] Fix ScatterND last unflatten step

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -4327,6 +4327,10 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         // through scatter and are already in place. The inverse is therefore
         // an unflatten of axis 0 alone, splitting it back into
         // dataDims[0:indicesLastDim].
+        if (indicesLastDim == 1) {
+          rewriter.replaceOp(binder.op, scatter);
+          return success();
+        }
         SmallVector<Value> collapsedDataDims(dataDims.begin(),
                                              dataDims.begin() + indicesLastDim);
         Value unflattenSizeList = Torch::PrimListConstructOp::create(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -4320,17 +4320,22 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
               /*include_self=*/constTrue);
         }
 
-        // step 11. Unflatten the collapsed data dims of scatter result.
-        if (indicesLastDim == 1) {
-          rewriter.replaceOp(binder.op, scatter);
-          return success();
-        }
+        // step 11. Unflatten the collapsed indexed prefix of the scatter
+        // result to restore the original data shape. Step 9 flattened only
+        // dims [0 .. indicesLastDim-1] of data into a single leading axis;
+        // the trailing dims [indicesLastDim .. dataRank-1] were preserved
+        // through scatter and are already in place. The inverse is therefore
+        // an unflatten of axis 0 alone, splitting it back into
+        // dataDims[0:indicesLastDim].
+        SmallVector<Value> collapsedDataDims(dataDims.begin(),
+                                             dataDims.begin() + indicesLastDim);
         Value unflattenSizeList = Torch::PrimListConstructOp::create(
-            rewriter, loc, intListTy, dataDims);
+            rewriter, loc, intListTy, collapsedDataDims);
         rewriter.replaceOpWithNewOp<Torch::AtenUnflattenIntOp>(
             binder.op, resultType, scatter, constZero, unflattenSizeList);
         return success();
       });
+
   // split to sequence
   // Arguments:
   // - input: the tensor to split

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3340,6 +3340,24 @@ func.func @test_scatternd(%arg0: !torch.vtensor<[4,4,4],f32>, %arg1: !torch.vten
   return %0 : !torch.vtensor<[4,4,4],f32>
 }
 
+// CHECK-LABEL:   func.func @test_scatternd_unflatten_indexed_prefix(
+// CHECK-SAME:        %[[DATA:.*]]: !torch.vtensor<[2,3,4],f32>,
+// CHECK-SAME:        %[[INDICES:.*]]: !torch.vtensor<[5,2],si64>,
+// CHECK-SAME:        %[[UPDATES:.*]]: !torch.vtensor<[5,4],f32>) -> !torch.vtensor<[2,3,4],f32>
+func.func @test_scatternd_unflatten_indexed_prefix(%arg0: !torch.vtensor<[2,3,4],f32>, %arg1: !torch.vtensor<[5,2],si64>, %arg2: !torch.vtensor<[5,4],f32>) -> !torch.vtensor<[2,3,4],f32> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 16 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  // CHECK-DAG:       %[[D0:.*]] = torch.aten.size.int %[[DATA]], {{.*}} : !torch.vtensor<[2,3,4],f32>, !torch.int -> !torch.int
+  // CHECK-DAG:       %[[D1:.*]] = torch.aten.size.int %[[DATA]], {{.*}} : !torch.vtensor<[2,3,4],f32>, !torch.int -> !torch.int
+  // CHECK-DAG:       %[[D2:.*]] = torch.aten.size.int %[[DATA]], {{.*}} : !torch.vtensor<[2,3,4],f32>, !torch.int -> !torch.int
+  // CHECK:           %[[FLAT_DATA:.*]] = torch.aten.flatten.using_ints %[[DATA]], {{.*}}, {{.*}} : !torch.vtensor<[2,3,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[6,4],f32>
+  // CHECK:           %[[SCATTER:.*]] = torch.aten.scatter.src %[[FLAT_DATA]], {{.*}}, {{.*}}, {{.*}} : !torch.vtensor<[6,4],f32>, !torch.int, !torch.vtensor<[5,4],si64>, !torch.vtensor<[5,4],f32> -> !torch.vtensor<[6,4],f32>
+  // CHECK:           %[[UNFLATTEN_DIMS:.*]] = torch.prim.ListConstruct %[[D0]], %[[D1]] : (!torch.int, !torch.int) -> !torch.list<int>
+  // CHECK:           %[[UNFLATTEN:.*]] = torch.aten.unflatten.int %[[SCATTER]], {{.*}}, %[[UNFLATTEN_DIMS]] : !torch.vtensor<[6,4],f32>, !torch.int, !torch.list<int> -> !torch.vtensor<[2,3,4],f32>
+  // CHECK:           return %[[UNFLATTEN]] : !torch.vtensor<[2,3,4],f32>
+  %none = torch.constant.none
+  %0 = torch.operator "onnx.ScatterND"(%arg0, %arg1, %arg2) : (!torch.vtensor<[2,3,4],f32>, !torch.vtensor<[5,2],si64>, !torch.vtensor<[5,4],f32>) -> !torch.vtensor<[2,3,4],f32>
+  return %0 : !torch.vtensor<[2,3,4],f32>
+}
+
 // CHECK-LABEL:   func.func @test_scatternd_add(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: !torch.vtensor<[4,4,4],f32>,
 // CHECK-SAME:                                  %[[VAL_1:.*]]: !torch.vtensor<[2,1],si64>,


### PR DESCRIPTION
The issue was seen when trying to lower [this bevformer-tiny checkpoint](https://huggingface.co/AXERA-TECH/bevformer).

The ScatterND lowering flattens the first X dimensions of the data tensor for aten.scatter.src, then tries to restore the original ONNX result shape, which can produce invalid operations.

For bevformer-tiny, there is a ScatterND operation:
```mlir
%667 = onnx.Reshape ... -> [2500,1,256]
%668 = onnx.Gather(%667, axis=1) -> [2500,256]
%669 = onnx.Reshape(%668, ...) -> [2500,1,256]
%670 = onnx.ScatterND(%arg3, %341, %669) -> [2500,1,256]
```
converted to:
```mlir
%670 = torch.operator "onnx.ScatterND"(%arg3, %341, %669)
  : (!torch.vtensor<[2500,1,256],f32>,
     !torch.vtensor<[2500,1,2],si64>,
     !torch.vtensor<[2500,1,256],f32>)
 -> !torch.vtensor<[2500,1,256],f32>
```
and its lowering produces:
```mlir
%939 = torch.prim.ListConstruct %915, %916, %917 // 2500, 1, 256
%940 = torch.aten.unflatten.int %938, %int0_654, %939
  : !torch.vtensor<[2500,256],f32>, !torch.int, !torch.list<int>
 -> !torch.vtensor<[2500,1,256],f32>
```
The latter IR is trying to reshape a [2500, 256] tensor into [2500, 1, 256] by replacing dim 0 (2500) by [2500, 1, 256] which is wrong: 2500 at dim 0 should be replaced by [2500, 1] instead (and leave the trailing 256 unaffected).

**Fix:**
This PR re-writes the unflattening step of ScatterND lowering to properly unflatten the flattened dim 0 into its original shape, and not the original shape of the whole data tensor. Replacing:
```cpp
        // step 11. Unflatten the collapsed data dims of scatter result.
        if (indicesLastDim == 1) {
          rewriter.replaceOp(binder.op, scatter);
          return success();
        }
        Value unflattenSizeList = Torch::PrimListConstructOp::create(
            rewriter, loc, intListTy, dataDims);
        rewriter.replaceOpWithNewOp<Torch::AtenUnflattenIntOp>(
            binder.op, resultType, scatter, constZero, unflattenSizeList);
        return success();
```

```cpp
        // step 11. Unflatten the collapsed indexed prefix of the scatter
        // result to restore the original data shape. Step 9 flattened only
        // dims [0 .. indicesLastDim-1] of data into a single leading axis;
        // the trailing dims [indicesLastDim .. dataRank-1] were preserved
        // through scatter and are already in place. The inverse is therefore
        // an unflatten of axis 0 alone, splitting it back into
        // dataDims[0:indicesLastDim].
        if (indicesLastDim == 1) {
          rewriter.replaceOp(binder.op, scatter);
          return success();
        }
        SmallVector<Value> collapsedDataDims(dataDims.begin(),
                                             dataDims.begin() + indicesLastDim);
        Value unflattenSizeList = Torch::PrimListConstructOp::create(
            rewriter, loc, intListTy, collapsedDataDims);
        rewriter.replaceOpWithNewOp<Torch::AtenUnflattenIntOp>(
            binder.op, resultType, scatter, constZero, unflattenSizeList);
        return success();
      });
```
