### PR TITLE
[TorchOnnxToTorch] Fix QLinearGlobalAveragePool kernel size for unknown result dims

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/ComMicrosoftDomain.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/ComMicrosoftDomain.cpp
@@ -1208,7 +1208,12 @@ void mlir::torch::onnx_c::populateComMicrosoftDomain(
             rewriter, loc, rewriter.getI64IntegerAttr(1));
         unsigned inputRank = inputShape.size();
         for (unsigned i = 2; i < inputRank; i++) {
-          if (inputShape[i] == Torch::kUnknownSize) {
+          // For a global average pool the result spatial dims are 1, so the
+          // kernel size is the full input spatial dim. Take the dynamic path
+          // if either dim is unknown; a statically unknown result dim
+          // (kUnknownSize = -1) must not feed the arithmetic below.
+          if (inputShape[i] == Torch::kUnknownSize ||
+              resultShape[i] == Torch::kUnknownSize) {
             Value dim = Torch::ConstantIntOp::create(
                 rewriter, loc, rewriter.getI64IntegerAttr(i));
             Value inputDimSize =

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3884,6 +3884,25 @@ func.func @test_qlinearglobalavgpool(%arg0: !torch.vtensor<[1,1000,13,13],ui8>, 
 
 // -----
 
+// A statically unknown result dim must not feed the kernel-size arithmetic
+// (kernel = in - out + 1 with out = kUnknownSize gave kernel > input and an
+// invalid tensor type downstream); the kernel must come from the input dims.
+// CHECK-LABEL: @test_qlinearglobalavgpool_dynamic_result(
+// CHECK-SAME:                   %[[X:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !torch.vtensor<[1,1000,13,13],ui8>,
+func.func @test_qlinearglobalavgpool_dynamic_result(%arg0: !torch.vtensor<[1,1000,13,13],ui8>, %arg1: !torch.vtensor<[],f32>, %arg2: !torch.vtensor<[],ui8>, %arg3: !torch.vtensor<[],f32>, %arg4: !torch.vtensor<[],ui8>) -> !torch.vtensor<[?,?,?,?],ui8> attributes {torch.onnx_meta.ir_version = 5 : si64, torch.onnx_meta.opset_version = 10 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  %0 = torch.operator "onnx.QLinearGlobalAveragePool"(%arg0, %arg1, %arg2, %arg3, %arg4) {torch.onnx.channels_last = 0 : si64} : (!torch.vtensor<[1,1000,13,13],ui8>, !torch.vtensor<[],f32>, !torch.vtensor<[],ui8>, !torch.vtensor<[],f32>, !torch.vtensor<[],ui8>) -> !torch.vtensor<[?,?,?,?],ui8>
+  // CHECK: %[[X_F32:.+]] = torch.aten.dequantize.self
+  // CHECK: %[[C2:.*]] = torch.constant.int 2
+  // CHECK: %[[DIM2:.*]] = torch.aten.size.int %[[X_F32]], %[[C2]] : !torch.vtensor<[1,1000,13,13],f32>, !torch.int -> !torch.int
+  // CHECK: %[[C3:.*]] = torch.constant.int 3
+  // CHECK: %[[DIM3:.*]] = torch.aten.size.int %[[X_F32]], %[[C3]] : !torch.vtensor<[1,1000,13,13],f32>, !torch.int -> !torch.int
+  // CHECK: %[[KERNELSIZE:.*]] = torch.prim.ListConstruct %[[DIM2]], %[[DIM3]] : (!torch.int, !torch.int) -> !torch.list<int>
+  // CHECK: torch.aten.avg_pool2d %[[X_F32]], %[[KERNELSIZE]]
+  return %0 : !torch.vtensor<[?,?,?,?],ui8>
+}
+
+// -----
+
 // CHECK-LABEL: @test_qlinear_sigmoid(
 // CHECK-SAME:                   %[[X:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !torch.vtensor<[?,?],ui8>,
 // CHECK-SAME:                   %[[X_SCALE:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !torch.vtensor<[],f32>,


### PR DESCRIPTION
The kernel size was computed as `inputShape[i] - resultShape[i] + 1`, with a check for `kUnknownSize` on the input dim only. When the result spatial dim was statically unknown, its `kUnknownSize` (`== -1`) went into the formula and produced a kernel larger than the input (e.g. 9 for a 7x7 input), crashing the downstream AvgPool lowering.

For a global average pool the kernel is just the full input spatial extent, so take the dynamic path (`aten.size.int` on the input) when either the input or result dim is unknown.

This issue was discovered when importing MobileNetV2-int8 from onnx model zoo.