### PR TITLE
[FX] Fix scaled_mm_v2 test shape for PyTorch compatibility

### DIFF
--- a/test/python/fx_importer/scaled_mm_test.py
+++ b/test/python/fx_importer/scaled_mm_test.py
@@ -301,7 +301,7 @@ def test_import_scaled_mm_v2_out_dtype_fp4():
 
 @run
 # CHECK-LABEL: test_import_scaled_mm_v2_rowwise_fp4
-# CHECK: func.func @test_import_scaled_mm_v2_rowwise_fp4(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[128],f32>, %arg3: !torch.vtensor<[128],f32>) -> !torch.vtensor<[128,128],bf16>
+# CHECK: func.func @test_import_scaled_mm_v2_rowwise_fp4(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[128,1],f32>, %arg3: !torch.vtensor<[128,1],f32>) -> !torch.vtensor<[128,128],bf16>
 # CHECK-NOT: torch.operator
 # CHECK: %[[SCALE_A:.*]] = torch.prim.ListConstruct %arg2
 # CHECK: %[[RECIPE_A_VALUE:.*]] = torch.constant.int 1
@@ -337,8 +337,8 @@ def test_import_scaled_mm_v2_rowwise_fp4():
 
     a = make_fp4_tensor((128, 64))
     b = make_fp4_tensor((64, 128), stride=(1, 64))
-    a_scale = torch.zeros((128,), dtype=torch.float32)
-    b_scale = torch.zeros((128,), dtype=torch.float32)
+    a_scale = torch.zeros((128, 1), dtype=torch.float32)
+    b_scale = torch.zeros((128, 1), dtype=torch.float32)
 
     m = fx.export_and_import(
         Basic(),


### PR DESCRIPTION
 ## Description

PyTorch requires `scale_a/b` to be 2D tensors for `scaled_mm_v2` (see [validate_scaled_mm_v2_inputs](https://github.com/pytorch/pytorch/blob/d4165ba8f7d119c23f08273aa6979734f843845c/aten/src/ATen/native/ScaledBlasUtils.cpp#L449)). 

In older PyTorch versions, this check was enforced in Python meta-registrations (prior to [this commit](https://github.com/pytorch/pytorch/commit/1a00857cdb1c63f99d3d71f232de4e27f64ba251) moving the validation to C++). However, `test_import_scaled_mm_v2_rowwise_fp4` was using 1D tensors, causing tracing and metadata checks to fail on PyTorch 2.3+.

This PR fixes the test case by updating the scale tensors to `(128, 1)`.