### PR TITLE
[Torch] Support negative permute dimensions

### DIFF
--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -5676,14 +5676,12 @@ LogicalResult AtenPermuteOp::verify() {
       continue;
     }
 
-    // if 'from' is the unkwown index, continue.
-    if (from == -1) {
-      continue;
-    }
+    const int64_t originalFrom = from;
+    from = toPositiveDim(from, outRank);
 
     if (!isValidDim(from, outRank)) {
       return emitError("observed invalid index in permutation (")
-             << from << ") for input tensor of rank " << outRank << '.';
+             << originalFrom << ") for input tensor of rank " << outRank << '.';
     }
 
     if (reversePermutation[from] != -1) {

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -866,14 +866,14 @@ class PermuteNegativeIndexModule(torch.nn.Module):
         super().__init__()
 
     @export
-    @annotate_args([None, ([3, 4, 2], torch.float32, True)])
+    @annotate_args([None, ([1, 2, 3, 4], torch.float32, True)])
     def forward(self, x):
-        return x.permute(0, -1, 1)
+        return x.permute(0, -2, -1, 1)
 
 
 @register_test_case(module_factory=lambda: PermuteNegativeIndexModule())
 def PermuteNegativeIndexModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(3, 4, 2))
+    module.forward(tu.rand(1, 2, 3, 4))
 
 
 # ==============================================================================

--- a/test/Dialect/Torch/invalid.mlir
+++ b/test/Dialect/Torch/invalid.mlir
@@ -331,6 +331,22 @@ func.func @torch.permute$duplicate_index_in_permutation (%arg0: !torch.vtensor<[
 
 // -----
 
+func.func @torch.permute$duplicate_negative_index_in_permutation (%arg0: !torch.vtensor<[1,2,3,4],f32>) -> !torch.vtensor<[1,2,4,4],f32> {
+
+  %intm1 = torch.constant.int -1
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %perm = torch.prim.ListConstruct %int0, %int1, %int3, %intm1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+
+  // expected-error@+1 {{'torch.aten.permute' op has a duplicate dimension (3) in its permutation}}
+  %3 = torch.aten.permute %arg0, %perm : !torch.vtensor<[1,2,3,4],f32>, !torch.list<int> -> !torch.vtensor<[1,2,4,4],f32>
+
+  return %3 : !torch.vtensor<[1,2,4,4],f32>
+}
+
+// -----
+
 func.func @torch.permute$incorrect_output_shape (%arg0: !torch.vtensor<[1,2,3],f32>) -> !torch.vtensor<[3,1,2],f32> {
 
   %int0 = torch.constant.int 0
@@ -361,6 +377,22 @@ func.func @torch.permute$invalid_index_in_permutation (%arg0: !torch.vtensor<[1,
   %3 = torch.aten.permute %arg0, %perm : !torch.vtensor<[1,2,3],f32>, !torch.list<int> -> !torch.vtensor<[1,2,3],f32>
 
    return %3 : !torch.vtensor<[1,2,3],f32>
+}
+
+// -----
+
+func.func @torch.permute$invalid_negative_index_in_permutation (%arg0: !torch.vtensor<[1,2,3,4],f32>) -> !torch.vtensor<[1,2,3,4],f32> {
+
+  %intm5 = torch.constant.int -5
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %perm = torch.prim.ListConstruct %int0, %int1, %int2, %intm5 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+
+  // expected-error@+1 {{observed invalid index in permutation (-5) for input tensor of rank 4.}}
+  %3 = torch.aten.permute %arg0, %perm : !torch.vtensor<[1,2,3,4],f32>, !torch.list<int> -> !torch.vtensor<[1,2,3,4],f32>
+
+  return %3 : !torch.vtensor<[1,2,3,4],f32>
 }
 
 // -----

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -181,14 +181,15 @@ func.func @prim_list_construct$valid_shape_subtype(%arg0: !torch.vtensor<[1,53,5
   return %arg2 : !torch.list<vtensor<[1,?,56,96],f16>>
 }
 
-// Check that verification passes with '-1' as a permutation index.
-func.func @torch.permute$negative_index_valid (%arg0: !torch.vtensor<[1,2,3],f32>) -> !torch.vtensor<[1,2,3],f32> {
+// Check that verification passes with negative permutation indices.
+func.func @torch.permute$negative_index_valid (%arg0: !torch.vtensor<[1,2,3,4],f32>) -> !torch.vtensor<[1,3,4,2],f32> {
+  %intm2 = torch.constant.int -2
   %intm1 = torch.constant.int -1
   %int0 = torch.constant.int 0
   %int1 = torch.constant.int 1
-  %perm = torch.prim.ListConstruct %int0, %int1, %intm1 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
-  %3 = torch.aten.permute %arg0, %perm : !torch.vtensor<[1,2,3],f32>, !torch.list<int> -> !torch.vtensor<[1,2,3],f32>
-  return %3 : !torch.vtensor<[1,2,3],f32>
+  %perm = torch.prim.ListConstruct %int0, %intm2, %intm1, %int1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %3 = torch.aten.permute %arg0, %perm : !torch.vtensor<[1,2,3,4],f32>, !torch.list<int> -> !torch.vtensor<[1,3,4,2],f32>
+  return %3 : !torch.vtensor<[1,3,4,2],f32>
 }
 
 // Check fake quantize ops


### PR DESCRIPTION
Summary

Update the `aten.permute` verifier to normalize valid negative dimensions before duplicate-dimension and result-shape validation.

Diagnostics retain the original invalid dimension value. Positive and negative aliases, such as `3` and `-1` for a rank-four tensor, are correctly rejected as duplicates.

Testing

- Added verifier lit coverage for valid negative dimensions, duplicate dimensions, and out-of-range dimensions.
- Added `PermuteNegativeIndexModule_basic` PT1 e2e coverage.
- Ran the full Torch-MLIR regression suite.