### PR TITLE
[fx_importer] Fix KeyError when as_strided is a graph output

### DIFF
--- a/python/torch_mlir/extras/fx_as_strided.py
+++ b/python/torch_mlir/extras/fx_as_strided.py
@@ -41,7 +41,14 @@ def rewrite_as_strided(g: fx.Graph) -> bool:
             continue
         replacement = _rewrite(g, node)
         node.replace_all_uses_with(replacement)
+        # An ExportedProgram graph_signature references nodes by name (output
+        # specs, buffer/input mutation targets). replace_all_uses_with only
+        # rewires graph edges, so give the replacement the erased node's name to
+        # keep every name-keyed signature entry valid without the callers having
+        # to know about this rewrite.
+        old_name = node.name
         g.erase_node(node)
+        replacement.name = old_name
         changed = True
     if changed:
         g.eliminate_dead_code()

--- a/test/python/fx_importer/as_strided_test.py
+++ b/test/python/fx_importer/as_strided_test.py
@@ -24,6 +24,16 @@ def import_module(module, *args):
     print(str(imported).split("{-#", 1)[0])
 
 
+def import_module_mutation(module, *args):
+    # experimental_support_mutation=True routes through import_program (the
+    # ExportedProgram path), which reads graph_signature output specs by node
+    # name. The default path (import_frozen_program) does not, so the mutation
+    # path is the one that exercises signature fixup after the as_strided
+    # rewrite erases nodes.
+    imported = fx.export_and_import(module, *args, experimental_support_mutation=True)
+    print(str(imported).split("{-#", 1)[0])
+
+
 def expect_reject(module, *args, **kwargs):
     try:
         fx.export_and_import(module, *args, **kwargs)
@@ -272,3 +282,26 @@ def test_as_strided_rejects_unmappable_program_input():
         M(),
         torch.arange(8, dtype=torch.float32)[::2],
     )
+
+
+@run
+# CHECK-LABEL: test_as_strided_output_mutation_path
+# CHECK: func.func @main(%arg0: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[2,2],f32>
+# CHECK: %[[M_INDEX0:.*]] = torch.vtensor.literal{{.*}}tensor<2x2xsi64>
+# CHECK: %[[M_INDEX1:.*]] = torch.vtensor.literal{{.*}}tensor<2x2xsi64>
+# CHECK: %[[M_INDICES:.*]] = torch.prim.ListConstruct %[[M_INDEX0]], %[[M_INDEX1]] : (!torch.vtensor<[2,2],si64>, !torch.vtensor<[2,2],si64>) -> !torch.list<optional<vtensor>>
+# CHECK-NOT: torch.aten.as_strided
+# CHECK: %[[M_RESULT:.*]] = torch.aten.index.Tensor %arg0, %[[M_INDICES]] : !torch.vtensor<[3,4],f32>, !torch.list<optional<vtensor>> -> !torch.vtensor<[2,2],f32>
+# CHECK-NOT: torch.aten.as_strided
+# CHECK: return %[[M_RESULT]] : !torch.vtensor<[2,2],f32>
+def test_as_strided_output_mutation_path():
+    # Regression: when as_strided is a graph output and import goes through the
+    # ExportedProgram path (experimental_support_mutation=True), the rewrite
+    # erases the as_strided node but its output spec still referenced it by
+    # name, raising KeyError. The importer must remap the signature to the
+    # replacement node.
+    class M(nn.Module):
+        def forward(self, x):
+            return torch.ops.aten.as_strided.default(x, [2, 2], [4, 1], 0)
+
+    import_module_mutation(M(), torch.arange(12, dtype=torch.float32).reshape(3, 4))


### PR DESCRIPTION
`rewrite_as_strided` replaces each `aten.as_strided.default` node with `aten.index.Tensor` using `replace_all_uses_with` + `erase_node`. This rewires the graph's edges, but an `ExportedProgram`'s `graph_signature` references nodes **by name** — so any spec that named the erased `as_strided` node is left dangling.

`FxImporter.import_program` then dereferences those names in several places:

```python
output_producer_node = all_producer_nodes[arg.name]          # USER_OUTPUT
mutable_buffer_target_producers[output_spec.target] = arg.name  # BUFFER_MUTATION
# ... and USER_INPUT_MUTATION producer names
```

So when `as_strided` result is a graph output, the lookup raises: `KeyError: 'as_strided'`

This only manifests on the `ExportedProgram` import path — `export_and_import(experimental_support_mutation=True)` → `import_program`. The default frozen path (`import_frozen_program` → `import_stateless_graph`) derives its outputs from the graph's `output` node rather than the signature, so it never dereferences the stale names and was unaffected. That's why the existing e2e `AsStrided` tests passed.