### PR TITLE
[TorchToTosa] Support embedding forward flags

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -5257,7 +5257,8 @@ LogicalResult ConvertAtenOp<AtenEmbeddingOp>::matchAndRewriteImpl(
   if (weightType.getRank() != 2)
     return op.emitError("weight must be of rank 2");
 
-  // FIXME: padding_idx, scale_grad_by_freq and sparse are not handled yet.
+  // padding_idx, scale_grad_by_freq, and sparse only affect gradient
+  // computation. They do not change the forward embedding result.
   int64_t paddingIdx;
   if (!matchPattern(op.getPaddingIdx(), m_TorchConstantInt(&paddingIdx)))
     return rewriter.notifyMatchFailure(
@@ -5268,18 +5269,11 @@ LogicalResult ConvertAtenOp<AtenEmbeddingOp>::matchAndRewriteImpl(
                     m_TorchConstantBool(&scaleGradByFreq)))
     return rewriter.notifyMatchFailure(
         op, "only supports constant bool scale_grad_by_freq for embedding op");
-  if (scaleGradByFreq)
-    return rewriter.notifyMatchFailure(
-        op,
-        "only supports scale_grad_by_freq equals to False for embedding op");
 
   bool isSparse;
   if (!matchPattern(op.getSparse(), m_TorchConstantBool(&isSparse)))
     return rewriter.notifyMatchFailure(
         op, "only supports constant bool sparse for embedding op");
-  if (isSparse)
-    return rewriter.notifyMatchFailure(
-        op, "only support sparse equals to False for embedding op");
 
   // For inference:
   //    Weights [num_embeddings, embedding_dim], Indices [X, Y]

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -5257,8 +5257,10 @@ LogicalResult ConvertAtenOp<AtenEmbeddingOp>::matchAndRewriteImpl(
   if (weightType.getRank() != 2)
     return op.emitError("weight must be of rank 2");
 
-  // padding_idx, scale_grad_by_freq, and sparse only affect gradient
-  // computation. They do not change the forward embedding result.
+  // PyTorch's forward implementation does not use padding_idx,
+  // scale_grad_by_freq, or sparse:
+  // https://github.com/pytorch/pytorch/blob/fa6f338ab692e5bec4537eb13cbf72cda0a7c6e7/aten/src/ATen/native/Embedding.cpp#L37
+  // These arguments only affect gradient computation.
   int64_t paddingIdx;
   if (!matchPattern(op.getPaddingIdx(), m_TorchConstantInt(&paddingIdx)))
     return rewriter.notifyMatchFailure(

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -558,6 +558,8 @@ FX_IMPORTER_STABLEHLO_XFAIL_SET = {
     "AtenPolarFloatModule_basic",
     "DiagonalWithStaticShapeModule_basic",
     "EinsumStaticDiagonalDimensionModule_basic",
+    # StableHLO does not support non-default embedding forward flags.
+    "EmbeddingForwardFlagsModule_basic",
     "ElementwiseAtanTensorBFloat16SpecialValuesModule_basic",
     "ElementwiseClampIntToFloatModule_basic",
     "ElementwiseRemainderScalarModule_Bool_NegativeDivisor_basic",
@@ -2445,6 +2447,7 @@ TOSA_PASS_SET = {
     "ElementwiseWhereScalarModule_basic",
     "ElementwiseNanToNumWithNoneModule_Basic",
     "ElementwiseNanToNumModule_Basic",
+    "EmbeddingForwardFlagsModule_basic",
     "EmbeddingModule1DIndices_basic",
     "EmbeddingModuleI32Static_basic",
     "FlattenRank0Module_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -2127,6 +2127,33 @@ def EmbeddingModule1DIndices_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class EmbeddingForwardFlagsModule(torch.nn.Module):
+    @export
+    @annotate_args(
+        [
+            None,
+            ([10, 4], torch.float32, True),
+            ([2, 2], torch.int32, True),
+        ]
+    )
+    def forward(self, weight, indices):
+        scale_grad_by_freq = torch.nn.functional.embedding(
+            indices, weight, padding_idx=-1, scale_grad_by_freq=True
+        )
+        sparse = torch.nn.functional.embedding(
+            indices, weight, padding_idx=-1, sparse=True
+        )
+        return scale_grad_by_freq, sparse
+
+
+@register_test_case(module_factory=lambda: EmbeddingForwardFlagsModule())
+def EmbeddingForwardFlagsModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(10, 4), tu.randint(2, 2, high=10).to(torch.int32))
+
+
+# ==============================================================================
+
+
 class SoftmaxIntModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -2133,7 +2133,7 @@ class EmbeddingForwardFlagsModule(torch.nn.Module):
         [
             None,
             ([10, 4], torch.float32, True),
-            ([2, 2], torch.int32, True),
+            ([2, 2], torch.int64, True),
         ]
     )
     def forward(self, weight, indices):
@@ -2148,7 +2148,7 @@ class EmbeddingForwardFlagsModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: EmbeddingForwardFlagsModule())
 def EmbeddingForwardFlagsModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(10, 4), tu.randint(2, 2, high=10).to(torch.int32))
+    module.forward(tu.rand(10, 4), tu.randint(2, 2, high=10))
 
 
 # ==============================================================================

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -1,5 +1,21 @@
 // RUN: torch-mlir-opt <%s -convert-torch-to-tosa -split-input-file -verify-diagnostics | FileCheck %s
 
+// CHECK-LABEL: func.func @torch.aten.embedding$forward_flags
+// CHECK-COUNT-2: tosa.gather
+func.func @torch.aten.embedding$forward_flags(
+    %weight: !torch.vtensor<[5,5],f32>,
+    %indices: !torch.vtensor<[2,2],si32>)
+    -> (!torch.vtensor<[2,2,5],f32>, !torch.vtensor<[2,2,5],f32>) {
+  %int-1 = torch.constant.int -1
+  %false = torch.constant.bool false
+  %true = torch.constant.bool true
+  %scale_grad_by_freq = torch.aten.embedding %weight, %indices, %int-1, %true, %false : !torch.vtensor<[5,5],f32>, !torch.vtensor<[2,2],si32>, !torch.int, !torch.bool, !torch.bool -> !torch.vtensor<[2,2,5],f32>
+  %sparse = torch.aten.embedding %weight, %indices, %int-1, %false, %true : !torch.vtensor<[5,5],f32>, !torch.vtensor<[2,2],si32>, !torch.int, !torch.bool, !torch.bool -> !torch.vtensor<[2,2,5],f32>
+  return %scale_grad_by_freq, %sparse : !torch.vtensor<[2,2,5],f32>, !torch.vtensor<[2,2,5],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.tanh$basic(
 // CHECK-SAME:                                %[[ARG:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:           %[[ARG_BUILTIN:.*]] = torch_c.to_builtin_tensor %[[ARG]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -1,21 +1,5 @@
 // RUN: torch-mlir-opt <%s -convert-torch-to-tosa -split-input-file -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL: func.func @torch.aten.embedding$forward_flags
-// CHECK-COUNT-2: tosa.gather
-func.func @torch.aten.embedding$forward_flags(
-    %weight: !torch.vtensor<[5,5],f32>,
-    %indices: !torch.vtensor<[2,2],si32>)
-    -> (!torch.vtensor<[2,2,5],f32>, !torch.vtensor<[2,2,5],f32>) {
-  %int-1 = torch.constant.int -1
-  %false = torch.constant.bool false
-  %true = torch.constant.bool true
-  %scale_grad_by_freq = torch.aten.embedding %weight, %indices, %int-1, %true, %false : !torch.vtensor<[5,5],f32>, !torch.vtensor<[2,2],si32>, !torch.int, !torch.bool, !torch.bool -> !torch.vtensor<[2,2,5],f32>
-  %sparse = torch.aten.embedding %weight, %indices, %int-1, %false, %true : !torch.vtensor<[5,5],f32>, !torch.vtensor<[2,2],si32>, !torch.int, !torch.bool, !torch.bool -> !torch.vtensor<[2,2,5],f32>
-  return %scale_grad_by_freq, %sparse : !torch.vtensor<[2,2,5],f32>, !torch.vtensor<[2,2,5],f32>
-}
-
-// -----
-
 // CHECK-LABEL:   func.func @torch.aten.tanh$basic(
 // CHECK-SAME:                                %[[ARG:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:           %[[ARG_BUILTIN:.*]] = torch_c.to_builtin_tensor %[[ARG]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
@@ -2832,6 +2816,47 @@ func.func @torch.aten.index_select(%arg0: !torch.vtensor<[4,5,6],f32>, %arg1: !t
   %int2 = torch.constant.int 2
   %0 = torch.aten.index_select %arg0, %int2, %arg1 : !torch.vtensor<[4,5,6],f32>, !torch.int, !torch.vtensor<[2],si64> -> !torch.vtensor<[4,5,2],f32>
   return %0 : !torch.vtensor<[4,5,2],f32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten.embedding$forward_flags(
+// CHECK-SAME:        %[[WEIGHT:.*]]: !torch.vtensor<[5,5],f32>,
+// CHECK-SAME:        %[[INDICES:.*]]: !torch.vtensor<[2,2],si64>) -> (!torch.vtensor<[2,2,5],f32>, !torch.vtensor<[2,2,5],f32>) {
+// CHECK:           %[[INDICES_BUILTIN:.*]] = torch_c.to_builtin_tensor %[[INDICES]] : !torch.vtensor<[2,2],si64> -> tensor<2x2xi64>
+// CHECK:           %[[WEIGHT_BUILTIN:.*]] = torch_c.to_builtin_tensor %[[WEIGHT]] : !torch.vtensor<[5,5],f32> -> tensor<5x5xf32>
+// CHECK:           %[[PADDING_IDX:.*]] = torch.constant.int -1
+// CHECK:           %[[FALSE:.*]] = torch.constant.bool false
+// CHECK:           %[[TRUE:.*]] = torch.constant.bool true
+// CHECK:           %[[SCALE_WEIGHT_SHAPE:.*]] = tosa.const_shape  {values = dense<[1, 5, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_WEIGHT:.*]] = tosa.reshape %[[WEIGHT_BUILTIN]], %[[SCALE_WEIGHT_SHAPE]] : (tensor<5x5xf32>, !tosa.shape<3>) -> tensor<1x5x5xf32>
+// CHECK:           %[[SCALE_INDICES_SHAPE:.*]] = tosa.const_shape  {values = dense<[1, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           %[[SCALE_INDICES_I64:.*]] = tosa.reshape %[[INDICES_BUILTIN]], %[[SCALE_INDICES_SHAPE]] : (tensor<2x2xi64>, !tosa.shape<2>) -> tensor<1x4xi64>
+// CHECK:           %[[SCALE_INDICES_I32:.*]] = tosa.cast %[[SCALE_INDICES_I64]] : (tensor<1x4xi64>) -> tensor<1x4xi32>
+// CHECK:           %[[SCALE_GATHER:.*]] = tosa.gather %[[SCALE_WEIGHT]], %[[SCALE_INDICES_I32]] : (tensor<1x5x5xf32>, tensor<1x4xi32>) -> tensor<1x4x5xf32>
+// CHECK:           %[[SCALE_RESULT_SHAPE:.*]] = tosa.const_shape  {values = dense<[2, 2, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SCALE_RESULT_BUILTIN:.*]] = tosa.reshape %[[SCALE_GATHER]], %[[SCALE_RESULT_SHAPE]] : (tensor<1x4x5xf32>, !tosa.shape<3>) -> tensor<2x2x5xf32>
+// CHECK:           %[[SCALE_RESULT:.*]] = torch_c.from_builtin_tensor %[[SCALE_RESULT_BUILTIN]] : tensor<2x2x5xf32> -> !torch.vtensor<[2,2,5],f32>
+// CHECK:           %[[SPARSE_WEIGHT_SHAPE:.*]] = tosa.const_shape  {values = dense<[1, 5, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SPARSE_WEIGHT:.*]] = tosa.reshape %[[WEIGHT_BUILTIN]], %[[SPARSE_WEIGHT_SHAPE]] : (tensor<5x5xf32>, !tosa.shape<3>) -> tensor<1x5x5xf32>
+// CHECK:           %[[SPARSE_INDICES_SHAPE:.*]] = tosa.const_shape  {values = dense<[1, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           %[[SPARSE_INDICES_I64:.*]] = tosa.reshape %[[INDICES_BUILTIN]], %[[SPARSE_INDICES_SHAPE]] : (tensor<2x2xi64>, !tosa.shape<2>) -> tensor<1x4xi64>
+// CHECK:           %[[SPARSE_INDICES_I32:.*]] = tosa.cast %[[SPARSE_INDICES_I64]] : (tensor<1x4xi64>) -> tensor<1x4xi32>
+// CHECK:           %[[SPARSE_GATHER:.*]] = tosa.gather %[[SPARSE_WEIGHT]], %[[SPARSE_INDICES_I32]] : (tensor<1x5x5xf32>, tensor<1x4xi32>) -> tensor<1x4x5xf32>
+// CHECK:           %[[SPARSE_RESULT_SHAPE:.*]] = tosa.const_shape  {values = dense<[2, 2, 5]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK:           %[[SPARSE_RESULT_BUILTIN:.*]] = tosa.reshape %[[SPARSE_GATHER]], %[[SPARSE_RESULT_SHAPE]] : (tensor<1x4x5xf32>, !tosa.shape<3>) -> tensor<2x2x5xf32>
+// CHECK:           %[[SPARSE_RESULT:.*]] = torch_c.from_builtin_tensor %[[SPARSE_RESULT_BUILTIN]] : tensor<2x2x5xf32> -> !torch.vtensor<[2,2,5],f32>
+// CHECK:           return %[[SCALE_RESULT]], %[[SPARSE_RESULT]] : !torch.vtensor<[2,2,5],f32>, !torch.vtensor<[2,2,5],f32>
+func.func @torch.aten.embedding$forward_flags(
+    %weight: !torch.vtensor<[5,5],f32>,
+    %indices: !torch.vtensor<[2,2],si64>)
+    -> (!torch.vtensor<[2,2,5],f32>, !torch.vtensor<[2,2,5],f32>) {
+  %int-1 = torch.constant.int -1
+  %false = torch.constant.bool false
+  %true = torch.constant.bool true
+  %scale_grad_by_freq = torch.aten.embedding %weight, %indices, %int-1, %true, %false : !torch.vtensor<[5,5],f32>, !torch.vtensor<[2,2],si64>, !torch.int, !torch.bool, !torch.bool -> !torch.vtensor<[2,2,5],f32>
+  %sparse = torch.aten.embedding %weight, %indices, %int-1, %false, %true : !torch.vtensor<[5,5],f32>, !torch.vtensor<[2,2],si64>, !torch.int, !torch.bool, !torch.bool -> !torch.vtensor<[2,2,5],f32>
+  return %scale_grad_by_freq, %sparse : !torch.vtensor<[2,2,5],f32>, !torch.vtensor<[2,2,5],f32>
 }
 
 // -----


### PR DESCRIPTION
Summary

Support non-default `scale_grad_by_freq` and `sparse` flags when lowering `aten.embedding` to TOSA.

These flags affect gradient computation but do not change the forward embedding result. The TOSA forward lowering can therefore use the existing `tosa.gather` implementation when either flag is enabled, provided the flag values are compile-time constants.

Testing

- Added a Torch-to-TOSA lit test covering `scale_grad_by_freq=True` and `sparse=True`.
- Added `EmbeddingForwardFlagsModule_basic` to exercise both forward flag combinations end to end.
- Enabled and passed the test for the TOSA configuration.
- Recorded the existing StableHLO limitation as an expected failure.
- Passed pre-commit checks.