### PR TITLE
[TorchToLinalg] Reconcile 1-D x 1-D matmul rank-1 result

### DIFF
--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -380,6 +380,13 @@ public:
         dotProd = torch_to_linalg::convertTensorToElementType(
             rewriter, loc, dotProd, resultElementType);
       }
+      // reconcile the rank-0 dot result with a declared rank-1 result type
+      if (resultType.getRank() == 1) {
+        SmallVector<ReassociationIndices> reassociation;
+        auto unsqueezeType = RankedTensorType::get({1}, resultElementType);
+        dotProd = tensor::ExpandShapeOp::create(rewriter, loc, unsqueezeType,
+                                                dotProd, reassociation);
+      }
       rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, dotProd);
       return success();
     }

--- a/test/Conversion/TorchToLinalg/basic.mlir
+++ b/test/Conversion/TorchToLinalg/basic.mlir
@@ -72,6 +72,29 @@ func.func @torch.aten.matmul$dot_f16(%arg0: !torch.vtensor<[4],f16>, %arg1: !tor
 
 // -----
 
+// CHECK-LABEL: func.func @torch.aten.matmul$dot_rank1_f16
+// CHECK:      %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:      linalg.dot ins(%{{.*}}, %{{.*}} : tensor<4xf16>, tensor<4xf16>) outs(%{{.*}} : tensor<f32>) -> tensor<f32>
+// CHECK:      arith.truncf %{{.*}} : f32 to f16
+// CHECK:      tensor.expand_shape %{{.*}} [] output_shape [1] : tensor<f16> into tensor<1xf16>
+func.func @torch.aten.matmul$dot_rank1_f16(%arg0: !torch.vtensor<[4],f16>, %arg1: !torch.vtensor<[4],f16>) -> !torch.vtensor<[1],f16> {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[4],f16>, !torch.vtensor<[4],f16> -> !torch.vtensor<[1],f16>
+  return %0 : !torch.vtensor<[1],f16>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @torch.aten.matmul$dot_rank1_dynamic_f16
+// CHECK:      linalg.dot ins(%{{.*}}, %{{.*}} : tensor<4xf16>, tensor<4xf16>) outs(%{{.*}} : tensor<f32>) -> tensor<f32>
+// CHECK:      %[[EXPANDED:.+]] = tensor.expand_shape %{{.*}} [] output_shape [1] : tensor<f16> into tensor<1xf16>
+// CHECK:      tensor.cast %[[EXPANDED]] : tensor<1xf16> to tensor<?xf16>
+func.func @torch.aten.matmul$dot_rank1_dynamic_f16(%arg0: !torch.vtensor<[4],f16>, %arg1: !torch.vtensor<[4],f16>) -> !torch.vtensor<[?],f16> {
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[4],f16>, !torch.vtensor<[4],f16> -> !torch.vtensor<[?],f16>
+  return %0 : !torch.vtensor<[?],f16>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @torch.aten.matmul$vecmat_f16
 // CHECK:      %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK:      linalg.vecmat ins(%{{.*}}, %{{.*}} : tensor<4xf16>, tensor<4x8xf16>) outs(%{{.*}} : tensor<8xf32>) -> tensor<8xf32>


### PR DESCRIPTION
The dot-product lowering of `aten.matmul` always emits a rank-0
`linalg.dot` result and casts it to the declared result type. ONNX
`MatMul` of two 1-D operands may type the result as rank-1
(`vtensor<[1]>`) rather than rank-0 (`vtensor<[]>`), making the rank-0 ->
rank-1 `tensor.cast` illegal and failing legalization.

When the declared result is rank-1, expand the rank-0 dot result to a
static `tensor<1xT>` and let the existing cast reconcile it with the
declared type. This handles both the static `<1xT>` result and a dynamic
`<?xT>` result (a static-to-dynamic cast), and leaves the rank-0 scalar
path unchanged.

Testing: adds lit coverage for the static and dynamic rank-1 cases
alongside the existing rank-0 dot test in
`test/Conversion/TorchToLinalg/basic.mlir`. No e2e test is added because
the rank-1 typing is an ONNX shape-inference artifact -
`torch.matmul(1d, 1d)` in eager PyTorch always yields a rank-0 scalar, so
the e2e frontend cannot produce the result type that triggers this path;
the conversion-level lit test is the appropriate gate.

Fixes #4309.