### PR TITLE
[TOSA] Avoid materializing splat constants

### DIFF
--- a/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TosaLegalizeUtils.h
@@ -66,6 +66,13 @@ std::optional<Value> getConstTensor(PatternRewriter &rewriter, Operation *op,
                                     ArrayRef<T> vec, ArrayRef<int64_t> shape,
                                     std::optional<Type> dtype = {});
 
+// Create a splat constant without materializing one host value per tensor
+// element.
+template <typename T>
+std::optional<Value>
+getSplatConstTensor(PatternRewriter &rewriter, Operation *op, T value,
+                    ArrayRef<int64_t> shape, std::optional<Type> dtype = {});
+
 // Default function to create tosa.cast op. This should be called instead of
 // directly calling rewriter.create<tosa::CastOp>.
 std::optional<Value> tosaCastTensorToType(PatternRewriter &rewriter, Value src,

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -1018,16 +1018,10 @@ LogicalResult torchScalarToTosaTensor(ConversionPatternRewriter &rewriter,
     return rewriter.notifyMatchFailure(op,
                                        "Unable to extract the scalar constant");
 
-  int64_t numElem = 1;
-  for (int64_t dim : dshape)
-    numElem *= dim;
-
   if (isa<mlir::FloatType>(dtype)) {
     tosaTensor =
-        tosa::getConstTensor<float>(
-            rewriter, op,
-            SmallVector<float>(numElem, (isFloat ? doubleValue : intValue)),
-            dshape, dtype)
+        tosa::getSplatConstTensor<float>(
+            rewriter, op, (isFloat ? doubleValue : intValue), dshape, dtype)
             .value();
   } else if (auto intType = dyn_cast<mlir::IntegerType>(dtype)) {
     auto width = intType.getWidth();
@@ -1044,9 +1038,8 @@ LogicalResult torchScalarToTosaTensor(ConversionPatternRewriter &rewriter,
       }
       bool d = isFloat ? static_cast<bool>(doubleValue)
                        : static_cast<bool>(intValue);
-      tosaTensor = tosa::getConstTensor<bool>(
-                       rewriter, op, SmallVector<bool>(numElem, d), dshape)
-                       .value();
+      tosaTensor =
+          tosa::getSplatConstTensor<bool>(rewriter, op, d, dshape).value();
     } else if (width == 8) {
       if (!isInValidRange<int8_t>(isFloat, doubleValue, isInt, intValue)) {
         return rewriter.notifyMatchFailure(
@@ -1055,9 +1048,8 @@ LogicalResult torchScalarToTosaTensor(ConversionPatternRewriter &rewriter,
       }
       int8_t d = isFloat ? static_cast<int8_t>(doubleValue)
                          : static_cast<int8_t>(intValue);
-      tosaTensor = tosa::getConstTensor<int8_t>(
-                       rewriter, op, SmallVector<int8_t>(numElem, d), dshape)
-                       .value();
+      tosaTensor =
+          tosa::getSplatConstTensor<int8_t>(rewriter, op, d, dshape).value();
     } else if (width == 32) {
       if (!isInValidRange<int32_t>(isFloat, doubleValue, isInt, intValue)) {
         return rewriter.notifyMatchFailure(
@@ -1066,9 +1058,8 @@ LogicalResult torchScalarToTosaTensor(ConversionPatternRewriter &rewriter,
       }
       int32_t d = isFloat ? static_cast<int32_t>(doubleValue)
                           : static_cast<int32_t>(intValue);
-      tosaTensor = tosa::getConstTensor<int32_t>(
-                       rewriter, op, SmallVector<int32_t>(numElem, d), dshape)
-                       .value();
+      tosaTensor =
+          tosa::getSplatConstTensor<int32_t>(rewriter, op, d, dshape).value();
     } else if (width == 64) {
       if (!isInValidRange<int64_t>(isFloat, doubleValue, isInt, intValue)) {
         return rewriter.notifyMatchFailure(
@@ -1076,9 +1067,8 @@ LogicalResult torchScalarToTosaTensor(ConversionPatternRewriter &rewriter,
                 "of destination type");
       }
       int64_t d = (isFloat ? static_cast<int64_t>(doubleValue) : intValue);
-      tosaTensor = tosa::getConstTensor<int64_t>(
-                       rewriter, op, SmallVector<int64_t>(numElem, d), dshape)
-                       .value();
+      tosaTensor =
+          tosa::getSplatConstTensor<int64_t>(rewriter, op, d, dshape).value();
     }
   } else {
     return rewriter.notifyMatchFailure(op, "Usupported element type");
@@ -5006,34 +4996,24 @@ LogicalResult ConvertAtenOp<AtenGeluOp>::matchAndRewriteImpl(
           op, "Only static shape tensor types are currently supported for Tanh "
               "approximation");
 
-    auto numElem = std::accumulate(selfShape.begin(), selfShape.end(), 1,
-                                   std::multiplies<int64_t>());
-
-    Value half = tosa::getConstTensor<float>(rewriter, op,
-                                             SmallVector<float>(numElem, 0.5f),
-                                             selfShape, selfElemTy)
+    Value half = tosa::getSplatConstTensor<float>(rewriter, op, 0.5f, selfShape,
+                                                  selfElemTy)
                      .value();
-    Value one = tosa::getConstTensor<float>(rewriter, op,
-                                            SmallVector<float>(numElem, 1.0f),
-                                            selfShape, selfElemTy)
+    Value one = tosa::getSplatConstTensor<float>(rewriter, op, 1.0f, selfShape,
+                                                 selfElemTy)
                     .value();
-    Value three = tosa::getConstTensor<float>(rewriter, op,
-                                              SmallVector<float>(numElem, 3.0f),
-                                              selfShape, selfElemTy)
+    Value three = tosa::getSplatConstTensor<float>(rewriter, op, 3.0f,
+                                                   selfShape, selfElemTy)
                       .value();
 
     // 0.044715
-    Value magicNumber =
-        tosa::getConstTensor<float>(rewriter, op,
-                                    SmallVector<float>(numElem, 0.044715f),
-                                    selfShape, selfElemTy)
-            .value();
+    Value magicNumber = tosa::getSplatConstTensor<float>(
+                            rewriter, op, 0.044715f, selfShape, selfElemTy)
+                            .value();
 
     Value twoOverPi =
-        tosa::getConstTensor<float>(
-            rewriter, op,
-            SmallVector<float>(numElem,
-                               static_cast<float>(2.0 / llvm::numbers::pi)),
+        tosa::getSplatConstTensor<float>(
+            rewriter, op, static_cast<float>(2.0 / llvm::numbers::pi),
             selfShape, selfElemTy)
             .value();
 
@@ -8376,9 +8356,9 @@ public:
           op, "Shape must not have a dimension of size zero");
     }
 
-    SmallVector<int32_t> values(size, fillVal);
     auto constOp =
-        tosa::getConstTensor<int32_t>(rewriter, op, values, shape).value();
+        tosa::getSplatConstTensor<int32_t>(rewriter, op, fillVal, shape)
+            .value();
 
     auto result =
         tosa::tosaCastTensorToType(rewriter, constOp, outType).value();
@@ -9265,40 +9245,29 @@ LogicalResult ConvertAtenOp<AtenDiagEmbedOp>::matchAndRewriteImpl(
   zeroShape.push_back(diagSize + offset);
   zeroShape.push_back(diagSize + offset);
 
-  int64_t numElemOfZeroTensor = 1;
-  for (int64_t &d : zeroShape)
-    numElemOfZeroTensor *= d;
-
-  Value zero =
-      TypeSwitch<Type, Value>(selfElemTy)
-          .Case<mlir::FloatType>([&](auto) {
-            return tosa::getConstTensor<float>(
-                       rewriter, op, SmallVector<float>(numElemOfZeroTensor, 0),
-                       zeroShape)
-                .value();
-          })
-          .Case<mlir::IntegerType>([&](auto intType) {
-            switch (intType.getWidth()) {
-            case 1:
-              return tosa::getConstTensor<bool>(
-                         rewriter, op,
-                         SmallVector<bool>(numElemOfZeroTensor, 0), zeroShape)
-                  .value();
-            case 32:
-              return tosa::getConstTensor<int32_t>(
-                         rewriter, op,
-                         SmallVector<int32_t>(numElemOfZeroTensor, 0),
-                         zeroShape)
-                  .value();
-            case 64:
-              return tosa::getConstTensor<int64_t>(
-                         rewriter, op,
-                         SmallVector<int64_t>(numElemOfZeroTensor, 0),
-                         zeroShape)
-                  .value();
-            }
-            llvm_unreachable("Invalid integer width");
-          });
+  Value zero = TypeSwitch<Type, Value>(selfElemTy)
+                   .Case<mlir::FloatType>([&](auto) {
+                     return tosa::getSplatConstTensor<float>(rewriter, op, 0.0f,
+                                                             zeroShape)
+                         .value();
+                   })
+                   .Case<mlir::IntegerType>([&](auto intType) {
+                     switch (intType.getWidth()) {
+                     case 1:
+                       return tosa::getSplatConstTensor<bool>(rewriter, op,
+                                                              false, zeroShape)
+                           .value();
+                     case 32:
+                       return tosa::getSplatConstTensor<int32_t>(rewriter, op,
+                                                                 0, zeroShape)
+                           .value();
+                     case 64:
+                       return tosa::getSplatConstTensor<int64_t>(rewriter, op,
+                                                                 0, zeroShape)
+                           .value();
+                     }
+                     llvm_unreachable("Invalid integer width");
+                   });
 
   // Convert PyTorch index and dim to TensorFlow-style indices
   auto indicesTf = tosa::convertTorchIndexToTfIndices(rewriter, op, zero, index,

--- a/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeUtils.cpp
@@ -260,6 +260,41 @@ std::optional<Value> getConstTensor<float>(PatternRewriter &rewriter,
   return const_op.getResult();
 }
 
+template <typename T>
+std::optional<Value>
+getSplatConstTensor(PatternRewriter &rewriter, Operation *op, T value,
+                    ArrayRef<int64_t> shape, std::optional<Type> dtype) {
+  auto width = sizeof(T) * 8;
+  if constexpr (std::is_same_v<T, bool>)
+    width = 1;
+
+  auto constType = RankedTensorType::get(shape, rewriter.getIntegerType(width));
+  auto constAttr = DenseElementsAttr::get(constType, value);
+  Value constTensor =
+      tosa::ConstOp::create(rewriter, op->getLoc(), constType, constAttr);
+
+  if (dtype)
+    return tosa::tosaCastTensorToType(rewriter, constTensor,
+                                      RankedTensorType::get(shape, *dtype));
+  return constTensor;
+}
+
+template <>
+std::optional<Value> getSplatConstTensor<float>(PatternRewriter &rewriter,
+                                                Operation *op, float value,
+                                                ArrayRef<int64_t> shape,
+                                                std::optional<Type> dtype) {
+  auto constType = RankedTensorType::get(shape, rewriter.getF32Type());
+  auto constAttr = DenseElementsAttr::get(constType, value);
+  Value constTensor =
+      tosa::ConstOp::create(rewriter, op->getLoc(), constType, constAttr);
+
+  if (dtype)
+    return tosa::tosaCastTensorToType(rewriter, constTensor,
+                                      RankedTensorType::get(shape, *dtype));
+  return constTensor;
+}
+
 // Valid TOSA casting pairs according to TOSA spec:
 // https://www.mlplatform.org/tosa/tosa_spec.html#_cast
 // Note: currently TOSA doesn't support casting to and from I64 and F64
@@ -459,6 +494,29 @@ template std::optional<Value>
 getConstTensor<int64_t>(PatternRewriter &, Operation *, ArrayRef<int64_t> vec,
                         ArrayRef<int64_t> shape, std::optional<Type> dtype);
 
+template std::optional<Value>
+getSplatConstTensor<bool>(PatternRewriter &, Operation *, bool value,
+                          ArrayRef<int64_t> shape, std::optional<Type> dtype);
+
+template std::optional<Value>
+getSplatConstTensor<int8_t>(PatternRewriter &, Operation *, int8_t value,
+                            ArrayRef<int64_t> shape, std::optional<Type> dtype);
+
+template std::optional<Value>
+getSplatConstTensor<int16_t>(PatternRewriter &, Operation *, int16_t value,
+                             ArrayRef<int64_t> shape,
+                             std::optional<Type> dtype);
+
+template std::optional<Value>
+getSplatConstTensor<int32_t>(PatternRewriter &, Operation *, int32_t value,
+                             ArrayRef<int64_t> shape,
+                             std::optional<Type> dtype);
+
+template std::optional<Value>
+getSplatConstTensor<int64_t>(PatternRewriter &, Operation *, int64_t value,
+                             ArrayRef<int64_t> shape,
+                             std::optional<Type> dtype);
+
 LogicalResult getAvgPool2dAccType(PatternRewriter &rewriter, Value input,
                                   TypeAttr &accType) {
   auto inputTy = llvm::dyn_cast<ShapedType>(input.getType());
@@ -560,14 +618,10 @@ FailureOr<Value> getConvBiasForNoneType(Operation *op,
 
   int32_t oc = static_cast<int32_t>(numOutputChannels);
 
-  if (biasElemTy.isInteger()) {
-    SmallVector<int32_t> zeroVec(oc, 0);
-    return tosa::getConstTensor<int32_t>(rewriter, op, zeroVec, {oc}).value();
-  } else {
-    SmallVector<float> zeroVec(oc, 0);
-    return tosa::getConstTensor<float>(rewriter, op, zeroVec, {oc}, biasElemTy)
-        .value();
-  }
+  if (biasElemTy.isInteger())
+    return tosa::getSplatConstTensor<int32_t>(rewriter, op, 0, {oc}).value();
+  return tosa::getSplatConstTensor<float>(rewriter, op, 0.0f, {oc}, biasElemTy)
+      .value();
 }
 
 Value emitExplicitZeroPadNHWC(Location loc, PatternRewriter &rewriter,


### PR DESCRIPTION
Repeated-value constants currently build a host vector with one entry per tensor element before DenseElementsAttr recognizes the splat. This makes legalization of large tensors, including tanh GELU constants, unnecessarily slow and memory intensive. Add a splat-specific helper and use it at repeated-constant call sites so only the scalar value is materialized. The emitted TOSA constants remain unchanged.