### PR TITLE
[Torch] Fold shape-preserving empty softmax

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -2484,6 +2484,12 @@ static Value getSoftmaxResult(Operation *op, Value self, Value dim,
   return result;
 }
 
+static bool isShapePreservingEmptyTensor(Value input, Type resultType) {
+  auto inputType = dyn_cast<BaseTensorType>(input.getType());
+  return input.getType() == resultType && inputType && inputType.hasSizes() &&
+         llvm::is_contained(inputType.getSizes(), 0);
+}
+
 // Decompose softmax into: exp(x) / sum(exp(x))
 namespace {
 class DecomposeAtenSoftmaxIntOp : public OpRewritePattern<AtenSoftmaxIntOp> {
@@ -2493,6 +2499,11 @@ public:
                                 PatternRewriter &rewriter) const override {
     Value self = op.getSelf();
     BaseTensorType resultTensorType = cast<BaseTensorType>(op.getType());
+    if (isShapePreservingEmptyTensor(self, op.getType())) {
+      rewriter.replaceOp(op, self);
+      return success();
+    }
+
     if (!resultTensorType.hasDtype()) {
       return rewriter.notifyMatchFailure(
           op, "expected result type to have a dtype");
@@ -2534,6 +2545,11 @@ public:
   LogicalResult matchAndRewrite(Aten_SoftmaxOp op,
                                 PatternRewriter &rewriter) const override {
     Value self = op.getSelf();
+    if (isShapePreservingEmptyTensor(self, op.getType())) {
+      rewriter.replaceOp(op, self);
+      return success();
+    }
+
     BaseTensorType tensorType = cast<BaseTensorType>(self.getType());
     if (!tensorType.hasDtype() || !isa<mlir::FloatType>(tensorType.getDtype()))
       return rewriter.notifyMatchFailure(op, "Only support floating type");

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -537,6 +537,8 @@ FX_IMPORTER_XFAIL_SET = {
 
 FX_IMPORTER_CRASHING_SET = LINALG_CRASHING_SET | {
     "HBC_basic",
+    # Zero-extent memref argument verification fails on a stride mismatch.
+    "SoftmaxIntEmptyModule_basic",
     # Runtime op verification: out-of-bounds access
     "_SoftmaxModule_basic",
     "UpSampleNearest2dDynamicFactor_basic",
@@ -1818,6 +1820,8 @@ TOSA_CRASHING_SET = {
 }
 
 FX_IMPORTER_TOSA_CRASHING_SET = {
+    # Zero-extent memref argument verification fails on a stride mismatch.
+    "SoftmaxIntEmptyModule_basic",
     "Aten_TrilinearModuleSumAllDims_basic",
     "Aten_TrilinearModuleSumdims_basic",
     "Aten_TrilinearModuleVaryingRanksUnorderedExpands_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -2148,6 +2148,23 @@ def SoftmaxIntModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 2, 4))
 
 
+class SoftmaxIntEmptyModule(torch.nn.Module):
+    @export
+    @annotate_args(
+        [
+            None,
+            ([0], torch.float32, True),
+        ]
+    )
+    def forward(self, tensor):
+        return torch.softmax(tensor, dim=-1)
+
+
+@register_test_case(module_factory=lambda: SoftmaxIntEmptyModule())
+def SoftmaxIntEmptyModule_basic(module, tu: TestUtils):
+    module.forward(torch.empty(0))
+
+
 class SoftmaxIntNonNoneDtypeModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1,5 +1,29 @@
 // RUN: torch-mlir-opt -torch-decompose-complex-ops -split-input-file %s | FileCheck %s
 
+// CHECK-LABEL: func.func @softmax_shape_preserving_empty(
+// CHECK-NOT:     torch.aten.max.dim
+// CHECK:         return %arg0
+func.func @softmax_shape_preserving_empty(%arg0: !torch.vtensor<[5,0,0],f32>) -> !torch.vtensor<[5,0,0],f32> {
+  %int-1 = torch.constant.int -1
+  %none = torch.constant.none
+  %0 = torch.aten.softmax.int %arg0, %int-1, %none : !torch.vtensor<[5,0,0],f32>, !torch.int, !torch.none -> !torch.vtensor<[5,0,0],f32>
+  return %0 : !torch.vtensor<[5,0,0],f32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @_softmax_shape_preserving_empty(
+// CHECK-NOT:     torch.aten.max.dim
+// CHECK:         return %arg0
+func.func @_softmax_shape_preserving_empty(%arg0: !torch.vtensor<[5,0,0],f32>) -> !torch.vtensor<[5,0,0],f32> {
+  %int-1 = torch.constant.int -1
+  %false = torch.constant.bool false
+  %0 = torch.aten._softmax %arg0, %int-1, %false : !torch.vtensor<[5,0,0],f32>, !torch.int, !torch.bool -> !torch.vtensor<[5,0,0],f32>
+  return %0 : !torch.vtensor<[5,0,0],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @matmul_no_decompose
 // CHECK:           torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
 func.func @matmul_no_decompose(%arg0: !torch.vtensor<[?,?,?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {


### PR DESCRIPTION
Summary

Fold `torch.aten.softmax.int` and `torch.aten._softmax` to their input when:

- The input and result have exactly the same tensor type.
- The input has known sizes.
- At least one input dimension has size zero.

A shape- and dtype-preserving softmax over an empty tensor has no element values to compute, so returning the input is equivalent to decomposing the operation.

This prevents empty softmax operations from being decomposed into unsupported reductions and dtype conversions, including `torch.aten.max.dim`.

Testing

- Added lit coverage for both `torch.aten.softmax.int` and `torch.aten._softmax`.
- The lit tests verify that the empty operations are replaced by their input and do not produce `torch.aten.max.dim`.
- Added an end-to-end test for softmax over an empty one-dimensional tensor.
- Recorded the existing runtime limitation for zero-extent memref arguments, which fail stride verification in the affected runtime configurations.