### PR TITLE
[Torch] Fuse per-channel quantized convolution and matmul to integer ops

### DIFF
--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -111,6 +111,22 @@ public:
     getZeroPoint(op.getSelf(), lhsZeroPoint);
     getZeroPoint(op.getMat2(), rhsZeroPoint);
 
+    // Per-channel quantized weight (symmetric): the per-channel scale is
+    // applied by the dequantize on the i32 accumulator, so the matmul uses a
+    // scalar zero weight zero-point. Requires a constant all-zero zero-point.
+    if (auto make =
+            op.getMat2()
+                .getDefiningOp<Aten_MakePerChannelQuantizedTensorOp>()) {
+      DenseElementsAttr zpAttr;
+      if (!matchPattern(make.getZeroPoint(), m_Constant(&zpAttr)) ||
+          !llvm::all_of(zpAttr.getValues<APInt>(),
+                        [](const APInt &v) { return v.isZero(); }))
+        return rewriter.notifyMatchFailure(
+            op, "unimplemented: per-channel quantized mm requires a constant "
+                "all-zero zero-point");
+      rhsZeroPoint = Torch::ConstantIntOp::create(rewriter, loc, 0);
+    }
+
     if (static_cast<bool>(lhsZeroPoint) != static_cast<bool>(rhsZeroPoint)) {
       return rewriter.notifyMatchFailure(
           op, "unsupported: aten.mm with mixed quantization");
@@ -836,6 +852,28 @@ public:
           weightZp);
       weightZp = arith::TruncIOp::create(rewriter, loc, rewriter.getI32Type(),
                                          weightZp);
+      auto torchDtype = cast<ValueTensorType>(make.getType()).getDtype();
+      weightUnsigned = torch_to_linalg::isUnsignedTorchType(torchDtype);
+    } else if (auto make =
+                   op.getWeight()
+                       .getDefiningOp<Aten_MakePerChannelQuantizedTensorOp>()) {
+      // Per-channel quantized weights participate in the convolution
+      // exactly like per-tensor ones as long as the zero-point is zero for
+      // every channel (symmetric quantization): only the scale differs per
+      // channel, and the scale is applied by the dequantize that consumes the
+      // i32 accumulator, not here.
+      DenseElementsAttr zpAttr;
+      if (!matchPattern(make.getZeroPoint(), m_Constant(&zpAttr)) ||
+          !llvm::all_of(zpAttr.getValues<APInt>(),
+                        [](const APInt &v) { return v.isZero(); }))
+        return rewriter.notifyMatchFailure(
+            op, "unimplemented: per-channel quantized weight requires a "
+                "constant all-zero zero-point");
+      weight = make.getSelf();
+      weight = typeConverter->materializeTargetConversion(
+          rewriter, loc, typeConverter->convertType(weight.getType()), weight);
+      weightZp = arith::ConstantOp::create(rewriter, loc,
+                                           rewriter.getI32IntegerAttr(0));
       auto torchDtype = cast<ValueTensorType>(make.getType()).getDtype();
       weightUnsigned = torch_to_linalg::isUnsignedTorchType(torchDtype);
     }

--- a/lib/Dialect/Torch/Transforms/FuseQuantizedOps.cpp
+++ b/lib/Dialect/Torch/Transforms/FuseQuantizedOps.cpp
@@ -51,6 +51,12 @@ bool isQCommutingOp(mlir::Operation *op) {
 struct QuantizedChain {
   std::stack<mlir::Operation *> commutingOpStack;
   Value dequantOpd, MPTQTOpd, scale, zeroPoint;
+  Value axis; // Set only for per-channel chains (weights): scale/zeroPoint are
+              // tensors.
+  bool onlyTransposeCommuting = true; // Per-channel chains may only replay
+                                      // transposes (a reshape/view could
+                                      // split or merge the channel axis),
+                                      // true while every commuting op is one.
 };
 
 // The following conversion takes patterns of the form [op0 -> MPTQT -> dequant
@@ -91,6 +97,7 @@ public:
         // Case 1 : currOp is a q commuting op (continue loop)
         if (isQCommutingOp(currOp)) {
           chain.commutingOpStack.push(currOp);
+          chain.onlyTransposeCommuting &= llvm::isa<AtenTransposeIntOp>(currOp);
           // set operand to currOp for next k-iteration
           operand = currOp->getOperand(0);
           continue;
@@ -98,18 +105,30 @@ public:
         // Case 2 : currOp is a dequant op (end loop)
         if (llvm::isa<AtenDequantizeSelfOp, AtenDequantizeTensorOp>(currOp)) {
           chain.dequantOpd = currOp->getOperand(0);
-          // Bail out if any operand is per-channel quantized, which would
-          // require more complex fusion logic.
-          if (llvm::isa<Aten_MakePerChannelQuantizedTensorOp>(
-                  chain.dequantOpd.getDefiningOp()))
-            break;
-
-          auto MPTQTOp =
-              chain.dequantOpd
-                  .getDefiningOp<Aten_MakePerTensorQuantizedTensorOp>();
-          chain.MPTQTOpd = MPTQTOp.getOperand(0);
-          chain.scale = MPTQTOp.getOperand(1);
-          chain.zeroPoint = MPTQTOp.getOperand(2);
+          if (auto MPCQTOp =
+                  chain.dequantOpd
+                      .getDefiningOp<Aten_MakePerChannelQuantizedTensorOp>()) {
+            // Per-channel is only supported on the weight operand, and only
+            // past transposes (the axis swap is replayed below).
+            if (i != 1 || !chain.onlyTransposeCommuting)
+              break;
+            // Only a constant all-zero (symmetric) per-channel weight
+            // zero-point can be fused, anything else falls back to QDQ.
+            DenseElementsAttr zpAttr;
+            if (!matchPattern(MPCQTOp.getZeroPoint(), m_Constant(&zpAttr)) ||
+                !llvm::all_of(zpAttr.getValues<APInt>(),
+                              [](const APInt &v) { return v.isZero(); }))
+              break;
+            chain.MPTQTOpd = MPCQTOp.getSelf();
+            chain.scale = MPCQTOp.getScale();
+            chain.zeroPoint = MPCQTOp.getZeroPoint();
+            chain.axis = MPCQTOp.getAxis();
+          } else if (auto MPTQTOp = chain.dequantOpd.getDefiningOp<
+                                    Aten_MakePerTensorQuantizedTensorOp>()) {
+            chain.MPTQTOpd = MPTQTOp.getOperand(0);
+            chain.scale = MPTQTOp.getOperand(1);
+            chain.zeroPoint = MPTQTOp.getOperand(2);
+          }
         }
         // either a dequant was found or chain broken, so break loop
         break;
@@ -188,6 +207,23 @@ public:
           // quantPadValue is a float, but will get converted/truncated
           currOperands.back() = quantPadValue;
         }
+        if (chain.axis) {
+          auto transposeOp = cast<AtenTransposeIntOp>(currOp);
+          int64_t dim0, dim1, axis;
+          if (matchPattern(transposeOp.getDim0(), m_TorchConstantInt(&dim0)) &&
+              matchPattern(transposeOp.getDim1(), m_TorchConstantInt(&dim1)) &&
+              matchPattern(chain.axis, m_TorchConstantInt(&axis))) {
+            int64_t rank =
+                cast<ValueTensorType>(transposeOp.getType()).getSizes().size();
+            dim0 = toPositiveDim(dim0, rank);
+            dim1 = toPositiveDim(dim1, rank);
+            axis = toPositiveDim(axis, rank);
+            if (axis == dim0 || axis == dim1) {
+              chain.axis = Torch::ConstantIntOp::create(
+                  rewriter, loc, axis == dim0 ? dim1 : dim0);
+            }
+          }
+        }
         // get new result type
         auto oldType = cast<ValueTensorType>(currOp->getResultTypes()[0]);
         auto intType =
@@ -203,14 +239,18 @@ public:
       // stack is empty, so oldOpd is now the corrected verion of the
       // SrcOp's original operand
       // convert operand -> SrcOp to oldOpd -> newMPTQTOp -> SrcOp
-      auto MPTQTOperands = chain.dequantOpd.getDefiningOp()->getOperands();
       auto qTorchType =
           cast<ValueTensorType>(chain.dequantOpd.getType()).getOptionalDtype();
       auto newMPTQTType = rewriter.getType<ValueTensorType>(
           cast<ValueTensorType>(operands[i].getType()).getSizes(), qTorchType);
-      operands[i] = Aten_MakePerTensorQuantizedTensorOp::create(
-          rewriter, loc, newMPTQTType, oldOpd, MPTQTOperands[1],
-          MPTQTOperands[2]);
+      if (chain.axis) {
+        operands[i] = Aten_MakePerChannelQuantizedTensorOp::create(
+            rewriter, loc, newMPTQTType, oldOpd, chain.scale, chain.zeroPoint,
+            chain.axis);
+      } else {
+        operands[i] = Aten_MakePerTensorQuantizedTensorOp::create(
+            rewriter, loc, newMPTQTType, oldOpd, chain.scale, chain.zeroPoint);
+      }
     }
 
     rewriter.replaceOpWithNewOp<SrcOp>(op, op.getType(), operands);
@@ -238,7 +278,18 @@ public:
             operands[1].getDefiningOp<Aten_MakePerTensorQuantizedTensorOp>())
       rhsScale = qRhs.getScale();
 
-    if (!rhsScale || !lhsScale)
+    Value rhsScaleTensor, rhsZpTensor;
+    if (auto qRhs =
+            operands[1].getDefiningOp<Aten_MakePerChannelQuantizedTensorOp>()) {
+      int64_t axisInt;
+      if (matchPattern(qRhs.getAxis(), m_TorchConstantInt(&axisInt)) &&
+          axisInt == 0) {
+        rhsScaleTensor = qRhs.getScale();
+        rhsZpTensor = qRhs.getZeroPoint();
+      }
+    }
+
+    if (!(rhsScale || rhsScaleTensor) || !lhsScale)
       return failure();
 
     auto resultTy = cast<ValueTensorType>(op.getType());
@@ -252,6 +303,45 @@ public:
       auto biasETy = biasTy.getOptionalDtype();
       if (!biasETy || !isa<mlir::FloatType>(biasETy))
         return failure();
+    }
+
+    if (rhsScaleTensor) {
+      auto loc = op.getLoc();
+      auto scaleTy = cast<ValueTensorType>(rhsScaleTensor.getType());
+      Value biasScaleT = AtenMulScalarOp::create(rewriter, loc, scaleTy,
+                                                 rhsScaleTensor, lhsScale);
+      auto si32Dtype = rewriter.getIntegerType(32, /*isSigned=*/true);
+      if (biasTy) {
+        Value biasDiv =
+            AtenDivTensorOp::create(rewriter, loc, biasTy, bias, biasScaleT);
+        Value biasRound = AtenRoundOp::create(rewriter, loc, biasTy, biasDiv);
+        auto biasIntTy = rewriter.getType<ValueTensorType>(
+            biasTy.getOptionalSizes(), si32Dtype);
+        Value dtypeVal = getDtypeIntValueForType(rewriter, loc, si32Dtype);
+        Value cstFalse = Torch::ConstantBoolOp::create(rewriter, loc, false);
+        Value none = Torch::ConstantNoneOp::create(rewriter, loc);
+        bias = AtenToDtypeOp::create(rewriter, loc, biasIntTy, biasRound,
+                                     dtypeVal, /*non_blocking=*/cstFalse,
+                                     /*copy=*/cstFalse,
+                                     /*memory_format=*/none);
+        operands[2] = bias;
+      }
+
+      auto qi32Ty = rewriter.getType<QInt32Type>();
+      auto convTy = rewriter.getType<ValueTensorType>(
+          resultTy.getOptionalSizes(), si32Dtype);
+      auto conv = SrcOp::create(rewriter, loc, convTy, operands);
+
+      Value axisOut = Torch::ConstantIntOp::create(
+          rewriter, loc, rewriter.getType<Torch::IntType>(),
+          rewriter.getIntegerAttr(rewriter.getIntegerType(64), 1));
+      auto convQTy = rewriter.getType<ValueTensorType>(
+          resultTy.getOptionalSizes(), qi32Ty);
+      auto makeOut = Aten_MakePerChannelQuantizedTensorOp::create(
+          rewriter, loc, convQTy, conv, biasScaleT, rhsZpTensor, axisOut);
+      rewriter.replaceOpWithNewOp<AtenDequantizeSelfOp>(op, op.getType(),
+                                                        makeOut);
+      return success();
     }
 
     Value biasScale = AtenMulFloatOp::create(
@@ -322,6 +412,44 @@ public:
     if (auto defining =
             rhs.template getDefiningOp<Aten_MakePerTensorQuantizedTensorOp>()) {
       rhsScale = defining.getScale();
+    }
+
+    if (!rhsScale) {
+      auto qRhs =
+          rhs.template getDefiningOp<Aten_MakePerChannelQuantizedTensorOp>();
+      auto rhsTy =
+          qRhs ? dyn_cast<ValueTensorType>(rhs.getType()) : ValueTensorType();
+      int64_t rhsChannelAxis;
+      if (qRhs && lhsScale && rhsTy && rhsTy.hasSizes() &&
+          matchPattern(qRhs.getAxis(), m_TorchConstantInt(&rhsChannelAxis)) &&
+          toPositiveDim(rhsChannelAxis,
+                        static_cast<int64_t>(rhsTy.getSizes().size())) ==
+              static_cast<int64_t>(rhsTy.getSizes().size()) - 1) {
+        auto loc = op.getLoc();
+        Value rhsScaleTensor = qRhs.getScale();
+        Value rhsZpTensor = qRhs.getZeroPoint();
+        auto scaleTy = cast<ValueTensorType>(rhsScaleTensor.getType());
+        Value accScale = AtenMulScalarOp::create(rewriter, loc, scaleTy,
+                                                 rhsScaleTensor, lhsScale);
+        auto si32Dtype = rewriter.getIntegerType(32, /*isSigned=*/true);
+        auto newResultTy = rewriter.getType<ValueTensorType>(
+            resultTy.getOptionalSizes(), si32Dtype);
+        llvm::SmallVector<Value> operands(op.getOperands());
+        auto mm = SrcOp::create(rewriter, loc, newResultTy, operands);
+        int64_t resultRank = cast<ValueTensorType>(resultTy).getSizes().size();
+        Value axisOut = Torch::ConstantIntOp::create(
+            rewriter, loc, rewriter.getType<Torch::IntType>(),
+            rewriter.getIntegerAttr(rewriter.getIntegerType(64),
+                                    resultRank - 1));
+        auto qi32Ty = rewriter.getType<QInt32Type>();
+        auto mmQTy = rewriter.getType<ValueTensorType>(
+            resultTy.getOptionalSizes(), qi32Ty);
+        auto makeOut = Aten_MakePerChannelQuantizedTensorOp::create(
+            rewriter, loc, mmQTy, mm, accScale, rhsZpTensor, axisOut);
+        rewriter.replaceOpWithNewOp<AtenDequantizeSelfOp>(op, op.getType(),
+                                                          makeOut);
+        return success();
+      }
     }
 
     if (!lhsScale || !rhsScale)
@@ -453,6 +581,7 @@ public:
         RemoveUnused<AtenDequantizeTensorOp>,
         RemoveUnused<AtenQuantizePerTensorOp>,
         RemoveUnused<Aten_MakePerTensorQuantizedTensorOp>,
+        RemoveUnused<Aten_MakePerChannelQuantizedTensorOp>,
         RemoveUnused<AtenTransposeIntOp>, RemoveUnused<AtenSliceTensorOp>,
         RemoveUnused<AtenReshapeOp>, RemoveUnused<PrimsCollapseOp>,
         RemoveUnused<AtenViewOp>, RemoveUnused<AtenPadOp>,

--- a/test/Dialect/Torch/fuse-quantized-ops.mlir
+++ b/test/Dialect/Torch/fuse-quantized-ops.mlir
@@ -190,3 +190,142 @@ func.func @convolution_nobias(%arg0: !torch.vtensor<[1,3,8,8],si8>, %arg1: !torc
   // CHECK: %[[FOUT:.+]] = torch.aten.dequantize.tensor %[[QOUT]] : !torch.vtensor<[1,3,7,7],!torch.qint32> -> !torch.vtensor<[1,3,7,7],f32>
   return %16 : !torch.vtensor<[1,3,7,7],f32>
 }
+
+
+// -----
+
+// CHECK-LABEL: @per_channel_conv
+func.func @per_channel_conv(%arg0: !torch.vtensor<[1,2,4,4],si8>, %arg1: !torch.vtensor<[3,2,2,2],si8>, %arg2: !torch.vtensor<[3],si32>) -> !torch.vtensor<[1,3,3,3],f32> {
+  %scale = torch.constant.float 0.5
+  %zero = torch.constant.int 0
+  %one = torch.constant.int 1
+  %false = torch.constant.bool false
+  %wscale = torch.vtensor.literal(dense<[1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<3xf32>) : !torch.vtensor<[3],f32>
+  %wzp = torch.vtensor.literal(dense<0> : tensor<3xsi8>) : !torch.vtensor<[3],si8>
+  %bscale = torch.vtensor.literal(dense<[5.000000e-02, 1.000000e-01, 1.500000e-01]> : tensor<3xf32>) : !torch.vtensor<[3],f32>
+  %bzp = torch.vtensor.literal(dense<0> : tensor<3xsi32>) : !torch.vtensor<[3],si32>
+  %0 = torch.aten._make_per_tensor_quantized_tensor %arg0, %scale, %zero : !torch.vtensor<[1,2,4,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[1,2,4,4],!torch.qint8>
+  %1 = torch.aten.dequantize.self %0 : !torch.vtensor<[1,2,4,4],!torch.qint8> -> !torch.vtensor<[1,2,4,4],f32>
+  %2 = torch.aten._make_per_channel_quantized_tensor %arg1, %wscale, %wzp, %zero : !torch.vtensor<[3,2,2,2],si8>, !torch.vtensor<[3],f32>, !torch.vtensor<[3],si8>, !torch.int -> !torch.vtensor<[3,2,2,2],!torch.qint8>
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[3,2,2,2],!torch.qint8> -> !torch.vtensor<[3,2,2,2],f32>
+  %4 = torch.aten._make_per_channel_quantized_tensor %arg2, %bscale, %bzp, %zero : !torch.vtensor<[3],si32>, !torch.vtensor<[3],f32>, !torch.vtensor<[3],si32>, !torch.int -> !torch.vtensor<[3],!torch.qint32>
+  %5 = torch.aten.dequantize.self %4 : !torch.vtensor<[3],!torch.qint32> -> !torch.vtensor<[3],f32>
+  %6 = torch.prim.ListConstruct %one, %one : (!torch.int, !torch.int) -> !torch.list<int>
+  %7 = torch.prim.ListConstruct %zero, %zero : (!torch.int, !torch.int) -> !torch.list<int>
+  %8 = torch.prim.ListConstruct  : () -> !torch.list<int>
+
+  // CHECK-DAG: %[[SI32:.+]] = torch.constant.int 3
+  // CHECK-DAG: %[[FALSE:.+]] = torch.constant.bool false
+  // CHECK-DAG: %[[ONE:.+]] = torch.constant.int 1
+  // CHECK-DAG: %[[WSCALE:.+]] = torch.vtensor.literal(dense<[1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<3xf32>)
+  // CHECK-DAG: %[[WZP:.+]] = torch.vtensor.literal(dense<0> : tensor<3xsi8>)
+  // CHECK-DAG: %[[QLHS:.+]] = torch.aten._make_per_tensor_quantized_tensor %arg0, %{{.+}}, %{{.+}} : !torch.vtensor<[1,2,4,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[1,2,4,4],!torch.qint8>
+  // CHECK-DAG: %[[QRHS:.+]] = torch.aten._make_per_channel_quantized_tensor %arg1, %[[WSCALE]], %[[WZP]], %{{.+}} : !torch.vtensor<[3,2,2,2],si8>, {{.*}} -> !torch.vtensor<[3,2,2,2],!torch.qint8>
+  // CHECK-DAG: %[[BDIV:.+]] = torch.aten.div.Tensor %{{.+}}, %{{.+}} : !torch.vtensor<[3],f32>, !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
+  // CHECK-DAG: %[[BROUND:.+]] = torch.aten.round %[[BDIV]]
+  // CHECK-DAG: %[[BIAS:.+]] = torch.aten.to.dtype %[[BROUND]], %[[SI32]], %[[FALSE]], %[[FALSE]], %{{.+}} : {{.*}} -> !torch.vtensor<[3],si32>
+  // CHECK-DAG: %[[CONV:.+]] = torch.aten.convolution %[[QLHS]], %[[QRHS]], %[[BIAS]], {{.*}} : !torch.vtensor<[1,2,4,4],!torch.qint8>, !torch.vtensor<[3,2,2,2],!torch.qint8>, !torch.vtensor<[3],si32>, {{.*}} -> !torch.vtensor<[1,3,3,3],si32>
+  // CHECK-DAG: %[[QOUT:.+]] = torch.aten._make_per_channel_quantized_tensor %[[CONV]], %{{.+}}, %[[WZP]], %[[ONE]] : !torch.vtensor<[1,3,3,3],si32>, {{.*}} -> !torch.vtensor<[1,3,3,3],!torch.qint32>
+  // CHECK-DAG: torch.aten.dequantize.self %[[QOUT]] : !torch.vtensor<[1,3,3,3],!torch.qint32> -> !torch.vtensor<[1,3,3,3],f32>
+  %9 = torch.aten.convolution %1, %3, %5, %6, %7, %6, %false, %8, %one : !torch.vtensor<[1,2,4,4],f32>, !torch.vtensor<[3,2,2,2],f32>, !torch.vtensor<[3],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,3,3,3],f32>
+  return %9 : !torch.vtensor<[1,3,3,3],f32>
+}
+
+// -----
+
+// CHECK-LABEL: @per_channel_mm_transpose
+func.func @per_channel_mm_transpose(%arg0: !torch.vtensor<[1,4],si8>, %arg1: !torch.vtensor<[3,4],si8>) -> !torch.vtensor<[1,3],f32> {
+  %scale = torch.constant.float 0.5
+  %zero = torch.constant.int 0
+  %one = torch.constant.int 1
+  %wscale = torch.vtensor.literal(dense<[1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<3xf32>) : !torch.vtensor<[3],f32>
+  %wzp = torch.vtensor.literal(dense<0> : tensor<3xsi8>) : !torch.vtensor<[3],si8>
+  %0 = torch.aten._make_per_tensor_quantized_tensor %arg0, %scale, %zero : !torch.vtensor<[1,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[1,4],!torch.qint8>
+  %1 = torch.aten.dequantize.self %0 : !torch.vtensor<[1,4],!torch.qint8> -> !torch.vtensor<[1,4],f32>
+  %2 = torch.aten._make_per_channel_quantized_tensor %arg1, %wscale, %wzp, %zero : !torch.vtensor<[3,4],si8>, !torch.vtensor<[3],f32>, !torch.vtensor<[3],si8>, !torch.int -> !torch.vtensor<[3,4],!torch.qint8>
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[3,4],!torch.qint8> -> !torch.vtensor<[3,4],f32>
+  %4 = torch.aten.transpose.int %3, %zero, %one : !torch.vtensor<[3,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[4,3],f32>
+
+  // CHECK-DAG: %[[ONE:.+]] = torch.constant.int 1
+  // CHECK-DAG: %[[WSCALE:.+]] = torch.vtensor.literal(dense<[1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<3xf32>)
+  // CHECK-DAG: %[[WZP:.+]] = torch.vtensor.literal(dense<0> : tensor<3xsi8>)
+  // CHECK-DAG: %[[QLHS:.+]] = torch.aten._make_per_tensor_quantized_tensor %arg0, %{{.+}}, %{{.+}} : !torch.vtensor<[1,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[1,4],!torch.qint8>
+  // CHECK-DAG: %[[WT:.+]] = torch.aten.transpose.int %arg1, %{{.+}}, %[[ONE]] : !torch.vtensor<[3,4],si8>, !torch.int, !torch.int -> !torch.vtensor<[4,3],si8>
+  // CHECK-DAG: %[[QRHS:.+]] = torch.aten._make_per_channel_quantized_tensor %[[WT]], %[[WSCALE]], %[[WZP]], %[[ONE]] : !torch.vtensor<[4,3],si8>, {{.*}} -> !torch.vtensor<[4,3],!torch.qint8>
+  // CHECK-DAG: %[[MM:.+]] = torch.aten.mm %[[QLHS]], %[[QRHS]] : !torch.vtensor<[1,4],!torch.qint8>, !torch.vtensor<[4,3],!torch.qint8> -> !torch.vtensor<[1,3],si32>
+  // CHECK-DAG: %[[QOUT:.+]] = torch.aten._make_per_channel_quantized_tensor %[[MM]], %{{.+}}, %[[WZP]], %[[ONE]] : !torch.vtensor<[1,3],si32>, {{.*}} -> !torch.vtensor<[1,3],!torch.qint32>
+  // CHECK-DAG: torch.aten.dequantize.self %[[QOUT]] : !torch.vtensor<[1,3],!torch.qint32> -> !torch.vtensor<[1,3],f32>
+  %5 = torch.aten.mm %1, %4 : !torch.vtensor<[1,4],f32>, !torch.vtensor<[4,3],f32> -> !torch.vtensor<[1,3],f32>
+  return %5 : !torch.vtensor<[1,3],f32>
+}
+
+// -----
+
+// CHECK-LABEL: @per_channel_mm_transpose_neg_axis
+func.func @per_channel_mm_transpose_neg_axis(%arg0: !torch.vtensor<[1,4],si8>, %arg1: !torch.vtensor<[3,4],si8>) -> !torch.vtensor<[1,3],f32> {
+  %scale = torch.constant.float 0.5
+  %zero = torch.constant.int 0
+  %one = torch.constant.int 1
+  %negtwo = torch.constant.int -2
+  %wscale = torch.vtensor.literal(dense<[1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<3xf32>) : !torch.vtensor<[3],f32>
+  %wzp = torch.vtensor.literal(dense<0> : tensor<3xsi8>) : !torch.vtensor<[3],si8>
+  %0 = torch.aten._make_per_tensor_quantized_tensor %arg0, %scale, %zero : !torch.vtensor<[1,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[1,4],!torch.qint8>
+  %1 = torch.aten.dequantize.self %0 : !torch.vtensor<[1,4],!torch.qint8> -> !torch.vtensor<[1,4],f32>
+  %2 = torch.aten._make_per_channel_quantized_tensor %arg1, %wscale, %wzp, %negtwo : !torch.vtensor<[3,4],si8>, !torch.vtensor<[3],f32>, !torch.vtensor<[3],si8>, !torch.int -> !torch.vtensor<[3,4],!torch.qint8>
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[3,4],!torch.qint8> -> !torch.vtensor<[3,4],f32>
+  %4 = torch.aten.transpose.int %3, %zero, %one : !torch.vtensor<[3,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[4,3],f32>
+
+  // The per-channel axis -2 (== 0 on the rank-2 weight) is normalized and
+  // remapped through the transpose to 1.
+  // CHECK-DAG: %[[ONE:.+]] = torch.constant.int 1
+  // CHECK-DAG: %[[WT:.+]] = torch.aten.transpose.int %arg1, %{{.+}}, %[[ONE]] : !torch.vtensor<[3,4],si8>, !torch.int, !torch.int -> !torch.vtensor<[4,3],si8>
+  // CHECK-DAG: torch.aten._make_per_channel_quantized_tensor %[[WT]], %{{.+}}, %{{.+}}, %[[ONE]] : !torch.vtensor<[4,3],si8>, {{.*}} -> !torch.vtensor<[4,3],!torch.qint8>
+  // CHECK-DAG: torch.aten.mm %{{.+}}, %{{.+}} : !torch.vtensor<[1,4],!torch.qint8>, !torch.vtensor<[4,3],!torch.qint8> -> !torch.vtensor<[1,3],si32>
+  %5 = torch.aten.mm %1, %4 : !torch.vtensor<[1,4],f32>, !torch.vtensor<[4,3],f32> -> !torch.vtensor<[1,3],f32>
+  return %5 : !torch.vtensor<[1,3],f32>
+}
+
+// -----
+
+// A non-constant per-channel weight zero-point cannot be verified all-zero, so
+// the op is left in QDQ form.
+
+// CHECK-LABEL: @per_channel_mm_nonconst_zp
+func.func @per_channel_mm_nonconst_zp(%arg0: !torch.vtensor<[1,4],si8>, %arg1: !torch.vtensor<[3,4],si8>, %arg2: !torch.vtensor<[3],si8>) -> !torch.vtensor<[1,3],f32> {
+  %scale = torch.constant.float 0.5
+  %zero = torch.constant.int 0
+  %one = torch.constant.int 1
+  %wscale = torch.vtensor.literal(dense<[1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<3xf32>) : !torch.vtensor<[3],f32>
+  %0 = torch.aten._make_per_tensor_quantized_tensor %arg0, %scale, %zero : !torch.vtensor<[1,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[1,4],!torch.qint8>
+  %1 = torch.aten.dequantize.self %0 : !torch.vtensor<[1,4],!torch.qint8> -> !torch.vtensor<[1,4],f32>
+  %2 = torch.aten._make_per_channel_quantized_tensor %arg1, %wscale, %arg2, %zero : !torch.vtensor<[3,4],si8>, !torch.vtensor<[3],f32>, !torch.vtensor<[3],si8>, !torch.int -> !torch.vtensor<[3,4],!torch.qint8>
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[3,4],!torch.qint8> -> !torch.vtensor<[3,4],f32>
+  %4 = torch.aten.transpose.int %3, %zero, %one : !torch.vtensor<[3,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[4,3],f32>
+
+  // CHECK: torch.aten.mm %{{.+}}, %{{.+}} : !torch.vtensor<[1,4],f32>, !torch.vtensor<[4,3],f32> -> !torch.vtensor<[1,3],f32>
+  %5 = torch.aten.mm %1, %4 : !torch.vtensor<[1,4],f32>, !torch.vtensor<[4,3],f32> -> !torch.vtensor<[1,3],f32>
+  return %5 : !torch.vtensor<[1,3],f32>
+}
+
+// -----
+
+// A non-zero (asymmetric) per-channel weight zero-point is unsupported by the
+// integer lowering, so the op is left in QDQ form.
+
+// CHECK-LABEL: @per_channel_mm_nonzero_zp
+func.func @per_channel_mm_nonzero_zp(%arg0: !torch.vtensor<[1,4],si8>, %arg1: !torch.vtensor<[3,4],si8>) -> !torch.vtensor<[1,3],f32> {
+  %scale = torch.constant.float 0.5
+  %zero = torch.constant.int 0
+  %one = torch.constant.int 1
+  %wscale = torch.vtensor.literal(dense<[1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<3xf32>) : !torch.vtensor<[3],f32>
+  %wzp = torch.vtensor.literal(dense<[1, 0, 0]> : tensor<3xsi8>) : !torch.vtensor<[3],si8>
+  %0 = torch.aten._make_per_tensor_quantized_tensor %arg0, %scale, %zero : !torch.vtensor<[1,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[1,4],!torch.qint8>
+  %1 = torch.aten.dequantize.self %0 : !torch.vtensor<[1,4],!torch.qint8> -> !torch.vtensor<[1,4],f32>
+  %2 = torch.aten._make_per_channel_quantized_tensor %arg1, %wscale, %wzp, %zero : !torch.vtensor<[3,4],si8>, !torch.vtensor<[3],f32>, !torch.vtensor<[3],si8>, !torch.int -> !torch.vtensor<[3,4],!torch.qint8>
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[3,4],!torch.qint8> -> !torch.vtensor<[3,4],f32>
+  %4 = torch.aten.transpose.int %3, %zero, %one : !torch.vtensor<[3,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[4,3],f32>
+
+  // CHECK: torch.aten.mm %{{.+}}, %{{.+}} : !torch.vtensor<[1,4],f32>, !torch.vtensor<[4,3],f32> -> !torch.vtensor<[1,3],f32>
+  %5 = torch.aten.mm %1, %4 : !torch.vtensor<[1,4],f32>, !torch.vtensor<[4,3],f32> -> !torch.vtensor<[1,3],f32>
+  return %5 : !torch.vtensor<[1,3],f32>
+}


### PR DESCRIPTION
`FuseQuantizedOps` currently bails on any per-channel quantized tensor. As a result, convolutions and matmuls whose weights are per-channel quantized — the default for ONNX / onnxruntime static quantization — are left in QDQ form. They dequantize the weight to f32, compute the contraction in f32, and requantize, which defeats the purpose of quantization.

This PR updates the pass to fuse a per-channel weight into an integer convolution or matmul when the weight zero-point is a constant all-zero tensor (symmetric quantization — what ONNX quantizers emit for weights).

This was discovered in IREE (which consumes `torch-mlir` output) when working on enabling quantized int8 resnet18 and resnet50. Due to quantization fusing bailing on weights, the performance penalty was ~10x, compared to what IREE can do with the model imported with torch-mlir with this patch.