### PR TITLE
Remove stale ONNX clamp int16 xfail for nightly

### DIFF
--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3569,9 +3569,6 @@ if torch_version_for_comparison() > version.parse("2.12.0.dev"):
     FX_IMPORTER_STABLEHLO_XFAIL_SET = FX_IMPORTER_STABLEHLO_XFAIL_SET - {
         "ElementwiseClampInt16Module_basic",
     }
-    FX_IMPORTER_TOSA_XFAIL_SET = FX_IMPORTER_TOSA_XFAIL_SET - {
-        "ElementwiseClampInt16Module_basic",
-    }
 
 if torch_version_for_comparison() < version.parse("2.4.0.dev"):
     STABLEHLO_PASS_SET = STABLEHLO_PASS_SET - {
@@ -4079,6 +4076,11 @@ FX_IMPORTER_TOSA_XFAIL_SET = {
     "ElementwiseReluModule_bfloat16",
     "ElementwiseClampInt16Module_basic",  # 'memref<3x5xi16>'
 }
+
+if torch_version_for_comparison() > version.parse("2.12.0.dev"):
+    FX_IMPORTER_TOSA_XFAIL_SET = FX_IMPORTER_TOSA_XFAIL_SET - {
+        "ElementwiseClampInt16Module_basic",
+    }
 
 ONNX_TOSA_CRASHING_SET = {
     "ScatterSrcStaticModule_basic",

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3559,6 +3559,11 @@ if torch_version_for_comparison() > version.parse("2.10.0.dev"):
         "ElementwiseClampInt16Module_basic",
     }
 
+if torch_version_for_comparison() > version.parse("2.12.0.dev"):
+    ONNX_XFAIL_SET = ONNX_XFAIL_SET - {
+        "ElementwiseClampInt16Module_basic",
+    }
+
 if torch_version_for_comparison() < version.parse("2.4.0.dev"):
     STABLEHLO_PASS_SET = STABLEHLO_PASS_SET - {
         "AtenIntMM_basic",

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3563,6 +3563,9 @@ if torch_version_for_comparison() > version.parse("2.12.0.dev"):
     ONNX_XFAIL_SET = ONNX_XFAIL_SET - {
         "ElementwiseClampInt16Module_basic",
     }
+    FX_IMPORTER_XFAIL_SET = FX_IMPORTER_XFAIL_SET - {
+        "ElementwiseClampInt16Module_basic",
+    }
 
 if torch_version_for_comparison() < version.parse("2.4.0.dev"):
     STABLEHLO_PASS_SET = STABLEHLO_PASS_SET - {

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3566,6 +3566,9 @@ if torch_version_for_comparison() > version.parse("2.12.0.dev"):
     FX_IMPORTER_XFAIL_SET = FX_IMPORTER_XFAIL_SET - {
         "ElementwiseClampInt16Module_basic",
     }
+    FX_IMPORTER_STABLEHLO_XFAIL_SET = FX_IMPORTER_STABLEHLO_XFAIL_SET - {
+        "ElementwiseClampInt16Module_basic",
+    }
 
 if torch_version_for_comparison() < version.parse("2.4.0.dev"):
     STABLEHLO_PASS_SET = STABLEHLO_PASS_SET - {

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3569,6 +3569,9 @@ if torch_version_for_comparison() > version.parse("2.12.0.dev"):
     FX_IMPORTER_STABLEHLO_XFAIL_SET = FX_IMPORTER_STABLEHLO_XFAIL_SET - {
         "ElementwiseClampInt16Module_basic",
     }
+    FX_IMPORTER_TOSA_XFAIL_SET = FX_IMPORTER_TOSA_XFAIL_SET - {
+        "ElementwiseClampInt16Module_basic",
+    }
 
 if torch_version_for_comparison() < version.parse("2.4.0.dev"):
     STABLEHLO_PASS_SET = STABLEHLO_PASS_SET - {


### PR DESCRIPTION
ElementwiseClampInt16Module_basic now passes with current torch-nightly after i16 memref ABI support, so keep the older xfail but remove it for newer nightlies to avoid XPASS failures.