### PR TITLE
[TorchToTosa] Handle empty tensor pow broadcast

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -821,6 +821,8 @@ public:
     const TypeConverter *typeConverter = this->getTypeConverter();
     bool canHandleZeroDimInputOperands =
         canHandleZeroDimInputs(op, adaptor, typeConverter);
+    bool canHandleZeroDimOutputResults =
+        canHandleZeroDimOutputs(op, adaptor, typeConverter);
 
     // Pre-check: all tensor operands and outputs must have no zero-sized
     // dimensions.
@@ -840,7 +842,8 @@ public:
     for (auto res : op->getResults()) {
       auto rankedOutputType =
           dyn_cast<RankedTensorType>(typeConverter->convertType(res.getType()));
-      if (rankedOutputType && mlir::tosa::typeHasZeroDim(rankedOutputType)) {
+      if (rankedOutputType && mlir::tosa::typeHasZeroDim(rankedOutputType) &&
+          !canHandleZeroDimOutputResults) {
         return rewriter.notifyMatchFailure(
             op,
             "TOSA lowering does not support output tensors with a zero-sized "
@@ -854,6 +857,12 @@ protected:
   virtual bool
   canHandleZeroDimInputs(AtenOpT op, OpAdaptor adaptor,
                          const TypeConverter *typeConverter) const {
+    return false;
+  }
+
+  virtual bool
+  canHandleZeroDimOutputs(AtenOpT op, OpAdaptor adaptor,
+                          const TypeConverter *typeConverter) const {
     return false;
   }
 
@@ -2278,6 +2287,13 @@ public:
       return rewriter.notifyMatchFailure(
           op, "Only floating-point datatype result types are supported");
 
+    if (Value replacement =
+            getEmptyTensorTensorReplacement(op, adaptor,
+                                            this->getTypeConverter())) {
+      rewriter.replaceOp(op, replacement);
+      return success();
+    }
+
     Value selfTensor;
     if constexpr (std::is_same<AtenOpT, AtenPowScalarOp>()) {
       Value selfScalar = op.getSelf();
@@ -2334,6 +2350,42 @@ public:
     rewriter.replaceOp(op, powOp.getResult());
 
     return success();
+  }
+
+protected:
+  bool
+  canHandleZeroDimInputs(AtenOpT op, OpAdaptor adaptor,
+                         const TypeConverter *typeConverter) const override {
+    return getEmptyTensorTensorReplacement(op, adaptor, typeConverter) !=
+           nullptr;
+  }
+
+  bool
+  canHandleZeroDimOutputs(AtenOpT op, OpAdaptor adaptor,
+                          const TypeConverter *typeConverter) const override {
+    return getEmptyTensorTensorReplacement(op, adaptor, typeConverter) !=
+           nullptr;
+  }
+
+private:
+  static Value
+  getEmptyTensorTensorReplacement(AtenOpT op, OpAdaptor adaptor,
+                                  const TypeConverter *typeConverter) {
+    if constexpr (!std::is_same_v<AtenOpT, AtenPowTensorTensorOp>) {
+      return nullptr;
+    } else {
+      auto resultType = dyn_cast<RankedTensorType>(
+          typeConverter->convertType(op.getType()));
+      if (!resultType || !resultType.hasStaticShape() ||
+          !mlir::tosa::typeHasZeroDim(resultType))
+        return nullptr;
+
+      for (Value operand : {adaptor.getSelf(), adaptor.getExponent()}) {
+        if (operand.getType() == resultType)
+          return operand;
+      }
+      return nullptr;
+    }
   }
 };
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1818,6 +1818,8 @@ TOSA_CRASHING_SET = {
 }
 
 FX_IMPORTER_TOSA_CRASHING_SET = {
+    # Zero-extent memref argument verification fails on a stride mismatch.
+    "ElementwisePowTensorEmptyBroadcastModule_basic",
     "Aten_TrilinearModuleSumAllDims_basic",
     "Aten_TrilinearModuleSumdims_basic",
     "Aten_TrilinearModuleVaryingRanksUnorderedExpands_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -3947,6 +3947,32 @@ def ElementwisePowTensorBroadcastStaticModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwisePowTensorEmptyBroadcastModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([0, 1, 3], torch.float32, True),
+            ([0, 10, 3], torch.float32, True),
+        ]
+    )
+    def forward(self, a, b):
+        return torch.pow(a, b)
+
+
+@register_test_case(
+    module_factory=lambda: ElementwisePowTensorEmptyBroadcastModule()
+)
+def ElementwisePowTensorEmptyBroadcastModule_basic(module, tu: TestUtils):
+    module.forward(torch.empty(0, 1, 3), torch.empty(0, 10, 3))
+
+
+# ==============================================================================
+
+
 class ElementwisePowScalarModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -2631,6 +2631,19 @@ func.func @torch.aten.pow.Tensor_Tensor$basic(%arg0: !torch.vtensor<[?,?],f32>, 
 
 // -----
 
+// CHECK-LABEL: func.func @torch.aten.pow.Tensor_Tensor$empty_broadcast(
+// CHECK-SAME:      %[[SELF:.*]]: !torch.vtensor<[0,1,3],f32>, %[[EXPONENT:.*]]: !torch.vtensor<[0,10,3],f32>
+// CHECK-NOT:     tosa.pow
+// CHECK:         return %[[EXPONENT]] : !torch.vtensor<[0,10,3],f32>
+func.func @torch.aten.pow.Tensor_Tensor$empty_broadcast(
+    %arg0: !torch.vtensor<[0,1,3],f32>,
+    %arg1: !torch.vtensor<[0,10,3],f32>) -> !torch.vtensor<[0,10,3],f32> {
+  %0 = torch.aten.pow.Tensor_Tensor %arg0, %arg1 : !torch.vtensor<[0,1,3],f32>, !torch.vtensor<[0,10,3],f32> -> !torch.vtensor<[0,10,3],f32>
+  return %0 : !torch.vtensor<[0,10,3],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.erf$basic(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>


### PR DESCRIPTION
Summary

Handle `aten.pow.Tensor_Tensor` when broadcasting produces a statically
known empty result.

TOSA does not permit `tosa.pow` with zero-sized tensor dimensions. Since
an empty tensor contains no element values to compute, the conversion
reuses an operand when that operand already has exactly the required
result type.

The generic Torch-to-TOSA conversion precheck is extended with an
operation-specific zero-sized-output hook so this case can be handled
before attempting to create `tosa.pow`.

Testing

- Added a Torch-to-TOSA lit test for broadcasting
  `[0, 1, 3]` and `[0, 10, 3]`.
- Added a Torch-MLIR PT1 end-to-end test for the same empty broadcast.
- The PT1 test is listed in `FX_IMPORTER_TOSA_CRASHING_SET` because the
  runtime currently aborts while verifying zero-extent memref argument
  strides. The compiler transformation itself is covered by the lit test.
- Verified the Torch-to-TOSA lit test.