### PR TITLE
Always lift buffers when importing frozen programs

### DIFF
--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -532,7 +532,6 @@ FX_IMPORTER_XFAIL_SET = {
 }
 
 FX_IMPORTER_CRASHING_SET = LINALG_CRASHING_SET | {
-    "HBC_basic",
     # Runtime op verification: out-of-bounds access
     "_SoftmaxModule_basic",
     "UpSampleNearest2dDynamicFactor_basic",
@@ -753,7 +752,6 @@ FX_IMPORTER_STABLEHLO_XFAIL_SET = {
     "GeIntModule_basic",
     "GtFloatIntModule_basic",
     "GtIntModule_basic",
-    "HBC_basic",
     "HardtanhBackward_basic",
     "IndexPut1DFloatAccumulateModule_basic",
     "IndexPut1DFloatNonAccumulateModule_basic",
@@ -1811,7 +1809,6 @@ FX_IMPORTER_TOSA_CRASHING_SET = {
     "Aten_TrilinearModuleVaryingRanksUnorderedExpands_basic",
     "ScatterSrcModule_basic",
     "ScatterSrcStaticModule_basic",
-    "HBC_basic",
     # 1D inputs cause generated tosa.negate ops to crash downstream
     "NllLossModule_1D_basic",
     # BertModule is not crashing, but is timing out due to TosaLayerwiseConstantFoldPass:

--- a/projects/pt1/python/torch_mlir_e2e_test/configs/fx_importer_backend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/configs/fx_importer_backend.py
@@ -149,20 +149,12 @@ class FxImporterTestConfig(TestConfig):
             )
             module = self._backend.compile(module)
             backend_module = self._backend.load(module)
-            input_buffers = prog.graph_signature.inputs_to_buffers.values()
-            params = {
-                # **dict(artifact.named_parameters(remove_duplicate=False)),
-                name: value
-                for (name, value) in artifact.named_buffers(remove_duplicate=False)
-                if name in input_buffers
-            }
-            params_flat, params_spec = pytree.tree_flatten(params)
-            params_flat = list(params_flat)
             with torch.no_grad():
-                numpy_inputs = recursively_convert_to_numpy(params_flat + item.inputs)
+                numpy_inputs = recursively_convert_to_numpy(item.inputs)
             outputs = getattr(backend_module, artifact.__class__.__name__)(
                 *numpy_inputs
             )
+
             output = refine_result_type(outputs)
             if isinstance(output, (tuple, list)):
                 user_output = []

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -958,16 +958,14 @@ class FxImporter:
                         "Could not find state mapping for tensor constants"
                     ) from e
                 arg_replacements[input_name] = state_value
-        else:
-            # Lift buffers.
-            for input_name, state_name in sig.inputs_to_buffers.items():
-                try:
-                    state_value = state_dict[state_name]
-                except KeyError as e:
-                    raise AssertionError(
-                        "Could not find state mapping for buffer"
-                    ) from e
-                arg_replacements[input_name] = state_value
+
+        # Always lift buffers.
+        for input_name, state_name in sig.inputs_to_buffers.items():
+            try:
+                state_value = state_dict[state_name]
+            except KeyError as e:
+                raise AssertionError("Could not find state mapping for buffer") from e
+            arg_replacements[input_name] = state_value
 
         # Lift parameters.
         for input_name, state_name in sig.inputs_to_parameters.items():

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -464,7 +464,7 @@ def test_stack_trace():
 
 @run
 # Asserting a single input argument here, since the frozen program should have
-# its BatchNorm parameters lifted from function arguments to inlined constants.
+# its BatchNorm buffers lifted from function arguments to inlined constants.
 # CHECK-LABEL: test_import_frozen_exported_program_with_multiple_buffers
 # CHECK: func.func @main(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[2,10,20,20],f32>)
 # CHECK-COUNT-8: = torch.vtensor.literal(dense_resource<{{.*}}> : tensor<10xf32>)

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -465,6 +465,8 @@ def test_stack_trace():
 @run
 # Asserting a single input argument here, since the frozen program should have
 # its BatchNorm buffers lifted from function arguments to inlined constants.
+# 2 BatchNorm layers × 4 float tensors each: weight, bias, running_mean,
+# running_var. This gives 8 expected function arguments.
 # CHECK-LABEL: test_import_frozen_exported_program_with_multiple_buffers
 # CHECK: func.func @main(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[2,10,20,20],f32>)
 # CHECK-COUNT-8: = torch.vtensor.literal(dense_resource<{{.*}}> : tensor<10xf32>)

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -460,3 +460,27 @@ def test_stack_trace():
     m = fx.export_and_import(Basic(), x, y, func_name="test_stack_trace")
     mlir_asm = m.operation.get_asm(enable_debug_info=True)
     print(mlir_asm)
+
+
+@run
+# Asserting a single input argument here, since the frozen program should have
+# its BatchNorm parameters lifted from function arguments to inlined constants.
+# CHECK-LABEL: test_import_frozen_exported_program_with_multiple_buffers
+# CHECK: func.func @main(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[2,10,20,20],f32>)
+# CHECK-COUNT-8: = torch.vtensor.literal(dense_resource<{{.*}}> : tensor<10xf32>)
+def test_import_frozen_exported_program_with_multiple_buffers():
+    class DoubleBatchNorm(nn.Module):
+        def __init__(self, num_features):
+            super().__init__()
+            self.bn1 = nn.BatchNorm2d(num_features)
+            self.bn2 = nn.BatchNorm2d(num_features)
+
+        def forward(self, x):
+            x = self.bn1(x)
+            x = self.bn2(x)
+            return x
+
+    model = DoubleBatchNorm(10)
+    model.eval()
+    m = fx.export_and_import(model, torch.randn(2, 10, 20, 20))
+    print(m)


### PR DESCRIPTION
Reproduction: https://gist.github.com/j2kun/c2539e1fd9a7de0d10e9513cff0e989c

In fx_importer.py, import_frozen_program only lifts buffers from `state_dict` to inlined constants in the else block of `if hasattr(prog, "constants"):`

It should always lift these buffers since the program is frozen.  I ran into this because I was exporting a torch model that had batch norms in it, and the batch norm parameters were left as (many many) function arguments when I wanted to freeze them from the values they got during training.

(Followed up from Discord)