### PR TITLE
[TorchOnnxToTorch] Dequantize the bias in the per-channel QLinearConv lowering

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -487,6 +487,7 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           // Then, we compute the dequantized weight:
           // weight = weight.to(dtype=torch.float32)
           // weight_dequant = (weight - weight_zero_point) * weight_scale
+          Value weightScalePerChannel = weightScale;
           int64_t diffRank = weightShape.size() - weightScaleShape.size();
           for (int i = 1; i <= diffRank; i++) {
             Value cstDim = Torch::ConstantIntOp::create(
@@ -532,6 +533,14 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
                                                 /*non_blocking=*/cstFalse,
                                                 /*copy=*/cstFalse,
                                                 /*memory_format=*/none);
+            // Per the ONNX spec, the int32 bias is quantized with
+            // scale = input_scale * weight_scale[c] and zero_point = 0. Since
+            // the convolution is performed on the dequantized input and
+            // weight, the bias must be dequantized the same way.
+            bias = Torch::AtenMulTensorOp::create(rewriter, loc, f32BiasType,
+                                                  bias, weightScalePerChannel);
+            bias = Torch::AtenMulScalarOp::create(rewriter, loc, f32BiasType,
+                                                  bias, inputScale);
           }
 
         } else {
@@ -552,7 +561,6 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         for (auto namedAttr : binder.op->getAttrDictionary()) {
           if (namedAttr.getName().getValue().compare("name") == 0)
             continue;
-          llvm::errs() << namedAttr.getName() << "\n";
           newAttributes.push_back(namedAttr);
         }
 

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -213,6 +213,8 @@ func.func @test_qlinearconv_weight_per_channel_quantization(%arg0: !torch.vtenso
   // CHECK:           %[[VAL_30:.*]] = torch.aten.sub.Tensor %[[F32_WEIGHT]], %[[WEIGHT_ZP]], %float1.000000e00 : !torch.vtensor<[64,3,7,7],f32>, !torch.vtensor<[64,1,1,1],si8>, !torch.float -> !torch.vtensor<[64,3,7,7],f32>
   // CHECK:           %[[DEQUANT_WEIGHT:.*]] = torch.aten.mul.Tensor %[[VAL_30]], %[[WEIGHT_SCALE]] : !torch.vtensor<[64,3,7,7],f32>, !torch.vtensor<[64,1,1,1],f32> -> !torch.vtensor<[64,3,7,7],f32>
   // CHECK:           %[[F32_BIAS:.*]] = torch.aten.to.dtype %arg8, %[[F32DTYPE]], %[[FALSE]], %[[FALSE]], %[[NONE]] : !torch.vtensor<[64],si32>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[64],f32>
+  // CHECK:           %[[BIAS_WSCALE:.*]] = torch.aten.mul.Tensor %[[F32_BIAS]], %arg4 : !torch.vtensor<[64],f32>, !torch.vtensor<[64],f32> -> !torch.vtensor<[64],f32>
+  // CHECK:           %[[DEQUANT_BIAS:.*]] = torch.aten.mul.Scalar %[[BIAS_WSCALE]], %[[INPUT_SCALE]] : !torch.vtensor<[64],f32>, !torch.float -> !torch.vtensor<[64],f32>
   // CHECK:           %[[VAL_33:.*]] = torch.constant.int 3
   // CHECK:           %[[VAL_34:.*]] = torch.constant.int 3
   // CHECK:           %[[VAL_40:.*]] = torch.constant.int 0
@@ -226,7 +228,7 @@ func.func @test_qlinearconv_weight_per_channel_quantization(%arg0: !torch.vtenso
   // CHECK:           %[[STRIDE:.*]] = torch.prim.ListConstruct %[[VAL_40]], %[[VAL_40]] : (!torch.int, !torch.int) -> !torch.list<int>
   // CHECK:           %[[TRANSPOSED:.*]] = torch.constant.bool false
   // CHECK:           %[[GROUPS:.*]] = torch.constant.int 1
-  // CHECK:           %[[CONV:.*]] = torch.aten.convolution %[[DEQUANT_INPUT]], %[[DEQUANT_WEIGHT]], %[[F32_BIAS]], %[[DILATION]], %[[PAD]], %[[KERNEL]], %[[TRANSPOSED]], %[[STRIDE]], %[[GROUPS]] : !torch.vtensor<[?,3,224,224],f32>, !torch.vtensor<[64,3,7,7],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[?,64,112,112],f32>
+  // CHECK:           %[[CONV:.*]] = torch.aten.convolution %[[DEQUANT_INPUT]], %[[DEQUANT_WEIGHT]], %[[DEQUANT_BIAS]], %[[DILATION]], %[[PAD]], %[[KERNEL]], %[[TRANSPOSED]], %[[STRIDE]], %[[GROUPS]] : !torch.vtensor<[?,3,224,224],f32>, !torch.vtensor<[64,3,7,7],f32>, !torch.vtensor<[64],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[?,64,112,112],f32>
   // CHECK:           %[[DTYPE:.*]] = torch.constant.int 13
   // CHECK:           %[[QUANT:.*]] = torch.aten.quantize_per_tensor %[[CONV]], %[[OUTPUT_SCALE]], %[[OUTPUT_ZP]], %[[DTYPE]] : !torch.vtensor<[?,64,112,112],f32>, !torch.float, !torch.int, !torch.int -> !torch.vtensor<[?,64,112,112],!torch.quint8>
   // CHECK:           %[[OUTPUT:.*]] = torch.aten.int_repr %[[QUANT]] : !torch.vtensor<[?,64,112,112],!torch.quint8> -> !torch.vtensor<[?,64,112,112],ui8>


### PR DESCRIPTION
In the per-channel-weight path, the convolution runs on the dequantized (f32) input and weight, but the int32 bias was only cast to f32, not dequantized. Per [ONNX spec](https://github.com/onnx/onnx/blob/main/docs/Operators.md#qlinearconv) its scale is `input_scale * weight_scale[c]` (zero_point 0), so the raw bias was added at the wrong magnitude, skewing every per-channel QLinearConv that has a bias.

Fix by scaling the f32 bias by the per-channel weight scale and the input scale.
Also remove a leftover llvm::errs() debug print.

I found this issue on MobileNetV2-int8 from the ONNX model zoo.