### PR TITLE
[Python] Build JIT importer targets as C++20

### DIFF
--- a/projects/jit_ir_common/csrc/jit_ir_importer/CMakeLists.txt
+++ b/projects/jit_ir_common/csrc/jit_ir_importer/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(TorchMLIRJITIRImporter STATIC
   ivalue_importer.cpp
   torch_to_mlir_utils.cpp
   )
+# PyTorch headers now use C++20-only syntax that MSVC rejects in C++17 mode.
+target_compile_features(TorchMLIRJITIRImporter PUBLIC cxx_std_20)
 message(STATUS "Linking TorchMLIRJITImporter with ${TORCH_LIBRARIES}")
 target_link_libraries(TorchMLIRJITIRImporter
   TorchMLIRAggregateCAPI

--- a/projects/pt1/python/torch_mlir/csrc/jit_ir_importer/CMakeLists.txt
+++ b/projects/pt1/python/torch_mlir/csrc/jit_ir_importer/CMakeLists.txt
@@ -7,6 +7,7 @@ Python3_add_library(TorchMLIRJITIRImporterPybind MODULE WITH_SOABI
   init_python_bindings.cpp
   module_builder.cpp
   )
+target_compile_features(TorchMLIRJITIRImporterPybind PRIVATE cxx_std_20)
 add_dependencies(TorchMLIRJITIRImporterPybind
   TorchMLIRJITIRImporter
   )


### PR DESCRIPTION
Recent PyTorch headers use bit-field default member initializers, which MSVC rejects when these targets compile as C++17.