### PR TITLE
[tosa] Fix dynamic dims crashes in torch to tosa legalization

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -4216,9 +4216,14 @@ LogicalResult ConvertAtenOp<AtenUnflattenIntOp>::matchAndRewriteImpl(
   auto newType = RankedTensorType::get(makeShapeLLVMCompatible(newShape),
                                        selfType.getElementType());
 
-  rewriter.replaceOpWithNewOp<tosa::ReshapeOp>(
-      op, getTypeConverter()->convertType(newType), adaptor.getSelf(),
+  // Reshape to the static type, then tensor.cast to the (possibly dynamic)
+  // converted result type.
+  auto reshapeOp = tosa::ReshapeOp::create(
+      rewriter, op.getLoc(), newType, adaptor.getSelf(),
       tosa::getTosaConstShape(rewriter, op->getLoc(), newShape));
+
+  rewriter.replaceOpWithNewOp<tensor::CastOp>(
+      op, getTypeConverter()->convertType(op.getType()), reshapeOp);
 
   return success();
 }

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -4480,21 +4480,31 @@ LogicalResult ConvertAtenOp<AtenViewOp>::matchAndRewriteImpl(
   }
 
   auto inputShape = selfType.getShape();
-  size_t totalSize = 1;
-  for (size_t i = 0; i < inputShape.size(); i++) {
-    totalSize *= inputShape[i];
-  }
-
-  size_t otherSize = 1;
-  for (size_t i = 0; i < outShape.size(); i++) {
-    if (outShape[i] > 0) {
-      otherSize *= outShape[i];
+  // The size list may carry a -1, meaning "infer this dim from the total
+  // element count".
+  //  - Fully static input: resolve -1 here via integer arithmetic on the
+  //    known dims, yielding a fully static result.
+  //  - Any dynamic (?) input dim: the element count is unknown, and the ?
+  //    (ShapedType::kDynamic) would poison the arithmetic when computing
+  //    totalSize. Leave -1 in place and let tosa.reshape infer it at runtime.
+  bool inputFullyStatic = llvm::none_of(inputShape, ShapedType::isDynamic);
+  if (inputFullyStatic) {
+    size_t totalSize = 1;
+    for (size_t i = 0; i < inputShape.size(); i++) {
+      totalSize *= inputShape[i];
     }
-  }
-  for (size_t i = 0; i < outShape.size(); i++) {
-    if (outShape[i] < 0) {
-      outShape[i] = totalSize / otherSize;
-      break;
+
+    size_t otherSize = 1;
+    for (size_t i = 0; i < outShape.size(); i++) {
+      if (outShape[i] > 0) {
+        otherSize *= outShape[i];
+      }
+    }
+    for (size_t i = 0; i < outShape.size(); i++) {
+      if (outShape[i] < 0) {
+        outShape[i] = totalSize / otherSize;
+        break;
+      }
     }
   }
 

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -2287,9 +2287,13 @@ public:
       }
       commonValue = commonValue < 0 ? kUnknownSize : commonValue;
 
-      // TODO: Handle the case when there are dynamic batch dimensions.
+      // Dynamic batch dims would make both commonValue and lhsSqueezedValue
+      // kUnknownSize, yielding two -1 slots in the tosa.reshape output type,
+      // which the TOSA verifier rejects. Bail out cleanly until a proper
+      // dynamic-batch matmul lowering is added.
       if (hasDynamicDims)
-        commonValue = kUnknownSize;
+        return rewriter.notifyMatchFailure(
+            op, "dynamic batch dims in matmul not supported");
 
       // Step: generate the LHS squeezed dim/shape information.
       for (uint32_t dim = 0; dim < maxInputRank - 2; dim++) {
@@ -2551,6 +2555,9 @@ public:
       // Perform reshape
       auto reshapedOpType = RankedTensorType::get(
           makeShapeLLVMCompatible(reshapedOpShape), accElemTy);
+      if (reshapedOpType.getNumDynamicDims() > 1)
+        return rewriter.notifyMatchFailure(
+            op, "matmul output reshape has multiple dynamic dims");
       auto reshapedOp = tosa::ReshapeOp::create(
           rewriter, op->getLoc(),
           OpConversionPattern<AtenOpT>::getTypeConverter()->convertType(

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -8320,6 +8320,9 @@ ConvertAtenOp<Aten__InterpolateSizeListScaleListOp>::matchAndRewriteImpl(
 
   auto inputShape = inputTy.getShape();
 
+  if (llvm::any_of(inputShape, ShapedType::isDynamic))
+    return rewriter.notifyMatchFailure(op, "dynamic input dims not supported");
+
   int outputHeight, outputWidth;
   if (!isa<Torch::NoneType>(op.getScaleFactor().getType())) {
     SmallVector<double, 2> scaleFactor;

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -5098,6 +5098,14 @@ func.func @torch.aten.matmul$zero_k_f32(%arg0: !torch.vtensor<[5,0],f32>, %arg1:
 }
 
 // -----
+
+func.func @torch.aten.matmul$dynamic_batch(%arg0: !torch.vtensor<[?,?,4,5],f32>, %arg1: !torch.vtensor<[?,?,5,6],f32>) -> !torch.vtensor<[?,?,4,6],f32> {
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.matmul' that was explicitly marked illegal}}
+  %0 = torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,4,5],f32>, !torch.vtensor<[?,?,5,6],f32> -> !torch.vtensor<[?,?,4,6],f32>
+  return %0 : !torch.vtensor<[?,?,4,6],f32>
+}
+
+// -----
 // CHECK-LABEL:   func.func @torch.aten.bmm$zero_k_f32(
 // CHECK-SAME:      %[[LHS:.*]]: !torch.vtensor<[2,5,0],f32>,
 // CHECK-SAME:      %[[RHS:.*]]: !torch.vtensor<[2,0,10],f32>) -> !torch.vtensor<[2,5,10],f32> {

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -2173,6 +2173,19 @@ func.func @torch.aten.__interpolate.size_list_scale_list.nearest(%arg0: !torch.v
 
 // -----
 
+func.func @torch.aten.__interpolate$dynamic_input(%arg0: !torch.vtensor<[1,16,?,?],f32>) -> !torch.vtensor<[1,16,?,?],f32> {
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %str = torch.constant.str "bilinear"
+  %float2.000000e00 = torch.constant.float 2.000000e+00
+  %0 = torch.prim.ListConstruct %float2.000000e00, %float2.000000e00 : (!torch.float, !torch.float) -> !torch.list<float>
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.__interpolate.size_list_scale_list' that was explicitly marked illegal}}
+  %1 = torch.aten.__interpolate.size_list_scale_list %arg0, %none, %0, %str, %false, %none, %false : !torch.vtensor<[1,16,?,?],f32>, !torch.none, !torch.list<float>, !torch.str, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[1,16,?,?],f32>
+  return %1 : !torch.vtensor<[1,16,?,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.tril$basic(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: !torch.vtensor<[2,4],si32>) -> !torch.vtensor<[2,4],si32> {
 // CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[2,4],si32> -> tensor<2x4xi32>

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -899,7 +899,8 @@ func.func @torch.aten.flatten.using_ints$basic(%arg0: !torch.vtensor<[10,3,8,9,3
 // CHECK:           %[[VAL_5:.*]] = torch.prim.ListConstruct %[[VAL_3]], %[[VAL_4]] : (!torch.int, !torch.int) -> !torch.list<int>
 // CHECK:           %[[VAL_6:.*]] = tosa.const_shape  {values = dense<[1, 2, 3, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK:           %[[VAL_7:.*]] = tosa.reshape %[[VAL_1]], %[[VAL_6]] : (tensor<1x6x4xf32>, !tosa.shape<4>) -> tensor<1x2x3x4xf32>
-// CHECK:           %[[VAL_8:.*]] = torch_c.from_builtin_tensor %[[VAL_7]] : tensor<1x2x3x4xf32> -> !torch.vtensor<[1,2,3,4],f32>
+// CHECK:           %[[CAST:.*]] = tensor.cast %[[VAL_7]] : tensor<1x2x3x4xf32> to tensor<1x2x3x4xf32>
+// CHECK:           %[[VAL_8:.*]] = torch_c.from_builtin_tensor %[[CAST]] : tensor<1x2x3x4xf32> -> !torch.vtensor<[1,2,3,4],f32>
 // CHECK:           return %[[VAL_8]] : !torch.vtensor<[1,2,3,4],f32>
 // CHECK:         }
 func.func @torch.aten.unflatten.int$basic(%arg0: !torch.vtensor<[1,6,4],f32> ) -> !torch.vtensor<[1,2,3,4],f32> {

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -800,6 +800,24 @@ func.func @torch.aten.reshape$basic(%arg0: !torch.vtensor<[?,?,?,?],f32>) -> !to
 
 // -----
 
+// CHECK-LABEL:   func.func @torch.aten.view$dynamic_input_neg_one(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: !torch.vtensor<[?,64,4,4],f32>) -> !torch.vtensor<[?,1024],f32> {
+// CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[?,64,4,4],f32> -> tensor<?x64x4x4xf32>
+// CHECK:           %[[SHAPE:.*]] = tosa.const_shape  {values = dense<[-1, 1024]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           %[[VIEW:.*]] = tosa.reshape %[[VAL_1]], %[[SHAPE]] : (tensor<?x64x4x4xf32>, !tosa.shape<2>) -> tensor<?x1024xf32>
+// CHECK:           %[[OUT:.*]] = torch_c.from_builtin_tensor %[[VIEW]] : tensor<?x1024xf32> -> !torch.vtensor<[?,1024],f32>
+// CHECK:           return %[[OUT]] : !torch.vtensor<[?,1024],f32>
+// CHECK:         }
+func.func @torch.aten.view$dynamic_input_neg_one(%arg0: !torch.vtensor<[?,64,4,4],f32>) -> !torch.vtensor<[?,1024],f32> {
+  %dim0 = torch.constant.int -1
+  %dim1 = torch.constant.int 1024
+  %shape = torch.prim.ListConstruct %dim0, %dim1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.view %arg0, %shape : !torch.vtensor<[?,64,4,4],f32>, !torch.list<int> -> !torch.vtensor<[?,1024],f32>
+  return %0 : !torch.vtensor<[?,1024],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.native_batch_norm$basic(
 // CHECK-SAME:                                                  %[[VAL_0:.*]]: !torch.vtensor<[10,4,3],f32>) -> !torch.vtensor<[10,4,3],f32> {
 // CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[10,4,3],f32> -> tensor<10x4x3xf32>


### PR DESCRIPTION
Several `TorchToTosa` lowerings assume statically-shaped inputs and either crash or emit invalid TOSA IR when given tensors with dynamic `(?)` dimensions. Each lowering is fixed to either resolve the dynamic case correctly or bail cleanly instead of crashing or producing illegal tosa ops.
