### PR TITLE
[TorchConversion] Fix tm_tensor leakage in linalg-on-tensors backend output

### DIFF
--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"
@@ -27,6 +28,96 @@ using namespace mlir::torch;
 using namespace mlir::torch::Torch;
 
 namespace {
+enum class CumReductionKind { Sum, Prod };
+
+static Value buildCumulativeScanLoopNest(
+    OpBuilder &builder, Location loc, Value input, Type elementType,
+    ValueRange upperBounds, int64_t scanDim, CumReductionKind reductionKind,
+    ArrayRef<int64_t> loopOrder, SmallVectorImpl<Value> &ivByDim, int64_t depth,
+    Value outputTensor) {
+  Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(builder, loc, 1);
+
+  if (depth == static_cast<int64_t>(loopOrder.size())) {
+    Value inputElem = tensor::ExtractOp::create(builder, loc, input, ivByDim);
+    Value scanIv = ivByDim[scanDim];
+    Value isFirstIndex = arith::CmpIOp::create(
+        builder, loc, arith::CmpIPredicate::eq, scanIv, c0);
+
+    SmallVector<Value> prevIndices(ivByDim.begin(), ivByDim.end());
+    prevIndices[scanDim] = arith::SubIOp::create(builder, loc, scanIv, c1);
+    Value prevElem =
+        tensor::ExtractOp::create(builder, loc, outputTensor, prevIndices);
+
+    Value scannedElem;
+    switch (reductionKind) {
+    case CumReductionKind::Sum:
+      scannedElem =
+          isa<mlir::FloatType>(elementType)
+              ? Value(arith::AddFOp::create(builder, loc, prevElem, inputElem)
+                          .getResult())
+              : Value(arith::AddIOp::create(builder, loc, prevElem, inputElem)
+                          .getResult());
+      break;
+    case CumReductionKind::Prod:
+      scannedElem =
+          isa<mlir::FloatType>(elementType)
+              ? Value(arith::MulFOp::create(builder, loc, prevElem, inputElem)
+                          .getResult())
+              : Value(arith::MulIOp::create(builder, loc, prevElem, inputElem)
+                          .getResult());
+      break;
+    }
+
+    Value currentElem = arith::SelectOp::create(builder, loc, isFirstIndex,
+                                                inputElem, scannedElem)
+                            .getResult();
+    return tensor::InsertOp::create(builder, loc, currentElem, outputTensor,
+                                    ivByDim)
+        .getResult();
+  }
+
+  int64_t dim = loopOrder[depth];
+  auto forOp = scf::ForOp::create(
+      builder, loc, c0, upperBounds[dim], c1, ValueRange{outputTensor},
+      [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
+          ValueRange iterArgs) {
+        ivByDim[dim] = iv;
+        Value updatedTensor = buildCumulativeScanLoopNest(
+            nestedBuilder, nestedLoc, input, elementType, upperBounds, scanDim,
+            reductionKind, loopOrder, ivByDim, depth + 1, iterArgs[0]);
+        scf::YieldOp::create(nestedBuilder, nestedLoc, updatedTensor);
+      });
+  return forOp.getResult(0);
+}
+
+static FailureOr<Value> createCumulativeScanWithForLoops(
+    ConversionPatternRewriter &rewriter, Location loc, Value input,
+    Value initOutput, int64_t scanDim, CumReductionKind reductionKind) {
+  auto inputType = cast<RankedTensorType>(input.getType());
+  int64_t rank = inputType.getRank();
+  Type elementType = inputType.getElementType();
+  if (!isa<mlir::FloatType, mlir::IntegerType>(elementType))
+    return rewriter.notifyMatchFailure(
+        loc, "cumsum/cumprod requires floating-point or integer element type");
+
+  SmallVector<int64_t> loopOrder;
+  loopOrder.reserve(rank);
+  loopOrder.push_back(scanDim);
+  for (int64_t d = 0; d < rank; ++d)
+    if (d != scanDim)
+      loopOrder.push_back(d);
+
+  SmallVector<Value> upperBounds(rank);
+  for (int64_t d = 0; d < rank; ++d)
+    upperBounds[d] = tensor::DimOp::create(rewriter, loc, input, d);
+
+  SmallVector<Value> ivByDim(rank);
+  return buildCumulativeScanLoopNest(
+      rewriter, loc, input, elementType, upperBounds, scanDim, reductionKind,
+      loopOrder, ivByDim, /*depth=*/0, initOutput);
+}
+
 // Aten max.dim (min.dim) lowering represents the MaxDimOp (MinDimOp) as an
 // linalg.indexed_generic op, producing two output buffers.
 //
@@ -812,6 +903,103 @@ public:
 };
 } // namespace
 
+namespace {
+template <typename OpTy, CumReductionKind reductionKind>
+class ConvertAtenCumReductionOp : public OpConversionPattern<OpTy> {
+public:
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+  using OpAdaptor = typename OpTy::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value input = adaptor.getSelf();
+    auto resultType = cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op->getResult(0).getType()));
+    Type elementType = resultType.getElementType();
+    Type inputElementType =
+        cast<RankedTensorType>(input.getType()).getElementType();
+
+    if constexpr (std::is_same_v<OpTy, AtenCumsumOp>) {
+      Value dtype = op.getDtype();
+      if (!isa<Torch::NoneType>(dtype.getType())) {
+        int64_t dtypeInt;
+        if (!matchPattern(dtype, m_TorchConstantInt(&dtypeInt)))
+          return rewriter.notifyMatchFailure(
+              op, "unimplemented: only constant int dtype value is supported");
+        FailureOr<Type> resDtype = getTypeForScalarType(
+            op->getContext(), (torch_upstream::ScalarType)dtypeInt);
+        if (failed(resDtype))
+          return rewriter.notifyMatchFailure(
+              op, "unsupported: dtype not defined for the given dtype int "
+                  "value");
+        Value torchInput =
+            convertTensorToDtype(rewriter, loc, op.getSelf(), resDtype.value());
+        input = this->getTypeConverter()->materializeTargetConversion(
+            rewriter, loc,
+            this->getTypeConverter()->convertType(torchInput.getType()),
+            torchInput);
+      } else if (elementType != inputElementType &&
+                 isa<IntegerType>(elementType) &&
+                 isa<IntegerType>(inputElementType)) {
+        Value torchInput = convertTensorToDtype(
+            rewriter, loc, op.getSelf(),
+            rewriter.getIntegerType(64, IntegerType::Signed));
+        input = this->getTypeConverter()->materializeTargetConversion(
+            rewriter, loc,
+            this->getTypeConverter()->convertType(torchInput.getType()),
+            torchInput);
+      }
+    } else {
+      // aten.cumprod only supports dtype=None in this lowering.
+      Value dtype = op.getDtype();
+      if (!isa<Torch::NoneType>(dtype.getType()))
+        return rewriter.notifyMatchFailure(
+            op, "unsupported: dtype argument not supported");
+      if (elementType != inputElementType) {
+        Value torchInput = convertTensorToDtype(
+            rewriter, loc, op.getSelf(),
+            rewriter.getIntegerType(64, IntegerType::Signed));
+        input = this->getTypeConverter()->materializeTargetConversion(
+            rewriter, loc,
+            this->getTypeConverter()->convertType(torchInput.getType()),
+            torchInput);
+      }
+    }
+
+    int64_t rank = resultType.getRank();
+    int64_t dim;
+    if (!matchPattern(op.getDim(), m_TorchConstantInt(&dim)))
+      return rewriter.notifyMatchFailure(
+          op, "unimplemented: only constant dim value is supported");
+    dim = toPositiveDim(dim, rank);
+    if (!isValidDim(dim, rank))
+      return rewriter.notifyMatchFailure(op, "invalid dim");
+
+    SmallVector<Value> sizes = getTensorSizes(rewriter, loc, input);
+    Value initOutput;
+    switch (reductionKind) {
+    case CumReductionKind::Sum:
+      initOutput = createZeroInitTensor(rewriter, loc, sizes, elementType);
+      break;
+    case CumReductionKind::Prod:
+      initOutput = createOneInitTensor(rewriter, loc, sizes, elementType);
+      break;
+    }
+    initOutput = tensor::CastOp::create(rewriter, loc, resultType, initOutput);
+
+    FailureOr<Value> scanResult = createCumulativeScanWithForLoops(
+        rewriter, loc, input, initOutput, dim, reductionKind);
+    if (failed(scanResult))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, resultType, *scanResult);
+    return success();
+  }
+};
+} // namespace
+
 void mlir::torch::torch_to_linalg::populateReductionPatternsAndLegality(
     TypeConverter &typeConverter, RewritePatternSet &patterns,
     ConversionTarget &target, bool allowNonFinites) {
@@ -837,5 +1025,12 @@ void mlir::torch::torch_to_linalg::populateReductionPatternsAndLegality(
   target.addIllegalOp<AtenNormScalarOp>();
   target.addIllegalOp<AtenLinalgVectorNormOp>();
   target.addIllegalOp<AtenFrobeniusNormDimOp>();
+  target.addIllegalOp<AtenCumsumOp>();
+  target.addIllegalOp<AtenCumprodOp>();
+  patterns.add<ConvertAtenCumReductionOp<AtenCumsumOp, CumReductionKind::Sum>>(
+      typeConverter, context);
+  patterns
+      .add<ConvertAtenCumReductionOp<AtenCumprodOp, CumReductionKind::Prod>>(
+          typeConverter, context);
   patterns.add<ConvertReductionOp>(typeConverter, context, allowNonFinites);
 }

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -16,7 +16,6 @@
 #include "torch-mlir/Conversion/TorchToArith/TorchToArith.h"
 #include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
-#include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 #include "torch-mlir/Conversion/TorchToTensor/TorchToTensor.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
 
@@ -81,9 +80,6 @@ void TorchConversion::createTorchBackendToLinalgOnTensorsBackendPipeline(
   // We do this first as it tends to involve pattern-matching against constants,
   // (e.g. dimensions which must be constant in a ranked programming model)
   // and those constants get somewhat obscured by TorchToArith.
-  pm.addNestedPass<func::FuncOp>(
-      createConvertTorchToTMTensorPass(options.allowNonFinites));
-  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(
       createConvertTorchToLinalgPass(options.allowNonFinites));
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
@@ -19,7 +19,6 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
 #include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h"
 
@@ -28,7 +27,6 @@
 using namespace mlir;
 using namespace mlir::torch;
 using namespace mlir::torch::TorchConversion;
-using namespace TMTensor;
 namespace mlir::torch::TorchConversion {
 
 #define GEN_PASS_DEF_VERIFYLINALGONTENSORSBACKENDCONTRACT
@@ -84,7 +82,6 @@ class VerifyLinalgOnTensorsBackendContractPass
     target.addDynamicallyLegalDialect<tensor::TensorDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<affine::AffineDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<cf::ControlFlowDialect>(opHasLegalTypes);
-    target.addDynamicallyLegalDialect<TMTensorDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<scf::SCFDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<ml_program::MLProgramDialect>(
         opHasLegalTypes);

--- a/test/Conversion/TorchToLinalg/torch-backend-to-linalg-on-tensors-backend.mlir
+++ b/test/Conversion/TorchToLinalg/torch-backend-to-linalg-on-tensors-backend.mlir
@@ -33,3 +33,17 @@ func.func @torch.aten.max.dim$basic(%arg0: tensor<3x2x3xf32>) -> tensor<3x2x1xf3
   %1 = torch_c.to_builtin_tensor %values : !torch.vtensor<[3,2,1],f32> -> tensor<3x2x1xf32>
   return %1 : tensor<3x2x1xf32>
 }
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.cumsum.basic
+// CHECK-NOT: tm_tensor.
+// CHECK: scf.for
+// CHECK: arith.addf
+func.func @torch.aten.cumsum.basic(%arg0: tensor<2x3xf32>) -> tensor<2x3xf32> {
+  %0 = torch_c.from_builtin_tensor %arg0 : tensor<2x3xf32> -> !torch.vtensor<[2,3],f32>
+  %dim = torch.constant.int 1
+  %none = torch.constant.none
+  %1 = torch.aten.cumsum %0, %dim, %none : !torch.vtensor<[2,3],f32>, !torch.int, !torch.none -> !torch.vtensor<[2,3],f32>
+  %2 = torch_c.to_builtin_tensor %1 : !torch.vtensor<[2,3],f32> -> tensor<2x3xf32>
+  return %2 : tensor<2x3xf32>
+}


### PR DESCRIPTION
Closes #4574 

This PR fixes tm_tensor.scan leakage in linalg-on-tensors backend output, which caused downstream parse failures when tm_tensor is not registered.

It adds Torch-to-Linalg lowering for aten.cumsum / aten.cumprod using upstream dialect ops, removes the Torch-to-TMTensor stage from the linalg-on-tensors backend pipeline, and tightens backend contract verification to reject tm_tensor ops in final output. A regression test is added to cover conversion behavior and full backend pipeline execution.