### PR TITLE
[Torch] Decompose scalar mean dim with divisor one

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -6823,10 +6823,12 @@ public:
     } else {
       productDimSize = Torch::ConstantIntOp::create(
           rewriter, loc, rewriter.getI64IntegerAttr(1));
-      for (Value dim : dimListElements) {
-        Value dimSize = AtenSizeIntOp::create(rewriter, loc, input, dim);
-        productDimSize =
-            AtenMulIntOp::create(rewriter, loc, productDimSize, dimSize);
+      if (inputRank > 0) {
+        for (Value dim : dimListElements) {
+          Value dimSize = AtenSizeIntOp::create(rewriter, loc, input, dim);
+          productDimSize =
+              AtenMulIntOp::create(rewriter, loc, productDimSize, dimSize);
+        }
       }
     }
     rewriter.replaceOpWithNewOp<AtenDivScalarOp>(op, outputType, sumAlongDims,

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1155,3 +1155,22 @@ func.func @mean_dim_scalar(%arg0: !torch.vtensor<[],f32>) -> !torch.vtensor<[],f
   %0 = torch.aten.mean.dim %arg0, %dims, %keepdim, %dtype : !torch.vtensor<[],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
   return %0 : !torch.vtensor<[],f32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @mean_dim_scalar_negative_dim
+// CHECK-SAME: (%[[ARG0:.*]]: !torch.vtensor<[],f32>) -> !torch.vtensor<[],f32>
+// CHECK: %[[ONE:.*]] = torch.constant.int 1
+// CHECK-NOT: torch.aten.size.int
+// CHECK: %[[SUM:.*]] = torch.aten.sum.dim_IntList %[[ARG0]]
+// CHECK-NOT: torch.aten.size.int
+// CHECK: %[[DIV:.*]] = torch.aten.div.Scalar %[[SUM]], %[[ONE]]
+// CHECK: return %[[DIV]] : !torch.vtensor<[],f32>
+func.func @mean_dim_scalar_negative_dim(%arg0: !torch.vtensor<[],f32>) -> !torch.vtensor<[],f32> {
+  %dim = torch.constant.int -1
+  %dims = torch.prim.ListConstruct %dim : (!torch.int) -> !torch.list<int>
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  %0 = torch.aten.mean.dim %arg0, %dims, %keepdim, %dtype : !torch.vtensor<[],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1136,3 +1136,22 @@ func.func @repeat_broadcasts_static_singleton_dims(%arg0: !torch.vtensor<[1,1,6,
   %0 = torch.aten.repeat %arg0, %repeats : !torch.vtensor<[1,1,6,1,4,4],f32>, !torch.list<int> -> !torch.vtensor<[4,1,6,2500,4,4],f32>
   return %0 : !torch.vtensor<[4,1,6,2500,4,4],f32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @mean_dim_scalar
+// CHECK-SAME: (%[[ARG0:.*]]: !torch.vtensor<[],f32>) -> !torch.vtensor<[],f32>
+// CHECK: %[[ONE:.*]] = torch.constant.int 1
+// CHECK-NOT: torch.aten.size.int
+// CHECK: %[[SUM:.*]] = torch.aten.sum.dim_IntList %[[ARG0]]
+// CHECK-NOT: torch.aten.size.int
+// CHECK: %[[DIV:.*]] = torch.aten.div.Scalar %[[SUM]], %[[ONE]]
+// CHECK: return %[[DIV]] : !torch.vtensor<[],f32>
+func.func @mean_dim_scalar(%arg0: !torch.vtensor<[],f32>) -> !torch.vtensor<[],f32> {
+  %dim = torch.constant.int 0
+  %dims = torch.prim.ListConstruct %dim : (!torch.int) -> !torch.list<int>
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  %0 = torch.aten.mean.dim %arg0, %dims, %keepdim, %dtype : !torch.vtensor<[],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}


### PR DESCRIPTION
Use a constant divisor of one when decomposing mean over a rank-0 input. This matches Pytorch's reference behavior and avoids producing aten.size.int on a scalar tensor.