### PR TITLE
[TorchToTosa] Lower MXFP4 aten._scaled_mm_v2 to TOSA

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
@@ -126,6 +126,25 @@ enum class ScalarType : int8_t {
 };
 
 //===----------------------------------------------------------------------===//
+// Mirrors PyTorch ScalingType and SwizzleType enum values used by
+// aten._scaled_mm_v2 metadata.
+// https://github.com/pytorch/pytorch/blob/449aa5b695056c4c14c3134909de5ad1a3078cc8/aten/src/ATen/BlasBackend.h#L34-L43
+//===----------------------------------------------------------------------===//
+enum class ScaledMmV2ScalingType : int64_t {
+  TensorWise = 0,
+  RowWise = 1,
+  BlockWise1x16 = 2,
+  BlockWise1x32 = 3,
+  BlockWise1x128 = 4,
+  BlockWise128x128 = 5,
+};
+
+enum class ScaledMmV2SwizzleType : int64_t {
+  NoSwizzle = 0,
+  Swizzle32x4x4 = 1,
+};
+
+//===----------------------------------------------------------------------===//
 // Type promotion related functions and struct definitions are copied from
 // aten/src/ATen/native/TypeProperties.*
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -26,6 +26,7 @@
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
 #include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
@@ -114,6 +115,14 @@ static bool isSupportedStaticScaledMmScaleElementType(Type type) {
   return type.isF32();
 }
 
+static bool isSupportedScaledMmV2DataElementType(Type type) {
+  return isa<Float4E2M1FNType>(type);
+}
+
+static bool isSupportedBlockedScaledMmScaleElementType(Type type) {
+  return isa<Float8E8M0FNUType>(type);
+}
+
 static bool isSupportedStaticScaledMmResultElementType(Type type) {
   return type.isF32() || type.isF16() || type.isBF16();
 }
@@ -161,6 +170,99 @@ getStaticScaledMmTensorwiseOrRowwiseBatchedScaleShapes(
     return StaticScaledMmScaleShapes{{1, m, 1}, {1, 1, n}};
 
   return std::nullopt;
+}
+
+static FailureOr<Value> getSingleListConstructElement(Value value) {
+  auto listConstruct = value.getDefiningOp<PrimListConstructOp>();
+  if (!listConstruct || listConstruct.getElements().size() != 1)
+    return failure();
+  return listConstruct.getElements().front();
+}
+
+static FailureOr<Value> convertSingleTensorListConstructElement(
+    Value value, const TypeConverter *converter,
+    ConversionPatternRewriter &rewriter, Location loc) {
+  FailureOr<Value> element = getSingleListConstructElement(value);
+  if (failed(element))
+    return failure();
+
+  auto convertedTy = dyn_cast_or_null<RankedTensorType>(
+      converter->convertType(element->getType()));
+  if (!convertedTy)
+    return failure();
+
+  return TorchConversion::ToBuiltinTensorOp::create(rewriter, loc, convertedTy,
+                                                    *element)
+      .getResult();
+}
+
+static FailureOr<int64_t> getSingleConstantIntListValue(Value value) {
+  SmallVector<int64_t> values;
+  if (!matchPattern(value, m_TorchListOfConstantInts(values)) ||
+      values.size() != 1)
+    return failure();
+  return values.front();
+}
+
+static FailureOr<Value> reshapeScaledMmV2BlockedScaleForTosa(
+    Value scale, RankedTensorType scaleTy, int64_t rows, int64_t scaleCols,
+    ConversionPatternRewriter &rewriter, Location loc) {
+  if (!scaleTy.hasStaticShape() ||
+      !isSupportedBlockedScaledMmScaleElementType(scaleTy.getElementType()))
+    return failure();
+
+  SmallVector<int64_t> scaleShape = {1, rows, scaleCols};
+  auto reshapedTy = RankedTensorType::get(scaleShape, scaleTy.getElementType());
+
+  auto sliceScale = [&](Value source, ArrayRef<int64_t> sourceShape) -> Value {
+    auto sourceTy =
+        RankedTensorType::get(sourceShape, scaleTy.getElementType());
+    source = tosa::ReshapeOp::create(
+                 rewriter, loc, sourceTy, source,
+                 tosa::getTosaConstShape(rewriter, loc, sourceShape))
+                 .getResult();
+    return tosa::SliceOp::create(
+               rewriter, loc, reshapedTy, source,
+               tosa::getTosaConstShape(rewriter, loc, {0, 0, 0}),
+               tosa::getTosaConstShape(rewriter, loc, scaleShape))
+        .getResult();
+  };
+
+  if (scaleTy.getRank() == 3) {
+    if (scaleTy.getDimSize(0) != 1 || scaleTy.getDimSize(1) != rows ||
+        scaleTy.getDimSize(2) < scaleCols)
+      return failure();
+    if (scaleTy.getDimSize(2) == scaleCols)
+      return scale;
+    return sliceScale(scale, scaleTy.getShape());
+  }
+
+  if (scaleTy.getRank() == 2) {
+    if (scaleTy.getDimSize(0) != rows || scaleTy.getDimSize(1) < scaleCols)
+      return failure();
+    if (scaleTy.getDimSize(1) == scaleCols)
+      return tosa::ReshapeOp::create(
+                 rewriter, loc, reshapedTy, scale,
+                 tosa::getTosaConstShape(rewriter, loc, scaleShape))
+          .getResult();
+    return sliceScale(scale, {1, rows, scaleTy.getDimSize(1)});
+  }
+
+  if (scaleTy.getRank() != 1)
+    return failure();
+
+  int64_t compactNumel = rows * scaleCols;
+  int64_t numel = scaleTy.getDimSize(0);
+  if (numel == compactNumel)
+    return tosa::ReshapeOp::create(
+               rewriter, loc, reshapedTy, scale,
+               tosa::getTosaConstShape(rewriter, loc, scaleShape))
+        .getResult();
+
+  int64_t paddedScaleCols = llvm::alignTo(scaleCols, int64_t{4});
+  if (numel != rows * paddedScaleCols)
+    return failure();
+  return sliceScale(scale, {1, rows, paddedScaleCols});
 }
 
 struct ZeroInsertionResult {
@@ -2940,6 +3042,172 @@ public:
     return rewriteScaledMmToMatMulOp(
         op, lhs, rhs, scaleA, scaleB, bias, lhsTy, rhsTy, scaleATy, scaleBTy,
         resultTy, *batchedScaleShapes, m, k, n, rewriter, loc);
+  }
+};
+
+class ConvertAtenScaledMmV2Op
+    : public TorchToTosaOpConversionPattern<Aten_ScaledMmV2Op> {
+public:
+  using TorchToTosaOpConversionPattern<
+      Aten_ScaledMmV2Op>::TorchToTosaOpConversionPattern;
+  using OpAdaptor = typename Aten_ScaledMmV2Op::Adaptor;
+
+  LogicalResult
+  matchAndRewriteImpl(Aten_ScaledMmV2Op op, OpAdaptor adaptor,
+                      ConversionPatternRewriter &rewriter) const override {
+    constexpr int64_t kScalingTypeBlockWise1x32 = static_cast<int64_t>(
+        torch_upstream::ScaledMmV2ScalingType::BlockWise1x32);
+    constexpr int64_t kSwizzle32x4x4 = static_cast<int64_t>(
+        torch_upstream::ScaledMmV2SwizzleType::Swizzle32x4x4);
+    constexpr int64_t kTosaBlockScaledMmBlockSize = 32;
+
+    SmallVector<int64_t> contractionDims;
+    if (!matchPattern(op.getContractionDim(),
+                      m_TorchListOfConstantInts(contractionDims)) ||
+        !contractionDims.empty())
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires empty contraction_dim");
+
+    bool useFastAccum = false;
+    if (!matchPattern(op.getUseFastAccum(), m_TorchConstantBool(&useFastAccum)))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires constant use_fast_accum");
+    // TOSA does not expose a separate fast-accumulation mode. Lower both modes
+    // to the same f32-accumulating block-scaled matmul.
+
+    if (!isa<Torch::NoneType>(adaptor.getBias().getType()))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 with bias is not supported");
+
+    FailureOr<int64_t> recipeA = getSingleConstantIntListValue(op.getRecipeA());
+    FailureOr<int64_t> swizzleA =
+        getSingleConstantIntListValue(op.getSwizzleA());
+    FailureOr<int64_t> recipeB = getSingleConstantIntListValue(op.getRecipeB());
+    FailureOr<int64_t> swizzleB =
+        getSingleConstantIntListValue(op.getSwizzleB());
+    if (failed(recipeA) || failed(swizzleA) || failed(recipeB) ||
+        failed(swizzleB))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires constant single-element scale "
+              "recipes and swizzles");
+    if (*recipeA != kScalingTypeBlockWise1x32 ||
+        *recipeB != kScalingTypeBlockWise1x32 || *swizzleA != kSwizzle32x4x4 ||
+        *swizzleB != kSwizzle32x4x4)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 only supports BlockWise1x32 scales with "
+              "SWIZZLE_32_4_4");
+
+    Value lhs = adaptor.getSelf();
+    Value rhs = adaptor.getMat2();
+    auto lhsTy = dyn_cast<RankedTensorType>(lhs.getType());
+    auto rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
+    auto resultTy = dyn_cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getType()));
+    if (!lhsTy || !rhsTy || !resultTy)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires ranked tensor operands and result");
+
+    Type lhsElementTy = lhsTy.getElementType();
+    Type rhsElementTy = rhsTy.getElementType();
+    if (!isSupportedScaledMmV2DataElementType(lhsElementTy) ||
+        !isSupportedScaledMmV2DataElementType(rhsElementTy))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects FP4 input types");
+    if (lhsElementTy != rhsElementTy)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects matching FP4 input types");
+    if (!isSupportedStaticScaledMmResultElementType(resultTy.getElementType()))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects f32, f16 or bf16 result type");
+    if (lhsTy.getRank() != 2 || rhsTy.getRank() != 2 || resultTy.getRank() != 2)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects rank-2 input/result tensors");
+
+    // This lowering materializes TOSA reshape and slice shapes, so keep the
+    // supported MXFP4 path static-only, matching the existing scaled_mm TOSA
+    // lowering. Dtype/rank/metadata checks above do not require static sizes.
+    if (!lhsTy.hasStaticShape() || !rhsTy.hasStaticShape() ||
+        !resultTy.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires static input/result shapes for "
+              "TOSA block-scaled matmul");
+
+    int64_t m = lhsTy.getDimSize(0);
+    int64_t rawK = lhsTy.getDimSize(1);
+    int64_t rhsRawK = rhsTy.getDimSize(0);
+    int64_t n = rhsTy.getDimSize(1);
+    if (rawK != rhsRawK)
+      return rewriter.notifyMatchFailure(
+          op,
+          "aten._scaled_mm_v2 requires matching raw contracting dimensions");
+    // FP4 tensor shapes use the packed/storage contracting dimension. TOSA's
+    // BLOCK_SIZE_32 scales are also indexed over this raw K dimension.
+    if (rawK % kTosaBlockScaledMmBlockSize != 0)
+      return rewriter.notifyMatchFailure(op,
+                                         "aten._scaled_mm_v2 expects raw K to "
+                                         "be divisible by the TOSA block size");
+    if (resultTy.getDimSize(0) != m || resultTy.getDimSize(1) != n)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects result shape [M, N]");
+
+    Location loc = op.getLoc();
+    FailureOr<Value> scaleA = convertSingleTensorListConstructElement(
+        op.getScaleA(), this->getTypeConverter(), rewriter, loc);
+    FailureOr<Value> scaleB = convertSingleTensorListConstructElement(
+        op.getScaleB(), this->getTypeConverter(), rewriter, loc);
+    if (failed(scaleA) || failed(scaleB))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires single tensor scale lists");
+    auto scaleATy = dyn_cast<RankedTensorType>(scaleA->getType());
+    auto scaleBTy = dyn_cast<RankedTensorType>(scaleB->getType());
+    if (!scaleATy || !scaleBTy)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires ranked scale tensors");
+
+    int64_t scaleCols = rawK / kTosaBlockScaledMmBlockSize;
+    FailureOr<Value> scaleABlocked = reshapeScaledMmV2BlockedScaleForTosa(
+        *scaleA, scaleATy, m, scaleCols, rewriter, loc);
+    FailureOr<Value> scaleBBlocked = reshapeScaledMmV2BlockedScaleForTosa(
+        *scaleB, scaleBTy, n, scaleCols, rewriter, loc);
+    if (failed(scaleABlocked) || failed(scaleBBlocked))
+      return rewriter.notifyMatchFailure(
+          op, "failed to reshape aten._scaled_mm_v2 block scales");
+
+    auto lhsBlockedTy = RankedTensorType::get({1, m, rawK}, lhsElementTy);
+    lhs = tosa::ReshapeOp::create(
+              rewriter, loc, lhsBlockedTy, lhs,
+              tosa::getTosaConstShape(rewriter, loc, {1, m, rawK}))
+              .getResult();
+
+    auto rhsTransposedTy = RankedTensorType::get({n, rawK}, rhsElementTy);
+    rhs = tosa::TransposeOp::create(rewriter, loc, rhsTransposedTy, rhs,
+                                    rewriter.getDenseI32ArrayAttr({1, 0}))
+              .getResult();
+    auto rhsBlockedTy = RankedTensorType::get({1, n, rawK}, rhsElementTy);
+    rhs = tosa::ReshapeOp::create(
+              rewriter, loc, rhsBlockedTy, rhs,
+              tosa::getTosaConstShape(rewriter, loc, {1, n, rawK}))
+              .getResult();
+
+    auto matmulTy = RankedTensorType::get({1, m, n}, rewriter.getF32Type());
+    Value matmul = tosa::MatmulTBlockScaledOp::create(
+                       rewriter, loc, matmulTy, lhs, *scaleABlocked, rhs,
+                       *scaleBBlocked, tosa::BlockSize::BLOCK_SIZE_32)
+                       .getResult();
+
+    auto batchedResultTy =
+        RankedTensorType::get({1, m, n}, resultTy.getElementType());
+    Value batchedResult = matmul;
+    if (resultTy.getElementType() != rewriter.getF32Type())
+      batchedResult =
+          tosa::tosaCastTensorToType(rewriter, matmul, batchedResultTy).value();
+
+    Value result =
+        tosa::ReshapeOp::create(rewriter, loc, resultTy, batchedResult,
+                                tosa::getTosaConstShape(rewriter, loc, {m, n}))
+            .getResult();
+    rewriter.replaceOp(op, {result});
+    return success();
   }
 };
 
@@ -11333,6 +11601,10 @@ std::set<StringRef> populateTorchToTosaConversionPatternsAndIllegalOps(
   illegalOps.insert(Aten_ScaledMmOp::getOperationName());
   patterns.addWithLabel<ConvertAtenScaledMmOp<Aten_ScaledMmOp>>(
       Aten_ScaledMmOp::getOperationName(), typeConverter, context);
+
+  illegalOps.insert(Aten_ScaledMmV2Op::getOperationName());
+  patterns.addWithLabel<ConvertAtenScaledMmV2Op>(
+      Aten_ScaledMmV2Op::getOperationName(), typeConverter, context);
 
 #define INSERT_ADAPTIVE_POOLING_ATENOP_PATTERN(AtenOp, TosaOpT)                \
   illegalOps.insert(AtenOp::getOperationName());                               \

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -26,6 +26,7 @@
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
 #include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
@@ -115,8 +116,8 @@ static bool isSupportedStaticScaledMmScaleElementType(Type type) {
   return type.isF32();
 }
 
-static bool isSupportedStaticScaledMmResultElementType(Type type) {
-  return type.isF32() || type.isF16() || type.isBF16();
+static bool isSupportedScaledMmV2DataElementType(Type type) {
+  return isa<Float4E2M1FNType>(type);
 }
 
 static bool isSupportedBlockedScaledMmScaleElementType(Type type) {
@@ -133,6 +134,10 @@ static constexpr int64_t kTosaBlockedScaleSwizzleTileRows = 32;
 static constexpr int64_t kTosaBlockedScaleSwizzleTileCols = 16;
 static constexpr int64_t kTosaBlockedScaleSwizzleTileSize =
     kTosaBlockedScaleSwizzleTileRows * kTosaBlockedScaleSwizzleTileCols;
+
+static bool isSupportedStaticScaledMmResultElementType(Type type) {
+  return type.isF32() || type.isF16() || type.isBF16();
+}
 
 static SmallVector<int64_t> getTensorShape(RankedTensorType tensorTy) {
   return SmallVector<int64_t>(tensorTy.getShape().begin(),
@@ -206,6 +211,255 @@ getStaticScaledMmTensorwiseOrRowwiseBatchedScaleShapes(
     return StaticScaledMmScaleShapes{{1, m, 1}, {1, 1, n}};
 
   return std::nullopt;
+}
+
+static FailureOr<Value> getSingleListConstructElement(Value value) {
+  auto listConstruct = value.getDefiningOp<PrimListConstructOp>();
+  if (!listConstruct || listConstruct.getElements().size() != 1)
+    return failure();
+  return listConstruct.getElements().front();
+}
+
+static FailureOr<Value> convertSingleTensorListConstructElement(
+    Value value, const TypeConverter *converter,
+    ConversionPatternRewriter &rewriter, Location loc) {
+  FailureOr<Value> element = getSingleListConstructElement(value);
+  if (failed(element))
+    return failure();
+
+  auto convertedTy = dyn_cast_or_null<RankedTensorType>(
+      converter->convertType(element->getType()));
+  if (!convertedTy)
+    return failure();
+
+  return TorchConversion::ToBuiltinTensorOp::create(rewriter, loc, convertedTy,
+                                                    *element)
+      .getResult();
+}
+
+static FailureOr<int64_t> getSingleConstantIntListValue(Value value) {
+  SmallVector<int64_t> values;
+  if (!matchPattern(value, m_TorchListOfConstantInts(values)) ||
+      values.size() != 1)
+    return failure();
+  return values.front();
+}
+
+static bool hasPaddedBlockedScaleShape(RankedTensorType scaleTy, int64_t rows,
+                                       int64_t scaleCols) {
+  if (!scaleTy.hasStaticShape())
+    return false;
+
+  int64_t rowBlocks = llvm::divideCeil(rows, kTosaBlockedScaleRowBlock);
+  int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
+  int64_t paddedRows = rowBlocks * kTosaBlockedScaleRowBlock;
+  int64_t paddedCols = colBlocks * kTosaBlockedScaleColBlock;
+
+  if (scaleTy.getRank() == 1)
+    return scaleTy.getDimSize(0) == paddedRows * paddedCols;
+  if (scaleTy.getRank() == 2)
+    return scaleTy.getDimSize(0) == paddedRows &&
+           scaleTy.getDimSize(1) == paddedCols;
+  if (scaleTy.getRank() == 3)
+    return scaleTy.getDimSize(0) == 1 && scaleTy.getDimSize(1) == paddedRows &&
+           scaleTy.getDimSize(2) == paddedCols;
+  return false;
+}
+
+static bool hasSwizzledBlockedScaleShape(RankedTensorType scaleTy, int64_t rows,
+                                         int64_t scaleCols) {
+  if (!scaleTy.hasStaticShape() || scaleTy.getRank() != 2)
+    return false;
+
+  int64_t rowBlocks = llvm::divideCeil(rows, kTosaBlockedScaleRowBlock);
+  int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
+  return scaleTy.getDimSize(0) ==
+             rowBlocks * colBlocks * kTosaBlockedScaleSwizzleTileRows &&
+         scaleTy.getDimSize(1) == kTosaBlockedScaleSwizzleTileCols;
+}
+
+static bool hasScaledMmV2BlockedScaleStorageShape(RankedTensorType scaleTy,
+                                                  int64_t rows,
+                                                  int64_t scaleCols) {
+  return hasPaddedBlockedScaleShape(scaleTy, rows, scaleCols) ||
+         hasSwizzledBlockedScaleShape(scaleTy, rows, scaleCols);
+}
+
+static FailureOr<ArrayRef<char>>
+getDenseElementsRawByteData(ElementsAttr attr) {
+  if (auto denseAttr = dyn_cast<DenseElementsAttr>(attr))
+    return denseAttr.getRawData();
+
+  if (auto resourceAttr = dyn_cast<DenseResourceElementsAttr>(attr)) {
+    auto *blob = resourceAttr.getRawHandle().getBlob();
+    if (!blob)
+      return failure();
+    return blob->getData();
+  }
+
+  return failure();
+}
+
+static FailureOr<ArrayRef<char>> getDenseConstantRawByteData(Value value) {
+  if (auto toBuiltinTensor =
+          value.getDefiningOp<TorchConversion::ToBuiltinTensorOp>())
+    value = toBuiltinTensor.getOperand();
+
+  if (auto constOp = value.getDefiningOp<tosa::ConstOp>())
+    return getDenseElementsRawByteData(constOp.getValues());
+
+  if (auto literalOp = value.getDefiningOp<ValueTensorLiteralOp>())
+    return getDenseElementsRawByteData(literalOp.getValueAttr());
+
+  return failure();
+}
+
+static SmallVector<char> expandRawByteData(ArrayRef<char> rawData,
+                                           int64_t numElements) {
+  if (rawData.size() == 1 && numElements > 1)
+    return SmallVector<char>(numElements, rawData.front());
+  return SmallVector<char>(rawData.begin(), rawData.end());
+}
+
+static FailureOr<SmallVector<char>>
+getDenseConstantRawByteData(Value value, int64_t numElements) {
+  FailureOr<ArrayRef<char>> rawData = getDenseConstantRawByteData(value);
+  if (failed(rawData))
+    return failure();
+  return expandRawByteData(*rawData, numElements);
+}
+
+enum class ScaledMmV2BlockedScaleLayout {
+  Invalid,
+  SwizzledConstant,
+  SwizzledRuntime,
+};
+
+struct ScaledMmV2BlockedScaleClassification {
+  ScaledMmV2BlockedScaleLayout layout = ScaledMmV2BlockedScaleLayout::Invalid;
+  SmallVector<char> rawSwizzledData = {};
+};
+
+static ScaledMmV2BlockedScaleClassification
+classifyScaledMmV2BlockedScale(Value scale, RankedTensorType scaleTy,
+                               int64_t rows, int64_t scaleCols) {
+  if (!scaleTy.hasStaticShape() ||
+      !isSupportedBlockedScaledMmScaleElementType(scaleTy.getElementType()) ||
+      !hasScaledMmV2BlockedScaleStorageShape(scaleTy, rows, scaleCols))
+    return {};
+
+  FailureOr<SmallVector<char>> rawData =
+      getDenseConstantRawByteData(scale, scaleTy.getNumElements());
+  if (failed(rawData))
+    return {ScaledMmV2BlockedScaleLayout::SwizzledRuntime, {}};
+  if (static_cast<int64_t>(rawData->size()) != scaleTy.getNumElements())
+    return {};
+  return {ScaledMmV2BlockedScaleLayout::SwizzledConstant, std::move(*rawData)};
+}
+
+static FailureOr<Value> reorderSwizzledScaledMmV2BlockedScaleConstant(
+    RankedTensorType scaleTy, int64_t rows, int64_t scaleCols,
+    ArrayRef<char> rawData, ConversionPatternRewriter &rewriter, Location loc) {
+  if (static_cast<int64_t>(rawData.size()) != scaleTy.getNumElements())
+    return failure();
+
+  int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
+  SmallVector<char> compactData(rows * scaleCols);
+  for (int64_t row = 0; row < rows; ++row) {
+    int64_t rowBlock = row / kTosaBlockedScaleRowBlock;
+    int64_t rowInBlock = row % kTosaBlockedScaleRowBlock;
+    for (int64_t col = 0; col < scaleCols; ++col) {
+      int64_t colBlock = col / kTosaBlockedScaleColBlock;
+      int64_t colInBlock = col % kTosaBlockedScaleColBlock;
+      int64_t block = rowBlock * colBlocks + colBlock;
+      // Same SWIZZLE_32_4_4 byte mapping used by the merged MXFP8 lowering.
+      int64_t srcIndex = block * kTosaBlockedScaleSwizzleTileSize +
+                         (rowInBlock % kTosaBlockedScaleSwizzleTileRows) *
+                             kTosaBlockedScaleSwizzleTileCols +
+                         (rowInBlock / kTosaBlockedScaleSwizzleTileRows) *
+                             kTosaBlockedScaleColBlock +
+                         colInBlock;
+      compactData[row * scaleCols + col] = rawData[srcIndex];
+    }
+  }
+
+  SmallVector<int64_t> compactShape = {1, rows, scaleCols};
+  auto compactTy =
+      RankedTensorType::get(compactShape, scaleTy.getElementType());
+  auto attr = DenseElementsAttr::getFromRawBuffer(compactTy, compactData);
+  return tosa::ConstOp::create(rewriter, loc, compactTy, attr).getResult();
+}
+
+static FailureOr<Value> reorderSwizzledScaledMmV2BlockedScaleRuntime(
+    Value scale, RankedTensorType scaleTy, int64_t rows, int64_t scaleCols,
+    ConversionPatternRewriter &rewriter, Location loc) {
+  if (!hasScaledMmV2BlockedScaleStorageShape(scaleTy, rows, scaleCols))
+    return failure();
+
+  int64_t rowBlocks = llvm::divideCeil(rows, kTosaBlockedScaleRowBlock);
+  int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
+  int64_t paddedRows = rowBlocks * kTosaBlockedScaleRowBlock;
+  int64_t paddedScaleCols = colBlocks * kTosaBlockedScaleColBlock;
+  int64_t rowGroups =
+      kTosaBlockedScaleRowBlock / kTosaBlockedScaleSwizzleTileRows;
+
+  SmallVector<int64_t> swizzledShape = {rowBlocks, colBlocks,
+                                        kTosaBlockedScaleSwizzleTileRows,
+                                        rowGroups, kTosaBlockedScaleColBlock};
+  auto swizzledTy =
+      RankedTensorType::get(swizzledShape, scaleTy.getElementType());
+  Value swizzled = tosa::ReshapeOp::create(
+                       rewriter, loc, swizzledTy, scale,
+                       tosa::getTosaConstShape(rewriter, loc, swizzledShape))
+                       .getResult();
+
+  SmallVector<int32_t> deswizzlePerm = {0, 3, 2, 1, 4};
+  SmallVector<int64_t> deswizzledShape =
+      permuteShape(swizzledShape, deswizzlePerm);
+  auto deswizzledTy =
+      RankedTensorType::get(deswizzledShape, scaleTy.getElementType());
+  Value deswizzled =
+      tosa::TransposeOp::create(rewriter, loc, deswizzledTy, swizzled,
+                                rewriter.getDenseI32ArrayAttr(deswizzlePerm))
+          .getResult();
+
+  SmallVector<int64_t> paddedShape = {1, paddedRows, paddedScaleCols};
+  auto paddedTy = RankedTensorType::get(paddedShape, scaleTy.getElementType());
+  Value padded = tosa::ReshapeOp::create(
+                     rewriter, loc, paddedTy, deswizzled,
+                     tosa::getTosaConstShape(rewriter, loc, paddedShape))
+                     .getResult();
+
+  SmallVector<int64_t> scaleShape = {1, rows, scaleCols};
+  if (paddedShape == scaleShape)
+    return padded;
+
+  auto scaleResultTy =
+      RankedTensorType::get(scaleShape, scaleTy.getElementType());
+  return tosa::SliceOp::create(
+             rewriter, loc, scaleResultTy, padded,
+             tosa::getTosaConstShape(rewriter, loc, {0, 0, 0}),
+             tosa::getTosaConstShape(rewriter, loc, scaleShape))
+      .getResult();
+}
+
+static FailureOr<Value>
+getScaledMmV2BlockedScale(Value scale, RankedTensorType scaleTy, int64_t rows,
+                          int64_t scaleCols,
+                          ScaledMmV2BlockedScaleClassification classification,
+                          ConversionPatternRewriter &rewriter, Location loc) {
+  switch (classification.layout) {
+  case ScaledMmV2BlockedScaleLayout::SwizzledConstant:
+    return reorderSwizzledScaledMmV2BlockedScaleConstant(
+        scaleTy, rows, scaleCols, classification.rawSwizzledData, rewriter,
+        loc);
+  case ScaledMmV2BlockedScaleLayout::SwizzledRuntime:
+    return reorderSwizzledScaledMmV2BlockedScaleRuntime(
+        scale, scaleTy, rows, scaleCols, rewriter, loc);
+  case ScaledMmV2BlockedScaleLayout::Invalid:
+    return failure();
+  }
+  llvm_unreachable("unhandled scaled_mm_v2 blocked scale layout");
 }
 
 struct ZeroInsertionResult {
@@ -397,40 +651,6 @@ reshapeFlatBlockedScale(Value scale, RankedTensorType scaleTy, int64_t rows,
       .getResult();
 }
 
-static FailureOr<ArrayRef<char>> getDenseConstantRawByteData(Value value) {
-  auto constOp = value.getDefiningOp<tosa::ConstOp>();
-  if (!constOp)
-    return failure();
-
-  ElementsAttr attr = constOp.getValues();
-  if (auto denseAttr = dyn_cast<DenseElementsAttr>(attr))
-    return denseAttr.getRawData();
-
-  if (auto resourceAttr = dyn_cast<DenseResourceElementsAttr>(attr)) {
-    auto *blob = resourceAttr.getRawHandle().getBlob();
-    if (!blob)
-      return failure();
-    return blob->getData();
-  }
-
-  return failure();
-}
-
-static SmallVector<char> expandRawByteData(ArrayRef<char> rawData,
-                                           int64_t numElements) {
-  if (rawData.size() == 1 && numElements > 1)
-    return SmallVector<char>(numElements, rawData.front());
-  return SmallVector<char>(rawData.begin(), rawData.end());
-}
-
-static FailureOr<SmallVector<char>>
-getDenseConstantRawByteData(Value value, int64_t numElements) {
-  FailureOr<ArrayRef<char>> rawData = getDenseConstantRawByteData(value);
-  if (failed(rawData))
-    return failure();
-  return expandRawByteData(*rawData, numElements);
-}
-
 // PyTorch accepts blocked scales in two encodings:
 //   FlatPadded: a runtime value already padded to ceil(rows, 128) x
 //     ceil(K / 32, 4), either rank-2 or flattened. Lowering reshapes it and
@@ -472,18 +692,6 @@ static BlockedScaleLayout classifyFlatBlockedScale(RankedTensorType scaleTy,
   return scaleTy.getDimSize(0) == paddedRows * paddedCols
              ? BlockedScaleLayout::FlatPadded
              : BlockedScaleLayout::Invalid;
-}
-
-static bool hasSwizzledBlockedScaleShape(RankedTensorType scaleTy, int64_t rows,
-                                         int64_t scaleCols) {
-  if (!scaleTy.hasStaticShape() || scaleTy.getRank() != 2)
-    return false;
-
-  int64_t rowBlocks = llvm::divideCeil(rows, kTosaBlockedScaleRowBlock);
-  int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
-  return scaleTy.getDimSize(0) ==
-             rowBlocks * colBlocks * kTosaBlockedScaleSwizzleTileRows &&
-         scaleTy.getDimSize(1) == kTosaBlockedScaleSwizzleTileCols;
 }
 
 static FailureOr<SmallVector<char>>
@@ -3329,6 +3537,178 @@ public:
     return rewriteBlockedScaledMmToMatmulTBlockScaledOp(
         op, lhs, rhs, scaleA, scaleB, bias, lhsTy, rhsTy, scaleATy, scaleBTy,
         resultTy, rewriter, loc);
+  }
+};
+
+class ConvertAtenScaledMmV2Op
+    : public TorchToTosaOpConversionPattern<Aten_ScaledMmV2Op> {
+public:
+  using TorchToTosaOpConversionPattern<
+      Aten_ScaledMmV2Op>::TorchToTosaOpConversionPattern;
+  using OpAdaptor = typename Aten_ScaledMmV2Op::Adaptor;
+
+  LogicalResult
+  matchAndRewriteImpl(Aten_ScaledMmV2Op op, OpAdaptor adaptor,
+                      ConversionPatternRewriter &rewriter) const override {
+    constexpr int64_t kScalingTypeBlockWise1x32 = static_cast<int64_t>(
+        torch_upstream::ScaledMmV2ScalingType::BlockWise1x32);
+    constexpr int64_t kSwizzle32x4x4 = static_cast<int64_t>(
+        torch_upstream::ScaledMmV2SwizzleType::Swizzle32x4x4);
+    constexpr int64_t kTosaBlockScaledMmBlockSize = 32;
+
+    SmallVector<int64_t> contractionDims;
+    if (!matchPattern(op.getContractionDim(),
+                      m_TorchListOfConstantInts(contractionDims)) ||
+        !contractionDims.empty())
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires empty contraction_dim");
+
+    // TOSA does not expose a separate fast-accumulation mode. Intentionally
+    // ignore this operand and lower both PyTorch modes to the same sequence.
+    (void)op.getUseFastAccum();
+
+    if (!isa<Torch::NoneType>(adaptor.getBias().getType()))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 with bias is not supported");
+
+    FailureOr<int64_t> recipeA = getSingleConstantIntListValue(op.getRecipeA());
+    FailureOr<int64_t> swizzleA =
+        getSingleConstantIntListValue(op.getSwizzleA());
+    FailureOr<int64_t> recipeB = getSingleConstantIntListValue(op.getRecipeB());
+    FailureOr<int64_t> swizzleB =
+        getSingleConstantIntListValue(op.getSwizzleB());
+    if (failed(recipeA) || failed(swizzleA) || failed(recipeB) ||
+        failed(swizzleB))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires constant single-element scale "
+              "recipes and swizzles");
+    if (*recipeA != kScalingTypeBlockWise1x32 ||
+        *recipeB != kScalingTypeBlockWise1x32 || *swizzleA != kSwizzle32x4x4 ||
+        *swizzleB != kSwizzle32x4x4)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 only supports BlockWise1x32 scales with "
+              "SWIZZLE_32_4_4");
+
+    Value lhs = adaptor.getSelf();
+    Value rhs = adaptor.getMat2();
+    auto lhsTy = dyn_cast<RankedTensorType>(lhs.getType());
+    auto rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
+    auto resultTy = dyn_cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getType()));
+    if (!lhsTy || !rhsTy || !resultTy)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires ranked tensor operands and result");
+
+    Type lhsElementTy = lhsTy.getElementType();
+    Type rhsElementTy = rhsTy.getElementType();
+    if (!isSupportedScaledMmV2DataElementType(lhsElementTy) ||
+        !isSupportedScaledMmV2DataElementType(rhsElementTy))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects FP4 input types");
+    if (lhsElementTy != rhsElementTy)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects matching FP4 input types");
+    if (!isSupportedStaticScaledMmResultElementType(resultTy.getElementType()))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects f32, f16 or bf16 result type");
+    if (lhsTy.getRank() != 2 || rhsTy.getRank() != 2 || resultTy.getRank() != 2)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects rank-2 input/result tensors");
+
+    // This lowering materializes TOSA reshape and slice shapes, so keep the
+    // supported MXFP4 path static-only, matching the existing scaled_mm TOSA
+    // lowering. Dtype/rank/metadata checks above do not require static sizes.
+    if (!lhsTy.hasStaticShape() || !rhsTy.hasStaticShape() ||
+        !resultTy.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires static input/result shapes for "
+              "TOSA block-scaled matmul");
+
+    int64_t m = lhsTy.getDimSize(0);
+    int64_t rawK = lhsTy.getDimSize(1);
+    int64_t rhsRawK = rhsTy.getDimSize(0);
+    int64_t n = rhsTy.getDimSize(1);
+    if (rawK != rhsRawK)
+      return rewriter.notifyMatchFailure(
+          op,
+          "aten._scaled_mm_v2 requires matching raw contracting dimensions");
+    // FP4 tensor shapes use the packed/storage contracting dimension. TOSA's
+    // BLOCK_SIZE_32 scales are also indexed over this raw K dimension.
+    if (rawK % kTosaBlockScaledMmBlockSize != 0)
+      return rewriter.notifyMatchFailure(op,
+                                         "aten._scaled_mm_v2 expects raw K to "
+                                         "be divisible by the TOSA block size");
+    if (resultTy.getDimSize(0) != m || resultTy.getDimSize(1) != n)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects result shape [M, N]");
+
+    Location loc = op.getLoc();
+    FailureOr<Value> scaleA = convertSingleTensorListConstructElement(
+        op.getScaleA(), this->getTypeConverter(), rewriter, loc);
+    FailureOr<Value> scaleB = convertSingleTensorListConstructElement(
+        op.getScaleB(), this->getTypeConverter(), rewriter, loc);
+    if (failed(scaleA) || failed(scaleB))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires single tensor scale lists");
+    auto scaleATy = dyn_cast<RankedTensorType>(scaleA->getType());
+    auto scaleBTy = dyn_cast<RankedTensorType>(scaleB->getType());
+    if (!scaleATy || !scaleBTy)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires ranked scale tensors");
+
+    int64_t scaleCols = rawK / kTosaBlockScaledMmBlockSize;
+    ScaledMmV2BlockedScaleClassification scaleAClassification =
+        classifyScaledMmV2BlockedScale(*scaleA, scaleATy, m, scaleCols);
+    ScaledMmV2BlockedScaleClassification scaleBClassification =
+        classifyScaledMmV2BlockedScale(*scaleB, scaleBTy, n, scaleCols);
+    if (scaleAClassification.layout == ScaledMmV2BlockedScaleLayout::Invalid ||
+        scaleBClassification.layout == ScaledMmV2BlockedScaleLayout::Invalid)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects SWIZZLE_32_4_4 block scale storage");
+
+    FailureOr<Value> scaleABlocked = getScaledMmV2BlockedScale(
+        *scaleA, scaleATy, m, scaleCols, scaleAClassification, rewriter, loc);
+    FailureOr<Value> scaleBBlocked = getScaledMmV2BlockedScale(
+        *scaleB, scaleBTy, n, scaleCols, scaleBClassification, rewriter, loc);
+    if (failed(scaleABlocked) || failed(scaleBBlocked))
+      return rewriter.notifyMatchFailure(
+          op, "failed to reorder aten._scaled_mm_v2 block scales");
+
+    auto lhsBlockedTy = RankedTensorType::get({1, m, rawK}, lhsElementTy);
+    lhs = tosa::ReshapeOp::create(
+              rewriter, loc, lhsBlockedTy, lhs,
+              tosa::getTosaConstShape(rewriter, loc, {1, m, rawK}))
+              .getResult();
+
+    auto rhsTransposedTy = RankedTensorType::get({n, rawK}, rhsElementTy);
+    rhs = tosa::TransposeOp::create(rewriter, loc, rhsTransposedTy, rhs,
+                                    rewriter.getDenseI32ArrayAttr({1, 0}))
+              .getResult();
+    auto rhsBlockedTy = RankedTensorType::get({1, n, rawK}, rhsElementTy);
+    rhs = tosa::ReshapeOp::create(
+              rewriter, loc, rhsBlockedTy, rhs,
+              tosa::getTosaConstShape(rewriter, loc, {1, n, rawK}))
+              .getResult();
+
+    auto matmulTy = RankedTensorType::get({1, m, n}, rewriter.getF32Type());
+    Value matmul = tosa::MatmulTBlockScaledOp::create(
+                       rewriter, loc, matmulTy, lhs, *scaleABlocked, rhs,
+                       *scaleBBlocked, tosa::BlockSize::BLOCK_SIZE_32)
+                       .getResult();
+
+    auto batchedResultTy =
+        RankedTensorType::get({1, m, n}, resultTy.getElementType());
+    Value batchedResult = matmul;
+    if (resultTy.getElementType() != rewriter.getF32Type())
+      batchedResult =
+          tosa::tosaCastTensorToType(rewriter, matmul, batchedResultTy).value();
+
+    Value result =
+        tosa::ReshapeOp::create(rewriter, loc, resultTy, batchedResult,
+                                tosa::getTosaConstShape(rewriter, loc, {m, n}))
+            .getResult();
+    rewriter.replaceOp(op, {result});
+    return success();
   }
 };
 
@@ -11746,6 +12126,10 @@ std::set<StringRef> populateTorchToTosaConversionPatternsAndIllegalOps(
   illegalOps.insert(Aten_ScaledMmOp::getOperationName());
   patterns.addWithLabel<ConvertAtenScaledMmOp<Aten_ScaledMmOp>>(
       Aten_ScaledMmOp::getOperationName(), typeConverter, context);
+
+  illegalOps.insert(Aten_ScaledMmV2Op::getOperationName());
+  patterns.addWithLabel<ConvertAtenScaledMmV2Op>(
+      Aten_ScaledMmV2Op::getOperationName(), typeConverter, context);
 
 #define INSERT_ADAPTIVE_POOLING_ATENOP_PATTERN(AtenOp, TosaOpT)                \
   illegalOps.insert(AtenOp::getOperationName());                               \

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -6576,23 +6576,6 @@ static LogicalResult getConstantIntList(Value value,
   return success();
 }
 
-// Mirrors PyTorch ScalingType and SwizzleType enum values used by
-// aten._scaled_mm_v2 metadata.
-// https://github.com/pytorch/pytorch/blob/449aa5b695056c4c14c3134909de5ad1a3078cc8/aten/src/ATen/BlasBackend.h#L34-L43
-enum class ScaledMmV2ScalingType : int64_t {
-  TensorWise = 0,
-  RowWise = 1,
-  BlockWise1x16 = 2,
-  BlockWise1x32 = 3,
-  BlockWise1x128 = 4,
-  BlockWise128x128 = 5,
-};
-
-enum class ScaledMmV2SwizzleType : int64_t {
-  NoSwizzle = 0,
-  Swizzle32x4x4 = 1,
-};
-
 enum class ScaledMmV2RecipeMode {
   Unknown,
   Tensorwise,
@@ -6629,11 +6612,13 @@ struct ScaledMmV2MatrixInfo {
   int64_t logicalK = kUnknownSize;
 };
 
-static bool isScaledMmV2Recipe(int64_t recipe, ScaledMmV2ScalingType type) {
+static bool isScaledMmV2Recipe(int64_t recipe,
+                               torch_upstream::ScaledMmV2ScalingType type) {
   return recipe == static_cast<int64_t>(type);
 }
 
-static bool isScaledMmV2Swizzle(int64_t swizzle, ScaledMmV2SwizzleType type) {
+static bool isScaledMmV2Swizzle(int64_t swizzle,
+                                torch_upstream::ScaledMmV2SwizzleType type) {
   return swizzle == static_cast<int64_t>(type);
 }
 
@@ -6796,12 +6781,16 @@ classifyScaledMmV2RecipeMode(Aten_ScaledMmV2Op op,
   ArrayRef<int64_t> recipeBValues = recipeInfo.recipeBValues;
 
   if (recipeAValues.size() == 2 && recipeBValues.size() == 2 &&
-      isScaledMmV2Recipe(recipeAValues[0],
-                         ScaledMmV2ScalingType::BlockWise1x16) &&
-      isScaledMmV2Recipe(recipeBValues[0],
-                         ScaledMmV2ScalingType::BlockWise1x16) &&
-      isScaledMmV2Recipe(recipeAValues[1], ScaledMmV2ScalingType::TensorWise) &&
-      isScaledMmV2Recipe(recipeBValues[1], ScaledMmV2ScalingType::TensorWise)) {
+      isScaledMmV2Recipe(
+          recipeAValues[0],
+          torch_upstream::ScaledMmV2ScalingType::BlockWise1x16) &&
+      isScaledMmV2Recipe(
+          recipeBValues[0],
+          torch_upstream::ScaledMmV2ScalingType::BlockWise1x16) &&
+      isScaledMmV2Recipe(recipeAValues[1],
+                         torch_upstream::ScaledMmV2ScalingType::TensorWise) &&
+      isScaledMmV2Recipe(recipeBValues[1],
+                         torch_upstream::ScaledMmV2ScalingType::TensorWise)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::NvTwoLevel;
     return success();
   }
@@ -6813,44 +6802,58 @@ classifyScaledMmV2RecipeMode(Aten_ScaledMmV2Op op,
   int64_t recipeA = recipeAValues[0];
   int64_t recipeB = recipeBValues[0];
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::TensorWise) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::TensorWise)) {
+  if (isScaledMmV2Recipe(recipeA,
+                         torch_upstream::ScaledMmV2ScalingType::TensorWise) &&
+      isScaledMmV2Recipe(recipeB,
+                         torch_upstream::ScaledMmV2ScalingType::TensorWise)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Tensorwise;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::RowWise) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::RowWise)) {
+  if (isScaledMmV2Recipe(recipeA,
+                         torch_upstream::ScaledMmV2ScalingType::RowWise) &&
+      isScaledMmV2Recipe(recipeB,
+                         torch_upstream::ScaledMmV2ScalingType::RowWise)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Rowwise;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise1x16) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise1x16)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise1x16) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise1x16)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::NvSingleLevel;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise1x32) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise1x32)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise1x32) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise1x32)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::MxBlockwise;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise1x128) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise1x128)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise1x128) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise1x128)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Blockwise1x128_1x128;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise1x128) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise128x128)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise1x128) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise128x128)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Blockwise1x128_128x128;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise128x128) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise1x128)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise128x128) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise1x128)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Blockwise128x128_1x128;
     return success();
   }
@@ -6876,10 +6879,12 @@ verifyScaledMmV2Swizzles(Aten_ScaledMmV2Op op,
     return op.emitOpError(
         "expected swizzle_a and swizzle_b to have entries for blockwise "
         "scaling");
-  if (!isScaledMmV2Swizzle(swizzleInfo.swizzleAValues[0],
-                           ScaledMmV2SwizzleType::Swizzle32x4x4) ||
-      !isScaledMmV2Swizzle(swizzleInfo.swizzleBValues[0],
-                           ScaledMmV2SwizzleType::Swizzle32x4x4))
+  if (!isScaledMmV2Swizzle(
+          swizzleInfo.swizzleAValues[0],
+          torch_upstream::ScaledMmV2SwizzleType::Swizzle32x4x4) ||
+      !isScaledMmV2Swizzle(
+          swizzleInfo.swizzleBValues[0],
+          torch_upstream::ScaledMmV2SwizzleType::Swizzle32x4x4))
     return op.emitOpError("expected blockwise swizzle_a and swizzle_b to be "
                           "SWIZZLE_32_4_4");
 

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -6575,23 +6575,6 @@ static LogicalResult getConstantIntList(Value value,
   return success();
 }
 
-// Mirrors PyTorch ScalingType and SwizzleType enum values used by
-// aten._scaled_mm_v2 metadata.
-// https://github.com/pytorch/pytorch/blob/449aa5b695056c4c14c3134909de5ad1a3078cc8/aten/src/ATen/BlasBackend.h#L34-L43
-enum class ScaledMmV2ScalingType : int64_t {
-  TensorWise = 0,
-  RowWise = 1,
-  BlockWise1x16 = 2,
-  BlockWise1x32 = 3,
-  BlockWise1x128 = 4,
-  BlockWise128x128 = 5,
-};
-
-enum class ScaledMmV2SwizzleType : int64_t {
-  NoSwizzle = 0,
-  Swizzle32x4x4 = 1,
-};
-
 enum class ScaledMmV2RecipeMode {
   Unknown,
   Tensorwise,
@@ -6628,11 +6611,13 @@ struct ScaledMmV2MatrixInfo {
   int64_t logicalK = kUnknownSize;
 };
 
-static bool isScaledMmV2Recipe(int64_t recipe, ScaledMmV2ScalingType type) {
+static bool isScaledMmV2Recipe(int64_t recipe,
+                               torch_upstream::ScaledMmV2ScalingType type) {
   return recipe == static_cast<int64_t>(type);
 }
 
-static bool isScaledMmV2Swizzle(int64_t swizzle, ScaledMmV2SwizzleType type) {
+static bool isScaledMmV2Swizzle(int64_t swizzle,
+                                torch_upstream::ScaledMmV2SwizzleType type) {
   return swizzle == static_cast<int64_t>(type);
 }
 
@@ -6795,12 +6780,16 @@ classifyScaledMmV2RecipeMode(Aten_ScaledMmV2Op op,
   ArrayRef<int64_t> recipeBValues = recipeInfo.recipeBValues;
 
   if (recipeAValues.size() == 2 && recipeBValues.size() == 2 &&
-      isScaledMmV2Recipe(recipeAValues[0],
-                         ScaledMmV2ScalingType::BlockWise1x16) &&
-      isScaledMmV2Recipe(recipeBValues[0],
-                         ScaledMmV2ScalingType::BlockWise1x16) &&
-      isScaledMmV2Recipe(recipeAValues[1], ScaledMmV2ScalingType::TensorWise) &&
-      isScaledMmV2Recipe(recipeBValues[1], ScaledMmV2ScalingType::TensorWise)) {
+      isScaledMmV2Recipe(
+          recipeAValues[0],
+          torch_upstream::ScaledMmV2ScalingType::BlockWise1x16) &&
+      isScaledMmV2Recipe(
+          recipeBValues[0],
+          torch_upstream::ScaledMmV2ScalingType::BlockWise1x16) &&
+      isScaledMmV2Recipe(recipeAValues[1],
+                         torch_upstream::ScaledMmV2ScalingType::TensorWise) &&
+      isScaledMmV2Recipe(recipeBValues[1],
+                         torch_upstream::ScaledMmV2ScalingType::TensorWise)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::NvTwoLevel;
     return success();
   }
@@ -6812,44 +6801,58 @@ classifyScaledMmV2RecipeMode(Aten_ScaledMmV2Op op,
   int64_t recipeA = recipeAValues[0];
   int64_t recipeB = recipeBValues[0];
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::TensorWise) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::TensorWise)) {
+  if (isScaledMmV2Recipe(recipeA,
+                         torch_upstream::ScaledMmV2ScalingType::TensorWise) &&
+      isScaledMmV2Recipe(recipeB,
+                         torch_upstream::ScaledMmV2ScalingType::TensorWise)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Tensorwise;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::RowWise) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::RowWise)) {
+  if (isScaledMmV2Recipe(recipeA,
+                         torch_upstream::ScaledMmV2ScalingType::RowWise) &&
+      isScaledMmV2Recipe(recipeB,
+                         torch_upstream::ScaledMmV2ScalingType::RowWise)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Rowwise;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise1x16) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise1x16)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise1x16) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise1x16)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::NvSingleLevel;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise1x32) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise1x32)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise1x32) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise1x32)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::MxBlockwise;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise1x128) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise1x128)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise1x128) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise1x128)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Blockwise1x128_1x128;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise1x128) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise128x128)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise1x128) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise128x128)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Blockwise1x128_128x128;
     return success();
   }
 
-  if (isScaledMmV2Recipe(recipeA, ScaledMmV2ScalingType::BlockWise128x128) &&
-      isScaledMmV2Recipe(recipeB, ScaledMmV2ScalingType::BlockWise1x128)) {
+  if (isScaledMmV2Recipe(
+          recipeA, torch_upstream::ScaledMmV2ScalingType::BlockWise128x128) &&
+      isScaledMmV2Recipe(
+          recipeB, torch_upstream::ScaledMmV2ScalingType::BlockWise1x128)) {
     recipeInfo.mode = ScaledMmV2RecipeMode::Blockwise128x128_1x128;
     return success();
   }
@@ -6875,10 +6878,12 @@ verifyScaledMmV2Swizzles(Aten_ScaledMmV2Op op,
     return op.emitOpError(
         "expected swizzle_a and swizzle_b to have entries for blockwise "
         "scaling");
-  if (!isScaledMmV2Swizzle(swizzleInfo.swizzleAValues[0],
-                           ScaledMmV2SwizzleType::Swizzle32x4x4) ||
-      !isScaledMmV2Swizzle(swizzleInfo.swizzleBValues[0],
-                           ScaledMmV2SwizzleType::Swizzle32x4x4))
+  if (!isScaledMmV2Swizzle(
+          swizzleInfo.swizzleAValues[0],
+          torch_upstream::ScaledMmV2SwizzleType::Swizzle32x4x4) ||
+      !isScaledMmV2Swizzle(
+          swizzleInfo.swizzleBValues[0],
+          torch_upstream::ScaledMmV2SwizzleType::Swizzle32x4x4))
     return op.emitOpError("expected blockwise swizzle_a and swizzle_b to be "
                           "SWIZZLE_32_4_4");
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -430,6 +430,7 @@ FX_IMPORTER_XFAIL_SET = {
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
     "AtenScaledMmPerTensorModule_basic",
+    "AtenScaledMmV2BlockwiseMxFP4Module_basic",
     "Aten_TrilinearModuleVaryingRanks_basic",
     "Aten_TrilinearModuleZerodDimBug_basic",
     "QuantizedReluInt32_basic",
@@ -667,6 +668,7 @@ FX_IMPORTER_STABLEHLO_XFAIL_SET = {
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
     "AtenScaledMmPerTensorModule_basic",
+    "AtenScaledMmV2BlockwiseMxFP4Module_basic",
     "AtenStftCenter1D_basic",
     "AtenStftCenter1DUnkSigLen_basic",
     "AtenStftCenter2D_basic",
@@ -2927,6 +2929,7 @@ ONNX_XFAIL_SET = {
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
     "AtenScaledMmPerTensorModule_basic",
+    "AtenScaledMmV2BlockwiseMxFP4Module_basic",
     "AtenOuterF32F64_basic",
     "AtenPolarFloatModule_basic",
     "AtenPolarDoubleModule_basic",
@@ -3653,11 +3656,13 @@ FX_IMPORTER_TOSA_XFAIL_SET = {
     "AtenSymConstrainRange_basic",
     "Aten_AssertScalar_basic",
     # These import through FX and lower to TOSA, but the TOSA execution backend
-    # cannot currently load FP8 tensor element types in the lowered matmul path.
+    # cannot currently load FP8/FP4 tensor element types in the lowered matmul
+    # path.
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
     "AtenScaledMmPerTensorModule_basic",
+    "AtenScaledMmV2BlockwiseMxFP4Module_basic",
     "ScatterAddDynamicModule_basic",
     "UniformModule_basic",
     "UniformStaticShapeModule_basic",

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -427,6 +427,9 @@ FX_IMPORTER_XFAIL_SET = {
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
     "AtenScaledMmPerTensorModule_basic",
+    # The generic FX importer path has no executable backend path for
+    # blockwise MXFP4 _scaled_mm_v2 with FP4 shell tensor inputs yet.
+    "AtenScaledMmV2BlockwiseMxFP4Module_basic",
     "Aten_TrilinearModuleZerodDimBug_basic",
     "QuantizedReluInt32_basic",
     "QuantizedReluInt8_basic",
@@ -659,6 +662,9 @@ FX_IMPORTER_STABLEHLO_XFAIL_SET = {
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
     "AtenScaledMmPerTensorModule_basic",
+    # StableHLO does not have a lowering for blockwise MXFP4 _scaled_mm_v2
+    # with FP4 shell tensor inputs and E8M0 block scales yet.
+    "AtenScaledMmV2BlockwiseMxFP4Module_basic",
     "AtenStftCenter1D_basic",
     "AtenStftCenter1DUnkSigLen_basic",
     "AtenStftCenter2D_basic",
@@ -2969,6 +2975,9 @@ ONNX_XFAIL_SET = {
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
     "AtenScaledMmPerTensorModule_basic",
+    # The ONNX exporter/importer path cannot represent blockwise MXFP4
+    # _scaled_mm_v2 with FP4 shell tensor inputs and E8M0 block scales yet.
+    "AtenScaledMmV2BlockwiseMxFP4Module_basic",
     "AtenPolarFloatModule_basic",
     "AtenPolarDoubleModule_basic",
     "AtenSubFloatModule_basic",
@@ -3431,16 +3440,18 @@ FX_IMPORTER_TOSA_XFAIL_SET = {
     "AtenSymConstrainRange_basic",
     "Aten_AssertScalar_basic",
     # These import through FX and lower to TOSA. To enable them end-to-end, the
-    # TOSA execution backend needs support for loading the FP8 input tensors and
-    # float8_e8m0fnu blocked-scale tensors used by matmul_t_block_scaled. The
-    # e2e framework also needs a non-CPU reference path because PyTorch CPU does
-    # not execute blocked-scale _scaled_mm.
+    # TOSA execution backend needs support for loading/executing the FP8 inputs
+    # used by _scaled_mm, and the FP4 inputs plus E8M0 block scales used by
+    # blockwise MXFP4 _scaled_mm_v2 in matmul_t_block_scaled. The e2e framework
+    # also needs a non-CPU reference path because PyTorch CPU does not execute
+    # blocked-scale _scaled_mm.
     "AtenScaledMmBlockScaledFp8Module_basic",
     "AtenScaledMmBlockScaledFp8SwizzledModule_basic",
     "AtenScaledMmPerTensorE5M2Module_basic",
     "AtenScaledMmPerTensorF16Module_basic",
     "AtenScaledMmPerTensorF32Module_basic",
     "AtenScaledMmPerTensorModule_basic",
+    "AtenScaledMmV2BlockwiseMxFP4Module_basic",
     "ScatterAddDynamicModule_basic",
     "UniformModule_basic",
     "UniformStaticShapeModule_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -4,10 +4,22 @@
 # Also available under a BSD-style license. See LICENSE.
 
 import torch
+import torch.nn.functional as F
 
 from torch_mlir_e2e_test.annotations import annotate_args, export
 from torch_mlir_e2e_test.framework import TestUtils
 from torch_mlir_e2e_test.registry import register_test_case
+
+
+def make_fp4_tensor(shape, stride=None):
+    if stride is None:
+        tensor = torch.empty(shape, dtype=torch.float4_e2m1fn_x2)
+    else:
+        tensor = torch.empty_strided(shape, stride, dtype=torch.float4_e2m1fn_x2)
+    # PyTorch's FP4 shell dtype does not implement fill_ directly.
+    tensor.view(torch.uint8).fill_(1)
+    return tensor
+
 
 # ==============================================================================
 
@@ -157,6 +169,46 @@ def AtenScaledMmPerTensorF32Module_basic(module, tu: TestUtils):
 )
 def AtenScaledMmPerTensorE5M2Module_basic(module, tu: TestUtils):
     module.forward(tu.rand(16, 16), tu.rand(16, 16), tu.rand(), tu.rand())
+
+
+class AtenScaledMmV2BlockwiseMxFP4Module(torch.nn.Module):
+    def __init__(self, out_dtype=torch.bfloat16):
+        super().__init__()
+        self.out_dtype = out_dtype
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([128, 64], torch.float4_e2m1fn_x2, True),
+            ([64, 128], torch.float4_e2m1fn_x2, True),
+            ([512], torch.float8_e8m0fnu, True),
+            ([512], torch.float8_e8m0fnu, True),
+        ]
+    )
+    def forward(self, lhs, rhs, scale_lhs, scale_rhs):
+        return F.scaled_mm(
+            lhs,
+            rhs,
+            scale_a=[scale_lhs],
+            scale_recipe_a=[F.ScalingType.BlockWise1x32],
+            swizzle_a=[F.SwizzleType.SWIZZLE_32_4_4],
+            scale_b=[scale_rhs],
+            scale_recipe_b=[F.ScalingType.BlockWise1x32],
+            swizzle_b=[F.SwizzleType.SWIZZLE_32_4_4],
+            bias=None,
+            output_dtype=self.out_dtype,
+        )
+
+
+@register_test_case(module_factory=lambda: AtenScaledMmV2BlockwiseMxFP4Module())
+def AtenScaledMmV2BlockwiseMxFP4Module_basic(module, tu: TestUtils):
+    module.forward(
+        make_fp4_tensor((128, 64)),
+        make_fp4_tensor((64, 128), stride=(1, 64)),
+        torch.zeros((512,), dtype=torch.float8_e8m0fnu),
+        torch.zeros((512,), dtype=torch.float8_e8m0fnu),
+    )
 
 
 # ==============================================================================

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -5424,6 +5424,239 @@ module {
 }
 
 // -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_flat_scales(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[128,64],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[64,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[512],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-DAG:       %[[LHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[128,64],f4E2M1FN> -> tensor<128x64xf4E2M1FN>
+// CHECK-DAG:       %[[RHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG1]] : !torch.vtensor<[64,128],f4E2M1FN> -> tensor<64x128xf4E2M1FN>
+// CHECK-DAG:       %[[SCALE_A_IN:.*]] = torch_c.to_builtin_tensor %[[ARG2]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B_IN:.*]] = torch_c.to_builtin_tensor %[[ARG3]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_PADDED:.*]] = tosa.reshape %[[SCALE_A_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A:.*]] = tosa.slice %[[SCALE_A_PADDED]]
+// CHECK-SAME:        -> tensor<1x128x2xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_PADDED:.*]] = tosa.reshape %[[SCALE_B_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B:.*]] = tosa.slice %[[SCALE_B_PADDED]]
+// CHECK-SAME:        -> tensor<1x128x2xf8E8M0FNU>
+// CHECK:           %[[LHS:.*]] = tosa.reshape %[[LHS_IN]], %{{.*}} : (tensor<128x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x64xf4E2M1FN>
+// CHECK:           %[[RHS_T:.*]] = tosa.transpose %[[RHS_IN]] {perms = array<i32: 1, 0>} : (tensor<64x128xf4E2M1FN>) -> tensor<128x64xf4E2M1FN>
+// CHECK:           %[[RHS:.*]] = tosa.reshape %[[RHS_T]], %{{.*}} : (tensor<128x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x64xf4E2M1FN>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A]], %[[RHS]], %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x128x64xf4E2M1FN>, tensor<1x128x2xf8E8M0FNU>, tensor<1x128x64xf4E2M1FN>, tensor<1x128x2xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[MATMUL]] : (tensor<1x128x128xf32>) -> tensor<1x128x128xbf16>
+// CHECK:           %[[RESHAPED:.*]] = tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x128x128xbf16>, !tosa.shape<2>) -> tensor<128x128xbf16>
+// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[RESHAPED]] : tensor<128x128xbf16> -> !torch.vtensor<[128,128],bf16>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[128,128],bf16>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_flat_scales(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank3_scales_f32(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[128,64],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[64,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[1,128,4],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],f32> {
+// CHECK-DAG:       %[[LHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[128,64],f4E2M1FN> -> tensor<128x64xf4E2M1FN>
+// CHECK-DAG:       %[[RHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG1]] : !torch.vtensor<[64,128],f4E2M1FN> -> tensor<64x128xf4E2M1FN>
+// CHECK-DAG:       %[[SCALE_A_IN:.*]] = torch_c.to_builtin_tensor %[[ARG2]] : !torch.vtensor<[1,128,4],f8E8M0FNU> -> tensor<1x128x4xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B_IN:.*]] = torch_c.to_builtin_tensor %[[ARG3]] : !torch.vtensor<[1,128,4],f8E8M0FNU> -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_PADDED:.*]] = tosa.reshape %[[SCALE_A_IN]], %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A:.*]] = tosa.slice %[[SCALE_A_PADDED]]
+// CHECK-SAME:        -> tensor<1x128x2xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_PADDED:.*]] = tosa.reshape %[[SCALE_B_IN]], %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B:.*]] = tosa.slice %[[SCALE_B_PADDED]]
+// CHECK-SAME:        -> tensor<1x128x2xf8E8M0FNU>
+// CHECK:           %[[LHS:.*]] = tosa.reshape %[[LHS_IN]], %{{.*}} : (tensor<128x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x64xf4E2M1FN>
+// CHECK:           %[[RHS_T:.*]] = tosa.transpose %[[RHS_IN]] {perms = array<i32: 1, 0>} : (tensor<64x128xf4E2M1FN>) -> tensor<128x64xf4E2M1FN>
+// CHECK:           %[[RHS:.*]] = tosa.reshape %[[RHS_T]], %{{.*}} : (tensor<128x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x64xf4E2M1FN>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A]], %[[RHS]], %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x128x64xf4E2M1FN>, tensor<1x128x2xf8E8M0FNU>, tensor<1x128x64xf4E2M1FN>, tensor<1x128x2xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK-NOT:       tosa.cast %[[MATMUL]]
+// CHECK:           %[[RESHAPED:.*]] = tosa.reshape %[[MATMUL]], %{{.*}} : (tensor<1x128x128xf32>, !tosa.shape<2>) -> tensor<128x128xf32>
+// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[RESHAPED]] : tensor<128x128xf32> -> !torch.vtensor<[128,128],f32>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[128,128],f32>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank3_scales_f32(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[1,128,4],f8E8M0FNU>, %arg3: !torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],f32> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int6 = torch.constant.int 6
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int6, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],f32>
+  return %0 : !torch.vtensor<[128,128],f32>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_raw_k_128_fast_accum(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[512],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-DAG:       %[[LHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[128,128],f4E2M1FN> -> tensor<128x128xf4E2M1FN>
+// CHECK-DAG:       %[[RHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG1]] : !torch.vtensor<[128,128],f4E2M1FN> -> tensor<128x128xf4E2M1FN>
+// CHECK-DAG:       %[[SCALE_A_IN:.*]] = torch_c.to_builtin_tensor %[[ARG2]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B_IN:.*]] = torch_c.to_builtin_tensor %[[ARG3]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK:           %[[SCALE_A:.*]] = tosa.reshape %[[SCALE_A_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B:.*]] = tosa.reshape %[[SCALE_B_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK-NOT:       tosa.slice
+// CHECK:           %[[LHS:.*]] = tosa.reshape %[[LHS_IN]], %{{.*}} : (tensor<128x128xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x128xf4E2M1FN>
+// CHECK:           %[[RHS_T:.*]] = tosa.transpose %[[RHS_IN]] {perms = array<i32: 1, 0>} : (tensor<128x128xf4E2M1FN>) -> tensor<128x128xf4E2M1FN>
+// CHECK:           %[[RHS:.*]] = tosa.reshape %[[RHS_T]], %{{.*}} : (tensor<128x128xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x128xf4E2M1FN>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A]], %[[RHS]], %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x128x128xf4E2M1FN>, tensor<1x128x4xf8E8M0FNU>, tensor<1x128x128xf4E2M1FN>, tensor<1x128x4xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[MATMUL]] : (tensor<1x128x128xf32>) -> tensor<1x128x128xbf16>
+// CHECK:           %[[RESHAPED:.*]] = tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x128x128xbf16>, !tosa.shape<2>) -> tensor<128x128xbf16>
+// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[RESHAPED]] : tensor<128x128xbf16> -> !torch.vtensor<[128,128],bf16>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[128,128],bf16>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_raw_k_128_fast_accum(%arg0: !torch.vtensor<[128,128],f4E2M1FN>, %arg1: !torch.vtensor<[128,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %true = torch.constant.bool true
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %true : !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank2_compact_scales(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[128,4],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-DAG:       %[[SCALE_A_IN:.*]] = torch_c.to_builtin_tensor %[[ARG2]] : !torch.vtensor<[128,4],f8E8M0FNU> -> tensor<128x4xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B_IN:.*]] = torch_c.to_builtin_tensor %[[ARG3]] : !torch.vtensor<[128,4],f8E8M0FNU> -> tensor<128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A:.*]] = tosa.reshape %[[SCALE_A_IN]], %{{.*}} : (tensor<128x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B:.*]] = tosa.reshape %[[SCALE_B_IN]], %{{.*}} : (tensor<128x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK-NOT:       tosa.slice
+// CHECK:           tosa.matmul_t_block_scaled %{{.*}}, %[[SCALE_A]], %{{.*}}, %[[SCALE_B]] {block_size = BLOCK_SIZE_32}
+// CHECK:           return
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank2_compact_scales(%arg0: !torch.vtensor<[128,128],f4E2M1FN>, %arg1: !torch.vtensor<[128,128],f4E2M1FN>, %arg2: !torch.vtensor<[128,4],f8E8M0FNU>, %arg3: !torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+module {
+  // MXFP4 with a valid bf16 bias is verifier-valid, but bias lowering for
+  // _scaled_mm_v2 is not supported by this TOSA pattern.
+  func.func @torch.aten._scaled_mm_v2$bias_rejected(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>, %arg4: !torch.vtensor<[128],bf16>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int1 = torch.constant.int 1
+    %int3 = torch.constant.int 3
+    %int15 = torch.constant.int 15
+    %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %arg4, %int15, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.vtensor<[128],bf16>, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // Explicit contraction_dim metadata is verifier-valid, but this TOSA lowering
+  // only supports the default empty contraction_dim.
+  func.func @torch.aten._scaled_mm_v2$explicit_contraction_dim_rejected(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int3 = torch.constant.int 3
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // RowWise is verifier-valid for _scaled_mm_v2, but this TOSA lowering only
+  // supports MXFP4 BlockWise1x32 with SWIZZLE_32_4_4.
+  func.func @torch.aten._scaled_mm_v2$rowwise_rejected(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[128],f32>, %arg3: !torch.vtensor<[128],f32>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[128],f32>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[128],f32>) -> !torch.list<vtensor>
+    %recipe_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // TensorWise FP8 _scaled_mm_v2 is verifier-valid, but this TOSA lowering is
+  // intentionally scoped to matching FP4 MX block-scaled inputs.
+  func.func @torch.aten._scaled_mm_v2$fp8_tensorwise_rejected(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[],f32>, %arg3: !torch.vtensor<[],f32>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[],f32>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[],f32>) -> !torch.list<vtensor>
+    %recipe_b = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
 // CHECK-LABEL:   func.func @torch.aten.matmul$broadcast(
 // CHECK-SAME:      %[[INP:.*]]: !torch.vtensor<[10,3,4],f32>,
 // CHECK-SAME:      %[[WTS:.*]]: !torch.vtensor<[4],f32>) -> !torch.vtensor<[10,3],f32> {

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -5988,6 +5988,354 @@ module {
 }
 
 // -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_flat_scales(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[128,64],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[64,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[512],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-DAG:       %[[LHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[128,64],f4E2M1FN> -> tensor<128x64xf4E2M1FN>
+// CHECK-DAG:       %[[RHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG1]] : !torch.vtensor<[64,128],f4E2M1FN> -> tensor<64x128xf4E2M1FN>
+// CHECK-DAG:       %[[SCALE_A_IN:.*]] = torch_c.to_builtin_tensor %[[ARG2]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B_IN:.*]] = torch_c.to_builtin_tensor %[[ARG3]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_SWIZZLED:.*]] = tosa.reshape %[[SCALE_A_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_A_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_PADDED:.*]] = tosa.reshape %[[SCALE_A_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_SLICE_START:.*]] = tosa.const_shape  {values = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_A_SLICE_SIZE:.*]] = tosa.const_shape  {values = dense<[1, 128, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_A:.*]] = tosa.slice %[[SCALE_A_PADDED]], %[[SCALE_A_SLICE_START]], %[[SCALE_A_SLICE_SIZE]] : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x128x2xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_SWIZZLED:.*]] = tosa.reshape %[[SCALE_B_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_B_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_PADDED:.*]] = tosa.reshape %[[SCALE_B_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_SLICE_START:.*]] = tosa.const_shape  {values = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_B_SLICE_SIZE:.*]] = tosa.const_shape  {values = dense<[1, 128, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_B:.*]] = tosa.slice %[[SCALE_B_PADDED]], %[[SCALE_B_SLICE_START]], %[[SCALE_B_SLICE_SIZE]] : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x128x2xf8E8M0FNU>
+// CHECK:           %[[LHS:.*]] = tosa.reshape %[[LHS_IN]], %{{.*}} : (tensor<128x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x64xf4E2M1FN>
+// CHECK:           %[[RHS_T:.*]] = tosa.transpose %[[RHS_IN]] {perms = array<i32: 1, 0>} : (tensor<64x128xf4E2M1FN>) -> tensor<128x64xf4E2M1FN>
+// CHECK:           %[[RHS:.*]] = tosa.reshape %[[RHS_T]], %{{.*}} : (tensor<128x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x64xf4E2M1FN>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A]], %[[RHS]], %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x128x64xf4E2M1FN>, tensor<1x128x2xf8E8M0FNU>, tensor<1x128x64xf4E2M1FN>, tensor<1x128x2xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[MATMUL]] : (tensor<1x128x128xf32>) -> tensor<1x128x128xbf16>
+// CHECK:           %[[RESHAPED:.*]] = tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x128x128xbf16>, !tosa.shape<2>) -> tensor<128x128xbf16>
+// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[RESHAPED]] : tensor<128x128xbf16> -> !torch.vtensor<[128,128],bf16>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[128,128],bf16>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_flat_scales(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_m64_flat_padded_scales(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[64,64],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[64,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[512],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[64,128],bf16> {
+// CHECK-DAG:       %[[LHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[64,64],f4E2M1FN> -> tensor<64x64xf4E2M1FN>
+// CHECK-DAG:       %[[RHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG1]] : !torch.vtensor<[64,128],f4E2M1FN> -> tensor<64x128xf4E2M1FN>
+// CHECK-DAG:       %[[SCALE_A_IN:.*]] = torch_c.to_builtin_tensor %[[ARG2]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B_IN:.*]] = torch_c.to_builtin_tensor %[[ARG3]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_SWIZZLED:.*]] = tosa.reshape %[[SCALE_A_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_A_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_PADDED:.*]] = tosa.reshape %[[SCALE_A_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_SLICE_START:.*]] = tosa.const_shape  {values = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_A_SLICE_SIZE:.*]] = tosa.const_shape  {values = dense<[1, 64, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_A:.*]] = tosa.slice %[[SCALE_A_PADDED]], %[[SCALE_A_SLICE_START]], %[[SCALE_A_SLICE_SIZE]] : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x64x2xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_SWIZZLED:.*]] = tosa.reshape %[[SCALE_B_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_B_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_PADDED:.*]] = tosa.reshape %[[SCALE_B_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_SLICE_START:.*]] = tosa.const_shape  {values = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_B_SLICE_SIZE:.*]] = tosa.const_shape  {values = dense<[1, 128, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_B:.*]] = tosa.slice %[[SCALE_B_PADDED]], %[[SCALE_B_SLICE_START]], %[[SCALE_B_SLICE_SIZE]] : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x128x2xf8E8M0FNU>
+// CHECK:           %[[LHS:.*]] = tosa.reshape %[[LHS_IN]], %{{.*}} : (tensor<64x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x64x64xf4E2M1FN>
+// CHECK:           %[[RHS_T:.*]] = tosa.transpose %[[RHS_IN]] {perms = array<i32: 1, 0>} : (tensor<64x128xf4E2M1FN>) -> tensor<128x64xf4E2M1FN>
+// CHECK:           %[[RHS:.*]] = tosa.reshape %[[RHS_T]], %{{.*}} : (tensor<128x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x64xf4E2M1FN>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A]], %[[RHS]], %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x64x64xf4E2M1FN>, tensor<1x64x2xf8E8M0FNU>, tensor<1x128x64xf4E2M1FN>, tensor<1x128x2xf8E8M0FNU>) -> tensor<1x64x128xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[MATMUL]] : (tensor<1x64x128xf32>) -> tensor<1x64x128xbf16>
+// CHECK:           %[[RESHAPED:.*]] = tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x64x128xbf16>, !tosa.shape<2>) -> tensor<64x128xbf16>
+// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[RESHAPED]] : tensor<64x128xbf16> -> !torch.vtensor<[64,128],bf16>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[64,128],bf16>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_m64_flat_padded_scales(%arg0: !torch.vtensor<[64,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[64,128],bf16> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[64,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[64,128],bf16>
+  return %0 : !torch.vtensor<[64,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank3_scales_f32(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[128,64],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[64,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[1,128,4],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],f32> {
+// CHECK-DAG:       %[[LHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[128,64],f4E2M1FN> -> tensor<128x64xf4E2M1FN>
+// CHECK-DAG:       %[[RHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG1]] : !torch.vtensor<[64,128],f4E2M1FN> -> tensor<64x128xf4E2M1FN>
+// CHECK-DAG:       %[[SCALE_A_IN:.*]] = torch_c.to_builtin_tensor %[[ARG2]] : !torch.vtensor<[1,128,4],f8E8M0FNU> -> tensor<1x128x4xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B_IN:.*]] = torch_c.to_builtin_tensor %[[ARG3]] : !torch.vtensor<[1,128,4],f8E8M0FNU> -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_SWIZZLED:.*]] = tosa.reshape %[[SCALE_A_IN]], %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_A_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_PADDED:.*]] = tosa.reshape %[[SCALE_A_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_SLICE_START:.*]] = tosa.const_shape  {values = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_A_SLICE_SIZE:.*]] = tosa.const_shape  {values = dense<[1, 128, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_A:.*]] = tosa.slice %[[SCALE_A_PADDED]], %[[SCALE_A_SLICE_START]], %[[SCALE_A_SLICE_SIZE]] : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x128x2xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_SWIZZLED:.*]] = tosa.reshape %[[SCALE_B_IN]], %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_B_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_PADDED:.*]] = tosa.reshape %[[SCALE_B_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_SLICE_START:.*]] = tosa.const_shape  {values = dense<0> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_B_SLICE_SIZE:.*]] = tosa.const_shape  {values = dense<[1, 128, 2]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_B:.*]] = tosa.slice %[[SCALE_B_PADDED]], %[[SCALE_B_SLICE_START]], %[[SCALE_B_SLICE_SIZE]] : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x128x2xf8E8M0FNU>
+// CHECK:           %[[LHS:.*]] = tosa.reshape %[[LHS_IN]], %{{.*}} : (tensor<128x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x64xf4E2M1FN>
+// CHECK:           %[[RHS_T:.*]] = tosa.transpose %[[RHS_IN]] {perms = array<i32: 1, 0>} : (tensor<64x128xf4E2M1FN>) -> tensor<128x64xf4E2M1FN>
+// CHECK:           %[[RHS:.*]] = tosa.reshape %[[RHS_T]], %{{.*}} : (tensor<128x64xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x64xf4E2M1FN>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A]], %[[RHS]], %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x128x64xf4E2M1FN>, tensor<1x128x2xf8E8M0FNU>, tensor<1x128x64xf4E2M1FN>, tensor<1x128x2xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK-NOT:       tosa.cast %[[MATMUL]]
+// CHECK:           %[[RESHAPED:.*]] = tosa.reshape %[[MATMUL]], %{{.*}} : (tensor<1x128x128xf32>, !tosa.shape<2>) -> tensor<128x128xf32>
+// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[RESHAPED]] : tensor<128x128xf32> -> !torch.vtensor<[128,128],f32>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[128,128],f32>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank3_scales_f32(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[1,128,4],f8E8M0FNU>, %arg3: !torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],f32> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int6 = torch.constant.int 6
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int6, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],f32>
+  return %0 : !torch.vtensor<[128,128],f32>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_raw_k_128_fast_accum(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[512],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-DAG:       %[[LHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[128,128],f4E2M1FN> -> tensor<128x128xf4E2M1FN>
+// CHECK-DAG:       %[[RHS_IN:.*]] = torch_c.to_builtin_tensor %[[ARG1]] : !torch.vtensor<[128,128],f4E2M1FN> -> tensor<128x128xf4E2M1FN>
+// CHECK-DAG:       %[[SCALE_A_IN:.*]] = torch_c.to_builtin_tensor %[[ARG2]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B_IN:.*]] = torch_c.to_builtin_tensor %[[ARG3]] : !torch.vtensor<[512],f8E8M0FNU> -> tensor<512xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_SWIZZLED:.*]] = tosa.reshape %[[SCALE_A_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_A_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A:.*]] = tosa.reshape %[[SCALE_A_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_SWIZZLED:.*]] = tosa.reshape %[[SCALE_B_IN]], %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_B_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B:.*]] = tosa.reshape %[[SCALE_B_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK-NOT:       tosa.slice
+// CHECK:           %[[LHS:.*]] = tosa.reshape %[[LHS_IN]], %{{.*}} : (tensor<128x128xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x128xf4E2M1FN>
+// CHECK:           %[[RHS_T:.*]] = tosa.transpose %[[RHS_IN]] {perms = array<i32: 1, 0>} : (tensor<128x128xf4E2M1FN>) -> tensor<128x128xf4E2M1FN>
+// CHECK:           %[[RHS:.*]] = tosa.reshape %[[RHS_T]], %{{.*}} : (tensor<128x128xf4E2M1FN>, !tosa.shape<3>) -> tensor<1x128x128xf4E2M1FN>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A]], %[[RHS]], %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x128x128xf4E2M1FN>, tensor<1x128x4xf8E8M0FNU>, tensor<1x128x128xf4E2M1FN>, tensor<1x128x4xf8E8M0FNU>) -> tensor<1x128x128xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[MATMUL]] : (tensor<1x128x128xf32>) -> tensor<1x128x128xbf16>
+// CHECK:           %[[RESHAPED:.*]] = tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x128x128xbf16>, !tosa.shape<2>) -> tensor<128x128xbf16>
+// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[RESHAPED]] : tensor<128x128xbf16> -> !torch.vtensor<[128,128],bf16>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[128,128],bf16>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_raw_k_128_fast_accum(%arg0: !torch.vtensor<[128,128],f4E2M1FN>, %arg1: !torch.vtensor<[128,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %true = torch.constant.bool true
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %true : !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_dynamic_fast_accum(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[512],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[512],f8E8M0FNU>, %[[FAST_ACCUM:.*]]: !torch.bool) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+// CHECK:           tosa.matmul_t_block_scaled
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+// CHECK:           return
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_dynamic_fast_accum(%arg0: !torch.vtensor<[128,128],f4E2M1FN>, %arg1: !torch.vtensor<[128,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>, %arg4: !torch.bool) -> !torch.vtensor<[128,128],bf16> {
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %arg4 : !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank2_compact_scales(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[128,128],f4E2M1FN>, %[[ARG2:.*]]: !torch.vtensor<[128,4],f8E8M0FNU>, %[[ARG3:.*]]: !torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+// CHECK-DAG:       %[[SCALE_A_IN:.*]] = torch_c.to_builtin_tensor %[[ARG2]] : !torch.vtensor<[128,4],f8E8M0FNU> -> tensor<128x4xf8E8M0FNU>
+// CHECK-DAG:       %[[SCALE_B_IN:.*]] = torch_c.to_builtin_tensor %[[ARG3]] : !torch.vtensor<[128,4],f8E8M0FNU> -> tensor<128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_SWIZZLED:.*]] = tosa.reshape %[[SCALE_A_IN]], %{{.*}} : (tensor<128x4xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_A_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A:.*]] = tosa.reshape %[[SCALE_A_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_SWIZZLED:.*]] = tosa.reshape %[[SCALE_B_IN]], %{{.*}} : (tensor<128x4xf8E8M0FNU>, !tosa.shape<5>) -> tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_DESWIZZLED:.*]] = tosa.transpose %[[SCALE_B_SWIZZLED]] {perms = array<i32: 0, 3, 2, 1, 4>} : (tensor<1x1x32x4x4xf8E8M0FNU>) -> tensor<1x4x32x1x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B:.*]] = tosa.reshape %[[SCALE_B_DESWIZZLED]], %{{.*}} : (tensor<1x4x32x1x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK-NOT:       tosa.slice
+// CHECK:           tosa.matmul_t_block_scaled %{{.*}}, %[[SCALE_A]], %{{.*}}, %[[SCALE_B]] {block_size = BLOCK_SIZE_32}
+// CHECK:           return
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank2_compact_scales(%arg0: !torch.vtensor<[128,128],f4E2M1FN>, %arg1: !torch.vtensor<[128,128],f4E2M1FN>, %arg2: !torch.vtensor<[128,4],f8E8M0FNU>, %arg3: !torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[128,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_swizzled_constant_scales(
+// CHECK-SAME:      %[[ARG0:.*]]: !torch.vtensor<[3,32],f4E2M1FN>, %[[ARG1:.*]]: !torch.vtensor<[32,64],f4E2M1FN>) -> !torch.vtensor<[3,64],bf16> {
+// CHECK:           %[[SCALE_A:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x3x1xf8E8M0FNU>}>
+// CHECK:           %[[SCALE_B:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x64x1xf8E8M0FNU>}>
+// CHECK-NOT:       tensor<1x1x32x4x4xf8E8M0FNU>
+// CHECK:           tosa.matmul_t_block_scaled %{{.*}}, %[[SCALE_A]], %{{.*}}, %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x64x32xf4E2M1FN>, tensor<1x64x1xf8E8M0FNU>) -> tensor<1x3x64xf32>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_swizzled_constant_scales(%arg0: !torch.vtensor<[3,32],f4E2M1FN>, %arg1: !torch.vtensor<[32,64],f4E2M1FN>) -> !torch.vtensor<[3,64],bf16> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a_literal = torch.vtensor.literal(dense<0x00> : tensor<32x16xf8E8M0FNU>) : !torch.vtensor<[32,16],f8E8M0FNU>
+  %scale_b_literal = torch.vtensor.literal(dense<0x00> : tensor<32x16xf8E8M0FNU>) : !torch.vtensor<[32,16],f8E8M0FNU>
+  %scale_a = torch.prim.ListConstruct %scale_a_literal : (!torch.vtensor<[32,16],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %scale_b_literal : (!torch.vtensor<[32,16],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[3,32],f4E2M1FN>, !torch.vtensor<[32,64],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,64],bf16>
+  return %0 : !torch.vtensor<[3,64],bf16>
+}
+
+// -----
+module {
+  // MXFP4 with a valid bf16 bias is verifier-valid, but bias lowering for
+  // _scaled_mm_v2 is not supported by this TOSA pattern.
+  func.func @torch.aten._scaled_mm_v2$bias_rejected(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>, %arg4: !torch.vtensor<[128],bf16>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int1 = torch.constant.int 1
+    %int3 = torch.constant.int 3
+    %int15 = torch.constant.int 15
+    %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %arg4, %int15, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.vtensor<[128],bf16>, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // Explicit contraction_dim metadata is verifier-valid, but this TOSA lowering
+  // only supports the default empty contraction_dim.
+  func.func @torch.aten._scaled_mm_v2$explicit_contraction_dim_rejected(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int3 = torch.constant.int 3
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // RowWise is verifier-valid for _scaled_mm_v2, but this TOSA lowering only
+  // supports MXFP4 BlockWise1x32 with SWIZZLE_32_4_4.
+  func.func @torch.aten._scaled_mm_v2$rowwise_rejected(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[128],f32>, %arg3: !torch.vtensor<[128],f32>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[128],f32>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[128],f32>) -> !torch.list<vtensor>
+    %recipe_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
+module {
+  // TensorWise FP8 _scaled_mm_v2 is verifier-valid, but this TOSA lowering is
+  // intentionally scoped to matching FP4 MX block-scaled inputs.
+  func.func @torch.aten._scaled_mm_v2$fp8_tensorwise_rejected(%arg0: !torch.vtensor<[128,128],f8E4M3FN>, %arg1: !torch.vtensor<[128,128],f8E4M3FN>, %arg2: !torch.vtensor<[],f32>, %arg3: !torch.vtensor<[],f32>) -> !torch.vtensor<[128,128],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[],f32>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[],f32>) -> !torch.list<vtensor>
+    %recipe_b = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,128],f8E4M3FN>, !torch.vtensor<[128,128],f8E4M3FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+    return %0 : !torch.vtensor<[128,128],bf16>
+  }
+}
+
+// -----
 // CHECK-LABEL:   func.func @torch.aten.matmul$broadcast(
 // CHECK-SAME:      %[[INP:.*]]: !torch.vtensor<[10,3,4],f32>,
 // CHECK-SAME:      %[[WTS:.*]]: !torch.vtensor<[4],f32>) -> !torch.vtensor<[10,3],f32> {


### PR DESCRIPTION
Adds TorchToTosa legalization for block-scaled MXFP4 aten._scaled_mm_v2.