### PR TITLE
[TorchToLinalg] Zero-extend unsigned operands in add/sub Tensor lowering

### DIFF
--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -965,13 +965,17 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
   if (auto add = dyn_cast<AtenAddTensorOp>(op)) {
     AtenAddTensorOp::Adaptor adaptor(operands);
     Type resultElementType = cast<BaseTensorType>(add.getType()).getDtype();
+    Type lhsOriginalDtype =
+        cast<BaseTensorType>(add.getSelf().getType()).getDtype();
+    Type rhsOriginalDtype =
+        cast<BaseTensorType>(add.getOther().getType()).getDtype();
     Type dtype = cast<RankedTensorType>(converter->convertType(add.getType()))
                      .getElementType();
     Value lhs = convertScalarToDtype(b, loc, payloadArgs[0], dtype,
-                                     /*srcOriginalDtype=*/std::nullopt,
+                                     /*srcOriginalDtype=*/lhsOriginalDtype,
                                      /*dstOriginalDtype=*/resultElementType);
     Value rhs = convertScalarToDtype(b, loc, payloadArgs[1], dtype,
-                                     /*srcOriginalDtype=*/std::nullopt,
+                                     /*srcOriginalDtype=*/rhsOriginalDtype,
                                      /*dstOriginalDtype=*/resultElementType);
     Value alpha = convertScalarToDtype(b, loc, adaptor.getAlpha(), dtype,
                                        /*srcOriginalDtype=*/std::nullopt,
@@ -992,11 +996,15 @@ static Value createLinalgPayloadCalculationForElementwiseOp(
     Type dtype = cast<RankedTensorType>(converter->convertType(sub.getType()))
                      .getElementType();
     Type resultElementType = cast<BaseTensorType>(sub.getType()).getDtype();
+    Type lhsOriginalDtype =
+        cast<BaseTensorType>(sub.getSelf().getType()).getDtype();
+    Type rhsOriginalDtype =
+        cast<BaseTensorType>(sub.getOther().getType()).getDtype();
     Value lhs = convertScalarToDtype(b, loc, payloadArgs[0], dtype,
-                                     /*srcOriginalDtype=*/std::nullopt,
+                                     /*srcOriginalDtype=*/lhsOriginalDtype,
                                      /*dstOriginalDtype=*/resultElementType);
     Value rhs = convertScalarToDtype(b, loc, payloadArgs[1], dtype,
-                                     /*srcOriginalDtype=*/std::nullopt,
+                                     /*srcOriginalDtype=*/rhsOriginalDtype,
                                      /*dstOriginalDtype=*/resultElementType);
     Value alpha = convertScalarToDtype(b, loc, adaptor.getAlpha(), dtype,
                                        /*srcOriginalDtype=*/std::nullopt,

--- a/test/Conversion/TorchToLinalg/elementwise.mlir
+++ b/test/Conversion/TorchToLinalg/elementwise.mlir
@@ -131,3 +131,31 @@ func.func @elementwise_add_non_broadcast_unit_dims(%arg0: !torch.vtensor<[6,1],b
   %11 = torch.aten.add.Tensor %arg0, %arg1, %int1_13 : !torch.vtensor<[6,1],bf16>, !torch.vtensor<[1],bf16>, !torch.int -> !torch.vtensor<[6,1],bf16>
   return %11 : !torch.vtensor<[6,1],bf16>
 }
+
+// -----
+
+// CHECK-LABEL:   func.func @elementwise_sub_unsigned_extend(
+// CHECK:           linalg.generic
+// CHECK:           ^bb0(%[[LHS:.*]]: i32, %[[RHS:.*]]: i8, %{{.*}}: i32):
+// CHECK-NOT:         arith.extsi %[[RHS]]
+// CHECK:             %[[EXT:.*]] = arith.extui %[[RHS]] : i8 to i32
+// CHECK:             arith.subi %[[LHS]], %{{.*}} : i32
+func.func @elementwise_sub_unsigned_extend(%arg0: !torch.vtensor<[?],si32>, %arg1: !torch.vtensor<[?],ui8>) -> !torch.vtensor<[?],si32> {
+  %int1 = torch.constant.int 1
+  %0 = torch.aten.sub.Tensor %arg0, %arg1, %int1 : !torch.vtensor<[?],si32>, !torch.vtensor<[?],ui8>, !torch.int -> !torch.vtensor<[?],si32>
+  return %0 : !torch.vtensor<[?],si32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @elementwise_add_unsigned_extend(
+// CHECK:           linalg.generic
+// CHECK:           ^bb0(%[[LHS:.*]]: i32, %[[RHS:.*]]: i8, %{{.*}}: i32):
+// CHECK-NOT:         arith.extsi %[[RHS]]
+// CHECK:             %[[EXT:.*]] = arith.extui %[[RHS]] : i8 to i32
+// CHECK:             arith.addi %[[LHS]], %{{.*}} : i32
+func.func @elementwise_add_unsigned_extend(%arg0: !torch.vtensor<[?],si32>, %arg1: !torch.vtensor<[?],ui8>) -> !torch.vtensor<[?],si32> {
+  %int1 = torch.constant.int 1
+  %0 = torch.aten.add.Tensor %arg0, %arg1, %int1 : !torch.vtensor<[?],si32>, !torch.vtensor<[?],ui8>, !torch.int -> !torch.vtensor<[?],si32>
+  return %0 : !torch.vtensor<[?],si32>
+}


### PR DESCRIPTION
The `aten.add.Tensor` and `aten.sub.Tensor` lowerings passed `srcOriginalDtype=std::nullopt`
to `convertScalarToDtype`, so an unsigned-integer operand (e.g. `ui8`) was sign-extended
instead of zero-extended when widened to the compute type. A `ui8` value >= 128 was corrupted:
128 became -128, 200 became -56. The builtin payload type for a `ui8` element is signless `i8`,
so the unsignedness is only recoverable from the torch `BaseTensorType` dtype, which the
lowering was not forwarding. The float branch had the same gap (`uitofp` vs `sitofp`).

This shows up in the ONNX `MatMulInteger` path, which emits `aten.sub.Tensor(matrix_si32, zp_ui8)`:
with the zero-point sign-extended, `A - zp` computed `A + 128` instead of `A - 128`, producing
wrong, always-positive output. Reported against IREE (which consumes torch-mlir) as
iree-org/iree#24583.

This patch derives each operand's torch element type via `cast<BaseTensorType>(...).getDtype()`
and passes it as `srcOriginalDtype` for both `self` and `other` in the add and sub branches,
mirroring the existing `createFpOpWithDtype` pattern. The change is confined to unsigned operands:
signed and float types still take `extsi`/`sitofp`, and equal-width operands early-return with no
extension. Adds lit coverage in `test/Conversion/TorchToLinalg/elementwise.mlir` for `ui8` add and
sub, checking `arith.extui` on the unsigned operand.

Signed-off-by: Javier de Jesus <javier.dejesusj9@gmail.com>
