### PR TITLE
[TorchToTosa] Legalize i8 tosa.equal operands

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -52,6 +52,40 @@ namespace mlir::torch {
 
 namespace {
 
+static bool isRankedI8Tensor(Type type) {
+  auto tensorTy = dyn_cast<RankedTensorType>(type);
+  return tensorTy && tensorTy.getElementType().isInteger(8);
+}
+
+static void legalizeI8EqualOpsForReferenceModel(func::FuncOp func) {
+  SmallVector<tosa::EqualOp> equalOps;
+  func.walk([&](tosa::EqualOp equalOp) {
+    if (isRankedI8Tensor(equalOp.getInput1().getType()) &&
+        isRankedI8Tensor(equalOp.getInput2().getType()))
+      equalOps.push_back(equalOp);
+  });
+
+  for (tosa::EqualOp equalOp : equalOps) {
+    OpBuilder builder(equalOp);
+    Location loc = equalOp.getLoc();
+    auto lhsTy = cast<RankedTensorType>(equalOp.getInput1().getType());
+    auto rhsTy = cast<RankedTensorType>(equalOp.getInput2().getType());
+    Type i32Ty = builder.getIntegerType(32);
+    Value lhs = tosa::CastOp::create(
+        builder, loc, RankedTensorType::get(lhsTy.getShape(), i32Ty),
+        equalOp.getInput1());
+    Value rhs = tosa::CastOp::create(
+        builder, loc, RankedTensorType::get(rhsTy.getShape(), i32Ty),
+        equalOp.getInput2());
+    Value replacement =
+        tosa::EqualOp::create(builder, loc, equalOp.getResult().getType(), lhs,
+                              rhs)
+            .getResult();
+    equalOp.getResult().replaceAllUsesWith(replacement);
+    equalOp.erase();
+  }
+}
+
 // Runs an in-place inclusive prefix sum along the middle dimension (K) of
 // `running` using a binary lifting scheme. The input must have shape [N, K, C].
 // After the loop, `running` holds the cumsum result with respect to axis=1.
@@ -1350,6 +1384,24 @@ public:
         } else {
           lhs = tosa::tosaCastTensorToType(rewriter, lhs, rhsTensorTy).value();
         }
+      }
+    }
+
+    if constexpr (std::is_same<TosaOpT, tosa::EqualOp>()) {
+      auto lhsRankedTy = dyn_cast<RankedTensorType>(lhs.getType());
+      auto rhsRankedTy = dyn_cast<RankedTensorType>(rhsTensor.getType());
+      if (lhsRankedTy && rhsRankedTy &&
+          lhsRankedTy.getElementType().isInteger(8) &&
+          rhsRankedTy.getElementType().isInteger(8)) {
+        auto i32Ty = rewriter.getIntegerType(32);
+        lhs = tosa::tosaCastTensorToType(
+                  rewriter, lhs,
+                  RankedTensorType::get(lhsRankedTy.getShape(), i32Ty))
+                  .value();
+        rhsTensor = tosa::tosaCastTensorToType(
+                        rewriter, rhsTensor,
+                        RankedTensorType::get(rhsRankedTy.getShape(), i32Ty))
+                        .value();
       }
     }
 
@@ -11428,6 +11480,8 @@ public:
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(frozenPatterns))))
       return signalPassFailure();
+
+    legalizeI8EqualOpsForReferenceModel(getOperation());
   }
 };
 } // namespace

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -781,6 +781,39 @@ func.func @torch.aten.eq.Tensor$basic(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !
 
 // -----
 
+// CHECK-LABEL:   func.func @torch.aten.eq.Tensor$int8(
+// CHECK-SAME:                                      %[[VAL_0:.*]]: !torch.vtensor<[8,1],si8>,
+// CHECK-SAME:                                      %[[VAL_1:.*]]: !torch.vtensor<[8,1],si8>) -> !torch.vtensor<[8,1],i1> {
+// CHECK-DAG:       %[[VAL_2:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[8,1],si8> -> tensor<8x1xi8>
+// CHECK-DAG:       %[[VAL_3:.*]] = torch_c.to_builtin_tensor %[[VAL_1]] : !torch.vtensor<[8,1],si8> -> tensor<8x1xi8>
+// CHECK-DAG:       %[[VAL_4:.*]] = tosa.cast %[[VAL_2]] : (tensor<8x1xi8>) -> tensor<8x1xi32>
+// CHECK-DAG:       %[[VAL_5:.*]] = tosa.cast %[[VAL_3]] : (tensor<8x1xi8>) -> tensor<8x1xi32>
+// CHECK:           %[[VAL_6:.*]] = tosa.equal %[[VAL_4]], %[[VAL_5]] : (tensor<8x1xi32>, tensor<8x1xi32>) -> tensor<8x1xi1>
+// CHECK:           %[[VAL_7:.*]] = torch_c.from_builtin_tensor %[[VAL_6]] : tensor<8x1xi1> -> !torch.vtensor<[8,1],i1>
+// CHECK:           return %[[VAL_7]] : !torch.vtensor<[8,1],i1>
+// CHECK:         }
+func.func @torch.aten.eq.Tensor$int8(%arg0: !torch.vtensor<[8,1],si8>, %arg1: !torch.vtensor<[8,1],si8>) -> !torch.vtensor<[8,1],i1> {
+  %0 = torch.aten.eq.Tensor %arg0, %arg1 : !torch.vtensor<[8,1],si8>, !torch.vtensor<[8,1],si8> -> !torch.vtensor<[8,1],i1>
+  return %0 : !torch.vtensor<[8,1],i1>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @tosa.equal$int8_generated(
+// CHECK-SAME:                                         %[[VAL_0:.*]]: tensor<8x1xi8>,
+// CHECK-SAME:                                         %[[VAL_1:.*]]: tensor<8x1xi8>) -> tensor<8x1xi1> {
+// CHECK-DAG:       %[[VAL_2:.*]] = tosa.cast %[[VAL_0]] : (tensor<8x1xi8>) -> tensor<8x1xi32>
+// CHECK-DAG:       %[[VAL_3:.*]] = tosa.cast %[[VAL_1]] : (tensor<8x1xi8>) -> tensor<8x1xi32>
+// CHECK:           %[[VAL_4:.*]] = tosa.equal %[[VAL_2]], %[[VAL_3]] : (tensor<8x1xi32>, tensor<8x1xi32>) -> tensor<8x1xi1>
+// CHECK:           return %[[VAL_4]] : tensor<8x1xi1>
+// CHECK:         }
+func.func @tosa.equal$int8_generated(%arg0: tensor<8x1xi8>, %arg1: tensor<8x1xi8>) -> tensor<8x1xi1> {
+  %0 = tosa.equal %arg0, %arg1 : (tensor<8x1xi8>, tensor<8x1xi8>) -> tensor<8x1xi1>
+  return %0 : tensor<8x1xi1>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.reshape$basic(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: !torch.vtensor<[?,?,?,?],f32>) -> !torch.vtensor<[?],f32> {
 // CHECK:           %[[VAL_1:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[?,?,?,?],f32> -> tensor<?x?x?x?xf32>


### PR DESCRIPTION
## Summary

Legalize i8 equality in TorchToTosa by casting i8 operands to i32 before `tosa.equal`.

Adds FileCheck coverage for both Torch-originated `aten.eq.Tensor` lowering and already-generated `tosa.equal` ops with i8 operands.
