### PR TITLE
[TorchToLinalg] Fix negative step slicing offset calculation

### DIFF
--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -1870,15 +1870,15 @@ public:
     // If stride is negative, then flip the input tensor corresponding to that
     // dim, update the stride for flipped tensor by multiplying it by -1, and
     // update the offset as follows:
-    // flipped_offset = input_shape[dim] - (result_shape[dim] * flipped_stride)
+    // flipped_offset[dim] = input_shape[dim] - 1 - offsets[dim]
     //
     // For example:
     // Input = [0, 1, 2, 3, 4, 5]
-    // stride = [-2], result_shape = [2], offset = [3]
+    // stride = [-2], offset = [3]
     // Result = [3, 1]
     // After flipping:
     // Input = [5, 4, 3, 2, 1, 0]
-    // stride = [2], result_shape = [2], offset = [6 - (2 * 2)] = [2]
+    // stride = [2], offset = [6 - 1 - 3] = [2]
     // Result = [3, 1]
 
     Value flippedInput = torch_to_linalg::flipTensor(rewriter, loc, input,
@@ -1888,11 +1888,12 @@ public:
     Value isNegativeStride = arith::CmpIOp::create(
         rewriter, loc, arith::CmpIPredicate::slt, strides[dim], zero);
     strides[dim] = math::AbsIOp::create(rewriter, loc, strides[dim]);
-    Value resShapeMulStride =
-        arith::MulIOp::create(rewriter, loc, resultShape[dim], strides[dim]);
+    Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
     Value inputDim = tensor::DimOp::create(rewriter, loc, input, cstDim);
+    Value inputDimMinusOne =
+        arith::SubIOp::create(rewriter, loc, inputDim, one);
     Value flippedOffset =
-        arith::SubIOp::create(rewriter, loc, inputDim, resShapeMulStride);
+        arith::SubIOp::create(rewriter, loc, inputDimMinusOne, offsets[dim]);
     offsets[dim] = arith::SelectOp::create(rewriter, loc, isNegativeStride,
                                            flippedOffset, offsets[dim]);
 

--- a/test/Conversion/TorchToLinalg/datamovement.mlir
+++ b/test/Conversion/TorchToLinalg/datamovement.mlir
@@ -177,3 +177,21 @@ func.func @torch.aten.slice$end_int64_max_dynamic_step2(%arg0: !torch.vtensor<[4
   %0 = torch.aten.slice.Tensor %arg0, %int1, %int2, %intmax, %int2 : !torch.vtensor<[4,?],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,?],f32>
   return %0 : !torch.vtensor<[4,?],f32>
 }
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten.slice.Tensor$negative_step(
+// CHECK-SAME:                                                     %[[ARG0:.*]]: !torch.vtensor<[10],f32>) -> !torch.vtensor<[9],f32> {
+// CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[10],f32> -> tensor<10xf32>
+// CHECK:           %[[VAL_4:.*]] = linalg.generic
+// CHECK:           %[[VAL_5:.*]] = tensor.extract_slice %[[VAL_4]][0] [9] [1] : tensor<10xf32> to tensor<9xf32>
+// CHECK:           %[[VAL_6:.*]] = torch_c.from_builtin_tensor %[[VAL_5]] : tensor<9xf32> -> !torch.vtensor<[9],f32>
+// CHECK:           return %[[VAL_6]] : !torch.vtensor<[9],f32>
+// CHECK:         }
+func.func @torch.aten.slice.Tensor$negative_step(%arg0: !torch.vtensor<[10],f32>) -> !torch.vtensor<[9],f32> {
+  %int0 = torch.constant.int 0
+  %int9 = torch.constant.int 9
+  %int_neg1 = torch.constant.int -1
+  %0 = torch.aten.slice.Tensor %arg0, %int0, %int9, %int0, %int_neg1 : !torch.vtensor<[10],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[9],f32>
+  return %0 : !torch.vtensor<[9],f32>
+}


### PR DESCRIPTION
## Description

Fixes an off-by-one error and incorrect offset calculations in `ConvertAtenSliceTensorOp` when lowering negative-step slicing operations to Linalg.

## Cause

The new offset in the flipped tensor was previously calculated as `input_shape - result_shape * flipped_stride`. This formula is incorrect and produces incorrect results when the slice is not aligned to the boundary of the input tensor.

## Solution

This updates the calculation to `input_shape - 1 - start` to correctly map the start index of the slice to the flipped coordinate space.

Fixes https://github.com/iree-org/iree/issues/24584