### PR TITLE
[Torch] Simplify empty matmul results

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -3354,8 +3354,57 @@ public:
 };
 } // namespace
 
-// Decompose aten.matmul into: aten.mm and aten.bmm according to ranks.
 namespace {
+static Value stripTypePreservingMatmulShapeOps(Value operand,
+                                               Type resultType) {
+  while (Operation *definingOp = operand.getDefiningOp()) {
+    Value source;
+    if (auto view = dyn_cast<AtenViewOp>(definingOp))
+      source = view.getSelf();
+    else if (auto expand = dyn_cast<AtenExpandOp>(definingOp))
+      source = expand.getSelf();
+    else if (auto broadcast = dyn_cast<AtenBroadcastToOp>(definingOp))
+      source = broadcast.getSelf();
+    else
+      break;
+
+    if (source.getType() != resultType)
+      return nullptr;
+    operand = source;
+  }
+  return operand;
+}
+
+static Value getEmptyMatmulReplacement(Type resultType, Value lhs, Value rhs) {
+  auto resultTensorType = dyn_cast<BaseTensorType>(resultType);
+  if (!resultTensorType || !resultTensorType.hasSizes() ||
+      !llvm::is_contained(resultTensorType.getSizes(), 0))
+    return nullptr;
+
+  // Prefer the right operand because FX matmul decomposition broadcasts the
+  // left operand even when the right operand already has the result type.
+  for (Value operand : {rhs, lhs}) {
+    if (operand.getType() == resultTensorType) {
+      if (Value replacement =
+              stripTypePreservingMatmulShapeOps(operand, resultType))
+        return replacement;
+    }
+  }
+  return nullptr;
+}
+
+static void eraseDeadMatmulShapeOps(PatternRewriter &rewriter, Value operand) {
+  while (Operation *definingOp = operand.getDefiningOp()) {
+    if (!operand.use_empty() ||
+        !isa<AtenViewOp, AtenExpandOp, AtenBroadcastToOp>(definingOp))
+      break;
+    Value source = definingOp->getOperand(0);
+    rewriter.eraseOp(definingOp);
+    operand = source;
+  }
+}
+
+// Decompose aten.matmul into: aten.mm and aten.bmm according to ranks.
 class DecomposeAtenMatmulOp : public OpRewritePattern<AtenMatmulOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -3363,6 +3412,12 @@ public:
                                 PatternRewriter &rewriter) const override {
     Value lhs = op.getSelf();
     Value rhs = op.getOther();
+
+    if (Value replacement =
+            getEmptyMatmulReplacement(op.getType(), lhs, rhs)) {
+      rewriter.replaceOp(op, replacement);
+      return success();
+    }
 
     std::optional<unsigned> maybeLhsRank = getTensorRank(lhs);
     std::optional<unsigned> maybeRhsRank = getTensorRank(rhs);
@@ -3403,6 +3458,38 @@ public:
       return failure();
     }
 
+    return success();
+  }
+};
+
+class SimplifyEmptyBmmOp : public OpRewritePattern<AtenBmmOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AtenBmmOp op,
+                                PatternRewriter &rewriter) const override {
+    Value lhs = op.getSelf();
+    Value rhs = op.getMat2();
+    Value replacement = getEmptyMatmulReplacement(op.getType(), lhs, rhs);
+    if (!replacement)
+      return failure();
+    rewriter.replaceOp(op, replacement);
+    eraseDeadMatmulShapeOps(rewriter, lhs);
+    eraseDeadMatmulShapeOps(rewriter, rhs);
+    return success();
+  }
+};
+
+class SimplifyEmptyViewOp : public OpRewritePattern<AtenViewOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AtenViewOp op,
+                                PatternRewriter &rewriter) const override {
+    auto resultType = dyn_cast<BaseTensorType>(op.getType());
+    if (!resultType || !resultType.hasSizes() ||
+        !llvm::is_contained(resultType.getSizes(), 0) ||
+        op.getSelf().getType() != resultType)
+      return failure();
+    rewriter.replaceOp(op, op.getSelf());
     return success();
   }
 };
@@ -13311,6 +13398,8 @@ public:
     addPatternIfTargetOpIsIllegal<DecomposeAtenStftCenterOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenSelectIntOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenMatmulOp>(patterns);
+    addPatternIfTargetOpIsIllegal<SimplifyEmptyBmmOp>(patterns);
+    addPatternIfTargetOpIsIllegal<SimplifyEmptyViewOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenMvOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenRenormOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenLinalgCrossOp>(patterns);

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1818,6 +1818,8 @@ TOSA_CRASHING_SET = {
 }
 
 FX_IMPORTER_TOSA_CRASHING_SET = {
+    # Zero-extent memref argument verification aborts on a stride mismatch.
+    "MatmulEmptyOutput_basic",
     "Aten_TrilinearModuleSumAllDims_basic",
     "Aten_TrilinearModuleSumdims_basic",
     "Aten_TrilinearModuleVaryingRanksUnorderedExpands_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/matmul.py
@@ -105,6 +105,30 @@ def MatmulZeroK_basic(module, tu: TestUtils):
     module.forward(torch.empty(5, 0), torch.empty(0, 10))
 
 
+# ==============================================================================
+
+
+class MatmulEmptyOutput(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([0, 0], torch.float32, True),
+            ([5, 0, 0], torch.float32, True),
+        ]
+    )
+    def forward(self, lhs, rhs):
+        return torch.matmul(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: MatmulEmptyOutput())
+def MatmulEmptyOutput_basic(module, tu: TestUtils):
+    module.forward(torch.empty(0, 0), torch.empty(5, 0, 0))
+
+
 class AtenScaledMmPerTensorModule(torch.nn.Module):
     def __init__(self, fp8_dtype=torch.float8_e4m3fn, out_dtype=torch.bfloat16):
         super().__init__()

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -10,6 +10,29 @@ func.func @matmul_no_decompose(%arg0: !torch.vtensor<[?,?,?,?,?],f32>, %arg1: !t
 
 // -----
 
+// CHECK-LABEL: func.func @matmul_empty_output
+// CHECK-SAME: %[[LHS:.*]]: !torch.vtensor<[0,0],f32>, %[[RHS:.*]]: !torch.vtensor<[5,0,0],f32>
+// CHECK-NOT: torch.aten.broadcast_to
+// CHECK-NOT: torch.aten.view
+// CHECK-NOT: torch.aten.bmm
+// CHECK: return %[[RHS]] : !torch.vtensor<[5,0,0],f32>
+func.func @matmul_empty_output(%arg0: !torch.vtensor<[0,0],f32>, %arg1: !torch.vtensor<[5,0,0],f32>) -> !torch.vtensor<[5,0,0],f32> {
+  %int5 = torch.constant.int 5
+  %int0 = torch.constant.int 0
+  %shape = torch.prim.ListConstruct %int5, %int0, %int0 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %false = torch.constant.bool false
+  %lhs = torch.aten.expand %arg0, %shape, %false : !torch.vtensor<[0,0],f32>, !torch.list<int>, !torch.bool -> !torch.vtensor<[5,0,0],f32>
+  %lhs_view = torch.aten.view %lhs, %shape : !torch.vtensor<[5,0,0],f32>, !torch.list<int> -> !torch.vtensor<[5,0,0],f32>
+  %rhs = torch.aten.expand %arg1, %shape, %false : !torch.vtensor<[5,0,0],f32>, !torch.list<int>, !torch.bool -> !torch.vtensor<[5,0,0],f32>
+  %rhs_view = torch.aten.view %rhs, %shape : !torch.vtensor<[5,0,0],f32>, !torch.list<int> -> !torch.vtensor<[5,0,0],f32>
+  %bmm = torch.aten.bmm %lhs_view, %rhs_view : !torch.vtensor<[5,0,0],f32>, !torch.vtensor<[5,0,0],f32> -> !torch.vtensor<[5,0,0],f32>
+  %result = torch.aten.view %bmm, %shape : !torch.vtensor<[5,0,0],f32>, !torch.list<int> -> !torch.vtensor<[5,0,0],f32>
+  return %result : !torch.vtensor<[5,0,0],f32>
+}
+
+
+// -----
+
 // CHECK-LABEL:   func.func @matmul_decompose_2d
 // CHECK:           torch.aten.mm %arg0, %arg1 : !torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],f32> -> !torch.tensor
 func.func @matmul_decompose_2d(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtensor<[?,?],f32>) -> !torch.tensor {


### PR DESCRIPTION
Summary

Simplify matrix multiplication when its statically known result is empty
and an operand already has exactly the required result type.

An empty tensor contains no element values to compute, so the matching
operand can be returned directly. This avoids retaining matrix and shape
operations that downstream backends cannot legalize for zero-sized
dimensions.

The rewrite handles both direct `aten.matmul` and the imported
`expand -> view -> bmm -> view` form. Type-preserving empty views and
now-unused shape-operation chains are removed as part of the
simplification.

Testing

- Added a decomposition lit test modeling the imported empty-matmul
  sequence for `[0, 0] @ [5, 0, 0]`.
- The lit test verifies that `broadcast_to`, `view`, and `bmm` are removed
  and the matching operand is returned directly.
- Added a Torch-MLIR PT1 end-to-end test for the same shapes.
- The native PT1 test passes and TOSA compilation succeeds.
- The TOSA PT1 test is listed in `FX_IMPORTER_TOSA_CRASHING_SET` because
  runtime verification currently aborts on zero-extent memref argument
  strides.