### PR TITLE
[Torch] Fix verifier crashes on malformed global slot initializer IR

### DIFF
--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -252,6 +252,7 @@ def Torch_GlobalSlotOp : Torch_Op<"global_slot", [
 
 def Torch_GlobalSlotModuleInitializerOp : Torch_Op<"global_slot.module_initializer", [
     IsolatedFromAbove,
+    HasParent<"::mlir::ModuleOp">,
     SingleBlockImplicitTerminator<"::mlir::torch::Torch::InitializeGlobalSlotsOp">,
     AllowedInModuleInitializer,
   ]> {
@@ -274,7 +275,7 @@ def Torch_GlobalSlotModuleInitializerOp : Torch_Op<"global_slot.module_initializ
   let assemblyFormat = [{
     $initializer attr-dict
   }];
-  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
 }
 
 def Torch_InitializeGlobalSlotsOp : Torch_Op<"initialize.global_slots", [
@@ -289,7 +290,7 @@ def Torch_InitializeGlobalSlotsOp : Torch_Op<"initialize.global_slots", [
   }];
 
   let arguments = (ins
-    SymbolRefArrayAttr:$slotSymNames,
+    FlatSymbolRefArrayAttr:$slotSymNames,
     Variadic<AnyTorchType>:$initialValues
   );
   let results = (outs);

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -6570,7 +6570,7 @@ LogicalResult DtypeCalculateYieldDtypesOp::verify() {
 // GlobalSlotModuleInitializerOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult GlobalSlotModuleInitializerOp::verify() {
+LogicalResult GlobalSlotModuleInitializerOp::verifyRegions() {
   // We centralize all verification of the global slots and the
   // InitializeGlobalSlotsOp into here, since it requires processing the whole
   // module.

--- a/test/Dialect/Torch/invalid.mlir
+++ b/test/Dialect/Torch/invalid.mlir
@@ -269,6 +269,41 @@ torch.global_slot.module_initializer {
 
 // -----
 
+// Nested (non-flat) symbol ref slot name.
+
+torch.global_slot.module_initializer {
+  %0 = torch.constant.int 1
+  // expected-error @+1 {{attribute 'slotSymNames' failed to satisfy constraint: flat symbol ref array attribute}}
+  "torch.initialize.global_slots"(%0) <{slotSymNames = [@a::@b]}> : (!torch.int) -> ()
+}
+
+// -----
+
+// Operand/slot count mismatch.
+
+torch.global_slot @slot0 : !torch.int
+
+torch.global_slot.module_initializer {
+  %0 = torch.constant.int 1
+  %1 = torch.constant.int 2
+  // expected-error @+1 {{expected number of operands to match number of slots}}
+  "torch.initialize.global_slots"(%0, %1) <{slotSymNames = [@slot0]}> : (!torch.int, !torch.int) -> ()
+}
+
+// -----
+
+// Module initializer nested under an op other than a module.
+
+func.func @f() {
+  // expected-error @+1 {{'torch.global_slot.module_initializer' op expects parent op 'builtin.module'}}
+  "torch.global_slot.module_initializer"() ({
+    "torch.initialize.global_slots"() <{slotSymNames = []}> : () -> ()
+  }) : () -> ()
+  return
+}
+
+// -----
+
 func.func @torch.tensor_static_info_cast$shape_mismatch(%arg0: !torch.vtensor<[],unk>) -> !torch.vtensor<[?],unk> {
   // expected-error@+1 {{'torch.tensor_static_info_cast' op operand type '!torch.vtensor<[],unk>' and result type '!torch.vtensor<[?],unk>' are cast incompatible}}
   %0 = torch.tensor_static_info_cast %arg0 : !torch.vtensor<[],unk> to !torch.vtensor<[?],unk>


### PR DESCRIPTION
Fixes #4411.

`torch-mlir-opt` asserts instead of emitting a diagnostic on a malformed `torch.global_slot.module_initializer`. #4411 reports one case — a non-symbol `slotSymNames` entry — but the same root cause produces two related crashes on the same op.

The root cause is verification ordering. `GlobalSlotModuleInitializerOp` used `hasVerifier`, so its `verify()` runs on op entrance, before the nested `torch.initialize.global_slots` terminator's own invariants. The verifier reaches into that terminator (`getBody()->getTerminator()`, then `cast<FlatSymbolRefAttr>` over `slotSymNames`) and dereferences attributes the child verifier has not validated yet. Three parseable inputs crash:

- a non-symbol or non-flat slot name hits `cast<FlatSymbolRefAttr>` (`TorchOps.cpp:6595`); #4411's `[159]` and a nested ref like `[@a::@b]` (a valid `SymbolRefArrayAttr` element, so the declared type did not guard it) both reach it,
- a slot/operand count mismatch indexes `getSlotSymNames()[i]` out of bounds (`TorchOps.cpp:6634`),
- a non-`builtin.module` parent hits `cast<ModuleOp>(getParentOp())` (`TorchOps.cpp:6581`).

Repro:
```mlir
torch.global_slot.module_initializer {
  %0 = torch.constant.int 1
  "torch.initialize.global_slots"(%0) <{slotSymNames = [159]}> : (!torch.int) -> ()
}
```

The fix closes each at the layer that owns the invariant:

- `verify()` → `verifyRegions()`, so the module-wide checks run on op exit, after the nested terminator is verified; the parent's casts then only run once the child's invariants hold,
- `slotSymNames`: `SymbolRefArrayAttr` → `FlatSymbolRefArrayAttr`, enforcing the element type declaratively (covers both `[159]` and `[@a::@b]`); the custom parser only emits flat refs, so no valid IR changes,
- add `HasParent<ModuleOp>`, matching the sibling `torch.initialize.global_slots` op.

Testing: `test/Dialect/Torch/invalid.mlir` adds three negative cases under `-verify-diagnostics`, one per fix — a nested-ref slot name (rejected by the `FlatSymbolRefArrayAttr` constraint), an operand/slot count mismatch (rejected by the terminator's own verifier, which now runs before the parent's per-slot loop), and a non-module parent (rejected by the `HasParent` trait). The existing `module_initializer` error tests and the `GlobalizeObjectGraph` / `inline-global-slots` / `erase-module-initializer` suites pass under the `verifyRegions()` move. No e2e test is added — this is a verifier guard, so the lit negative tests are the correct layer.
