### PR TITLE
[TorchToTosa] Fix transposed conv crop for nonzero output_padding

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -3761,40 +3761,30 @@ LogicalResult ConvertAtenOp<AtenConvolutionOp>::matchAndRewriteImpl(
         weight, weightShape, weightElemTy, transposedWeightPermutation,
         getTypeConverter(), rewriter, op->getLoc());
 
-    // TOSA 'out_pad' is a 4D array {top,bottom,left,right}.
-    // Map from PyTorch's (padding, output_padding):
-    //   out_pad_total(H/W) = output_padding(H/W) - 2*padding(H/W)
-    // Negative values need to be handled by cropping the output.
-    int64_t outPadH = outPaddingList[0] - 2 * paddingList[0];
-    int64_t outPadW = outPaddingList[1] - 2 * paddingList[1];
-
-    // Track if we need to slice to crop the output
-    bool needSlicing = (outPadH < 0 || outPadW < 0);
-
-    auto calculatePaddingOrCropping =
-        [](int64_t outPad) -> std::tuple<int64_t, int64_t, int64_t, int64_t> {
-      // Calculates padding or cropping for a single dimension
-      // in transposed convolution
-      // Returns {padBegin, padEnd, cropBegin, cropEnd}
-      if (outPad >= 0) {
-        int64_t padBegin = outPad / 2;
-        int64_t padEnd = outPad - padBegin;
-        return {padBegin, padEnd, 0, 0};
-      } else {
-        // Negative padding means we need to crop
-        int64_t totalCrop = -outPad;
-        int64_t cropBegin = (totalCrop + 1) / 2; // Crop more from begin if odd
-        int64_t cropEnd = totalCrop / 2;
-        return {0, 0, cropBegin, cropEnd};
-      }
+    // Map PyTorch's (padding, output_padding) to a TOSA out_pad plus an
+    // optional crop, per spatial dim. `padding` crops both sides; the end side
+    // is then shifted by (output_padding - padding): a positive delta pads the
+    // conv (out_pad_bottom), a negative delta crops the end.
+    // Returns {padBegin, padEnd, cropBegin, cropEnd}.
+    auto calculatePaddingOrCropping = [](int64_t padding, int64_t outputPadding)
+        -> std::tuple<int64_t, int64_t, int64_t, int64_t> {
+      int64_t cropBegin = padding;
+      int64_t endDelta = outputPadding - padding;
+      int64_t padEnd = endDelta > 0 ? endDelta : 0;
+      int64_t cropEnd = endDelta < 0 ? -endDelta : 0;
+      return {/*padBegin=*/0, padEnd, cropBegin, cropEnd};
     };
 
     // Determine cropping and actual padding
     auto [outPadTop, outPadBottom, cropTopH, cropBottomH] =
-        calculatePaddingOrCropping(outPadH);
+        calculatePaddingOrCropping(paddingList[0], outPaddingList[0]);
 
     auto [outPadLeft, outPadRight, cropTopW, cropBottomW] =
-        calculatePaddingOrCropping(outPadW);
+        calculatePaddingOrCropping(paddingList[1], outPaddingList[1]);
+
+    // We must slice whenever either dimension crops the conv output.
+    bool needSlicing =
+        (cropTopH > 0 || cropBottomH > 0 || cropTopW > 0 || cropBottomW > 0);
 
     SmallVector<int64_t, 4> outPad(
         {outPadTop, outPadBottom, outPadLeft, outPadRight});

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -947,6 +947,9 @@ FX_IMPORTER_STABLEHLO_XFAIL_SET = {
     "TraceSignedIntModule_basic",
     "TraceUnsignedIntModule_basic",
     "TraceUnsignedIntModule_empty",
+    # Transposed conv with nonzero output_padding: stablehlo infers a shape one
+    # element short in each spatial dim (197x227 vs 198x226).
+    "TransposedConv2dAsymmetricCrop_basic",
     "UnsafeIndexPutHackedTwin1DFloatNonAccumulateModule_basic",
     "UnsafeViewCollapseDynamicWithAtenSizeIntModule_basic",
     "UpSampleNearest1dVecNoneScales_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/conv.py
@@ -2341,3 +2341,35 @@ class TransposedConv3dNegativePadding(torch.nn.Module):
 @register_test_case(module_factory=lambda: TransposedConv3dNegativePadding())
 def TransposedConv3dNegativePadding_basic(module, tu: TestUtils):
     module.forward(tu.rand(4, 1, 8, 13, 17), tu.rand(1, 1, 3, 7, 3), tu.rand(1))
+
+
+class TransposedConv2dAsymmetricCrop(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([1, 1, 64, 57], torch.float32, True),
+            ([1, 1, 11, 7], torch.float32, True),
+            ([1], torch.float32, True),
+        ]
+    )
+    def forward(self, inputVec, weight, bias):
+        return torch.ops.aten.convolution(
+            inputVec,
+            weight,
+            bias=bias,
+            stride=[3, 4],
+            padding=[2, 3],
+            dilation=[1, 1],
+            transposed=True,
+            output_padding=[2, 1],
+            groups=1,
+        )
+
+
+@register_test_case(module_factory=lambda: TransposedConv2dAsymmetricCrop())
+def TransposedConv2dAsymmetricCrop_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1, 64, 57), tu.rand(1, 1, 11, 7), tu.rand(1))

--- a/test/Conversion/TorchToTosa/conv2d_transpose.mlir
+++ b/test/Conversion/TorchToTosa/conv2d_transpose.mlir
@@ -52,3 +52,24 @@ func.func @convTransposePositiveEffectivePadding(%arg0: !torch.vtensor<[1,2,4,4]
     %4 = torch.aten.convolution %arg0, %arg1, %none, %0, %1, %2, %true, %3, %int1 : !torch.vtensor<[1,2,4,4],f32>, !torch.vtensor<[2,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,2,10,10],f32>
     return %4 : !torch.vtensor<[1,2,10,10],f32>
   }
+
+// -----
+// CHECK-LABEL: func.func @convTransposeAsymmetricCrop
+// CHECK: %[[TCONV:.*]] = tosa.transpose_conv2d {{.*}} {acc_type = f32, out_pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 3, 3>} {{.*}} -> tensor<1x24x24x2xf32>
+// CHECK-DAG: %[[START_SHAPE:.*]] = tosa.const_shape {values = dense<[0, 2, 2, 0]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG: %[[SLICE_SHAPE:.*]] = tosa.const_shape {values = dense<[1, 22, 22, 2]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK: tosa.slice %[[TCONV]], %[[START_SHAPE]], %[[SLICE_SHAPE]] : (tensor<1x24x24x2xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<1x22x22x2xf32>
+func.func @convTransposeAsymmetricCrop(%arg0: !torch.vtensor<[1,2,8,8],f32>, %arg1: !torch.vtensor<[2,2,3,3],f32>) -> !torch.vtensor<[1,2,22,22],f32> {
+    %true = torch.constant.bool true
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int2 = torch.constant.int 2
+    %int3 = torch.constant.int 3
+    %none = torch.constant.none
+    %stride = torch.prim.ListConstruct %int3, %int3 : (!torch.int, !torch.int) -> !torch.list<int>
+    %pad = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+    %dilation = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+    %outpad = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+    %4 = torch.aten.convolution %arg0, %arg1, %none, %stride, %pad, %dilation, %true, %outpad, %int1 : !torch.vtensor<[1,2,8,8],f32>, !torch.vtensor<[2,2,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,2,22,22],f32>
+    return %4 : !torch.vtensor<[1,2,22,22],f32>
+  }


### PR DESCRIPTION
The `transpose_conv2d` lowering cropped a negative effective out_pad symmetrically, but PyTorch crops `padding` from the begin side and extends only the end by `output_padding`. The correct per-dim crop is asymmetric (`begin = padding`, `end = padding - output_padding`); the symmetric split is wrong whenever `output_padding != 0`.