### PR TITLE
[DecomposeComplexOps] Fix zero-rank ellipsis in aten.einsum

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -242,13 +242,10 @@ rewriteEquationWithEllipsisSlicing(std::string &equation,
   std::string ellipsisToken;
   int usedCount = 0;
   // Iterate over the alphabet to create a new token for ellipsis
-  for (char c = 'a'; c <= 'z'; ++c) {
+  for (char c = 'a'; c <= 'z' && usedCount < maxEllipsisRank; ++c) {
     if (!isTokenUsed(c)) {
       ellipsisToken.push_back(c);
       usedCount++;
-      if (usedCount == maxEllipsisRank) {
-        break;
-      }
     }
   }
 

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1136,3 +1136,17 @@ func.func @repeat_broadcasts_static_singleton_dims(%arg0: !torch.vtensor<[1,1,6,
   %0 = torch.aten.repeat %arg0, %repeats : !torch.vtensor<[1,1,6,1,4,4],f32>, !torch.list<int> -> !torch.vtensor<[4,1,6,2500,4,4],f32>
   return %0 : !torch.vtensor<[4,1,6,2500,4,4],f32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @einsum_zero_rank_ellipsis
+// CHECK-SAME: (%[[ARG0:.*]]: !torch.vtensor<[1,1,2,2,3,3],f32>, %[[ARG1:.*]]: !torch.vtensor<[1,280,2,2,3],f32>)
+// CHECK-NOT: torch.aten.einsum
+// CHECK: return %{{.*}} : !torch.vtensor<[1,280,1,2,2,3],f32>
+func.func @einsum_zero_rank_ellipsis(%arg0: !torch.vtensor<[1,1,2,2,3,3],f32>, %arg1: !torch.vtensor<[1,280,2,2,3],f32>) -> !torch.vtensor<[1,280,1,2,2,3],f32> {
+  %str = torch.constant.str "...bt pide , ...bo pie -> ...bot pid"
+  %none = torch.constant.none
+  %list = torch.prim.ListConstruct %arg0, %arg1 : (!torch.vtensor<[1,1,2,2,3,3],f32>, !torch.vtensor<[1,280,2,2,3],f32>) -> !torch.list<vtensor>
+  %0 = torch.aten.einsum %str, %list, %none : !torch.str, !torch.list<vtensor>, !torch.none -> !torch.vtensor<[1,280,1,2,2,3],f32>
+  return %0 : !torch.vtensor<[1,280,1,2,2,3],f32>
+}


### PR DESCRIPTION
Fixes #4535.

Fix zero-rank ellipsis case in aten.einsum decomposition, with a regression test.

Testing:
- `check-torch-mlir`
- `test/Dialect/Torch/decompose-complex-ops.mlir`