### PR TITLE
[TorchOnnxToTorch] Fix onnx.Unique lowering for optional trailing outputs

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -4423,6 +4423,14 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
             binder.tensorResultTypes(resultTypes))
           return failure();
 
+        // ONNX `Unique` exposes up to four outputs (Y, indices,
+        // inverse_indices, counts); the trailing ones are optional, so the
+        // model may request anywhere from 1 to 4 results.
+        unsigned numResults = resultTypes.size();
+        if (numResults < 1 || numResults > 4)
+          return rewriter.notifyMatchFailure(
+              binder.op, "expected between 1 and 4 results for onnx.Unique");
+
         Value zero = Torch::ConstantIntOp::create(rewriter, binder.getLoc(), 0);
 
         auto inputTy = cast<Torch::ValueTensorType>(input.getType());
@@ -4434,7 +4442,6 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         int64_t inputDim = static_cast<int64_t>(inputShape.size());
 
         Value axisVal;
-        SmallVector<int64_t> outputTensorSizes(inputDim);
         bool axisWasNone;
         if (!binder.optionalS64IntegerAttr(axis, "axis")) {
           if (axis < -1 * inputDim || axis > inputDim - 1)
@@ -4453,14 +4460,28 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         Value trueVal =
             Torch::ConstantBoolOp::create(rewriter, binder.getLoc(), true);
 
-        // The shape of inverse_indices is the same as input shape, but
-        // resulTypes[2] must be used to avoid live value after conversion.
-        Torch::ValueTensorType outputTy;
-        outputTy = cast<Torch::ValueTensorType>(resultTypes[0]);
-        Torch::ValueTensorType countsTy =
-            cast<Torch::ValueTensorType>(resultTypes[3]);
+        // `aten.unique_dim` always returns three values
+        // (output, inverse_indices, counts), so for any unrequested ONNX
+        // result we synthesize a sensible type. The synthesized dtype is
+        // signed-int64 to match what `aten.unique_dim` produces for
+        // inverse_indices/counts.
+        auto outputTy = cast<Torch::ValueTensorType>(resultTypes[0]);
+        Type i64Dtype =
+            IntegerType::get(rewriter.getContext(), 64, IntegerType::Signed);
+        Torch::ValueTensorType indicesTy =
+            numResults > 1
+                ? cast<Torch::ValueTensorType>(resultTypes[1])
+                : rewriter.getType<Torch::ValueTensorType>(
+                      ArrayRef<int64_t>{outputTy.getSizes()[0]}, i64Dtype);
         Torch::ValueTensorType inverseTy =
-            cast<Torch::ValueTensorType>(resultTypes[2]);
+            numResults > 2 ? cast<Torch::ValueTensorType>(resultTypes[2])
+                           : rewriter.getType<Torch::ValueTensorType>(
+                                 inputShape, i64Dtype);
+        Torch::ValueTensorType countsTy =
+            numResults > 3
+                ? cast<Torch::ValueTensorType>(resultTypes[3])
+                : rewriter.getType<Torch::ValueTensorType>(
+                      ArrayRef<int64_t>{outputTy.getSizes()[0]}, i64Dtype);
 
         if (axisWasNone) {
           int64_t inputNumel = 1;
@@ -4487,50 +4508,62 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
 
         SmallVector<Value> uniqueResults = intermResults.getResults();
 
-        // Calculate the indices where each of the unique elements first
-        // appeared in the original input tensor. Also, the counts tensor and
-        // the indices tensor have the same Dtype, int64, so reuse that here.
-        auto arangeResultType = rewriter.getType<Torch::ValueTensorType>(
-            ArrayRef<int64_t>({inputShape[0]}), countsTy.getOptionalDtype());
+        SmallVector<Value> finalResults;
+        finalResults.push_back(uniqueResults[0]);
 
-        Value inputDimZero = Torch::ConstantIntOp::create(
-            rewriter, binder.getLoc(),
-            rewriter.getI64IntegerAttr(inputShape[0]));
-        Value int64Type = Torch::ConstantIntOp::create(
-            rewriter, binder.getLoc(), rewriter.getI64IntegerAttr(4));
-        Value noneVal =
-            Torch::ConstantNoneOp::create(rewriter, binder.getLoc());
+        if (numResults > 1) {
+          // Calculate the indices where each of the unique elements first
+          // appeared in the original input tensor. Also, the counts tensor
+          // and the indices tensor have the same Dtype, int64, so reuse
+          // that here.
+          auto arangeResultType = rewriter.getType<Torch::ValueTensorType>(
+              ArrayRef<int64_t>({inputShape[0]}), countsTy.getOptionalDtype());
 
-        Value perm = Torch::AtenArangeOp::create(
-            rewriter, binder.getLoc(), arangeResultType, inputDimZero,
-            /*dtype=*/int64Type,
-            /*layout=*/noneVal, /*device=*/noneVal, /*pin_memory=*/noneVal);
+          Value inputDimZero = Torch::ConstantIntOp::create(
+              rewriter, binder.getLoc(),
+              rewriter.getI64IntegerAttr(inputShape[0]));
+          Value int64Type = Torch::ConstantIntOp::create(
+              rewriter, binder.getLoc(), rewriter.getI64IntegerAttr(4));
+          Value noneVal =
+              Torch::ConstantNoneOp::create(rewriter, binder.getLoc());
 
-        // Inverse has the same shape as input, but the dtype is not the same.
-        Value flipDims = createConstantIntList(binder, rewriter, {0});
-        Value inverse = Torch::AtenFlipOp::create(
-            rewriter, binder.getLoc(),
-            inputTy.getWithSizesAndDtype(inputShape, countsTy.getDtype()),
-            uniqueResults[1], flipDims);
-        perm = Torch::AtenFlipOp::create(
-            rewriter, binder.getLoc(),
-            cast<Torch::ValueTensorType>(perm.getType()), perm, flipDims);
+          Value perm = Torch::AtenArangeOp::create(
+              rewriter, binder.getLoc(), arangeResultType, inputDimZero,
+              /*dtype=*/int64Type,
+              /*layout=*/noneVal, /*device=*/noneVal, /*pin_memory=*/noneVal);
 
-        auto newInverseTy = rewriter.getType<Torch::ValueTensorType>(
-            ArrayRef<int64_t>({outputTy.getSizes()[0]}), countsTy.getDtype());
-        Value newInverseSize =
-            createConstantIntList(binder, rewriter, {outputTy.getSizes()[0]});
-        Value newInverse = Torch::AtenNewEmptyOp::create(
-            rewriter, binder.getLoc(), newInverseTy, inverse, newInverseSize,
-            /*dtype=*/int64Type, /*layout=*/noneVal, /*device=*/noneVal,
-            /*pin_memory=*/noneVal);
+          // Inverse has the same shape as input, but the dtype is not the
+          // same.
+          Value flipDims = createConstantIntList(binder, rewriter, {0});
+          Value inverse = Torch::AtenFlipOp::create(
+              rewriter, binder.getLoc(),
+              inputTy.getWithSizesAndDtype(inputShape, countsTy.getDtype()),
+              uniqueResults[1], flipDims);
+          perm = Torch::AtenFlipOp::create(
+              rewriter, binder.getLoc(),
+              cast<Torch::ValueTensorType>(perm.getType()), perm, flipDims);
 
-        Value firstOccurIndices = Torch::AtenScatterSrcOp::create(
-            rewriter, binder.getLoc(), resultTypes[1], newInverse, zero,
-            inverse, perm);
+          auto newInverseTy = rewriter.getType<Torch::ValueTensorType>(
+              ArrayRef<int64_t>({outputTy.getSizes()[0]}), countsTy.getDtype());
+          Value newInverseSize =
+              createConstantIntList(binder, rewriter, {outputTy.getSizes()[0]});
+          Value newInverse = Torch::AtenNewEmptyOp::create(
+              rewriter, binder.getLoc(), newInverseTy, inverse, newInverseSize,
+              /*dtype=*/int64Type, /*layout=*/noneVal, /*device=*/noneVal,
+              /*pin_memory=*/noneVal);
 
-        rewriter.replaceOp(binder.op, {uniqueResults[0], firstOccurIndices,
-                                       uniqueResults[1], uniqueResults[2]});
+          Value firstOccurIndices = Torch::AtenScatterSrcOp::create(
+              rewriter, binder.getLoc(), indicesTy, newInverse, zero, inverse,
+              perm);
+
+          finalResults.push_back(firstOccurIndices);
+        }
+        if (numResults > 2)
+          finalResults.push_back(uniqueResults[1]);
+        if (numResults > 3)
+          finalResults.push_back(uniqueResults[2]);
+
+        rewriter.replaceOp(binder.op, finalResults);
         return success();
       });
   patterns.onOp(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -4453,6 +4453,14 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
             binder.tensorResultTypes(resultTypes))
           return failure();
 
+        // ONNX `Unique` exposes up to four outputs (Y, indices,
+        // inverse_indices, counts); the trailing ones are optional, so the
+        // model may request anywhere from 1 to 4 results.
+        unsigned numResults = resultTypes.size();
+        if (numResults < 1 || numResults > 4)
+          return rewriter.notifyMatchFailure(
+              binder.op, "expected between 1 and 4 results for onnx.Unique");
+
         Value zero = Torch::ConstantIntOp::create(rewriter, binder.getLoc(), 0);
 
         auto inputTy = cast<Torch::ValueTensorType>(input.getType());
@@ -4464,7 +4472,6 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         int64_t inputDim = static_cast<int64_t>(inputShape.size());
 
         Value axisVal;
-        SmallVector<int64_t> outputTensorSizes(inputDim);
         bool axisWasNone;
         if (!binder.optionalS64IntegerAttr(axis, "axis")) {
           if (axis < -1 * inputDim || axis > inputDim - 1)
@@ -4483,14 +4490,28 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         Value trueVal =
             Torch::ConstantBoolOp::create(rewriter, binder.getLoc(), true);
 
-        // The shape of inverse_indices is the same as input shape, but
-        // resulTypes[2] must be used to avoid live value after conversion.
-        Torch::ValueTensorType outputTy;
-        outputTy = cast<Torch::ValueTensorType>(resultTypes[0]);
-        Torch::ValueTensorType countsTy =
-            cast<Torch::ValueTensorType>(resultTypes[3]);
+        // `aten.unique_dim` always returns three values
+        // (output, inverse_indices, counts), so for any unrequested ONNX
+        // result we synthesize a sensible type. The synthesized dtype is
+        // signed-int64 to match what `aten.unique_dim` produces for
+        // inverse_indices/counts.
+        auto outputTy = cast<Torch::ValueTensorType>(resultTypes[0]);
+        Type i64Dtype =
+            IntegerType::get(rewriter.getContext(), 64, IntegerType::Signed);
+        Torch::ValueTensorType indicesTy =
+            numResults > 1
+                ? cast<Torch::ValueTensorType>(resultTypes[1])
+                : rewriter.getType<Torch::ValueTensorType>(
+                      ArrayRef<int64_t>{outputTy.getSizes()[0]}, i64Dtype);
         Torch::ValueTensorType inverseTy =
-            cast<Torch::ValueTensorType>(resultTypes[2]);
+            numResults > 2 ? cast<Torch::ValueTensorType>(resultTypes[2])
+                           : rewriter.getType<Torch::ValueTensorType>(
+                                 inputShape, i64Dtype);
+        Torch::ValueTensorType countsTy =
+            numResults > 3
+                ? cast<Torch::ValueTensorType>(resultTypes[3])
+                : rewriter.getType<Torch::ValueTensorType>(
+                      ArrayRef<int64_t>{outputTy.getSizes()[0]}, i64Dtype);
 
         if (axisWasNone) {
           int64_t inputNumel = 1;
@@ -4517,50 +4538,62 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
 
         SmallVector<Value> uniqueResults = intermResults.getResults();
 
-        // Calculate the indices where each of the unique elements first
-        // appeared in the original input tensor. Also, the counts tensor and
-        // the indices tensor have the same Dtype, int64, so reuse that here.
-        auto arangeResultType = rewriter.getType<Torch::ValueTensorType>(
-            ArrayRef<int64_t>({inputShape[0]}), countsTy.getOptionalDtype());
+        SmallVector<Value> finalResults;
+        finalResults.push_back(uniqueResults[0]);
 
-        Value inputDimZero = Torch::ConstantIntOp::create(
-            rewriter, binder.getLoc(),
-            rewriter.getI64IntegerAttr(inputShape[0]));
-        Value int64Type = Torch::ConstantIntOp::create(
-            rewriter, binder.getLoc(), rewriter.getI64IntegerAttr(4));
-        Value noneVal =
-            Torch::ConstantNoneOp::create(rewriter, binder.getLoc());
+        if (numResults > 1) {
+          // Calculate the indices where each of the unique elements first
+          // appeared in the original input tensor. Also, the counts tensor
+          // and the indices tensor have the same Dtype, int64, so reuse
+          // that here.
+          auto arangeResultType = rewriter.getType<Torch::ValueTensorType>(
+              ArrayRef<int64_t>({inputShape[0]}), countsTy.getOptionalDtype());
 
-        Value perm = Torch::AtenArangeOp::create(
-            rewriter, binder.getLoc(), arangeResultType, inputDimZero,
-            /*dtype=*/int64Type,
-            /*layout=*/noneVal, /*device=*/noneVal, /*pin_memory=*/noneVal);
+          Value inputDimZero = Torch::ConstantIntOp::create(
+              rewriter, binder.getLoc(),
+              rewriter.getI64IntegerAttr(inputShape[0]));
+          Value int64Type = Torch::ConstantIntOp::create(
+              rewriter, binder.getLoc(), rewriter.getI64IntegerAttr(4));
+          Value noneVal =
+              Torch::ConstantNoneOp::create(rewriter, binder.getLoc());
 
-        // Inverse has the same shape as input, but the dtype is not the same.
-        Value flipDims = createConstantIntList(binder, rewriter, {0});
-        Value inverse = Torch::AtenFlipOp::create(
-            rewriter, binder.getLoc(),
-            inputTy.getWithSizesAndDtype(inputShape, countsTy.getDtype()),
-            uniqueResults[1], flipDims);
-        perm = Torch::AtenFlipOp::create(
-            rewriter, binder.getLoc(),
-            cast<Torch::ValueTensorType>(perm.getType()), perm, flipDims);
+          Value perm = Torch::AtenArangeOp::create(
+              rewriter, binder.getLoc(), arangeResultType, inputDimZero,
+              /*dtype=*/int64Type,
+              /*layout=*/noneVal, /*device=*/noneVal, /*pin_memory=*/noneVal);
 
-        auto newInverseTy = rewriter.getType<Torch::ValueTensorType>(
-            ArrayRef<int64_t>({outputTy.getSizes()[0]}), countsTy.getDtype());
-        Value newInverseSize =
-            createConstantIntList(binder, rewriter, {outputTy.getSizes()[0]});
-        Value newInverse = Torch::AtenNewEmptyOp::create(
-            rewriter, binder.getLoc(), newInverseTy, inverse, newInverseSize,
-            /*dtype=*/int64Type, /*layout=*/noneVal, /*device=*/noneVal,
-            /*pin_memory=*/noneVal);
+          // Inverse has the same shape as input, but the dtype is not the
+          // same.
+          Value flipDims = createConstantIntList(binder, rewriter, {0});
+          Value inverse = Torch::AtenFlipOp::create(
+              rewriter, binder.getLoc(),
+              inputTy.getWithSizesAndDtype(inputShape, countsTy.getDtype()),
+              uniqueResults[1], flipDims);
+          perm = Torch::AtenFlipOp::create(
+              rewriter, binder.getLoc(),
+              cast<Torch::ValueTensorType>(perm.getType()), perm, flipDims);
 
-        Value firstOccurIndices = Torch::AtenScatterSrcOp::create(
-            rewriter, binder.getLoc(), resultTypes[1], newInverse, zero,
-            inverse, perm);
+          auto newInverseTy = rewriter.getType<Torch::ValueTensorType>(
+              ArrayRef<int64_t>({outputTy.getSizes()[0]}), countsTy.getDtype());
+          Value newInverseSize =
+              createConstantIntList(binder, rewriter, {outputTy.getSizes()[0]});
+          Value newInverse = Torch::AtenNewEmptyOp::create(
+              rewriter, binder.getLoc(), newInverseTy, inverse, newInverseSize,
+              /*dtype=*/int64Type, /*layout=*/noneVal, /*device=*/noneVal,
+              /*pin_memory=*/noneVal);
 
-        rewriter.replaceOp(binder.op, {uniqueResults[0], firstOccurIndices,
-                                       uniqueResults[1], uniqueResults[2]});
+          Value firstOccurIndices = Torch::AtenScatterSrcOp::create(
+              rewriter, binder.getLoc(), indicesTy, newInverse, zero, inverse,
+              perm);
+
+          finalResults.push_back(firstOccurIndices);
+        }
+        if (numResults > 2)
+          finalResults.push_back(uniqueResults[1]);
+        if (numResults > 3)
+          finalResults.push_back(uniqueResults[2]);
+
+        rewriter.replaceOp(binder.op, finalResults);
         return success();
       });
   patterns.onOp(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -4470,6 +4470,9 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         }
         auto inputShape = inputTy.getSizes();
         int64_t inputDim = static_cast<int64_t>(inputShape.size());
+        if (inputDim < 1)
+          return rewriter.notifyMatchFailure(
+              binder.op, "Expected input to have a rank of at least one");
 
         Value axisVal;
         bool axisWasNone;

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -4490,28 +4490,12 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         Value trueVal =
             Torch::ConstantBoolOp::create(rewriter, binder.getLoc(), true);
 
-        // `aten.unique_dim` always returns three values
-        // (output, inverse_indices, counts), so for any unrequested ONNX
-        // result we synthesize a sensible type. The synthesized dtype is
-        // signed-int64 to match what `aten.unique_dim` produces for
-        // inverse_indices/counts.
-        auto outputTy = cast<Torch::ValueTensorType>(resultTypes[0]);
-        Type i64Dtype =
-            IntegerType::get(rewriter.getContext(), 64, IntegerType::Signed);
-        Torch::ValueTensorType indicesTy =
-            numResults > 1
-                ? cast<Torch::ValueTensorType>(resultTypes[1])
-                : rewriter.getType<Torch::ValueTensorType>(
-                      ArrayRef<int64_t>{outputTy.getSizes()[0]}, i64Dtype);
-        Torch::ValueTensorType inverseTy =
-            numResults > 2 ? cast<Torch::ValueTensorType>(resultTypes[2])
-                           : rewriter.getType<Torch::ValueTensorType>(
-                                 inputShape, i64Dtype);
-        Torch::ValueTensorType countsTy =
-            numResults > 3
-                ? cast<Torch::ValueTensorType>(resultTypes[3])
-                : rewriter.getType<Torch::ValueTensorType>(
-                      ArrayRef<int64_t>{outputTy.getSizes()[0]}, i64Dtype);
+        // ONNX flattens the input when `axis` is absent, so the trailing
+        // outputs are always indexed along a single dimension. Record which
+        // dimension that is, and how long the input is along it, so that the
+        // type of any output the model did not request can be synthesized.
+        int64_t axisDim = axisWasNone ? 0 : (axis < 0 ? axis + inputDim : axis);
+        int64_t axisSize = inputShape[axisDim];
 
         if (axisWasNone) {
           int64_t inputNumel = 1;
@@ -4530,7 +4514,33 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           input = Torch::AtenFlattenUsingIntsOp::create(
               rewriter, binder.getLoc(), flattenResultTy, input, zero,
               negativeOne);
+          axisSize = inputNumel;
         }
+
+        auto outputTy = cast<Torch::ValueTensorType>(resultTypes[0]);
+        if (!outputTy.hasSizes() ||
+            static_cast<int64_t>(outputTy.getSizes().size()) <= axisDim)
+          return rewriter.notifyMatchFailure(
+              binder.op, "Expected first result type to have sizes for axis");
+
+        // `aten.unique_dim` always returns three values (output,
+        // inverse_indices, counts), so the type of any output the model did
+        // not request has to be synthesized. All three optional ONNX outputs
+        // are 1-D si64: `indices` and `counts` are as long as the number of
+        // unique entries, which is the extent of the output along `axis`,
+        // while `inverse_indices` is as long as the input along `axis`.
+        Type i64Dtype =
+            IntegerType::get(rewriter.getContext(), 64, IntegerType::Signed);
+        Torch::ValueTensorType inverseTy =
+            numResults > 2 ? cast<Torch::ValueTensorType>(resultTypes[2])
+                           : rewriter.getType<Torch::ValueTensorType>(
+                                 ArrayRef<int64_t>{axisSize}, i64Dtype);
+        Torch::ValueTensorType countsTy =
+            numResults > 3
+                ? cast<Torch::ValueTensorType>(resultTypes[3])
+                : rewriter.getType<Torch::ValueTensorType>(
+                      ArrayRef<int64_t>{outputTy.getSizes()[axisDim]},
+                      i64Dtype);
 
         Torch::AtenUniqueDimOp intermResults = Torch::AtenUniqueDimOp::create(
             rewriter, binder.getLoc(), outputTy, inverseTy, countsTy, input,
@@ -4542,6 +4552,8 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         finalResults.push_back(uniqueResults[0]);
 
         if (numResults > 1) {
+          auto indicesTy = cast<Torch::ValueTensorType>(resultTypes[1]);
+
           // Calculate the indices where each of the unique elements first
           // appeared in the original input tensor. Also, the counts tensor
           // and the indices tensor have the same Dtype, int64, so reuse

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3700,6 +3700,56 @@ func.func @test_unique_sorted_with_negative_axis(%arg0: !torch.vtensor<[3,3],f32
 
 // -----
 
+// Regression test: ONNX Unique allows fewer than four outputs. Previously the
+// lowering blindly indexed `resultTypes[1..3]`, which on a single-output op
+// read garbage and crashed. Verify that requesting only Y produces valid IR
+// that returns a single value.
+
+// CHECK-LABEL: func.func @test_unique_one_output
+// CHECK-SAME:    %[[ARG0:.+]]: !torch.vtensor<[7],f32>
+// CHECK:         %[[INT0:.+]] = torch.constant.int 0
+// CHECK:         %[[NEG1:.+]] = torch.constant.int -1
+// CHECK:         %[[FLAT:.+]] = torch.aten.flatten.using_ints %[[ARG0]], %[[INT0]], %[[NEG1]]
+// CHECK:         %[[Y:.+]], %{{.+}}, %{{.+}} = torch.aten.unique_dim %[[FLAT]]
+// CHECK-NOT:     torch.aten.scatter.src
+// CHECK:         return %[[Y]] : !torch.vtensor<[?],f32>
+func.func @test_unique_one_output(%arg0: !torch.vtensor<[7],f32>) -> !torch.vtensor<[?],f32> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  %0 = torch.operator "onnx.Unique"(%arg0) {torch.onnx.sorted = 1 : si64} : (!torch.vtensor<[7],f32>) -> !torch.vtensor<[?],f32>
+  return %0 : !torch.vtensor<[?],f32>
+}
+
+// -----
+
+// Regression test: ONNX Unique with two outputs. The second output (indices
+// of first occurrence) must be computed; the third and fourth must not be
+// emitted on the result list.
+
+// CHECK-LABEL: func.func @test_unique_two_outputs
+// CHECK:         %[[Y:.+]], %[[INV:.+]], %{{.+}} = torch.aten.unique_dim
+// CHECK:         %[[SCATTER:.+]] = torch.aten.scatter.src
+// CHECK:         return %[[Y]], %[[SCATTER]]
+// CHECK-SAME:      !torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>
+func.func @test_unique_two_outputs(%arg0: !torch.vtensor<[7],f32>) -> (!torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>) attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  %0:2 = torch.operator "onnx.Unique"(%arg0) {torch.onnx.sorted = 1 : si64} : (!torch.vtensor<[7],f32>) -> (!torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>)
+  return %0#0, %0#1 : !torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>
+}
+
+// -----
+
+// Regression test: ONNX Unique with three outputs.
+
+// CHECK-LABEL: func.func @test_unique_three_outputs
+// CHECK:         %[[Y:.+]], %[[INV:.+]], %{{.+}} = torch.aten.unique_dim
+// CHECK:         %[[SCATTER:.+]] = torch.aten.scatter.src
+// CHECK:         return %[[Y]], %[[SCATTER]], %[[INV]]
+// CHECK-SAME:      !torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>, !torch.vtensor<[7],si64>
+func.func @test_unique_three_outputs(%arg0: !torch.vtensor<[7],f32>) -> (!torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>, !torch.vtensor<[7],si64>) attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  %0:3 = torch.operator "onnx.Unique"(%arg0) {torch.onnx.sorted = 1 : si64} : (!torch.vtensor<[7],f32>) -> (!torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>, !torch.vtensor<[7],si64>)
+  return %0#0, %0#1, %0#2 : !torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>, !torch.vtensor<[7],si64>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @test_scan_sum(
 // CHECK-SAME:                             %[[VAL_0:.*]]: !torch.vtensor<[2],f32>,
 // CHECK-SAME:                             %[[VAL_1:.*]]: !torch.vtensor<[3,2],f32>) -> (!torch.vtensor<[2],f32>, !torch.vtensor<[3,2],f32>) attributes {torch.onnx_meta.ir_version = 4 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3690,6 +3690,56 @@ func.func @test_unique_sorted_with_negative_axis(%arg0: !torch.vtensor<[3,3],f32
 
 // -----
 
+// Regression test: ONNX Unique allows fewer than four outputs. Previously the
+// lowering blindly indexed `resultTypes[1..3]`, which on a single-output op
+// read garbage and crashed. Verify that requesting only Y produces valid IR
+// that returns a single value.
+
+// CHECK-LABEL: func.func @test_unique_one_output
+// CHECK-SAME:    %[[ARG0:.+]]: !torch.vtensor<[7],f32>
+// CHECK:         %[[INT0:.+]] = torch.constant.int 0
+// CHECK:         %[[NEG1:.+]] = torch.constant.int -1
+// CHECK:         %[[FLAT:.+]] = torch.aten.flatten.using_ints %[[ARG0]], %[[INT0]], %[[NEG1]]
+// CHECK:         %[[Y:.+]], %{{.+}}, %{{.+}} = torch.aten.unique_dim %[[FLAT]]
+// CHECK-NOT:     torch.aten.scatter.src
+// CHECK:         return %[[Y]] : !torch.vtensor<[?],f32>
+func.func @test_unique_one_output(%arg0: !torch.vtensor<[7],f32>) -> !torch.vtensor<[?],f32> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  %0 = torch.operator "onnx.Unique"(%arg0) {torch.onnx.sorted = 1 : si64} : (!torch.vtensor<[7],f32>) -> !torch.vtensor<[?],f32>
+  return %0 : !torch.vtensor<[?],f32>
+}
+
+// -----
+
+// Regression test: ONNX Unique with two outputs. The second output (indices
+// of first occurrence) must be computed; the third and fourth must not be
+// emitted on the result list.
+
+// CHECK-LABEL: func.func @test_unique_two_outputs
+// CHECK:         %[[Y:.+]], %[[INV:.+]], %{{.+}} = torch.aten.unique_dim
+// CHECK:         %[[SCATTER:.+]] = torch.aten.scatter.src
+// CHECK:         return %[[Y]], %[[SCATTER]]
+// CHECK-SAME:      !torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>
+func.func @test_unique_two_outputs(%arg0: !torch.vtensor<[7],f32>) -> (!torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>) attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  %0:2 = torch.operator "onnx.Unique"(%arg0) {torch.onnx.sorted = 1 : si64} : (!torch.vtensor<[7],f32>) -> (!torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>)
+  return %0#0, %0#1 : !torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>
+}
+
+// -----
+
+// Regression test: ONNX Unique with three outputs.
+
+// CHECK-LABEL: func.func @test_unique_three_outputs
+// CHECK:         %[[Y:.+]], %[[INV:.+]], %{{.+}} = torch.aten.unique_dim
+// CHECK:         %[[SCATTER:.+]] = torch.aten.scatter.src
+// CHECK:         return %[[Y]], %[[SCATTER]], %[[INV]]
+// CHECK-SAME:      !torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>, !torch.vtensor<[7],si64>
+func.func @test_unique_three_outputs(%arg0: !torch.vtensor<[7],f32>) -> (!torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>, !torch.vtensor<[7],si64>) attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  %0:3 = torch.operator "onnx.Unique"(%arg0) {torch.onnx.sorted = 1 : si64} : (!torch.vtensor<[7],f32>) -> (!torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>, !torch.vtensor<[7],si64>)
+  return %0#0, %0#1, %0#2 : !torch.vtensor<[?],f32>, !torch.vtensor<[?],si64>, !torch.vtensor<[7],si64>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @test_scan_sum(
 // CHECK-SAME:                             %[[VAL_0:.*]]: !torch.vtensor<[2],f32>,
 // CHECK-SAME:                             %[[VAL_1:.*]]: !torch.vtensor<[3,2],f32>) -> (!torch.vtensor<[2],f32>, !torch.vtensor<[3,2],f32>) attributes {torch.onnx_meta.ir_version = 4 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3740,6 +3740,27 @@ func.func @test_unique_three_outputs(%arg0: !torch.vtensor<[7],f32>) -> (!torch.
 
 // -----
 
+// Regression test: ONNX Unique with a single output on a rank > 1 input with
+// an explicit axis. The types of the unrequested outputs are synthesized, and
+// they must follow the axis: inverse_indices is as long as the input along
+// `axis` (4), and counts is as long as the number of unique entries, i.e. the
+// output's extent along `axis` (3). Deriving either from dimension 0 or from
+// the full input shape produces a mistyped `torch.aten.unique_dim`.
+
+// CHECK-LABEL: func.func @test_unique_one_output_with_axis
+func.func @test_unique_one_output_with_axis(%arg0: !torch.vtensor<[2,4,2],f32>) -> !torch.vtensor<[2,3,2],f32> attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 11 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %[[INT1:.*]] = torch.constant.int 1
+  // CHECK: %[[TRUEVAL_0:.*]] = torch.constant.bool true
+  // CHECK: %[[TRUEVAL_1:.*]] = torch.constant.bool true
+  // CHECK: %[[UNIQUEOUTPUT:.*]], %[[INVERSEINDEX:.*]], %[[COUNTS:.*]] = torch.aten.unique_dim %arg0, %[[INT1]], %[[TRUEVAL_0]], %[[TRUEVAL_1]], %[[TRUEVAL_1]] : !torch.vtensor<[2,4,2],f32>, !torch.int, !torch.bool, !torch.bool, !torch.bool -> !torch.vtensor<[2,3,2],f32>, !torch.vtensor<[4],si64>, !torch.vtensor<[3],si64>
+  // CHECK-NOT: torch.aten.scatter.src
+  // CHECK: return %[[UNIQUEOUTPUT]] : !torch.vtensor<[2,3,2],f32>
+  %0 = torch.operator "onnx.Unique"(%arg0) {torch.onnx.axis = 1 : si64, torch.onnx.sorted = 1 : si64} : (!torch.vtensor<[2,4,2],f32>) -> !torch.vtensor<[2,3,2],f32>
+  return %0 : !torch.vtensor<[2,3,2],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @test_scan_sum(
 // CHECK-SAME:                             %[[VAL_0:.*]]: !torch.vtensor<[2],f32>,
 // CHECK-SAME:                             %[[VAL_1:.*]]: !torch.vtensor<[3,2],f32>) -> (!torch.vtensor<[2],f32>, !torch.vtensor<[3,2],f32>) attributes {torch.onnx_meta.ir_version = 4 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {


### PR DESCRIPTION
The `onnx.Unique` lowering assumed all four ONNX outputs (Y, indices, inverse_indices, counts) are always present. It indexed `resultTypes[1]`, `resultTypes[2]` and `resultTypes[3]` unconditionally and always pushed four values into `replaceOp`. Since Unique's trailing outputs are optional, a model that requests only Y (or Y plus indices) reads past the actual result list and crashes.

This validates the result count up front (`1 <= numResults <= 4`, otherwise `notifyMatchFailure`), and for any output that was not requested it synthesizes a sensible si64 result type instead of reading a nonexistent `resultTypes[i]`. First-occurrence indices are only computed when `numResults > 1`, and the final result list is trimmed to exactly the requested arity before `replaceOp`. `aten.unique_dim` still returns its three values internally; only the ONNX-facing result list is trimmed.

Adds three FileCheck regression tests in `simple_ops_q_to_z.mlir` covering the one-, two-, and three-output forms. The one-output case reproduces the original crash and now lowers to valid IR returning a single value; the two- and three-output cases verify that the first-occurrence scatter is emitted and the result arity is correct.
