### PR TITLE
Remove triu from FX decomposition table

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -8875,34 +8875,23 @@ LogicalResult convertTrilOrTriu(AtenOpT op, Value self, Value diagonalVal,
   maskShape.push_back(h);
   maskShape.push_back(w);
 
-  Value mask =
-      TypeSwitch<Type, Value>(resultType.getElementType())
-          .Case<mlir::FloatType>([&](auto) {
-            return createTrilOrTriuMask<float>(rewriter, op, maskShape, h, w,
-                                               diagonal, isTril);
-          })
-          .template Case<mlir::IntegerType>([&](auto intType) {
-            switch (intType.getWidth()) {
-            case 1:
-              return createTrilOrTriuMask<bool>(rewriter, op, maskShape, h, w,
-                                                diagonal, isTril);
-            case 32:
-              return createTrilOrTriuMask<int32_t>(rewriter, op, maskShape, h,
-                                                   w, diagonal, isTril);
-            case 64:
-              return createTrilOrTriuMask<int64_t>(rewriter, op, maskShape, h,
-                                                   w, diagonal, isTril);
-            }
-            llvm_unreachable("Invalid integer width");
-          });
+  // Use tosa.select(bool_mask, self, zeros) for all element types.
+  // tosa.mul would propagate NaN for float inputs (NaN * 0.0 = NaN, not 0.0).
+  Value boolMask = createTrilOrTriuMask<bool>(rewriter, op, maskShape, h, w,
+                                              diagonal, isTril);
 
-  if (mlir::tosa::EqualizeRanks(rewriter, op->getLoc(), self, mask).failed())
+  if (mlir::tosa::EqualizeRanks(rewriter, op->getLoc(), self, boolMask)
+          .failed())
     return rewriter.notifyMatchFailure(
         op, "Failed to equalize ranks among operands and result");
 
-  auto result = tosa::createMulOpAndCast(rewriter, op, resultType, self, mask,
-                                         /*shift=*/0);
-  rewriter.replaceOp(op, result.getResult());
+  auto zerosAttr = rewriter.getZeroAttr(resultType);
+  Value zeros = tosa::ConstOp::create(rewriter, op->getLoc(), resultType,
+                                      cast<ElementsAttr>(zerosAttr));
+  Value result = tosa::SelectOp::create(rewriter, op->getLoc(), resultType,
+                                        boolMask, self, zeros)
+                     .getResult();
+  rewriter.replaceOp(op, result);
 
   return success();
 }

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -7151,6 +7151,37 @@ def TriuModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class TrilModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([4, 5], torch.float32, True),
+        ]
+    )
+    def forward(self, x):
+        return torch.ops.aten.tril(x, 1)
+
+
+@register_test_case(module_factory=lambda: TrilModule())
+def TrilModule_basic(module, tu: TestUtils):
+    x = torch.tensor(
+        [
+            [0.5876, -0.0794, -1.8373, 0.6654, 0.2],
+            [-0.2447, 0.9556, -1.2919, 1.3378, 0.3],
+            [0.4333, 0.3146, 0.6576, -1.0432, 0.4],
+            [-0.9888, torch.nan, torch.inf, -torch.inf, 0.5],
+        ]
+    )
+    module.forward(x)
+
+
+# ==============================================================================
+
+
 class TriuBroadcastModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/python/torch_mlir/extras/fx_decomp_util.py
+++ b/python/torch_mlir/extras/fx_decomp_util.py
@@ -43,7 +43,6 @@ DEFAULT_DECOMPOSITIONS = [
     torch.ops.aten.lift_fresh_copy.default,
     torch.ops.aten._unsafe_index.Tensor,
     torch.ops.aten.linspace.default,
-    torch.ops.aten.triu.default,
     torch.ops.aten.nan_to_num.default,
     torch.ops.aten.unbind,
     torch.ops.aten.diag,

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -2190,9 +2190,9 @@ func.func @torch.aten.__interpolate$dynamic_input(%arg0: !torch.vtensor<[1,16,?,
 // CHECK-SAME:                                     %[[VAL_0:.*]]: !torch.vtensor<[2,4],si32>) -> !torch.vtensor<[2,4],si32> {
 // CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[2,4],si32> -> tensor<2x4xi32>
 // CHECK:           %[[VAL_2:.*]] = torch.constant.int 1
-// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{values = dense<{{\[\[}}1, 1, 0, 0], [1, 1, 1, 0]]> : tensor<2x4xi32>}> : () -> tensor<2x4xi32>
-// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
-// CHECK:           %[[VAL_5:.*]] = tosa.mul %[[VAL_1]], %[[VAL_3]], %[[VAL_4]] : (tensor<2x4xi32>, tensor<2x4xi32>, tensor<1xi8>) -> tensor<2x4xi32>
+// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{values = dense<{{\[\[}}true, true, false, false], [true, true, true, false]]> : tensor<2x4xi1>}> : () -> tensor<2x4xi1>
+// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{values = dense<0> : tensor<2x4xi32>}> : () -> tensor<2x4xi32>
+// CHECK:           %[[VAL_5:.*]] = tosa.select %[[VAL_3]], %[[VAL_1]], %[[VAL_4]] : (tensor<2x4xi1>, tensor<2x4xi32>, tensor<2x4xi32>) -> tensor<2x4xi32>
 // CHECK:           %[[VAL_6:.*]] = torch_c.from_builtin_tensor %[[VAL_5]] : tensor<2x4xi32> -> !torch.vtensor<[2,4],si32>
 // CHECK:           return %[[VAL_6]] : !torch.vtensor<[2,4],si32>
 // CHECK:         }
@@ -2208,9 +2208,9 @@ func.func @torch.aten.tril$basic(%arg0: !torch.vtensor<[2,4], si32>) -> !torch.v
 // CHECK-SAME:                                     %[[VAL_0:.*]]: !torch.vtensor<[2,4],si32>) -> !torch.vtensor<[2,4],si32> {
 // CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[2,4],si32> -> tensor<2x4xi32>
 // CHECK:           %[[VAL_2:.*]] = torch.constant.int 1
-// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{values = dense<{{\[\[}}0, 1, 1, 1], [0, 0, 1, 1]]> : tensor<2x4xi32>}> : () -> tensor<2x4xi32>
-// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
-// CHECK:           %[[VAL_5:.*]] = tosa.mul %[[VAL_1]], %[[VAL_3]], %[[VAL_4]] : (tensor<2x4xi32>, tensor<2x4xi32>, tensor<1xi8>) -> tensor<2x4xi32>
+// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{values = dense<{{\[\[}}false, true, true, true], [false, false, true, true]]> : tensor<2x4xi1>}> : () -> tensor<2x4xi1>
+// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{values = dense<0> : tensor<2x4xi32>}> : () -> tensor<2x4xi32>
+// CHECK:           %[[VAL_5:.*]] = tosa.select %[[VAL_3]], %[[VAL_1]], %[[VAL_4]] : (tensor<2x4xi1>, tensor<2x4xi32>, tensor<2x4xi32>) -> tensor<2x4xi32>
 // CHECK:           %[[VAL_6:.*]] = torch_c.from_builtin_tensor %[[VAL_5]] : tensor<2x4xi32> -> !torch.vtensor<[2,4],si32>
 // CHECK:           return %[[VAL_6]] : !torch.vtensor<[2,4],si32>
 // CHECK:         }
@@ -2218,6 +2218,26 @@ func.func @torch.aten.triu$basic(%arg0: !torch.vtensor<[2,4], si32>) -> !torch.v
   %int1 = torch.constant.int 1
   %0 = torch.aten.triu %arg0, %int1 : !torch.vtensor<[2,4],si32>, !torch.int -> !torch.vtensor<[2,4],si32>
   return %0 : !torch.vtensor<[2,4],si32>
+}
+
+// -----
+
+// Verify float triu uses tosa.select (not tosa.mul) so NaN inputs are masked to
+// 0.0 rather than propagated.
+// CHECK-LABEL:   func.func @torch.aten.triu$float(
+// CHECK-SAME:                                      %[[VAL_0:.*]]: !torch.vtensor<[2,4],f32>) -> !torch.vtensor<[2,4],f32> {
+// CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[2,4],f32> -> tensor<2x4xf32>
+// CHECK:           %[[VAL_2:.*]] = torch.constant.int 0
+// CHECK:           %[[VAL_3:.*]] = "tosa.const"() <{values = dense<{{\[\[}}true, true, true, true], [false, true, true, true]]> : tensor<2x4xi1>}> : () -> tensor<2x4xi1>
+// CHECK:           %[[VAL_4:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<2x4xf32>}> : () -> tensor<2x4xf32>
+// CHECK:           %[[VAL_5:.*]] = tosa.select %[[VAL_3]], %[[VAL_1]], %[[VAL_4]] : (tensor<2x4xi1>, tensor<2x4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32>
+// CHECK:           %[[VAL_6:.*]] = torch_c.from_builtin_tensor %[[VAL_5]] : tensor<2x4xf32> -> !torch.vtensor<[2,4],f32>
+// CHECK:           return %[[VAL_6]] : !torch.vtensor<[2,4],f32>
+// CHECK:         }
+func.func @torch.aten.triu$float(%arg0: !torch.vtensor<[2,4], f32>) -> !torch.vtensor<[2,4], f32> {
+  %int0 = torch.constant.int 0
+  %0 = torch.aten.triu %arg0, %int0 : !torch.vtensor<[2,4],f32>, !torch.int -> !torch.vtensor<[2,4],f32>
+  return %0 : !torch.vtensor<[2,4],f32>
 }
 
 // -----


### PR DESCRIPTION
`aten.triu` was listed in DEFAULT_DECOMPOSITIONS, causing PyTorch's FX pass to expand it into `arange+unsqueeze+sub+ge+where` before torch-mlir saw it. Fixes https://github.com/llvm/torch-mlir/issues/4604

That exposed a bug in the tosa legalization -- it used `tosa.mul` with a `0.0/1.0` float mask, which propagates `NaN (NaN * 0.0 = NaN)`. Replace with `tosa.select(bool_mask, input, zeros)` for all element types.

Note: Ideally this fix would also be accompanied by a test at the `fx.export_and_import` level that asserts the imported Torch dialect IR preserves `aten.triu`. However, adding a test that inspects the intermediate Torch dialect IR for a specific op feels too narrow in scope and is best left for consumers that want a specific lowering of this op.

Assisted by: Claude