### PR TITLE
[OnnxImporter] Fix duplicate output names collapsing into fewer func results

### DIFF
--- a/python/torch_mlir/extras/onnx_importer.py
+++ b/python/torch_mlir/extras/onnx_importer.py
@@ -284,8 +284,7 @@ class NodeImporter:
                 cc.type_proto_to_type(inp.type) for inp in graph_info.input_map.values()
             ]
             output_types = [
-                cc.type_proto_to_type(out.type)
-                for out in graph_info.output_map.values()
+                cc.type_proto_to_type(out.type) for out in graph_info.graph_proto.output
             ]
             ftype = FunctionType.get(input_types, output_types)
             func_op = func_dialect.FuncOp(
@@ -354,12 +353,12 @@ class NodeImporter:
             self.import_node(node)
 
         outputs = []
-        for output_name in self._gi.output_map.keys():
+        for out in self._gi.graph_proto.output:
             try:
-                outputs.append(self._nv_map[output_name])
+                outputs.append(self._nv_map[out.name])
             except KeyError:
                 raise OnnxImportError(
-                    f"Non topologically produced ONNX graph output '{output_name}'"
+                    f"Non topologically produced ONNX graph output '{out.name}'"
                 )
         with InsertionPoint(self._b), Location.unknown():
             if func:

--- a/test/python/onnx_importer/test_duplicate_output_names.py
+++ b/test/python/onnx_importer/test_duplicate_output_names.py
@@ -1,0 +1,49 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""Regression test: ONNX graphs with duplicate output names must preserve all outputs.
+
+ONNX permits the same tensor name to appear multiple times in graph.output
+(meaning "return this value in multiple output positions"). The importer must
+not collapse these into fewer func results.
+"""
+
+import onnx
+from onnx import TensorProto, helper
+
+from _torch_mlir_config import configure_context, ir, onnx_importer
+
+
+def _duplicate_output_model() -> onnx.ModelProto:
+    """Graph with 4 outputs but only 2 unique names (each repeated once)."""
+    inp = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 3])
+    n1 = helper.make_node("Identity", ["x"], ["a"])
+    n2 = helper.make_node("Relu", ["x"], ["b"])
+
+    out_a = helper.make_tensor_value_info("a", TensorProto.FLOAT, [2, 3])
+    out_b = helper.make_tensor_value_info("b", TensorProto.FLOAT, [2, 3])
+
+    graph = helper.make_graph(
+        [n1, n2],
+        "duplicate_outputs",
+        [inp],
+        [out_a, out_a, out_b, out_b],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+
+
+model = _duplicate_output_model()
+ctx = ir.Context()
+configure_context(ctx)
+mi = onnx_importer.ModelInfo(model)
+m = mi.create_module(context=ctx).operation
+onnx_importer.NodeImporter.define_function(mi.main_graph, m).import_all()
+print(m)
+
+# The func should have 4 results (not 2) and the return should have 4 operands.
+# CHECK-LABEL: func.func @duplicate_outputs
+# CHECK-SAME: -> (!torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>)
+# CHECK: return %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>, !torch.vtensor<[2,3],f32>


### PR DESCRIPTION
ONNX permits the same tensor name to appear multiple times in graph.output (returning the same value in multiple output positions). The importer keyed outputs by name in a dict, so duplicates collapsed — a graph with 6 outputs but 4 unique names produced a func with only 4 results. Ran into this issue when using a model converted by tf2onnx.