### PR TITLE
[TorchToStablehlo] [TorchToTosa] Add lowering support for torch.aten.triu

### DIFF
--- a/lib/Conversion/TorchToStablehlo/Basic.cpp
+++ b/lib/Conversion/TorchToStablehlo/Basic.cpp
@@ -2110,10 +2110,10 @@ LogicalResult ConvertAtenOp<AtenBitwiseRightShiftTensorOp>::matchAndRewrite(
 }
 
 template <typename AtenOpT>
-static LogicalResult convertTrilOrTriu(AtenOpT op, Value self, Value diagonal,
-                                       stablehlo::ComparisonDirection dir,
-                                       const TypeConverter *typeConverter,
-                                       ConversionPatternRewriter &rewriter) {
+LogicalResult convertTrilOrTriu(AtenOpT op, Value self, Value diagonal,
+                                stablehlo::ComparisonDirection dir,
+                                const TypeConverter *typeConverter,
+                                ConversionPatternRewriter &rewriter) {
   Location loc = op.getLoc();
 
   auto selfTy = cast<RankedTensorType>(self.getType());

--- a/lib/Conversion/TorchToStablehlo/Basic.cpp
+++ b/lib/Conversion/TorchToStablehlo/Basic.cpp
@@ -2109,14 +2109,12 @@ LogicalResult ConvertAtenOp<AtenBitwiseRightShiftTensorOp>::matchAndRewrite(
   return success();
 }
 
-template <>
-LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewrite(
-    AtenTrilOp op, OpAdaptor adaptor,
-    ConversionPatternRewriter &rewriter) const {
-
+template <typename AtenOpT>
+static LogicalResult convertTrilOrTriu(AtenOpT op, Value self, Value diagonal,
+                                       stablehlo::ComparisonDirection dir,
+                                       const TypeConverter *typeConverter,
+                                       ConversionPatternRewriter &rewriter) {
   Location loc = op.getLoc();
-
-  Value self = adaptor.getSelf();
 
   auto selfTy = cast<RankedTensorType>(self.getType());
   if (!selfTy.hasStaticShape()) {
@@ -2133,7 +2131,6 @@ LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewrite(
   Value rowIdxTensor =
       stablehlo::IotaOp::create(rewriter, loc, iotaTy, 0).getResult();
 
-  Value diagonal = adaptor.getDiagonal();
   Value diagonalTensor =
       tensor::FromElementsOp::create(rewriter, loc, diagonal).getResult();
 
@@ -2141,8 +2138,8 @@ LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewrite(
   Value shiftedRowIdxTensor = chlo::BroadcastAddOp::create(
       rewriter, loc, rowIdxTensor, diagonalTensor, bcastDimensions);
 
-  auto cmpDirectionAttr = stablehlo::ComparisonDirectionAttr::get(
-      rewriter.getContext(), stablehlo::ComparisonDirection::LE);
+  auto cmpDirectionAttr =
+      stablehlo::ComparisonDirectionAttr::get(rewriter.getContext(), dir);
   auto cmpTypeAttr = stablehlo::ComparisonTypeAttr::get(
       rewriter.getContext(), stablehlo::ComparisonType::SIGNED);
   auto cmpTy = iotaTy.clone(rewriter.getI1Type());
@@ -2150,8 +2147,7 @@ LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewrite(
                                               colIdxTensor, shiftedRowIdxTensor,
                                               cmpDirectionAttr, cmpTypeAttr);
 
-  auto resTy =
-      cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
+  auto resTy = cast<RankedTensorType>(typeConverter->convertType(op.getType()));
 
   auto bcastTy = resTy.clone(rewriter.getI1Type());
   auto bcastAttr = rewriter.getDenseI64ArrayAttr({selfRank - 2, selfRank - 1});
@@ -2162,8 +2158,9 @@ LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewrite(
   Value zeroTensor;
   if (isa<mlir::FloatType>(resElemTy)) {
     auto constAttr = SplatElementsAttr::get(
-        resTy, llvm::APFloat::getZero(
-                   cast<FloatType>(resElemTy).getFloatSemantics(), false));
+        resTy,
+        llvm::APFloat::getZero(
+            cast<mlir::FloatType>(resElemTy).getFloatSemantics(), false));
     zeroTensor = stablehlo::ConstantOp::create(rewriter, loc, resTy, constAttr);
   } else if (isa<mlir::IntegerType>(resElemTy)) {
     auto constAttr = SplatElementsAttr::get(
@@ -2171,13 +2168,31 @@ LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewrite(
         llvm::APInt::getZero(cast<mlir::IntegerType>(resElemTy).getWidth()));
     zeroTensor = stablehlo::ConstantOp::create(rewriter, loc, resTy, constAttr);
   } else {
-    return op.emitError("element type is not float or integer");
+    return op->emitError("element type is not float or integer");
   }
 
   rewriter.replaceOpWithNewOp<stablehlo::SelectOp>(
       op.getOperation(), resTy, bcastedCmpRes, self, zeroTensor);
 
   return success();
+}
+
+template <>
+LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewrite(
+    AtenTrilOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  return convertTrilOrTriu(op, adaptor.getSelf(), adaptor.getDiagonal(),
+                           stablehlo::ComparisonDirection::LE,
+                           getTypeConverter(), rewriter);
+}
+
+template <>
+LogicalResult ConvertAtenOp<AtenTriuOp>::matchAndRewrite(
+    AtenTriuOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  return convertTrilOrTriu(op, adaptor.getSelf(), adaptor.getDiagonal(),
+                           stablehlo::ComparisonDirection::GE,
+                           getTypeConverter(), rewriter);
 }
 
 template <>
@@ -2484,6 +2499,7 @@ void mlir::torch::torch_to_stablehlo::populateBasicOpPatternsAndLegality(
   INSERT_ATENOP_PATTERN(AtenBitwiseRightShiftTensorOp);
 
   INSERT_ATENOP_PATTERN(AtenTrilOp);
+  INSERT_ATENOP_PATTERN(AtenTriuOp);
   INSERT_ATENOP_PATTERN(AtenIsfiniteOp);
   INSERT_ATENOP_PATTERN(AtenSortOp);
 

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -8805,11 +8805,11 @@ ConvertAtenOp<Aten__InterpolateSizeListScaleListOp>::matchAndRewriteImpl(
   return success();
 }
 
-// Template to create supporting tril mask tensor for aten.tril
+// Template to create supporting mask tensor for aten.tril/triu
 template <typename T>
-Value createTrilMask(PatternRewriter &rewriter, Operation *op,
-                     ArrayRef<int64_t> shape, int64_t h, int64_t w,
-                     int64_t diagonal) {
+Value createTrilOrTriuMask(PatternRewriter &rewriter, Operation *op,
+                           ArrayRef<int64_t> shape, int64_t h, int64_t w,
+                           int64_t diagonal, bool isTril) {
   SmallVector<T> vec;
 
   for (int64_t i = 0; i < h; i++) {
@@ -8817,7 +8817,8 @@ Value createTrilMask(PatternRewriter &rewriter, Operation *op,
       // Positive diagonal value includes as many diagonals above the main
       // diagonal, while negative diagonal value excludes as many diagonals
       // below the main diagonal.
-      if (i >= j - diagonal) {
+      auto cmp = isTril ? i >= j - diagonal : i <= j - diagonal;
+      if (cmp) {
         vec.push_back(static_cast<T>(1));
       } else {
         vec.push_back(static_cast<T>(0));
@@ -8828,13 +8829,11 @@ Value createTrilMask(PatternRewriter &rewriter, Operation *op,
   return tosa::getConstTensor<T>(rewriter, op, vec, shape).value();
 }
 
-// Legalization for aten.tril
-template <>
-LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewriteImpl(
-    AtenTrilOp op, OpAdaptor adaptor,
-    ConversionPatternRewriter &rewriter) const {
-  auto self = adaptor.getSelf();
-
+template <typename AtenOpT>
+static LogicalResult
+convertTrilOrTriuTosa(AtenOpT op, Value self, Value diagonalVal, bool isTril,
+                      const TypeConverter *typeConverter,
+                      ConversionPatternRewriter &rewriter) {
   // Not a ranked tensor type
   auto selfType = dyn_cast<RankedTensorType>(self.getType());
   if (!selfType)
@@ -8851,27 +8850,33 @@ LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewriteImpl(
     return rewriter.notifyMatchFailure(
         op, "Currently only static shapes are supported");
 
-  const TypeConverter *typeConverter = this->getTypeConverter();
   RankedTensorType resultType = cast<RankedTensorType>(
       typeConverter->convertType(op->getResult(0).getType()));
   if (!resultType)
     return rewriter.notifyMatchFailure(op, "Result type cannot be empty");
 
+  // clang-format off
   // Get height, width of input tensor, and diagonal arg to create
   // a const mask tensor to multiply with input.
   // This mask tensor has the same height and width of input tensor
-  // and consists of 1's for the lower triangle part and 0's for the rest.
-  // For example, with h=4, w=6, diagonal=1:
+  // and consists of 1's for the lower/higher triangle part and 0's for the rest.
+  // For tril with h=4, w=6, diagonal=1:
   // tensor([[1, 1, 0, 0, 0, 0],
   //         [1, 1, 1, 0, 0, 0],
   //         [1, 1, 1, 1, 0, 0],
   //         [1, 1, 1, 1, 1, 0]])
+  // For triu with h=4, w=6, diagonal=1:
+  // tensor([[0, 1, 1, 1, 1, 1],
+  //         [0, 0, 1, 1, 1, 1],
+  //         [0, 0, 0, 1, 1, 1],
+  //         [0, 0, 0, 0, 1, 1]])
+  // clang-format on
   auto selfShape = selfType.getShape();
   int64_t h = selfShape[selfRank - 2];
   int64_t w = selfShape[selfRank - 1];
   int64_t diagonal;
 
-  if (!matchPattern(op.getDiagonal(), m_TorchConstantInt(&diagonal)))
+  if (!matchPattern(diagonalVal, m_TorchConstantInt(&diagonal)))
     return rewriter.notifyMatchFailure(op, "Diagonal value is not an integer");
 
   // Define shape for mask tensor based on rank
@@ -8881,37 +8886,54 @@ LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewriteImpl(
   maskShape.push_back(h);
   maskShape.push_back(w);
 
-  Value trilMask = TypeSwitch<Type, Value>(resultType.getElementType())
-                       .Case<mlir::FloatType>([&](auto) {
-                         return createTrilMask<float>(rewriter, op, maskShape,
-                                                      h, w, diagonal);
-                       })
-                       .Case<mlir::IntegerType>([&](auto intType) {
-                         switch (intType.getWidth()) {
-                         case 1:
-                           return createTrilMask<bool>(rewriter, op, maskShape,
-                                                       h, w, diagonal);
-                         case 32:
-                           return createTrilMask<int32_t>(
-                               rewriter, op, maskShape, h, w, diagonal);
-                         case 64:
-                           return createTrilMask<int64_t>(
-                               rewriter, op, maskShape, h, w, diagonal);
-                         }
-                         llvm_unreachable("Invalid integer width");
-                       });
+  Value mask =
+      TypeSwitch<Type, Value>(resultType.getElementType())
+          .Case<mlir::FloatType>([&](auto) {
+            return createTrilOrTriuMask<float>(rewriter, op, maskShape, h, w,
+                                               diagonal, isTril);
+          })
+          .template Case<mlir::IntegerType>([&](auto intType) {
+            switch (intType.getWidth()) {
+            case 1:
+              return createTrilOrTriuMask<bool>(rewriter, op, maskShape, h, w,
+                                                diagonal, isTril);
+            case 32:
+              return createTrilOrTriuMask<int32_t>(rewriter, op, maskShape, h,
+                                                   w, diagonal, isTril);
+            case 64:
+              return createTrilOrTriuMask<int64_t>(rewriter, op, maskShape, h,
+                                                   w, diagonal, isTril);
+            }
+            llvm_unreachable("Invalid integer width");
+          });
 
-  if (mlir::tosa::EqualizeRanks(rewriter, op->getLoc(), self, trilMask)
-          .failed())
+  if (mlir::tosa::EqualizeRanks(rewriter, op->getLoc(), self, mask).failed())
     return rewriter.notifyMatchFailure(
         op, "Failed to equalize ranks among operands and result");
 
-  auto result =
-      tosa::createMulOpAndCast(rewriter, op, resultType, self, trilMask,
-                               /*shift=*/0);
+  auto result = tosa::createMulOpAndCast(rewriter, op, resultType, self, mask,
+                                         /*shift=*/0);
   rewriter.replaceOp(op, result.getResult());
 
   return success();
+}
+
+// Legalization for aten.triu
+template <>
+LogicalResult ConvertAtenOp<AtenTriuOp>::matchAndRewriteImpl(
+    AtenTriuOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  return convertTrilOrTriuTosa(op, adaptor.getSelf(), op.getDiagonal(),
+                               /*isTril=*/false, getTypeConverter(), rewriter);
+}
+
+// Legalization for aten.tril
+template <>
+LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewriteImpl(
+    AtenTrilOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  return convertTrilOrTriuTosa(op, adaptor.getSelf(), op.getDiagonal(),
+                               /*isTril=*/true, getTypeConverter(), rewriter);
 }
 
 // Legalization for aten.flip
@@ -11766,6 +11788,7 @@ std::set<StringRef> populateTorchToTosaConversionPatternsAndIllegalOps(
   INSERT_ATENOP_PATTERN(AtenIscloseOp);
   INSERT_ATENOP_PATTERN(Aten__InterpolateSizeListScaleListOp);
   INSERT_ATENOP_PATTERN(AtenTrilOp);
+  INSERT_ATENOP_PATTERN(AtenTriuOp);
   INSERT_ATENOP_PATTERN(AtenDiagonalOp);
   INSERT_ATENOP_PATTERN(AtenIndexSelectOp);
   INSERT_ATENOP_PATTERN(AtenFlipOp);

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -8830,10 +8830,9 @@ Value createTrilOrTriuMask(PatternRewriter &rewriter, Operation *op,
 }
 
 template <typename AtenOpT>
-static LogicalResult
-convertTrilOrTriuTosa(AtenOpT op, Value self, Value diagonalVal, bool isTril,
-                      const TypeConverter *typeConverter,
-                      ConversionPatternRewriter &rewriter) {
+LogicalResult convertTrilOrTriu(AtenOpT op, Value self, Value diagonalVal,
+                                bool isTril, const TypeConverter *typeConverter,
+                                ConversionPatternRewriter &rewriter) {
   // Not a ranked tensor type
   auto selfType = dyn_cast<RankedTensorType>(self.getType());
   if (!selfType)
@@ -8923,8 +8922,8 @@ template <>
 LogicalResult ConvertAtenOp<AtenTriuOp>::matchAndRewriteImpl(
     AtenTriuOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  return convertTrilOrTriuTosa(op, adaptor.getSelf(), op.getDiagonal(),
-                               /*isTril=*/false, getTypeConverter(), rewriter);
+  return convertTrilOrTriu(op, adaptor.getSelf(), op.getDiagonal(),
+                           /*isTril=*/false, getTypeConverter(), rewriter);
 }
 
 // Legalization for aten.tril
@@ -8932,8 +8931,8 @@ template <>
 LogicalResult ConvertAtenOp<AtenTrilOp>::matchAndRewriteImpl(
     AtenTrilOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  return convertTrilOrTriuTosa(op, adaptor.getSelf(), op.getDiagonal(),
-                               /*isTril=*/true, getTypeConverter(), rewriter);
+  return convertTrilOrTriu(op, adaptor.getSelf(), op.getDiagonal(),
+                           /*isTril=*/true, getTypeConverter(), rewriter);
 }
 
 // Legalization for aten.flip

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -769,75 +769,6 @@ static Value performLastReduceAndPermute(PatternRewriter &rewriter,
   return out;
 }
 
-namespace {
-class DecomposeAtenTriuOp : public OpRewritePattern<AtenTriuOp> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(AtenTriuOp op,
-                                PatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-    Value input = op.getSelf();
-    auto inputType = cast<BaseTensorType>(input.getType());
-    if (!inputType.hasSizes() || !inputType.hasDtype()) {
-      return rewriter.notifyMatchFailure(op, "should have shape and dtype");
-    }
-    if (inputType.getSizes().size() < 2) {
-      return rewriter.notifyMatchFailure(op, "the rank of tensor should >= 2");
-    }
-
-    Value cstZero =
-        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(0));
-    Value cstOne =
-        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(1));
-    Value none = ConstantNoneOp::create(rewriter, loc);
-
-    Value rowSize = getTensorDimSize(rewriter, input, -2);
-    Value colSize = getTensorDimSize(rewriter, input, -1);
-
-    auto si64Type = rewriter.getIntegerType(/*width=*/64, /*isSigned*/ true);
-    auto int64DtypeInt = getDtypeIntValueForType(rewriter, loc, si64Type);
-    auto rowArrangeType = getTensorTypeFromShapeValues({rowSize}, si64Type);
-    auto colArrangeType = getTensorTypeFromShapeValues({colSize}, si64Type);
-
-    Value rowArange =
-        AtenArangeOp::create(rewriter, loc, rowArrangeType, rowSize,
-                             /*dtype=*/int64DtypeInt, /*layout=*/none,
-                             /*device=*/none, /*pin_memory=*/none);
-    Value colArange =
-        AtenArangeOp::create(rewriter, loc, colArrangeType, colSize,
-                             /*dtype=*/int64DtypeInt, /*layout=*/none,
-                             /*device=*/none, /*pin_memory=*/none);
-
-    auto unsqueezeRowArangeInfo =
-        unsqueezeTensor(rewriter, op, rowArange, cstOne);
-    auto unsqueezeColArangeInfo =
-        unsqueezeTensor(rewriter, op, colArange, cstZero);
-
-    if (failed(unsqueezeRowArangeInfo) || failed(unsqueezeColArangeInfo)) {
-      return rewriter.notifyMatchFailure(op,
-                                         "cannot generate unsqueeze tensor");
-    }
-
-    Value unsqueezeRowArange = unsqueezeRowArangeInfo.value();
-    Value unsqueezeColArange = unsqueezeColArangeInfo.value();
-
-    Value unsqueezeRowArangePlusDiagonal =
-        AtenAddScalarOp::create(rewriter, loc, unsqueezeRowArange.getType(),
-                                unsqueezeRowArange, op.getDiagonal(), cstOne);
-
-    auto boolType = rewriter.getI1Type();
-    auto condType = getTensorTypeFromShapeValues({rowSize, colSize}, boolType);
-    Value condTensor =
-        AtenGeTensorOp::create(rewriter, loc, condType, unsqueezeColArange,
-                               unsqueezeRowArangePlusDiagonal);
-
-    rewriter.replaceOpWithNewOp<AtenWhereScalarOtherOp>(
-        op, op.getResult().getType(), condTensor, input, cstZero);
-    return success();
-  }
-};
-} // namespace
-
 /*
  This function calculates the number of elements in the lower triangle (below
  the main diagonal) of a tensor with dimensions [row, col]. The main diagonal
@@ -13481,7 +13412,6 @@ public:
     addPatternIfTargetOpIsIllegal<DecomposeAtenTypeAsOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenTileOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenReshapeAsOp>(patterns);
-    addPatternIfTargetOpIsIllegal<DecomposeAtenTriuOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenTriuIndicesOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenTrilIndicesOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenDeg2radOp>(patterns);

--- a/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
+++ b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
@@ -581,7 +581,6 @@ static void markDecomposedOpsAsIllegal(MLIRContext *context,
   target.addIllegalOp<AtenTypeAsOp>();
   target.addIllegalOp<AtenTileOp>();
   target.addIllegalOp<AtenReshapeAsOp>();
-  target.addIllegalOp<AtenTriuOp>();
   target.addIllegalOp<AtenTriuIndicesOp>();
   target.addIllegalOp<AtenTrilIndicesOp>();
   target.addIllegalOp<AtenDeg2radOp>();

--- a/test/Conversion/TorchToStablehlo/basic.mlir
+++ b/test/Conversion/TorchToStablehlo/basic.mlir
@@ -360,3 +360,25 @@ func.func @torch.aten.sort(%arg0: !torch.vtensor<[2,3],f32>) -> (!torch.vtensor<
   %values, %indices = torch.aten.sort %arg0, %int-1, %true : !torch.vtensor<[2,3],f32>, !torch.int, !torch.bool -> !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],si64>
   return %values, %indices : !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],si64>
 }
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten.triu(
+// CHECK-SAME:                   %[[ARG_0:.*]]: !torch.vtensor<[2,3,5],f32>,
+// CHECK-SAME:                   %[[ARG_1:.*]]: !torch.int) -> !torch.vtensor<[2,3,5],f32>
+// CHECK-DAG:       %[[VAL_0:.*]] = torch_c.to_builtin_tensor %[[ARG_0]] : !torch.vtensor<[2,3,5],f32> -> tensor<2x3x5xf32>
+// CHECK-DAG:       %[[VAL_1:.*]] = torch_c.to_i64 %[[ARG_1]]
+// CHECK:           %[[VAL_2:.*]] = stablehlo.iota dim = 1 : tensor<3x5xi64>
+// CHECK:           %[[VAL_3:.*]] = stablehlo.iota dim = 0 : tensor<3x5xi64>
+// CHECK:           %[[VAL_4:.*]] = tensor.from_elements %[[VAL_1]] : tensor<1xi64>
+// CHECK:           %[[VAL_5:.*]] = chlo.broadcast_add %[[VAL_3]], %[[VAL_4]] {broadcast_dimensions = array<i64: 1>} : (tensor<3x5xi64>, tensor<1xi64>) -> tensor<3x5xi64>
+// CHECK:           %[[VAL_6:.*]] = stablehlo.compare  GE, %[[VAL_2]], %[[VAL_5]],  SIGNED : (tensor<3x5xi64>, tensor<3x5xi64>) -> tensor<3x5xi1>
+// CHECK:           %[[VAL_7:.*]] = stablehlo.broadcast_in_dim %[[VAL_6]], dims = [1, 2] : (tensor<3x5xi1>) -> tensor<2x3x5xi1>
+// CHECK:           %[[VAL_8:.*]] = stablehlo.constant dense<0.000000e+00> : tensor<2x3x5xf32>
+// CHECK:           %[[VAL_9:.*]] = stablehlo.select %[[VAL_7]], %[[VAL_0]], %[[VAL_8]] : tensor<2x3x5xi1>, tensor<2x3x5xf32>
+// CHECK:           %[[VAL_10:.*]] = torch_c.from_builtin_tensor %[[VAL_9]] : tensor<2x3x5xf32> -> !torch.vtensor<[2,3,5],f32>
+// CHECK:           return %[[VAL_10:.*]] : !torch.vtensor<[2,3,5],f32>
+func.func @torch.aten.triu(%arg0: !torch.vtensor<[2,3,5],f32>, %arg1: !torch.int) -> !torch.vtensor<[2,3,5],f32> {
+  %0 = torch.aten.triu %arg0, %arg1:!torch.vtensor<[2,3,5],f32>, !torch.int -> !torch.vtensor<[2,3,5],f32>
+  return %0 : !torch.vtensor<[2,3,5],f32>
+}

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -2204,6 +2204,24 @@ func.func @torch.aten.tril$basic(%arg0: !torch.vtensor<[2,4], si32>) -> !torch.v
 
 // -----
 
+// CHECK-LABEL:   func.func @torch.aten.triu$basic(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !torch.vtensor<[2,4],si32>) -> !torch.vtensor<[2,4],si32> {
+// CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[2,4],si32> -> tensor<2x4xi32>
+// CHECK:           %[[VAL_2:.*]] = torch.constant.int 1
+// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{values = dense<{{\[\[}}0, 1, 1, 1], [0, 0, 1, 1]]> : tensor<2x4xi32>}> : () -> tensor<2x4xi32>
+// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           %[[VAL_5:.*]] = tosa.mul %[[VAL_1]], %[[VAL_3]], %[[VAL_4]] : (tensor<2x4xi32>, tensor<2x4xi32>, tensor<1xi8>) -> tensor<2x4xi32>
+// CHECK:           %[[VAL_6:.*]] = torch_c.from_builtin_tensor %[[VAL_5]] : tensor<2x4xi32> -> !torch.vtensor<[2,4],si32>
+// CHECK:           return %[[VAL_6]] : !torch.vtensor<[2,4],si32>
+// CHECK:         }
+func.func @torch.aten.triu$basic(%arg0: !torch.vtensor<[2,4], si32>) -> !torch.vtensor<[2,4], si32> {
+  %int0 = torch.constant.int 1
+  %0 = torch.aten.triu %arg0, %int0 : !torch.vtensor<[2,4],si32>, !torch.int -> !torch.vtensor<[2,4],si32>
+  return %0 : !torch.vtensor<[2,4],si32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.min.dim$basic(
 // CHECK-SAME:                                        %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: tensor<3x2x3xf32>) -> tensor<3x2x1xf32> {
 // CHECK:           %[[VAL_1:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<3x2x3xf32> -> !torch.vtensor<[3,2,3],f32>

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -2215,8 +2215,8 @@ func.func @torch.aten.tril$basic(%arg0: !torch.vtensor<[2,4], si32>) -> !torch.v
 // CHECK:           return %[[VAL_6]] : !torch.vtensor<[2,4],si32>
 // CHECK:         }
 func.func @torch.aten.triu$basic(%arg0: !torch.vtensor<[2,4], si32>) -> !torch.vtensor<[2,4], si32> {
-  %int0 = torch.constant.int 1
-  %0 = torch.aten.triu %arg0, %int0 : !torch.vtensor<[2,4],si32>, !torch.int -> !torch.vtensor<[2,4],si32>
+  %int1 = torch.constant.int 1
+  %0 = torch.aten.triu %arg0, %int1 : !torch.vtensor<[2,4],si32>, !torch.int -> !torch.vtensor<[2,4],si32>
   return %0 : !torch.vtensor<[2,4],si32>
 }
 

--- a/test/Dialect/Torch/torch-onnx-to-torch-backend-pipeline.mlir
+++ b/test/Dialect/Torch/torch-onnx-to-torch-backend-pipeline.mlir
@@ -12,27 +12,6 @@ func.func @test_reshape_negative_dim_decompose(%arg0: !torch.vtensor<[2,3,4],f32
 
 // -----
 
-// CHECK-LABEL: func.func @test_triu_decompose
-func.func @test_triu_decompose(%arg0: !torch.vtensor<[4,5],si64>) -> !torch.vtensor<[4,5],si64> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 14 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-  // CHECK: %[[ZERO_TENSOR:.+]] = torch.vtensor.literal(dense<0> : tensor<si64>) : !torch.vtensor<[],si64>
-  // CHECK: %[[INT0:.+]] = torch.constant.int 0
-  // CHECK: %[[INT1:.+]] = torch.constant.int 1
-  // CHECK: %[[NONE:.+]] = torch.constant.none
-  // CHECK: %[[INT4:.+]] = torch.constant.int 4
-  // CHECK: %[[INT5:.+]] = torch.constant.int 5
-  // CHECK: %[[ARANGE:.+]] = torch.aten.arange.start_step %[[INT0]], %[[INT4]], %[[INT1]], %[[INT4]], %[[NONE]], %[[NONE]], %[[NONE]] : !torch.int, !torch.int, !torch.int, !torch.int, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[4],si64>
-  // CHECK: %[[ARANGE_0:.+]] = torch.aten.arange.start_step %[[INT0]], %[[INT5]], %[[INT1]], %[[INT4]], %[[NONE]], %[[NONE]], %[[NONE]] : !torch.int, !torch.int, !torch.int, !torch.int, !torch.none, !torch.none, !torch.none -> !torch.vtensor<[5],si64>
-  // CHECK: %[[UNSQUEEZE:.+]] = torch.aten.unsqueeze %[[ARANGE]], %[[INT1]] : !torch.vtensor<[4],si64>, !torch.int -> !torch.vtensor<[4,1],si64>
-  // CHECK: %[[UNSQUEEZE_0:.+]] = torch.aten.unsqueeze %[[ARANGE_0]], %[[INT0]] : !torch.vtensor<[5],si64>, !torch.int -> !torch.vtensor<[1,5],si64>
-  // CHECK: %[[ADD:.+]] = torch.aten.add.Scalar %[[UNSQUEEZE]], %[[INT0]], %[[INT1]] : !torch.vtensor<[4,1],si64>, !torch.int, !torch.int -> !torch.vtensor<[4,1],si64>
-  // CHECK: %[[COND:.+]] = torch.aten.ge.Tensor %[[UNSQUEEZE_0]], %[[ADD]] : !torch.vtensor<[1,5],si64>, !torch.vtensor<[4,1],si64> -> !torch.vtensor<[4,5],i1>
-  // CHECK: %[[RESULT:.+]] = torch.aten.where.self %[[COND]], %arg0, %[[ZERO_TENSOR]] : !torch.vtensor<[4,5],i1>, !torch.vtensor<[4,5],si64>, !torch.vtensor<[],si64> -> !torch.vtensor<[4,5],si64>
-  %0 = torch.operator "onnx.Trilu"(%arg0) : (!torch.vtensor<[4,5],si64>) -> !torch.vtensor<[4,5],si64>
-  return %0 : !torch.vtensor<[4,5],si64>
-}
-
-// -----
-
 module {
 // CHECK-LABEL: func.func @test_scalarize
   func.func @test_scalarize(%arg0: !torch.vtensor<[?,?,16,64],f32>) -> !torch.vtensor<[?,?,?],f32> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 21 : si64, torch.onnx_meta.producer_name = "pytorch", torch.onnx_meta.producer_version = "1.11.0"} {


### PR DESCRIPTION
## Description

Add support for lowering `torch.aten.triu` in both `TorchToStablehlo` and `TorchToTosa` conversion passes.

To prevent code duplication, the implementation refactors and unifies the core logic of `AtenTrilOp` and `AtenTriuOp` under shared helper templates (`convertTrilOrTriu` and `convertTrilOrTriuTosa`), parameterizing only the comparison direction (GE for triu, LE for tril) and mask generation.

## Tests

1. see unit tests added in the commit.
2. run e2e test via https://gist.github.com/hsqStephenZhang/66e0ed68cc43acdc18a4f4d9959c07a7. all backends generate code as efficient as code generated for `tril`

Fixes https://github.com/llvm/torch-mlir/issues/4604