### PR TITLE
[Torch] Fold shape-preserving empty repeat

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -5063,10 +5063,10 @@ public:
                                 PatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     Value self = op.getSelf();
-    auto selfTy = cast<BaseTensorType>(self.getType());
-    if (!selfTy.hasSizes())
+    auto selfTy = dyn_cast<ValueTensorType>(self.getType());
+    if (!selfTy || !selfTy.hasSizes())
       return rewriter.notifyMatchFailure(
-          op, "Unimplemented: no implementation for rankless tensor");
+          op, "Unimplemented: expected a ranked value tensor");
 
     SmallVector<Value> repeats;
     if (!getListConstructElements(op.getRepeats(), repeats))
@@ -5079,11 +5079,18 @@ public:
           op, "repeats are not matched with self's rank");
     }
 
+    auto resultTy = dyn_cast<ValueTensorType>(op.getType());
+    if (resultTy && resultTy.hasSizes() &&
+        llvm::none_of(resultTy.getSizes(),
+                      [](int64_t size) { return size == kUnknownSize; }) &&
+        self.getType() == op.getType() &&
+        llvm::is_contained(resultTy.getSizes(), 0)) {
+      rewriter.replaceOp(op, self);
+      return success();
+    }
+
     int64_t repeatSz = repeats.size();
     int64_t batch = repeatSz - rank;
-
-    if (!selfTy.hasSizes())
-      return rewriter.notifyMatchFailure(op, "input sizes unknown");
 
     // Fold the constant values so that we know which we materialize:
     llvm::SmallVector<int64_t> repeatInts;

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3759,6 +3759,7 @@ FX_IMPORTER_TOSA_XFAIL_SET = {
     "CrossEntropyLossNoReductionModule_basic",
     "NumpyTRank0Module_basic",
     "Permute0RankModule_basic",
+    "RepeatShapePreservingEmptyModule_basic",
     "ArgsortTensor_basic",
     "ArgsortTensorInteger_basic",
     "AtenSymConstrainRangeForSize_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -2630,6 +2630,24 @@ def RepeatModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class RepeatShapePreservingEmptyModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([None])
+    def forward(self):
+        return torch.empty(0).repeat(0)
+
+
+@register_test_case(module_factory=lambda: RepeatShapePreservingEmptyModule())
+def RepeatShapePreservingEmptyModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+# ==============================================================================
+
+
 class RepeatInterleaveSelfIntModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1148,6 +1148,31 @@ func.func @torch.aten.mish$f8E8M0FNU(%arg0: !torch.vtensor<[2,3],f8E8M0FNU>) -> 
 
 // -----
 
+// CHECK-LABEL: func.func @repeat_shape_preserving_empty(
+// CHECK-NOT:     torch.aten.repeat
+// CHECK:         return %arg0 : !torch.vtensor<[0],f32>
+func.func @repeat_shape_preserving_empty(%arg0: !torch.vtensor<[0],f32>) -> !torch.vtensor<[0],f32> {
+  %int0 = torch.constant.int 0
+  %repeats = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+  %0 = torch.aten.repeat %arg0, %repeats : !torch.vtensor<[0],f32>, !torch.list<int> -> !torch.vtensor<[0],f32>
+  return %0 : !torch.vtensor<[0],f32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @repeat_shape_preserving_empty_dynamic(
+// CHECK-NOT:     return %arg0
+// CHECK:         return %{{.*}} : !torch.vtensor<[?,0],f32>
+func.func @repeat_shape_preserving_empty_dynamic(%arg0: !torch.vtensor<[?,0],f32>) -> !torch.vtensor<[?,0],f32> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %repeats = torch.prim.ListConstruct %int0, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.repeat %arg0, %repeats : !torch.vtensor<[?,0],f32>, !torch.list<int> -> !torch.vtensor<[?,0],f32>
+  return %0 : !torch.vtensor<[?,0],f32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @repeat_mixed_dims_broadcast_singletons
 // CHECK-SAME: (%[[ARG0:.*]]: !torch.vtensor<[1,2,1],f32>) -> !torch.vtensor<[3,8,5],f32>
 // CHECK-DAG: %[[CNEG1:.*]] = torch.constant.int -1


### PR DESCRIPTION
Summary

Fold `aten.repeat` to its input when a statically shaped empty value tensor is repeated without changing its type.

The fold runs after the existing repeat-list and rank validation. It requires `ValueTensorType` with fully known sizes and leaves dynamic-shape cases undecomposed.

Testing

- Added lit coverage for the static fold and dynamic-shape rejection.
- Added `RepeatShapePreservingEmptyModule_basic` PT1 e2e coverage.
- Ran the full Torch-MLIR regression suite.