### PR TITLE
[TorchToLinalg] Fix depthwise conv_transpose2d collapse_shape error

### DIFF
--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -1304,12 +1304,23 @@ public:
         cast<RankedTensorType>(weight.getType()).getShape());
     if (inShape[1] == numGroups && weightShape[0] == numGroups &&
         weightShape[1] == 1) {
-      // Collapse weight shape (C/G == 1)
-      SmallVector<ReassociationIndices> collapsedDims = {{0, 1}};
-      SmallVector<int64_t> collapsedShape{weightShape[0] * weightShape[1]};
+      // Collapse weight shape (C/G == 1).
+      // For transposed grouped conv the weight has been pre-expanded by
+      // expandWeight (e.g. [G,1,kH,kW] -> [G,1,1,kH,kW]), adding an extra
+      // leading dim. Derive numLeadingGroupDims from the actual weight rank so
+      // the reassociation covers all leading dims in both the regular (rank 4)
+      // and transposed (rank 5) cases. All leading dims after the first are 1
+      // (depthwise invariant), so the collapsed group size is weightShape[0].
+      int weightRank = cast<RankedTensorType>(weight.getType()).getRank();
+      int numLeadingGroupDims = weightRank - (int)numSpatialDims;
+      ReassociationIndices leadingGroupIndices;
+      for (int i = 0; i < numLeadingGroupDims; i++)
+        leadingGroupIndices.push_back(i);
+      SmallVector<ReassociationIndices> collapsedDims = {leadingGroupIndices};
+      SmallVector<int64_t> collapsedShape{weightShape[0]};
       for (unsigned i = 0; i < numSpatialDims; i++) {
-        collapsedDims.push_back({i + 2});
-        collapsedShape.push_back(weightShape[i + 2]);
+        collapsedDims.push_back({numLeadingGroupDims + (int)i});
+        collapsedShape.push_back(weightShape[numLeadingGroupDims + i]);
       }
       Type collapsedType = RankedTensorType::get(
           makeShapeLLVMCompatible(collapsedShape), weightDTy);

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
@@ -1119,6 +1119,37 @@ def Conv_Transpose2dStaticModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(5, 2, 5, 6), tu.rand(2, 5, 2, 2))
 
 
+class Conv_Transpose2dDepthwiseModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, 4, -1, -1], torch.float32, True),
+            ([4, 1, -1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, inputVec, weight):
+        # groups == in_channels: depthwise transposed conv2d
+        return torch.ops.aten.conv_transpose2d(
+            inputVec,
+            weight,
+            bias=None,
+            stride=[1, 1],
+            padding=[0, 0],
+            dilation=[1, 1],
+            output_padding=[0, 0],
+            groups=4,
+        )
+
+
+@register_test_case(module_factory=lambda: Conv_Transpose2dDepthwiseModule())
+def Conv_Transpose2dDepthwiseModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 4, 5, 6), tu.rand(4, 1, 3, 3))
+
+
 class Conv_Transpose3dModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Conversion/TorchToLinalg/convolution.mlir
+++ b/test/Conversion/TorchToLinalg/convolution.mlir
@@ -151,6 +151,39 @@ func.func @transposedGroupedConvolution2D(%arg0: !torch.vtensor<[1,2,5,7],f32>) 
   return %6 : !torch.vtensor<[1,4,10,14],f32>
 }
 
+// -----
+
+// Depthwise transposed conv2d: in_channels == groups (4), out_channels/groups == 1.
+// Weight [4,1,3,3] is expanded to rank-5 [4,1,1,3,3] by expandWeight before the
+// spatial flip, so the collapse_shape reassociation must cover all 3 leading dims.
+// CHECK-LABEL:   func.func @transposedDepthwiseConvolution2D(
+// CHECK-SAME:       %[[INPUT_TENSOR:.*]]: !torch.vtensor<[1,4,5,7],f32>) -> !torch.vtensor<[1,4,11,15],f32>
+// CHECK:         %[[WEIGHT_TRANSPOSED:.*]] = linalg.generic
+// CHECK:         %[[COLLAPSED_WEIGHT:.*]] = tensor.collapse_shape %[[WEIGHT_TRANSPOSED]]
+// CHECK-SAME:        [0, 1, 2], [3], [4]
+// CHECK-SAME:        tensor<4x1x1x3x3xf32> into tensor<4x3x3xf32>
+// CHECK:         %[[CONV_RESULT:.*]] = linalg.depthwise_conv_2d_nchw_chw
+// CHECK-SAME:        {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+// CHECK-SAME:        ins(%[[PAD:.*]], %[[COLLAPSED_WEIGHT]] : tensor<1x4x13x17xf32>, tensor<4x3x3xf32>)
+// CHECK-SAME:        outs(%[[OUT:.*]] : tensor<1x4x11x15xf32>) -> tensor<1x4x11x15xf32>
+func.func @transposedDepthwiseConvolution2D(%arg0: !torch.vtensor<[1,4,5,7],f32>) -> !torch.vtensor<[1,4,11,15],f32> attributes {torch.assume_strict_symbolic_shapes} {
+  %int0 = torch.constant.int 0
+  %true = torch.constant.bool true
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int4 = torch.constant.int 4
+  %0 = torch.vtensor.literal(dense_resource<torch_tensor_4_1_3_3_torch.float32> : tensor<4x1x3x3xf32>) : !torch.vtensor<[4,1,3,3],f32>
+  %1 = torch.vtensor.literal(dense_resource<torch_tensor_4_torch.float32> : tensor<4xf32>) : !torch.vtensor<[4],f32>
+  %2 = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+  %3 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %4 = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %5 = torch.prim.ListConstruct %int0, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %6 = torch.aten.convolution %arg0, %0, %1, %2, %3, %4, %true, %5, %int4 : !torch.vtensor<[1,4,5,7],f32>, !torch.vtensor<[4,1,3,3],f32>, !torch.vtensor<[4],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,4,11,15],f32>
+  return %6 : !torch.vtensor<[1,4,11,15],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @tranConv2dNegativePadding(
 // CHECK-SAME:                                         %[[INPUT_VTENSOR:.*]]: !torch.vtensor<[1,1,4,7],f32>) -> !torch.vtensor<[1,2,6,3],f32> attributes {torch.assume_strict_symbolic_shapes} {
 // CHECK-DAG:       %[[C2:.*]] = arith.constant 2 : index


### PR DESCRIPTION
For transposed grouped depthwise conv2d (groups == in_channels), expandWeight expands the weight from rank 4 [G,1,kH,kW] to rank 5 [G,1,1,kH,kW] before the spatial flip. The subsequent collapse_shape reassociation was hardcoded for rank 4 and only covered 4 of 5 source dims, causing: error: 'tensor.collapse_shape' op expected reassociation map #0 to have size equal to the expanded rank (5), but it is 4.
Fix by deriving numLeadingGroupDims from the actual weight rank at that point (weightRank - numSpatialDims) instead of assuming 2.

@ramiro050 @zjgarvey