### PR TITLE
[cmake] Install the torch-mlir-dialects headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ endif()
 add_subdirectory(test)
 
 if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-  install(DIRECTORY include/torch-mlir include/torch-mlir-c
+  install(DIRECTORY include/torch-mlir include/torch-mlir-c include/torch-mlir-dialects
           DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
           COMPONENT torch-mlir-headers
           FILES_MATCHING
@@ -226,7 +226,7 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
           PATTERN "LICENSE.TXT"
           )
 
-  install(DIRECTORY ${TORCH_MLIR_BINARY_DIR}/include/torch-mlir
+  install(DIRECTORY ${TORCH_MLIR_BINARY_DIR}/include/torch-mlir ${TORCH_MLIR_BINARY_DIR}/include/torch-mlir-dialects
           DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
           COMPONENT torch-mlir-headers
           FILES_MATCHING


### PR DESCRIPTION
I work on a downstream project that builds against torch-mlir's install tree, and would like to upstream a few small local fixes in case they're useful to others.

The header install covers `include/torch-mlir` and `include/torch-mlir-c` but not `include/torch-mlir-dialects` (the TMTensor headers), so a consumer that links `TorchMLIRTMTensorDialect` and includes those headers can't build against the install tree. This adds it to the existing install rules.
