### PR TITLE
[RefBackend] Canonicalize zero-extent memref strides

### DIFF
--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -77,10 +77,6 @@ LINALG_CRASHING_SET = {
     "GridSamplerBasic2_basic",
     "GridSamplerBasic3_basic",
     "GridSamplerBasic4_basic",
-    # Runtime op verification: stride mismatch in memref.cast
-    "ReduceAllDimEmpty_basic",
-    "TraceUnsignedIntModule_empty",
-    "TraceModule_empty",
     # Crashes due to copy to a smaller destination buffer than the source buffer.
     "SliceCopyStartGreaterThanDimSize_Module_basic",
     # unimplemented: for conversion to byte or char type dstOriginalDtype has to be passed to convertScalarToDtype

--- a/projects/pt1/python/test/refbackend/zero_extent_memref.py
+++ b/projects/pt1/python/test/refbackend/zero_extent_memref.py
@@ -1,0 +1,39 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import numpy as np
+
+from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import (
+    _canonicalize_zero_element_strides,
+)
+
+
+def print_element_strides(shape):
+    array = np.empty(shape, dtype=np.float32)
+    array = np.lib.stride_tricks.as_strided(
+        array, shape=shape, strides=(0,) * len(shape)
+    )
+    canonical = _canonicalize_zero_element_strides(array)
+    strides = tuple(stride // canonical.itemsize for stride in canonical.strides)
+    print(f"{shape}: {strides}")
+
+
+print_element_strides((0,))
+# CHECK: (0,): (1,)
+
+print_element_strides((0, 10, 3))
+# CHECK: (0, 10, 3): (30, 3, 1)
+
+print_element_strides((5, 0, 0))
+# CHECK: (5, 0, 0): (0, 0, 1)
+
+print_element_strides((1, 0, 3))
+# CHECK: (1, 0, 3): (0, 3, 1)
+
+nonempty = np.empty((2, 3), dtype=np.float32)
+print(_canonicalize_zero_element_strides(nonempty) is nonempty)
+# CHECK: True

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -62,6 +62,24 @@ elemental_type_to_ctype = {
 CONSUME_RETURN_FUNC_PREFIX = "refbackend_consume_func_return_"
 
 
+def _canonicalize_zero_element_strides(array):
+    if array.size != 0:
+        return array
+
+    element_strides = [1] * array.ndim
+    for dim in range(array.ndim - 2, -1, -1):
+        element_strides[dim] = element_strides[dim + 1] * array.shape[dim + 1]
+
+    # NumPy reports zero strides for empty arrays converted from PyTorch.
+    # Empty arrays have no addressable elements, so presenting the canonical
+    # contiguous strides at the memref ABI boundary is semantics-preserving.
+    return np.lib.stride_tricks.as_strided(
+        array,
+        shape=array.shape,
+        strides=tuple(stride * array.itemsize for stride in element_strides),
+    )
+
+
 def get_return_funcs(module):
     return_prefix_len = len(CONSUME_RETURN_FUNC_PREFIX)
     return_funcs = []
@@ -123,6 +141,7 @@ class RefBackendInvoker:
             ffi_args = []
             for arg in args:
                 assert_arg_type_is_supported(arg.dtype)
+                arg = _canonicalize_zero_element_strides(arg)
                 ffi_args.append(
                     ctypes.pointer(ctypes.pointer(get_unranked_memref_descriptor(arg)))
                 )


### PR DESCRIPTION
Summary

Canonicalize the strides of zero-element NumPy arrays before constructing memref descriptors in the reference backend.

PyTorch-to-NumPy conversion can produce non-canonical strides for empty tensors. Although these tensors have no addressable elements, the resulting descriptors can fail runtime `memref.cast` verification when compared with statically shaped contiguous memrefs.

For zero-element arrays, this change presents canonical contiguous strides at the memref ABI boundary. Non-empty arrays are returned unchanged.

Scope: This change only corrects zero-element array representation at the RefBackend memref ABI boundary. It does not add support for zero-sized tensors in TOSA or imply that zero-extent TOSA graphs are conformant.

Testing

- Added a focused Python lit test covering representative zero-extent shapes and confirming that non-empty arrays are unchanged.
- Enabled and passed under the Linalg configuration:
  - `ReduceAllDimEmpty_basic`
  - `TraceModule_empty`
  - `TraceUnsignedIntModule_empty`
- Passed related non-empty reduce and trace regression tests.
- Passed all 18 Torch-MLIR Python lit tests.
- Passed pre-commit checks.