### PR TITLE
[TorchToTosa] Lower zero-K matmul to zero const

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -1827,6 +1827,8 @@ public:
           dyn_cast<RankedTensorType>(typeConverter->convertType(op.getType()));
       if (!lhsTy || !rhsTy || !resultTy)
         return false;
+      if (!resultTy.hasStaticShape())
+        return false;
       if (mlir::tosa::typeHasZeroDim(resultTy))
         return false;
       return hasStaticZeroContraction(lhsTy, rhsTy);
@@ -1857,7 +1859,8 @@ public:
     auto resultTy = dyn_cast<RankedTensorType>(
         OpConversionPattern<AtenOpT>::getTypeConverter()->convertType(
             op.getType()));
-    if (resultTy && !mlir::tosa::typeHasZeroDim(resultTy) &&
+    if (resultTy && resultTy.hasStaticShape() &&
+        !mlir::tosa::typeHasZeroDim(resultTy) &&
         hasStaticZeroContraction(lhsTy, rhsTy)) {
       auto zeroOutput = tosa::getZerosLikeTensor(rewriter, op, resultTy);
       if (!zeroOutput)

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -278,11 +278,16 @@ public:
   LogicalResult
   matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    const TypeConverter *typeConverter = this->getTypeConverter();
+    bool canHandleZeroDimInputOperands =
+        canHandleZeroDimInputs(op, adaptor, typeConverter);
+
     // Pre-check: all tensor operands and outputs must have no zero-sized
     // dimensions.
     for (auto v : adaptor.getOperands()) {
       auto rankedInputType = dyn_cast<RankedTensorType>(v.getType());
-      if (rankedInputType && mlir::tosa::typeHasZeroDim(rankedInputType)) {
+      if (rankedInputType && mlir::tosa::typeHasZeroDim(rankedInputType) &&
+          !canHandleZeroDimInputOperands) {
         return rewriter.notifyMatchFailure(
             op,
             "TOSA lowering does not support input tensors with a zero-sized "
@@ -292,7 +297,6 @@ public:
 
     // not all adaptors have results, instead get the result from the op
     // directly
-    const TypeConverter *typeConverter = this->getTypeConverter();
     for (auto res : op->getResults()) {
       auto rankedOutputType =
           dyn_cast<RankedTensorType>(typeConverter->convertType(res.getType()));
@@ -307,6 +311,12 @@ public:
   }
 
 protected:
+  virtual bool
+  canHandleZeroDimInputs(AtenOpT op, OpAdaptor adaptor,
+                         const TypeConverter *typeConverter) const {
+    return false;
+  }
+
   virtual LogicalResult
   matchAndRewriteImpl(AtenOpT op, OpAdaptor adaptor,
                       ConversionPatternRewriter &rewriter) const = 0;
@@ -1795,6 +1805,34 @@ public:
         op,
         "Unimplemented matrix multiplication variant input parsing function");
   }
+
+  bool
+  canHandleZeroDimInputs(AtenOpT op, OpAdaptor adaptor,
+                         const TypeConverter *typeConverter) const override {
+    if constexpr (!std::is_same_v<AtenOpT, AtenMatmulOp> &&
+                  !std::is_same_v<AtenOpT, AtenMmOp> &&
+                  !std::is_same_v<AtenOpT, AtenBmmOp>) {
+      return false;
+    } else {
+      auto lhs = adaptor.getSelf();
+      Value rhs;
+      if constexpr (std::is_same_v<AtenOpT, AtenMatmulOp>)
+        rhs = adaptor.getOther();
+      else
+        rhs = adaptor.getMat2();
+
+      auto lhsTy = dyn_cast<RankedTensorType>(lhs.getType());
+      auto rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
+      auto resultTy =
+          dyn_cast<RankedTensorType>(typeConverter->convertType(op.getType()));
+      if (!lhsTy || !rhsTy || !resultTy)
+        return false;
+      if (mlir::tosa::typeHasZeroDim(resultTy))
+        return false;
+      return hasStaticZeroContraction(lhsTy, rhsTy);
+    }
+  }
+
   LogicalResult performMatmul(AtenOpT op, OpAdaptor adaptor,
                               ConversionPatternRewriter &rewriter, Value &lhs,
                               Value &rhs, Value &lhsZp, Value &rhsZp,
@@ -1815,6 +1853,19 @@ public:
     if (lhsElemTy != rhsElemTy)
       return rewriter.notifyMatchFailure(op,
                                          "Matmul: input datatypes mismatched");
+
+    auto resultTy = dyn_cast<RankedTensorType>(
+        OpConversionPattern<AtenOpT>::getTypeConverter()->convertType(
+            op.getType()));
+    if (resultTy && !mlir::tosa::typeHasZeroDim(resultTy) &&
+        hasStaticZeroContraction(lhsTy, rhsTy)) {
+      auto zeroOutput = tosa::getZerosLikeTensor(rewriter, op, resultTy);
+      if (!zeroOutput)
+        return rewriter.notifyMatchFailure(
+            op, "failed to materialize zero-contraction matmul result");
+      output = *zeroOutput;
+      return success();
+    }
 
     if (!lhsZp) {
       // Initialize zero constant values as zero-points, if the op operands
@@ -2352,6 +2403,22 @@ public:
 
     return success();
   }
+
+private:
+  static bool hasStaticZeroContraction(RankedTensorType lhsTy,
+                                       RankedTensorType rhsTy) {
+    auto lhsShape = makeShapeTorchCompatible(lhsTy.getShape());
+    auto rhsShape = makeShapeTorchCompatible(rhsTy.getShape());
+    if (lhsShape.empty() || rhsShape.empty())
+      return false;
+
+    int64_t lhsK = lhsShape.back();
+    int64_t rhsK =
+        rhsShape.size() == 1 ? rhsShape.back() : rhsShape[rhsShape.size() - 2];
+    return lhsK == 0 && rhsK == 0;
+  }
+
+public:
   // The default version just reads two inputs, computes output and returns it.
   // Other versions may add a bias, apply GEMM-style alpha/beta scaling etc.
   virtual LogicalResult

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -88,6 +88,7 @@ LINALG_CRASHING_SET = {
     "SliceCopyStartGreaterThanDimSize_Module_basic",
     # unimplemented: for conversion to byte or char type dstOriginalDtype has to be passed to convertScalarToDtype
     "AtenMmInt8Types_basic",
+    "AtenMmInt8ZeroK_basic",
     # Hanging tests:
     "ConvolutionBackwardModule2DDilated_basic",
     "ConvolutionBackwardModule2DStridedPaddedDilatedGrouped_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -342,6 +342,27 @@ def AtenMmFloatTypes_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class AtenMmZeroK(torch.nn.Module):
+    @export
+    @annotate_args(
+        [
+            None,
+            ([5, 0], torch.float32, True),
+            ([0, 10], torch.float32, True),
+        ]
+    )
+    def forward(self, a, b):
+        return torch.ops.aten.mm(a, b)
+
+
+@register_test_case(module_factory=lambda: AtenMmZeroK())
+def AtenMmZeroK_basic(module, tu: TestUtils):
+    module.forward(torch.empty(5, 0), torch.empty(0, 10))
+
+
+# ==============================================================================
+
+
 class AtenMmIntTypes(torch.nn.Module):
     @export
     @annotate_args(

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -84,6 +84,30 @@ def Matmul_2d(module, tu: TestUtils):
 # ==============================================================================
 
 
+class MatmulZeroK(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([5, 0], torch.float32, True),
+            ([0, 10], torch.float32, True),
+        ]
+    )
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: MatmulZeroK())
+def MatmulZeroK_basic(module, tu: TestUtils):
+    module.forward(torch.empty(5, 0), torch.empty(0, 10))
+
+
+# ==============================================================================
+
+
 class MatmulVecMat(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -363,6 +387,27 @@ def AtenMmZeroK_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class AtenBmmZeroK(torch.nn.Module):
+    @export
+    @annotate_args(
+        [
+            None,
+            ([2, 5, 0], torch.float32, True),
+            ([2, 0, 10], torch.float32, True),
+        ]
+    )
+    def forward(self, a, b):
+        return torch.ops.aten.bmm(a, b)
+
+
+@register_test_case(module_factory=lambda: AtenBmmZeroK())
+def AtenBmmZeroK_basic(module, tu: TestUtils):
+    module.forward(torch.empty(2, 5, 0), torch.empty(2, 0, 10))
+
+
+# ==============================================================================
+
+
 class AtenMmIntTypes(torch.nn.Module):
     @export
     @annotate_args(
@@ -402,6 +447,30 @@ def AtenMmInt8Types_basic(module, tu: TestUtils):
     module.forward(
         tu.randint(16, 4, high=100).to(torch.int8),
         tu.randint(4, 16, high=100).to(torch.int8),
+    )
+
+
+# ==============================================================================
+
+
+class AtenMmInt8ZeroK(torch.nn.Module):
+    @export
+    @annotate_args(
+        [
+            None,
+            ([3, 0], torch.int8, True),
+            ([0, 3], torch.int8, True),
+        ]
+    )
+    def forward(self, a, b):
+        return torch.ops.aten.mm(a, b)
+
+
+@register_test_case(module_factory=lambda: AtenMmInt8ZeroK())
+def AtenMmInt8ZeroK_basic(module, tu: TestUtils):
+    module.forward(
+        torch.empty(3, 0, dtype=torch.int8),
+        torch.empty(0, 3, dtype=torch.int8),
     )
 
 

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -4904,11 +4904,33 @@ func.func @torch.aten.matmul$zero_k_f32(%arg0: !torch.vtensor<[5,0],f32>, %arg1:
 }
 
 // -----
+// CHECK-LABEL:   func.func @torch.aten.bmm$zero_k_f32(
+// CHECK-SAME:      %[[LHS:.*]]: !torch.vtensor<[2,5,0],f32>,
+// CHECK-SAME:      %[[RHS:.*]]: !torch.vtensor<[2,0,10],f32>) -> !torch.vtensor<[2,5,10],f32> {
+// CHECK-NOT:       tosa.matmul
+// CHECK:           %[[ZERO:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<2x5x10xf32>}> : () -> tensor<2x5x10xf32>
+// CHECK:           %[[RES:.*]] = torch_c.from_builtin_tensor %[[ZERO]] : tensor<2x5x10xf32> -> !torch.vtensor<[2,5,10],f32>
+// CHECK:           return %[[RES]]
+func.func @torch.aten.bmm$zero_k_f32(%arg0: !torch.vtensor<[2,5,0],f32>, %arg1: !torch.vtensor<[2,0,10],f32>) -> !torch.vtensor<[2,5,10],f32> {
+  %0 = torch.aten.bmm %arg0, %arg1 : !torch.vtensor<[2,5,0],f32>, !torch.vtensor<[2,0,10],f32> -> !torch.vtensor<[2,5,10],f32>
+  return %0 : !torch.vtensor<[2,5,10],f32>
+}
+
+// -----
 module {
   func.func @torch.aten.mm$zero_output_rejected(%arg0: !torch.vtensor<[0,5],f32>, %arg1: !torch.vtensor<[5,10],f32>) -> !torch.vtensor<[0,10],f32> {
     // expected-error @below {{failed to legalize operation 'torch.aten.mm' that was explicitly marked illegal}}
     %0 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[0,5],f32>, !torch.vtensor<[5,10],f32> -> !torch.vtensor<[0,10],f32>
     return %0 : !torch.vtensor<[0,10],f32>
+  }
+}
+
+// -----
+module {
+  func.func @torch.aten.mm$zero_k_dynamic_result_rejected(%arg0: !torch.vtensor<[?,0],f32>, %arg1: !torch.vtensor<[0,10],f32>) -> !torch.vtensor<[?,10],f32> {
+    // expected-error @below {{failed to legalize operation 'torch.aten.mm' that was explicitly marked illegal}}
+    %0 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[?,0],f32>, !torch.vtensor<[0,10],f32> -> !torch.vtensor<[?,10],f32>
+    return %0 : !torch.vtensor<[?,10],f32>
   }
 }
 

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -4878,6 +4878,41 @@ func.func @torch.aten.mm$bf16(%arg0: !torch.vtensor<[1,22],bf16>, %arg1: !torch.
 }
 
 // -----
+// CHECK-LABEL:   func.func @torch.aten.mm$zero_k_f32(
+// CHECK-SAME:      %[[LHS:.*]]: !torch.vtensor<[5,0],f32>,
+// CHECK-SAME:      %[[RHS:.*]]: !torch.vtensor<[0,10],f32>) -> !torch.vtensor<[5,10],f32> {
+// CHECK-NOT:       tosa.matmul
+// CHECK:           %[[ZERO:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<5x10xf32>}> : () -> tensor<5x10xf32>
+// CHECK:           %[[RES:.*]] = torch_c.from_builtin_tensor %[[ZERO]] : tensor<5x10xf32> -> !torch.vtensor<[5,10],f32>
+// CHECK:           return %[[RES]]
+func.func @torch.aten.mm$zero_k_f32(%arg0: !torch.vtensor<[5,0],f32>, %arg1: !torch.vtensor<[0,10],f32>) -> !torch.vtensor<[5,10],f32> {
+  %0 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[5,0],f32>, !torch.vtensor<[0,10],f32> -> !torch.vtensor<[5,10],f32>
+  return %0 : !torch.vtensor<[5,10],f32>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten.matmul$zero_k_f32(
+// CHECK-SAME:      %[[LHS:.*]]: !torch.vtensor<[5,0],f32>,
+// CHECK-SAME:      %[[RHS:.*]]: !torch.vtensor<[0,10],f32>) -> !torch.vtensor<[5,10],f32> {
+// CHECK-NOT:       tosa.matmul
+// CHECK:           %[[ZERO:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<5x10xf32>}> : () -> tensor<5x10xf32>
+// CHECK:           %[[RES:.*]] = torch_c.from_builtin_tensor %[[ZERO]] : tensor<5x10xf32> -> !torch.vtensor<[5,10],f32>
+// CHECK:           return %[[RES]]
+func.func @torch.aten.matmul$zero_k_f32(%arg0: !torch.vtensor<[5,0],f32>, %arg1: !torch.vtensor<[0,10],f32>) -> !torch.vtensor<[5,10],f32> {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[5,0],f32>, !torch.vtensor<[0,10],f32> -> !torch.vtensor<[5,10],f32>
+  return %0 : !torch.vtensor<[5,10],f32>
+}
+
+// -----
+module {
+  func.func @torch.aten.mm$zero_output_rejected(%arg0: !torch.vtensor<[0,5],f32>, %arg1: !torch.vtensor<[5,10],f32>) -> !torch.vtensor<[0,10],f32> {
+    // expected-error @below {{failed to legalize operation 'torch.aten.mm' that was explicitly marked illegal}}
+    %0 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[0,5],f32>, !torch.vtensor<[5,10],f32> -> !torch.vtensor<[0,10],f32>
+    return %0 : !torch.vtensor<[0,10],f32>
+  }
+}
+
+// -----
 // CHECK-LABEL:   func.func @torch.aten.matmul$broadcast(
 // CHECK-SAME:      %[[INP:.*]]: !torch.vtensor<[10,3,4],f32>,
 // CHECK-SAME:      %[[WTS:.*]]: !torch.vtensor<[4],f32>) -> !torch.vtensor<[10,3],f32> {


### PR DESCRIPTION
## Summary
- allow Torch-to-TOSA matmul lowering to handle static zero contraction when the result shape is non-empty
- lower those cases to a typed zero `tosa.const` instead of rejecting the zero-sized input
- keep zero-sized output tensors rejected as unsupported by TOSA