### PR TITLE
[TorchOnnxToTorch] Make onnx.LayerNormalization bias (B) input optional

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -2663,12 +2663,15 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         float epsilon;
         if (binder.tensorOperandAtIndex(x, 0) ||
             binder.tensorOperandAtIndex(scale, 1) ||
-            binder.tensorOperandAtIndex(b, 2) ||
             binder.tensorResultTypeAtIndex(yType, 0) ||
             binder.s64IntegerAttr(axis, "axis", -1) ||
             binder.f32FloatAttr(epsilon, "epsilon", 0.00001f) ||
             binder.s64IntegerAttr(stashType, "stash_type", 1))
           return failure();
+
+        // B (bias) is optional in ONNX LayerNormalization; bind None when it is
+        // absent so bias-less (RMS-style) norms still match.
+        bool hasBias = !binder.tensorOperandAtIndex(b, 2);
 
         std::optional<int64_t> stashTypeIntTorch =
             onnxDtypeIntToTorchDtypeInt(stashType);
@@ -2686,6 +2689,8 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         Value cstFalse =
             Torch::ConstantBoolOp::create(rewriter, binder.getLoc(), false);
         Value none = Torch::ConstantNoneOp::create(rewriter, binder.getLoc());
+        if (!hasBias)
+          b = none;
         if (*stashDtype != xType.getOptionalDtype()) {
           auto newXType =
               xType.getWithSizesAndDtype(xType.getOptionalSizes(), *stashDtype);

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
@@ -396,6 +396,18 @@ func.func @test_layer_norm_single_result(%arg0: !torch.vtensor<[1,4,768],f32>, %
 
 // -----
 
+// CHECK-LABEL: func.func @test_layer_norm_no_bias
+func.func @test_layer_norm_no_bias(%arg0: !torch.vtensor<[1,4,768],f32>, %arg1: !torch.vtensor<[768],f32>) -> (!torch.vtensor<[1,4,768], f32>)
+                           attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  // The optional bias (B) is absent (RMS-style norm); it must be bound to None.
+  // CHECK: %[[NONE:.*]] = torch.constant.none
+  // CHECK: %result0, %result1, %result2 = torch.aten.native_layer_norm %arg0, %0, %arg1, %[[NONE]]
+  %0 = torch.operator "onnx.LayerNormalization"(%arg0, %arg1) {torch.onnx.axis = -1 : si64, torch.onnx.epsilon = 9.99999974E-6 : f32} : (!torch.vtensor<[1,4,768],f32>, !torch.vtensor<[768],f32>) -> !torch.vtensor<[1,4,768],f32>
+  return %0 : !torch.vtensor<[1,4,768],f32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @test_leaky_relu
 func.func @test_leaky_relu(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],f32> attributes {torch.onnx_meta.opset_version = 16 : si64} {
   // CHECK-DAG: %[[F2:.+]] = torch.constant.float 2


### PR DESCRIPTION
ONNX LayerNormalization's B (bias) input is optional, but the ONNX->Torch conversion pattern bound it as a mandatory operand. Bias-less (RMS-style / pre-norm) layers therefore failed to convert: the op was left as a torch.operator and later rejected with "failed to legalize operation 'torch.operator' that was explicitly marked illegal".

Bind B optionally and pass None to aten.native_layer_norm (whose bias operand is already optional) when it is absent. The with-bias path is unchanged.

Add a no-bias lit test.