### PR TITLE
[TorchToTosa] Legalize FP16 to BF16 casts

### DIFF
--- a/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
@@ -375,6 +375,15 @@ std::optional<Value> tosaCastTensorToType(PatternRewriter &rewriter, Value src,
   if (srcElemTy == destElemTy)
     return src;
 
+  if (srcElemTy.isF16() && destElemTy.isBF16()) {
+    // The TOSA reference model rejects a direct f16-to-bf16 cast. Widen to f32
+    // first, which preserves every f16 value exactly, then narrow to bf16.
+    TensorType f32Type = srcType.clone(rewriter.getF32Type());
+    Value f32 = tosa::CastOp::create(rewriter, op->getLoc(), f32Type, src);
+    return tosa::CastOp::create(rewriter, op->getLoc(),
+                                srcType.clone(destElemTy), f32);
+  }
+
   if (llvm::isa<FloatType>(srcElemTy) && destElemTy.isInteger() &&
       !destElemTy.isInteger(1)) {
     // For float->int conversion, tosa.cast performs round-to-nearest.

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -4234,6 +4234,8 @@ ONNX_TOSA_CRASHING_SET = {
 }
 
 ONNX_TOSA_XFAIL_SET = {
+    # ONNX-TOSA does not legalize the imported f16-to-bf16 dtype conversion.
+    "TensorToBFloat16_basic",
     # ONNX export applies explicit offset to materialized slice storage.
     "AtenAsStridedAfterAliasDetachModule_basic",
     # ONNX export gathers from the materialized empty slice.

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -4,6 +4,8 @@
 # Also available under a BSD-style license. See LICENSE.
 
 import ctypes
+import struct
+
 import numpy as np
 
 from torch_mlir.ir import *
@@ -62,6 +64,31 @@ elemental_type_to_ctype = {
 CONSUME_RETURN_FUNC_PREFIX = "refbackend_consume_func_return_"
 
 
+def _trunc_f32_to_bf16(value):
+    bits = struct.unpack("=I", struct.pack("=f", value))[0]
+    upper = bits >> 16
+    lower = bits & 0xFFFF
+
+    # Preserve NaNs and force the destination quiet-NaN bit.
+    if bits & 0x7F800000 == 0x7F800000 and bits & 0x007FFFFF:
+        return upper | 0x40
+
+    # Round to nearest, ties to even.
+    if lower > 0x8000 or (lower == 0x8000 and upper & 1):
+        upper += 1
+    return upper & 0xFFFF
+
+
+def _trunc_f32_to_bf16_abi(value):
+    bits = _trunc_f32_to_bf16(value)
+    return struct.unpack("=f", struct.pack("=I", bits))[0]
+
+
+def _extend_bf16_to_f32_abi(value):
+    carrier_bits = struct.unpack("=I", struct.pack("=f", value))[0]
+    return struct.unpack("=f", struct.pack("=I", (carrier_bits & 0xFFFF) << 16))[0]
+
+
 def get_return_funcs(module):
     return_prefix_len = len(CONSUME_RETURN_FUNC_PREFIX)
     return_funcs = []
@@ -94,6 +121,19 @@ class RefBackendInvoker:
     def __init__(self, module):
         self.ee = ExecutionEngine(module)
         self.result = None
+
+        self._builtin_callbacks = [
+            ctypes.CFUNCTYPE(ctypes.c_float, ctypes.c_float)(_trunc_f32_to_bf16_abi),
+            ctypes.CFUNCTYPE(ctypes.c_float, ctypes.c_float)(_extend_bf16_to_f32_abi),
+        ]
+        self.ee.raw_register_runtime(
+            "__truncsfbf2",
+            ctypes.cast(self._builtin_callbacks[0], ctypes.c_void_p),
+        )
+        self.ee.raw_register_runtime(
+            "__extendbfsf2",
+            ctypes.cast(self._builtin_callbacks[1], ctypes.c_void_p),
+        )
 
         return_funcs = get_return_funcs(module)
 

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/cast.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/cast.py
@@ -145,3 +145,26 @@ class TensorToBool(torch.nn.Module):
 @register_test_case(module_factory=lambda: TensorToBool())
 def TensorToBool_basic(module, tu: TestUtils):
     module.forward(torch.tensor([[1]], dtype=torch.bool))
+
+
+# ==============================================================================
+
+
+class TensorToBFloat16(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float16, True),
+        ]
+    )
+    def forward(self, x):
+        return x.to(torch.bfloat16).to(torch.float32)
+
+
+@register_test_case(module_factory=lambda: TensorToBFloat16())
+def TensorToBFloat16_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, low=-10, high=10).to(torch.float16))

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -1522,6 +1522,22 @@ func.func @torch.aten.to.dtype$boolToFloat(%arg0: !torch.vtensor<[3,4],i1>) -> !
   return %0 : !torch.vtensor<[3,4],f32>
 }
 
+// -----
+// CHECK-LABEL:   func.func @torch.aten.to.dtype$float16ToBfloat16(
+// CHECK-SAME:                                                        %[[ARG:.*]]: !torch.vtensor<[3,4],f16>) -> !torch.vtensor<[3,4],bf16> {
+// CHECK:           %[[BUILTIN:.*]] = torch_c.to_builtin_tensor %[[ARG]] : !torch.vtensor<[3,4],f16> -> tensor<3x4xf16>
+// CHECK:           %[[F32:.*]] = tosa.cast %[[BUILTIN]] : (tensor<3x4xf16>) -> tensor<3x4xf32>
+// CHECK:           %[[BF16:.*]] = tosa.cast %[[F32]] : (tensor<3x4xf32>) -> tensor<3x4xbf16>
+// CHECK:           %[[RESULT:.*]] = torch_c.from_builtin_tensor %[[BF16]] : tensor<3x4xbf16> -> !torch.vtensor<[3,4],bf16>
+// CHECK:           return %[[RESULT]] : !torch.vtensor<[3,4],bf16>
+func.func @torch.aten.to.dtype$float16ToBfloat16(%arg0: !torch.vtensor<[3,4],f16>) -> !torch.vtensor<[3,4],bf16> {
+  %int15 = torch.constant.int 15
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  %0 = torch.aten.to.dtype %arg0, %int15, %false, %false, %none : !torch.vtensor<[3,4],f16>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[3,4],bf16>
+  return %0 : !torch.vtensor<[3,4],bf16>
+}
+
 
 // -----
 // CHECK-LABEL:   func.func @torch.aten.gather(


### PR DESCRIPTION
Summary

Legalize FP16-to-BF16 casts in the Torch-to-TOSA conversion.

The TOSA reference model rejects a direct cast from FP16 to BF16. This change widens FP16 values to FP32 before narrowing them to BF16. Every FP16 value is represented exactly in FP32, so the intermediate widening does not lose information.

The reference backend now provides the BF16 compiler runtime conversion helpers needed to execute the resulting casts during end-to-end testing.

Testing

- Added a Torch-to-TOSA lit test verifying that FP16-to-BF16 conversion is lowered through FP32.
- Added `TensorToBFloat16_basic` to exercise FP16-to-BF16 conversion end to end.
- Passed the focused TOSA and FX importer tests.
- Passed the native lit test suite.
- Recorded the existing ONNX-to-TOSA legalization limitation as an expected failure.
- Passed pre-commit checks.