### PR TITLE
[TorchToTosa] Handle empty tensor clamp broadcast

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -821,6 +821,8 @@ public:
     const TypeConverter *typeConverter = this->getTypeConverter();
     bool canHandleZeroDimInputOperands =
         canHandleZeroDimInputs(op, adaptor, typeConverter);
+    bool canHandleZeroDimOutputResults =
+        canHandleZeroDimOutputs(op, adaptor, typeConverter);
 
     // Pre-check: all tensor operands and outputs must have no zero-sized
     // dimensions.
@@ -840,7 +842,8 @@ public:
     for (auto res : op->getResults()) {
       auto rankedOutputType =
           dyn_cast<RankedTensorType>(typeConverter->convertType(res.getType()));
-      if (rankedOutputType && mlir::tosa::typeHasZeroDim(rankedOutputType)) {
+      if (rankedOutputType && mlir::tosa::typeHasZeroDim(rankedOutputType) &&
+          !canHandleZeroDimOutputResults) {
         return rewriter.notifyMatchFailure(
             op,
             "TOSA lowering does not support output tensors with a zero-sized "
@@ -854,6 +857,12 @@ protected:
   virtual bool
   canHandleZeroDimInputs(AtenOpT op, OpAdaptor adaptor,
                          const TypeConverter *typeConverter) const {
+    return false;
+  }
+
+  virtual bool
+  canHandleZeroDimOutputs(AtenOpT op, OpAdaptor adaptor,
+                          const TypeConverter *typeConverter) const {
     return false;
   }
 
@@ -1688,6 +1697,44 @@ public:
   LogicalResult
   matchAndRewriteImpl(AtenOpT op, OpAdaptor adaptor,
                       ConversionPatternRewriter &rewriter) const override;
+
+protected:
+  bool
+  canHandleZeroDimInputs(AtenOpT op, OpAdaptor adaptor,
+                         const TypeConverter *typeConverter) const override {
+    if constexpr (std::is_same_v<AtenOpT, AtenClampTensorOp>)
+      return getEmptyClampReplacement(op, adaptor, typeConverter) != nullptr;
+    return false;
+  }
+
+  bool
+  canHandleZeroDimOutputs(AtenOpT op, OpAdaptor adaptor,
+                          const TypeConverter *typeConverter) const override {
+    if constexpr (std::is_same_v<AtenOpT, AtenClampTensorOp>)
+      return getEmptyClampReplacement(op, adaptor, typeConverter) != nullptr;
+    return false;
+  }
+
+private:
+  static Value getEmptyClampReplacement(AtenOpT op, OpAdaptor adaptor,
+                                        const TypeConverter *typeConverter) {
+    if constexpr (!std::is_same_v<AtenOpT, AtenClampTensorOp>) {
+      return nullptr;
+    } else {
+      auto resultType = dyn_cast<RankedTensorType>(
+          typeConverter->convertType(op.getType()));
+      if (!resultType || !resultType.hasStaticShape() ||
+          !mlir::tosa::typeHasZeroDim(resultType))
+        return nullptr;
+
+      for (Value operand :
+           {adaptor.getSelf(), adaptor.getMin(), adaptor.getMax()}) {
+        if (operand.getType() == resultType)
+          return operand;
+      }
+      return nullptr;
+    }
+  }
 };
 
 template <typename AtenOpT, typename TosaOpT>
@@ -6997,6 +7044,12 @@ template <>
 LogicalResult ConvertAtenOp<AtenClampTensorOp>::matchAndRewriteImpl(
     AtenClampTensorOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
+  if (Value replacement =
+          getEmptyClampReplacement(op, adaptor, typeConverter)) {
+    rewriter.replaceOp(op, replacement);
+    return success();
+  }
+
   // We are not using tosa.clamp to lower aten.clamp.Tensor, as
   // aten.clamp.Tensor's min and max attributes are tensors that can have size
   // greater than 1, which is not compatible with tosa.clamp.

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1818,6 +1818,8 @@ TOSA_CRASHING_SET = {
 }
 
 FX_IMPORTER_TOSA_CRASHING_SET = {
+    # Zero-extent memref argument verification fails on a stride mismatch.
+    "ElementwiseClampTensorEmptyModule_basic",
     "Aten_TrilinearModuleSumAllDims_basic",
     "Aten_TrilinearModuleSumdims_basic",
     "Aten_TrilinearModuleVaryingRanksUnorderedExpands_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -2211,6 +2211,30 @@ def ElementwiseClampTensorFloatModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwiseClampTensorEmptyModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([0, 1, 3], torch.float32, True),
+            ([0, 10, 3], torch.float32, True),
+        ]
+    )
+    def forward(self, x, bound):
+        return torch.clamp(x, min=bound), torch.clamp(x, max=bound)
+
+
+@register_test_case(module_factory=lambda: ElementwiseClampTensorEmptyModule())
+def ElementwiseClampTensorEmptyModule_basic(module, tu: TestUtils):
+    module.forward(torch.empty(0, 1, 3), torch.empty(0, 10, 3))
+
+
+# ==============================================================================
+
+
 class ElementwiseClampTensorIntModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -1872,6 +1872,22 @@ func.func @torch.aten.clamp.tensor_broadcast(
 }
 
 
+// -----
+// CHECK-LABEL: func.func @torch.aten.clamp.tensor_empty_broadcast(
+// CHECK-SAME:      %[[SELF:.*]]: !torch.vtensor<[0,1,3],f32>, %[[BOUND:.*]]: !torch.vtensor<[0,10,3],f32>
+// CHECK-NOT:     tosa.minimum
+// CHECK-NOT:     tosa.maximum
+// CHECK:         return %[[BOUND]], %[[BOUND]]
+func.func @torch.aten.clamp.tensor_empty_broadcast(
+    %arg0: !torch.vtensor<[0,1,3],f32>,
+    %arg1: !torch.vtensor<[0,10,3],f32>) -> (!torch.vtensor<[0,10,3],f32>, !torch.vtensor<[0,10,3],f32>) {
+  %none = torch.constant.none
+  %0 = torch.aten.clamp.Tensor %arg0, %none, %arg1 : !torch.vtensor<[0,1,3],f32>, !torch.none, !torch.vtensor<[0,10,3],f32> -> !torch.vtensor<[0,10,3],f32>
+  %1 = torch.aten.clamp.Tensor %arg0, %arg1, %none : !torch.vtensor<[0,1,3],f32>, !torch.vtensor<[0,10,3],f32>, !torch.none -> !torch.vtensor<[0,10,3],f32>
+  return %0, %1 : !torch.vtensor<[0,10,3],f32>, !torch.vtensor<[0,10,3],f32>
+}
+
+
 
 // -----
 // CHECK-LABEL:   func.func @torch.aten.clamp.float(


### PR DESCRIPTION
Summary

Handle `torch.aten.clamp.Tensor` when broadcasting produces a statically shaped empty result.

The conversion now allows operation-specific handling of zero-sized results. For tensor clamp, it replaces the operation with an operand when:

- The result has a static shape containing a zero-sized dimension.
- An input, minimum, or maximum operand already has the exact converted result type.

Because the result contains no elements, forwarding an exact-result-typed operand preserves the result shape and dtype without requiring unsupported TOSA minimum or maximum operations over zero-sized tensors.

This covers both tensor minimum and tensor maximum forms of clamp.

Testing

- Added a lit test covering empty broadcasting for both tensor minimum and tensor maximum clamp operations.
- The lit test verifies that no `tosa.minimum` or `tosa.maximum` operation is emitted.
- Added an end-to-end test for broadcasting `[0,1,3]` against `[0,10,3]`.
- Recorded the existing zero-extent memref stride-verification limitation for the affected TOSA runtime configuration.