### PR TITLE
[fx] Align c10 ScalarType codes for complex dtypes

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -244,9 +244,9 @@ TORCH_DTYPE_TO_INT = {
     torch.float16: 5,
     torch.float32: 6,
     torch.float64: 7,
-    # torch.complex_half 8
-    torch.complex32: 9,
-    torch.complex64: 10,
+    torch.complex32: 8,  # ComplexHalf
+    torch.complex64: 9,  # ComplexFloat
+    torch.complex128: 10,  # ComplexDouble
     torch.bool: 11,
     # torch.qint8: 12, # quantized dtypes are not supported in all backends, currently we do not support them
     # torch.quint8: 13,

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -40,6 +40,24 @@ func.func @torch.aten.assert_tensor_metadata() {
   return
 }
 
+// CHECK-LABEL:   func.func @torch.aten.assert_tensor_metadata$complex64
+// CHECK-NEXT:      return
+func.func @torch.aten.assert_tensor_metadata$complex64(%arg0: !torch.vtensor<[4],complex<f32>>) {
+  %int9 = torch.constant.int 9
+  %none = torch.constant.none
+  torch.aten._assert_tensor_metadata %arg0, %none, %none, %int9, %none, %none : !torch.vtensor<[4],complex<f32>>, !torch.none, !torch.none, !torch.int, !torch.none, !torch.none
+  return
+}
+
+// CHECK-LABEL:   func.func @torch.aten.assert_tensor_metadata$complex128
+// CHECK-NEXT:      return
+func.func @torch.aten.assert_tensor_metadata$complex128(%arg0: !torch.vtensor<[4],complex<f64>>) {
+  %int10 = torch.constant.int 10
+  %none = torch.constant.none
+  torch.aten._assert_tensor_metadata %arg0, %none, %none, %int10, %none, %none : !torch.vtensor<[4],complex<f64>>, !torch.none, !torch.none, !torch.int, !torch.none, !torch.none
+  return
+}
+
 // CHECK-LABEL:   func.func @torch.aten.ones_item
 // CHECK:           %[[CONST:.*]] = torch.constant.int 1
 // CHECK:           return %[[CONST]] : !torch.int

--- a/test/python/fx_importer/complex_dtype_test.py
+++ b/test/python/fx_importer/complex_dtype_test.py
@@ -1,0 +1,57 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import torch
+import torch.nn as nn
+
+from torch_mlir import fx
+from torch_mlir.extras.fx_importer import TORCH_DTYPE_TO_INT
+
+
+def run(f):
+    print(f"{f.__name__}")
+    print("-" * len(f.__name__))
+    f()
+    print()
+
+
+@run
+# CHECK-LABEL: test_complex_dtype_int_codes
+# CHECK: complex32=8 complex64=9 complex128=10
+def test_complex_dtype_int_codes():
+    assert TORCH_DTYPE_TO_INT[torch.complex32] == 8
+    assert TORCH_DTYPE_TO_INT[torch.complex64] == 9
+    assert TORCH_DTYPE_TO_INT[torch.complex128] == 10
+    print(
+        f"complex32={TORCH_DTYPE_TO_INT[torch.complex32]} "
+        f"complex64={TORCH_DTYPE_TO_INT[torch.complex64]} "
+        f"complex128={TORCH_DTYPE_TO_INT[torch.complex128]}"
+    )
+
+
+@run
+# CHECK-LABEL: test_import_complex64
+# CHECK: %[[C9:.+]] = torch.constant.int 9
+# CHECK: torch.prims.convert_element_type %{{.+}}, %[[C9]] {{.*}}-> !torch.vtensor<[4],complex<f32>>
+def test_import_complex64():
+    class Model(nn.Module):
+        def forward(self, x):
+            return x.to(torch.complex64)
+
+    print(fx.export_and_import(Model(), torch.randn(4)))
+
+
+@run
+# CHECK-LABEL: test_import_complex128
+# CHECK: %[[C10:.+]] = torch.constant.int 10
+# CHECK: torch.prims.convert_element_type %{{.+}}, %[[C10]] {{.*}}-> !torch.vtensor<[4],complex<f64>>
+def test_import_complex128():
+    class Model(nn.Module):
+        def forward(self, x):
+            return x.to(torch.complex128)
+
+    print(fx.export_and_import(Model(), torch.randn(4)))


### PR DESCRIPTION
`TORCH_DTYPE_TO_INT` in the FX importer was off-by-one for the complex dtypes versus the c10 `ScalarType` enum in `TorchUpstream.h` (`AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS`): `ComplexHalf=8`,
`ComplexFloat=9`, `ComplexDouble=10`.
When I export a model with torch.complex128 dtype, I get an Key error. When a model has a complex64 dtype, I can get the .mlir but It cannot be optimized as the constant representing complex64 is not the same as in `TorchUpstream.h`.

@zjgarvey @stellaraccident 