### PR TITLE
[Torch] Simplify zero-K matrix multiplications

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -11720,6 +11720,63 @@ public:
 } // namespace
 
 namespace {
+template <typename AtenOpT>
+class SimplifyZeroKMatmulOp : public OpRewritePattern<AtenOpT> {
+public:
+  using OpRewritePattern<AtenOpT>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(AtenOpT op,
+                                PatternRewriter &rewriter) const override {
+    Value lhs = op.getSelf();
+    Value rhs;
+    if constexpr (std::is_same_v<AtenOpT, AtenMatmulOp>)
+      rhs = op.getOther();
+    else
+      rhs = op.getMat2();
+
+    auto lhsType = dyn_cast<ValueTensorType>(lhs.getType());
+    auto rhsType = dyn_cast<ValueTensorType>(rhs.getType());
+    auto resultType = dyn_cast<ValueTensorType>(op.getType());
+    if (!lhsType || !rhsType || !resultType || !lhsType.hasSizes() ||
+        !rhsType.hasSizes() || !resultType.hasSizes() ||
+        llvm::is_contained(lhsType.getSizes(), kUnknownSize) ||
+        llvm::is_contained(rhsType.getSizes(), kUnknownSize) ||
+        llvm::is_contained(resultType.getSizes(), kUnknownSize) ||
+        lhsType.getSizes().size() < 2 || rhsType.getSizes().size() < 2 ||
+        lhsType.getSizes().back() != 0 ||
+        rhsType.getSizes()[rhsType.getSizes().size() - 2] != 0 ||
+        llvm::is_contained(resultType.getSizes(), 0)) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+    MLIRContext *context = op.getContext();
+    SmallVector<Value> shape;
+    for (int64_t size : resultType.getSizes()) {
+      shape.push_back(ConstantIntOp::create(rewriter, loc,
+                                            rewriter.getI64IntegerAttr(size)));
+    }
+    Value shapeList = PrimListConstructOp::create(
+        rewriter, loc, ListType::get(IntType::get(context)), shape);
+    Value none = ConstantNoneOp::create(rewriter, loc);
+    Operation *lhsCast = lhs.getDefiningOp();
+    Operation *rhsCast = rhs.getDefiningOp();
+    if (!isa_and_nonnull<AtenToDtypeOp, PrimsConvertElementTypeOp>(lhsCast))
+      lhsCast = nullptr;
+    if (!isa_and_nonnull<AtenToDtypeOp, PrimsConvertElementTypeOp>(rhsCast))
+      rhsCast = nullptr;
+    rewriter.replaceOpWithNewOp<AtenZerosOp>(op, op.getType(), shapeList, none,
+                                             none, none, none);
+    if (lhsCast && lhsCast->use_empty())
+      rewriter.eraseOp(lhsCast);
+    if (rhsCast && rhsCast != lhsCast && rhsCast->use_empty())
+      rewriter.eraseOp(rhsCast);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 // decompose aten.argsort to aten.sort
 class DecomposeAtenArgsortOp : public OpRewritePattern<AtenArgsortOp> {
 public:
@@ -13603,6 +13660,13 @@ public:
     addPatternIfTargetOpIsIllegal<DecomposeAten_AssertScalarOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenRoundDecimalsOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenAbsoluteOp>(patterns);
+
+    // Eliminate zero-contraction matrix multiplications before zero-sized
+    // operands reach a backend that cannot represent operations on empty
+    // tensors.
+    patterns.add<SimplifyZeroKMatmulOp<AtenMmOp>,
+                 SimplifyZeroKMatmulOp<AtenMatmulOp>,
+                 SimplifyZeroKMatmulOp<AtenBmmOp>>(context);
 
     GreedyRewriteConfig config;
     config.setUseTopDownTraversal(true);

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -85,7 +85,6 @@ LINALG_CRASHING_SET = {
     "SliceCopyStartGreaterThanDimSize_Module_basic",
     # unimplemented: for conversion to byte or char type dstOriginalDtype has to be passed to convertScalarToDtype
     "AtenMmInt8Types_basic",
-    "AtenMmInt8ZeroK_basic",
     # Hanging tests:
     "ConvolutionBackwardModule2DDilated_basic",
     "ConvolutionBackwardModule2DStridedPaddedDilatedGrouped_basic",
@@ -1849,6 +1848,11 @@ FX_IMPORTER_TOSA_CRASHING_SET = {
 # Write the TOSA set as a "passing" set as it is very early in development
 # and very few tests work yet.
 TOSA_PASS_SET = {
+    "AtenBmmZeroK_basic",
+    "AtenCastedZeroKMatmulVariants_basic",
+    "AtenMmInt8ZeroK_basic",
+    "AtenMmZeroKAfterView_basic",
+    "AtenMmZeroK_basic",
     "AtenAsStridedAfterAliasDetachModule_basic",
     "AtenAsStridedAfterBroadcastToModule_basic",
     "AtenAsStridedAfterChainedViewsModule_basic",
@@ -2845,6 +2849,9 @@ LTC_XFAIL_SET = {
 }
 
 ONNX_XFAIL_SET = {
+    # ONNX zero-extent cast/view paths are not supported.
+    "AtenCastedZeroKMatmulVariants_basic",
+    "AtenMmZeroKAfterView_basic",
     # ONNX export applies explicit offset to materialized slice storage.
     "AtenAsStridedAfterAliasDetachModule_basic",
     # ONNX transpose materializes movedim before gather, so indexing uses new storage.
@@ -4234,6 +4241,9 @@ ONNX_TOSA_CRASHING_SET = {
 }
 
 ONNX_TOSA_XFAIL_SET = {
+    # ONNX zero-extent cast/view paths are not supported.
+    "AtenCastedZeroKMatmulVariants_basic",
+    "AtenMmZeroKAfterView_basic",
     # ONNX export applies explicit offset to materialized slice storage.
     "AtenAsStridedAfterAliasDetachModule_basic",
     # ONNX export gathers from the materialized empty slice.

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -515,6 +515,68 @@ def AtenMmZeroK_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class AtenMmZeroKAfterView(torch.nn.Module):
+    @export
+    @annotate_args(
+        [
+            None,
+            ([5, 5, 0], torch.float32, True),
+            ([0, 5], torch.float32, True),
+        ]
+    )
+    def forward(self, a, b):
+        result = torch.ops.aten.mm(a.view(25, 0), b)
+        return result.view(5, 5, 5)
+
+
+@register_test_case(module_factory=lambda: AtenMmZeroKAfterView())
+def AtenMmZeroKAfterView_basic(module, tu: TestUtils):
+    module.forward(torch.empty(5, 5, 0), torch.empty(0, 5))
+
+
+# ==============================================================================
+
+
+class AtenCastedZeroKMatmulVariants(torch.nn.Module):
+    @export
+    @annotate_args(
+        [
+            None,
+            ([5, 0], torch.float16, True),
+            ([0, 10], torch.float16, True),
+            ([2, 5, 0], torch.float16, True),
+            ([2, 0, 10], torch.float16, True),
+        ]
+    )
+    def forward(self, lhs, rhs, batched_lhs, batched_rhs):
+        lhs_f32 = torch.ops.prims.convert_element_type(lhs, dtype=torch.float32)
+        rhs_f32 = torch.ops.prims.convert_element_type(rhs, dtype=torch.float32)
+        batched_lhs_f32 = torch.ops.prims.convert_element_type(
+            batched_lhs, dtype=torch.float32
+        )
+        batched_rhs_f32 = torch.ops.prims.convert_element_type(
+            batched_rhs, dtype=torch.float32
+        )
+        return (
+            torch.ops.aten.mm(lhs_f32, rhs_f32),
+            torch.ops.aten.matmul(lhs_f32, rhs_f32),
+            torch.ops.aten.bmm(batched_lhs_f32, batched_rhs_f32),
+        )
+
+
+@register_test_case(module_factory=lambda: AtenCastedZeroKMatmulVariants())
+def AtenCastedZeroKMatmulVariants_basic(module, tu: TestUtils):
+    module.forward(
+        torch.empty(5, 0, dtype=torch.float16),
+        torch.empty(0, 10, dtype=torch.float16),
+        torch.empty(2, 5, 0, dtype=torch.float16),
+        torch.empty(2, 0, 10, dtype=torch.float16),
+    )
+
+
+# ==============================================================================
+
+
 class AtenBmmZeroK(torch.nn.Module):
     @export
     @annotate_args(

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1,5 +1,75 @@
 // RUN: torch-mlir-opt -torch-decompose-complex-ops -split-input-file %s | FileCheck %s
 
+// CHECK-LABEL: func.func @zero_k_mm_after_empty_view(
+// CHECK-NOT:     torch.aten.mm
+// CHECK:         %[[ZERO:.*]] = torch.vtensor.literal(dense<0.000000e+00> : tensor<5x5x5xf32>) : !torch.vtensor<[5,5,5],f32>
+// CHECK:         return %[[ZERO]]
+func.func @zero_k_mm_after_empty_view(%arg0: !torch.vtensor<[5,5,0],f32>, %arg1: !torch.vtensor<[0,5],f32>) -> !torch.vtensor<[5,5,5],f32> {
+  %int25 = torch.constant.int 25
+  %int0 = torch.constant.int 0
+  %0 = torch.prim.ListConstruct %int25, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %1 = torch.aten.view %arg0, %0 : !torch.vtensor<[5,5,0],f32>, !torch.list<int> -> !torch.vtensor<[25,0],f32>
+  %2 = torch.aten.mm %1, %arg1 : !torch.vtensor<[25,0],f32>, !torch.vtensor<[0,5],f32> -> !torch.vtensor<[25,5],f32>
+  %int5 = torch.constant.int 5
+  %result_shape = torch.prim.ListConstruct %int5, %int5, %int5 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %3 = torch.aten.view %2, %result_shape : !torch.vtensor<[25,5],f32>, !torch.list<int> -> !torch.vtensor<[5,5,5],f32>
+  return %3 : !torch.vtensor<[5,5,5],f32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @casted_zero_k_mm(
+// CHECK-NOT:     torch.aten.mm
+// CHECK:         %[[ZERO:.*]] = torch.vtensor.literal(dense<0.000000e+00> : tensor<5x10xf32>) : !torch.vtensor<[5,10],f32>
+// CHECK:         return %[[ZERO]]
+func.func @casted_zero_k_mm(%arg0: !torch.vtensor<[5,0],f16>, %arg1: !torch.vtensor<[0,10],f16>) -> !torch.vtensor<[5,10],f32> {
+  %int6 = torch.constant.int 6
+  %0 = torch.prims.convert_element_type %arg0, %int6 : !torch.vtensor<[5,0],f16>, !torch.int -> !torch.vtensor<[5,0],f32>
+  %1 = torch.prims.convert_element_type %arg1, %int6 : !torch.vtensor<[0,10],f16>, !torch.int -> !torch.vtensor<[0,10],f32>
+  %2 = torch.aten.mm %0, %1 : !torch.vtensor<[5,0],f32>, !torch.vtensor<[0,10],f32> -> !torch.vtensor<[5,10],f32>
+  return %2 : !torch.vtensor<[5,10],f32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @casted_zero_k_matmul(
+// CHECK-NOT:     torch.aten.matmul
+// CHECK-NOT:     torch.aten.mm
+// CHECK:         %[[ZERO:.*]] = torch.vtensor.literal(dense<0.000000e+00> : tensor<5x10xf32>) : !torch.vtensor<[5,10],f32>
+// CHECK:         return %[[ZERO]]
+func.func @casted_zero_k_matmul(%arg0: !torch.vtensor<[5,0],f16>, %arg1: !torch.vtensor<[0,10],f16>) -> !torch.vtensor<[5,10],f32> {
+  %int6 = torch.constant.int 6
+  %0 = torch.prims.convert_element_type %arg0, %int6 : !torch.vtensor<[5,0],f16>, !torch.int -> !torch.vtensor<[5,0],f32>
+  %1 = torch.prims.convert_element_type %arg1, %int6 : !torch.vtensor<[0,10],f16>, !torch.int -> !torch.vtensor<[0,10],f32>
+  %2 = torch.aten.matmul %0, %1 : !torch.vtensor<[5,0],f32>, !torch.vtensor<[0,10],f32> -> !torch.vtensor<[5,10],f32>
+  return %2 : !torch.vtensor<[5,10],f32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @casted_zero_k_bmm(
+// CHECK-NOT:     torch.aten.bmm
+// CHECK:         %[[ZERO:.*]] = torch.vtensor.literal(dense<0.000000e+00> : tensor<2x5x10xf32>) : !torch.vtensor<[2,5,10],f32>
+// CHECK:         return %[[ZERO]]
+func.func @casted_zero_k_bmm(%arg0: !torch.vtensor<[2,5,0],f16>, %arg1: !torch.vtensor<[2,0,10],f16>) -> !torch.vtensor<[2,5,10],f32> {
+  %int6 = torch.constant.int 6
+  %0 = torch.prims.convert_element_type %arg0, %int6 : !torch.vtensor<[2,5,0],f16>, !torch.int -> !torch.vtensor<[2,5,0],f32>
+  %1 = torch.prims.convert_element_type %arg1, %int6 : !torch.vtensor<[2,0,10],f16>, !torch.int -> !torch.vtensor<[2,0,10],f32>
+  %2 = torch.aten.bmm %0, %1 : !torch.vtensor<[2,5,0],f32>, !torch.vtensor<[2,0,10],f32> -> !torch.vtensor<[2,5,10],f32>
+  return %2 : !torch.vtensor<[2,5,10],f32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dynamic_zero_k_mm(
+// CHECK:         torch.aten.mm
+func.func @dynamic_zero_k_mm(%arg0: !torch.vtensor<[?,0],f32>, %arg1: !torch.vtensor<[0,10],f32>) -> !torch.vtensor<[?,10],f32> {
+  %0 = torch.aten.mm %arg0, %arg1 : !torch.vtensor<[?,0],f32>, !torch.vtensor<[0,10],f32> -> !torch.vtensor<[?,10],f32>
+  return %0 : !torch.vtensor<[?,10],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @matmul_no_decompose
 // CHECK:           torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
 func.func @matmul_no_decompose(%arg0: !torch.vtensor<[?,?,?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {


### PR DESCRIPTION
Summary

Simplify `aten.mm`, `aten.matmul`, and `aten.bmm` when the contraction dimension is statically zero by replacing the multiplication with a correctly shaped zero tensor.

The implementation handles direct, casted, and view-derived forms. It requires value tensors with fully known result sizes; dynamic-result cases remain undecomposed.

Testing

- Added lit coverage for `mm`, `matmul`, `bmm`, casts, views, and dynamic-shape rejection.
- Added PT1 e2e coverage for direct, casted, batched, int8, and after-view cases.
- Verified the supported backend configurations.
- Ran the full Torch-MLIR regression suite.