### PR TITLE
[TorchToTosa] Handle empty tensor div broadcast

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -821,6 +821,8 @@ public:
     const TypeConverter *typeConverter = this->getTypeConverter();
     bool canHandleZeroDimInputOperands =
         canHandleZeroDimInputs(op, adaptor, typeConverter);
+    bool canHandleZeroDimOutputResults =
+        canHandleZeroDimOutputs(op, adaptor, typeConverter);
 
     // Pre-check: all tensor operands and outputs must have no zero-sized
     // dimensions.
@@ -840,7 +842,8 @@ public:
     for (auto res : op->getResults()) {
       auto rankedOutputType =
           dyn_cast<RankedTensorType>(typeConverter->convertType(res.getType()));
-      if (rankedOutputType && mlir::tosa::typeHasZeroDim(rankedOutputType)) {
+      if (rankedOutputType && mlir::tosa::typeHasZeroDim(rankedOutputType) &&
+          !canHandleZeroDimOutputResults) {
         return rewriter.notifyMatchFailure(
             op,
             "TOSA lowering does not support output tensors with a zero-sized "
@@ -854,6 +857,12 @@ protected:
   virtual bool
   canHandleZeroDimInputs(AtenOpT op, OpAdaptor adaptor,
                          const TypeConverter *typeConverter) const {
+    return false;
+  }
+
+  virtual bool
+  canHandleZeroDimOutputs(AtenOpT op, OpAdaptor adaptor,
+                          const TypeConverter *typeConverter) const {
     return false;
   }
 
@@ -1576,6 +1585,13 @@ public:
   LogicalResult
   matchAndRewriteImpl(AtenOpT op, OpAdaptor adaptor,
                       ConversionPatternRewriter &rewriter) const override {
+    if (Value replacement =
+            getEmptyTensorReplacement(op, adaptor,
+                                      this->getTypeConverter())) {
+      rewriter.replaceOp(op, replacement);
+      return success();
+    }
+
     Value lhs = adaptor.getSelf();
     auto lhsTy = dyn_cast<TensorType>(lhs.getType());
     Value rhs = adaptor.getOther();
@@ -1674,6 +1690,39 @@ public:
 
     rewriter.replaceOp(op, {result});
     return success();
+  }
+
+protected:
+  bool
+  canHandleZeroDimInputs(AtenOpT op, OpAdaptor adaptor,
+                         const TypeConverter *typeConverter) const override {
+    return getEmptyTensorReplacement(op, adaptor, typeConverter) != nullptr;
+  }
+
+  bool
+  canHandleZeroDimOutputs(AtenOpT op, OpAdaptor adaptor,
+                          const TypeConverter *typeConverter) const override {
+    return getEmptyTensorReplacement(op, adaptor, typeConverter) != nullptr;
+  }
+
+private:
+  static Value getEmptyTensorReplacement(AtenOpT op, OpAdaptor adaptor,
+                                         const TypeConverter *typeConverter) {
+    if constexpr (!std::is_same_v<AtenOpT, AtenDivTensorOp>) {
+      return nullptr;
+    } else {
+      auto resultType = dyn_cast<RankedTensorType>(
+          typeConverter->convertType(op.getType()));
+      if (!resultType || !resultType.hasStaticShape() ||
+          !mlir::tosa::typeHasZeroDim(resultType))
+        return nullptr;
+
+      for (Value operand : {adaptor.getSelf(), adaptor.getOther()}) {
+        if (operand.getType() == resultType)
+          return operand;
+      }
+      return nullptr;
+    }
   }
 };
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1818,6 +1818,8 @@ TOSA_CRASHING_SET = {
 }
 
 FX_IMPORTER_TOSA_CRASHING_SET = {
+    # Zero-extent memref argument verification fails on a stride mismatch.
+    "ElementwiseDivTensorEmptyBroadcastModule_basic",
     "Aten_TrilinearModuleSumAllDims_basic",
     "Aten_TrilinearModuleSumdims_basic",
     "Aten_TrilinearModuleVaryingRanksUnorderedExpands_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -4975,6 +4975,32 @@ def ElementwiseDivTensorFloatModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwiseDivTensorEmptyBroadcastModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([0, 1, 3], torch.float32, True),
+            ([0, 10, 3], torch.float32, True),
+        ]
+    )
+    def forward(self, a, b):
+        return torch.true_divide(a, b)
+
+
+@register_test_case(
+    module_factory=lambda: ElementwiseDivTensorEmptyBroadcastModule()
+)
+def ElementwiseDivTensorEmptyBroadcastModule_basic(module, tu: TestUtils):
+    module.forward(torch.empty(0, 1, 3), torch.empty(0, 10, 3))
+
+
+# ==============================================================================
+
+
 class ElementwiseDivTensorIntegerModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -258,6 +258,20 @@ func.func @torch.aten.div$basic(%arg0: !torch.vtensor<[?, ?],f32>, %arg1: !torch
 
 // -----
 
+// CHECK-LABEL: func.func @torch.aten.div.Tensor$empty_broadcast(
+// CHECK-SAME:      %[[SELF:.*]]: !torch.vtensor<[0,1,3],f32>, %[[OTHER:.*]]: !torch.vtensor<[0,10,3],f32>
+// CHECK-NOT:     tosa.reciprocal
+// CHECK-NOT:     tosa.mul
+// CHECK:         return %[[OTHER]] : !torch.vtensor<[0,10,3],f32>
+func.func @torch.aten.div.Tensor$empty_broadcast(
+    %arg0: !torch.vtensor<[0,1,3],f32>,
+    %arg1: !torch.vtensor<[0,10,3],f32>) -> !torch.vtensor<[0,10,3],f32> {
+  %0 = torch.aten.div.Tensor %arg0, %arg1 : !torch.vtensor<[0,1,3],f32>, !torch.vtensor<[0,10,3],f32> -> !torch.vtensor<[0,10,3],f32>
+  return %0 : !torch.vtensor<[0,10,3],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.rsqrt$basic(
 // CHECK-SAME:                                 %[[VAL_0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>


### PR DESCRIPTION
Summary

Handle `torch.aten.div.Tensor` when broadcasting produces a statically shaped empty result.

The conversion now allows operation-specific handling of zero-sized results. For tensor division, it replaces the operation with an operand when:

- The result has a static shape containing a zero-sized dimension.
- One of the operands already has the exact converted result type.

Because the result contains no elements, forwarding an exact-result-typed operand preserves the result shape and dtype without emitting unsupported TOSA reciprocal or multiplication operations over zero-sized tensors.

Testing

- Added a lit test for division broadcasting `[0,1,3]` against `[0,10,3]`.
- The lit test verifies that no `tosa.reciprocal` or `tosa.mul` operation is emitted.
- Added an end-to-end test covering the same empty broadcast.
- Recorded the existing zero-extent memref stride-verification limitation for the affected TOSA runtime configuration.