### PR TITLE
[TorchToLinalg] Support k-dim loss in AtenNllLossForwardOp lowering

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -1112,10 +1112,14 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
             rewriter, binder.getLoc(),
             rewriter.getI64IntegerAttr(reduction_value));
 
-        Value nllLoss = Torch::AtenNllLossForwardOp::create(
-                            rewriter, binder.getLoc(), resultType, resultType,
-                            self, target, weight, reduction, ignore_index)
-                            ->getResult(0);
+        Type totalWeightTy = Torch::ValueTensorType::get(
+            rewriter.getContext(), ArrayRef<int64_t>(),
+            resultType.getOptionalDtype());
+        Value nllLoss =
+            Torch::AtenNllLossForwardOp::create(
+                rewriter, binder.getLoc(), resultType, totalWeightTy, self,
+                target, weight, reduction, ignore_index)
+                ->getResult(0);
 
         rewriter.replaceOp(binder.op, nllLoss);
         return success();

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -1858,21 +1858,14 @@ public:
 
     unsigned inputRank = cast<RankedTensorType>(input.getType()).getRank();
     unsigned targetRank = cast<RankedTensorType>(target.getType()).getRank();
-
-    // TODO: Add support for k-dim loss.
-    if (inputRank > 2) {
-      return rewriter.notifyMatchFailure(
-          op, "expected input and target to be rank <= 2");
-    }
     RankedTensorType resultType = cast<RankedTensorType>(
         getTypeConverter()->convertType(op->getResult(0).getType()));
-    Type elementType = resultType.getElementType();
+    Type resultEleType = resultType.getElementType();
 
-    Value zeroVal = arith::ConstantOp::create(
-        rewriter, loc, rewriter.getZeroAttr(elementType));
-
+    Value zeroResultVal = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(resultEleType));
     Value finalRes = torch_to_linalg::createElementwiseLinalgGeneric(
-        rewriter, loc, {target}, elementType,
+        rewriter, loc, {target}, resultEleType,
         [&](OpBuilder &b, Location loc, ValueRange args) {
           Value targetVal = args[0];
           Value indTarget = arith::IndexCastOp::create(
@@ -1884,120 +1877,97 @@ public:
           Value cmpEq =
               arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
                                     indTarget, ignoreIndexVal);
-
-          SmallVector<Value> extractionIndices{indTarget};
-          if (inputRank == 2) {
-            Value indI = linalg::IndexOp::create(rewriter, loc, 0);
-            extractionIndices.insert(extractionIndices.begin(), indI);
+          SmallVector<Value> extractionIndices;
+          if (inputRank == 1) {
+            extractionIndices.push_back(indTarget);
+          } else {
+            extractionIndices.push_back(
+                linalg::IndexOp::create(rewriter, loc, 0));
+            extractionIndices.push_back(indTarget);
+            for (int64_t idx = 1; idx < targetRank; ++idx) {
+              extractionIndices.push_back(
+                  linalg::IndexOp::create(rewriter, loc, idx));
+            }
           }
 
           Value result = tensor::ExtractOp::create(rewriter, loc, input,
                                                    extractionIndices);
-
           Value negate =
-              arith::NegFOp::create(rewriter, loc, elementType, result);
-          Value selectFinal =
-              arith::SelectOp::create(rewriter, loc, cmpEq, zeroVal, negate);
+              arith::NegFOp::create(rewriter, loc, resultEleType, result);
+          Value selectFinal = arith::SelectOp::create(rewriter, loc, cmpEq,
+                                                      zeroResultVal, negate);
           linalg::YieldOp::create(b, loc, selectFinal);
         });
 
-    llvm::iota_range<int64_t> dimsToReduce(0, targetRank,
-                                           /*inclusive=*/false);
-    DenseSet<int64_t> dimSet(dimsToReduce.begin(), dimsToReduce.end());
-
-    if (reduction == torch_upstream::Reduction::Sum ||
-        reduction == torch_upstream::Reduction::Mean) {
-
-      Value zeroIVal = arith::ConstantOp::create(
-          rewriter, loc, rewriter.getZeroAttr(rewriter.getI32Type()));
-      auto countInfo = torch_to_linalg::ReductionOpInfo{false, target, dimSet};
-      Value numOfElems = torch_to_linalg::createReductionLinalgGeneric(
-          rewriter, loc, countInfo,
-          /*initElem=*/zeroIVal,
-          [&](OpBuilder &b, Location loc, ValueRange args) {
-            Value targetVal = args[0];
-            Value indTarget = arith::IndexCastOp::create(
-                rewriter, loc, rewriter.getIndexType(), targetVal);
-            Value cmpEq =
-                arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ne,
-                                      indTarget, ignoreIndexVal);
-            cmpEq = arith::ExtUIOp::create(rewriter, loc, rewriter.getI32Type(),
-                                           cmpEq);
-            Value add = arith::AddIOp::create(rewriter, loc, args[1], cmpEq);
-            linalg::YieldOp::create(rewriter, loc, add);
-          });
-
-      numOfElems = tensor::ExtractOp::create(
-          rewriter, loc, rewriter.getI32Type(), numOfElems, ArrayRef<Value>{});
-      numOfElems = convertScalarToDtype(rewriter, loc, numOfElems, elementType);
-
-      auto opInfo = torch_to_linalg::ReductionOpInfo{false, finalRes, dimSet};
-      finalRes = torch_to_linalg::createReductionLinalgGeneric(
-          rewriter, loc, opInfo,
-          /*initElem=*/zeroVal,
-          [&](OpBuilder &b, Location loc, ValueRange args) {
-            Value newVal = args[0];
-            Value accumulator = args[1];
-            if (reduction == torch_upstream::Reduction::Mean)
-              newVal = arith::DivFOp::create(b, loc, newVal, numOfElems);
-            Value result = arith::AddFOp::create(b, loc, newVal, accumulator);
-            linalg::YieldOp::create(b, loc, result);
-          });
-    }
-
-    // The implementation for the `total_weight` has been adopted from here:
-    // https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/LossNLL.cpp#L154-L294
-    // As per the ref link, the `total_weight` value when the `weight` is
-    // `None`, is equal to `total_weight = batch_size - num_ignored_index`,
-    // where `batch_size` is equal to `target.shape[0]` when rank(target) > 0,
-    // otherwise 1. The value `num_ignored_index` is the number of elements of
-    // the `target` tensors that have been ignored.
-
-    if (reduction == torch_upstream::Reduction::None && inputRank == 2) {
-      Value totalWeight = createZeroInitTensor(rewriter, loc, {}, elementType);
+    if (reduction == torch_upstream::Reduction::None) {
+      Value totalWeight =
+          createZeroInitTensor(rewriter, loc, {}, resultEleType);
       rewriter.replaceOp(op, {finalRes, totalWeight});
       return success();
     }
 
+    llvm::iota_range<int64_t> dimsToReduce(0, targetRank,
+                                           /*inclusive=*/false);
+    DenseSet<int64_t> dimSet(dimsToReduce.begin(), dimsToReduce.end());
+    auto opInfo = torch_to_linalg::ReductionOpInfo{false, finalRes, dimSet};
+    finalRes = torch_to_linalg::createReductionLinalgGeneric(
+        rewriter, loc, opInfo,
+        /*initElem=*/zeroResultVal,
+        [&](OpBuilder &b, Location loc, ValueRange args) {
+          Value result = arith::AddFOp::create(b, loc, args[0], args[1]);
+          linalg::YieldOp::create(b, loc, result);
+        });
+
+    // Count how many target elements equal `ignore_index` so they can be
+    // excluded from the total weight (and thus from the mean reduction).
     Value numIgnoredIndex;
+    Type ignoreIdxTy = ignoreIndex.getType();
+    Value zero = getConstant(rewriter, loc, 0, ignoreIdxTy);
+    Value one = getConstant(rewriter, loc, 1, ignoreIdxTy);
     if (targetRank == 0) {
       Value targetVal = tensor::ExtractOp::create(rewriter, loc, target);
-      numIgnoredIndex = arith::CmpIOp::create(
-          rewriter, loc, arith::CmpIPredicate::eq, targetVal, ignoreIndex);
-      numIgnoredIndex = convertScalarToDtype(rewriter, loc, numIgnoredIndex,
-                                             ignoreIndex.getType());
+      numIgnoredIndex = arith::SelectOp::create(
+          rewriter, loc,
+          arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
+                                targetVal, ignoreIndex),
+          one, zero);
     } else {
-      Value zeroCstInt = arith::ConstantOp::create(
-          rewriter, loc, rewriter.getZeroAttr(ignoreIndex.getType()));
-
       auto opInfo =
           torch_to_linalg::ReductionOpInfo{/*keepDim=*/false, target, dimSet};
       numIgnoredIndex = torch_to_linalg::createReductionLinalgGeneric(
           rewriter, loc, opInfo,
-          /*initElem=*/zeroCstInt,
-          [&](OpBuilder &b, Location loc, ValueRange args) {
-            Value targetVal = args[0];
-            Value accumulator = args[1];
+          /*initElem=*/zero, [&](OpBuilder &b, Location loc, ValueRange args) {
             Value result = arith::CmpIOp::create(
-                b, loc, arith::CmpIPredicate::eq, targetVal, ignoreIndex);
-            result = arith::AddIOp::create(
-                b, loc,
-                convertScalarToDtype(rewriter, loc, result,
-                                     ignoreIndex.getType()),
-                accumulator);
+                b, loc, arith::CmpIPredicate::eq, args[0], ignoreIndex);
+            result = arith::SelectOp::create(b, loc, result, one, zero);
+            result = arith::AddIOp::create(b, loc, result, args[1]);
             linalg::YieldOp::create(b, loc, result);
           });
-
       numIgnoredIndex =
           tensor::ExtractOp::create(rewriter, loc, numIgnoredIndex);
     }
 
+    // The `weight` argument is not yet supported, so we follow the reference
+    // implementation at
+    // https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/LossNLL2d.cpp#L241
+    // where, with `weight == None`, the total weight reduces to the number of
+    // non-ignored targets: `total_weight = num_targets - num_ignored_index`.
     Value numtargetElems = getTensorSize(rewriter, loc, target);
-    Value totalWeightVal =
+    Value totalWeight =
         arith::SubIOp::create(rewriter, loc, numtargetElems, numIgnoredIndex);
-    Value totalWeight = createInitTensor(
-        rewriter, loc, {}, elementType,
-        convertScalarToDtype(rewriter, loc, totalWeightVal, elementType));
+    totalWeight = createInitTensor(
+        rewriter, loc, {}, resultEleType,
+        convertScalarToDtype(rewriter, loc, totalWeight, resultEleType));
+
+    if (reduction == torch_upstream::Reduction::Mean) {
+      // A single div after the reduction is sufficient.
+      finalRes = torch_to_linalg::createElementwiseLinalgGeneric(
+          rewriter, loc, {finalRes, totalWeight}, resultEleType,
+          [&](OpBuilder &b, Location loc, ValueRange args) {
+            Value mean = arith::DivFOp::create(b, loc, args[0], args[1]);
+            linalg::YieldOp::create(b, loc, mean);
+          });
+    }
 
     rewriter.replaceOp(op, {finalRes, totalWeight});
     return success();

--- a/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
+++ b/lib/Dialect/Torch/Transforms/ReduceOpVariants.cpp
@@ -12,8 +12,12 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
 #include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include <cstdint>
 
 using namespace mlir;
 using namespace mlir::torch;
@@ -263,6 +267,22 @@ void TorchMatchSpecializedBackendOp::populateSpecializedConversions(
         }
         return failure();
       });
+
+  matcher.populate("torch.aten.nll_loss_nd",
+                   [](Torch::OperatorOp op,
+                      ConversionPatternRewriter &rewriter) -> LogicalResult {
+                     ValueTensorType lossType =
+                         cast<ValueTensorType>(op->getResult(0).getType());
+                     Type totalWeightTy = ValueTensorType::get(
+                         rewriter.getContext(), ArrayRef<int64_t>(),
+                         lossType.getOptionalDtype());
+                     SmallVector<Type> resultTypes{lossType, totalWeightTy};
+                     auto newOp = Torch::AtenNllLossForwardOp::create(
+                         rewriter, op->getLoc(), resultTypes, op->getOperands(),
+                         op->getAttrs());
+                     rewriter.replaceOp(op, newOp->getResult(0));
+                     return success();
+                   });
 }
 
 bool isSpecializedOperation(Torch::OperatorOp op) { return true; }

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/nll_loss.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/nll_loss.py
@@ -183,6 +183,150 @@ def NllLossStaticModule_sum_basic(module, tu: TestUtils):
     module.forward(tu.rand(2, 3), tu.randint(2, low=0, high=3))
 
 
+class NllLossKDimModule_mean(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1, -1, -1], torch.float32, True),
+            ([-1, -1, -1], torch.int64, True),
+        ]
+    )
+    # Here the 2nd index is ignored.
+    def forward(self, x, y):
+        return torch.nn.functional.nll_loss(
+            x, target=y, weight=None, reduction="mean", ignore_index=2
+        )
+
+
+@register_test_case(module_factory=lambda: NllLossKDimModule_mean())
+def NllLossKDimModule_mean_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4, 5), tu.randint(2, 4, 5, low=0, high=3))
+
+
+class NllLossKDimStaticModule_mean(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([2, 3, 4, 5], torch.float32, True),
+            ([2, 4, 5], torch.int64, True),
+        ]
+    )
+    # Here the 2nd index is ignored.
+    def forward(self, x, y):
+        return torch.nn.functional.nll_loss(
+            x, target=y, weight=None, reduction="mean", ignore_index=2
+        )
+
+
+@register_test_case(module_factory=lambda: NllLossKDimStaticModule_mean())
+def NllLossKDimStaticModule_mean_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4, 5), tu.randint(2, 4, 5, low=0, high=3))
+
+
+class NllLossKDimModule_sum(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1, -1, -1], torch.float32, True),
+            ([-1, -1, -1], torch.int64, True),
+        ]
+    )
+    # Here the 2nd index is ignored.
+    def forward(self, x, y):
+        return torch.nn.functional.nll_loss(
+            x, target=y, weight=None, reduction="sum", ignore_index=2
+        )
+
+
+@register_test_case(module_factory=lambda: NllLossKDimModule_sum())
+def NllLossKDimModule_sum_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4, 5), tu.randint(2, 4, 5, low=0, high=3))
+
+
+class NllLossKDimStaticModule_sum(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([2, 3, 4, 5], torch.float32, True),
+            ([2, 4, 5], torch.int64, True),
+        ]
+    )
+    # Here the 2nd index is ignored.
+    def forward(self, x, y):
+        return torch.nn.functional.nll_loss(
+            x, target=y, weight=None, reduction="sum", ignore_index=2
+        )
+
+
+@register_test_case(module_factory=lambda: NllLossKDimStaticModule_sum())
+def NllLossKDimStaticModule_sum_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4, 5), tu.randint(2, 4, 5, low=0, high=3))
+
+
+class NllLossKDimModule_reduction_none(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1, -1, -1], torch.float32, True),
+            ([-1, -1, -1], torch.int64, True),
+        ]
+    )
+    # Here the 2nd index is ignored.
+    def forward(self, x, y):
+        return torch.nn.functional.nll_loss(
+            x, target=y, weight=None, reduction="none", ignore_index=2
+        )
+
+
+@register_test_case(module_factory=lambda: NllLossKDimModule_reduction_none())
+def NllLossKDimModule_reduction_none_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4, 5), tu.randint(2, 4, 5, low=0, high=3))
+
+
+class NllLossKDimStaticModule_reduction_none(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([2, 3, 4, 5], torch.float32, True),
+            ([2, 4, 5], torch.int64, True),
+        ]
+    )
+    # Here the 2nd index is ignored.
+    def forward(self, x, y):
+        return torch.nn.functional.nll_loss(
+            x, target=y, weight=None, reduction="none", ignore_index=2
+        )
+
+
+@register_test_case(module_factory=lambda: NllLossKDimStaticModule_reduction_none())
+def NllLossKDimStaticModule_reduction_none_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 3, 4, 5), tu.randint(2, 4, 5, low=0, high=3))
+
+
 class NllLossModule_1D(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
- Remove the rank <= 2 restriction and generalize the input/target index extraction to handle higher-rank targets, enabling k-dimensional NLL loss. 
- The reduction and total_weight computation is also refactored to count ignored indices via select/add and divide once after the reduction for the mean case.

related issue: https://github.com/iree-org/iree/issues/24582