### PR TITLE
[TorchToLinalg] Fix max/min lowering for bool

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -158,10 +158,9 @@ LogicalResult getPermutedType(BaseTensorType inType,
                               SmallVector<int64_t> permuteDims,
                               Type &permutedType);
 
-// Returns true when an IntegerType (as it appears in the Torch dtype) requires
-// unsigned comparison/arithmetic semantics. This is the case for explicitly
-// unsigned types and for signless i1 (bool): under signed compare, bit 1 is
-// -1, so e.g. maxsi([false, true]) would pick false.
+// Returns true when an IntegerType requires unsigned comparison/arithmetic
+// semantics: explicitly unsigned types, and signless i1 (bool) where unsigned
+// comparison correctly ranks true (1) above false (0).
 bool useUnsignedIntegerSemantics(IntegerType intType);
 
 } // namespace Torch

--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -158,6 +158,12 @@ LogicalResult getPermutedType(BaseTensorType inType,
                               SmallVector<int64_t> permuteDims,
                               Type &permutedType);
 
+// Returns true when an IntegerType (as it appears in the Torch dtype) requires
+// unsigned comparison/arithmetic semantics. This is the case for explicitly
+// unsigned types and for signless i1 (bool): under signed compare, bit 1 is
+// -1, so e.g. maxsi([false, true]) would pick false.
+bool useUnsignedIntegerSemantics(IntegerType intType);
+
 } // namespace Torch
 } // namespace torch
 } // namespace mlir

--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -27,13 +27,6 @@ using namespace mlir::torch;
 using namespace mlir::torch::Torch;
 
 namespace {
-// i1 is signless but must use unsigned semantics for max/min reductions:
-// under signed compare, `true` (bit 1) is -1, so e.g. maxsi([false,true])
-// picks false.
-bool useUnsignedForMinMax(IntegerType intType) {
-  return intType.isUnsigned() || intType.getWidth() == 1;
-}
-
 // Aten max.dim (min.dim) lowering represents the MaxDimOp (MinDimOp) as an
 // linalg.indexed_generic op, producing two output buffers.
 //
@@ -139,7 +132,7 @@ public:
     } else {
       auto width = cast<mlir::IntegerType>(inElementType).getWidth();
       APInt init;
-      if (useUnsignedForMinMax(torchIntTy)) {
+      if (useUnsignedIntegerSemantics(torchIntTy)) {
         init = isMax ? APInt::getMinValue(width) : APInt::getMaxValue(width);
       } else {
         init = isMax ? APSInt::getSignedMinValue(width)
@@ -204,7 +197,7 @@ public:
                                               newValue, oldValue);
           } else {
             arith::CmpIPredicate predType;
-            bool useUnsigned = useUnsignedForMinMax(torchIntTy);
+            bool useUnsigned = useUnsignedIntegerSemantics(torchIntTy);
             if (isMax) {
               predType = useUnsigned ? arith::CmpIPredicate::ugt
                                      : arith::CmpIPredicate::sgt;
@@ -400,7 +393,7 @@ static Value createLinalgPayloadForReduceOp(OpBuilder &b, Location loc,
     else if (isa<mlir::IntegerType>(resultElementType)) {
       IntegerType intType = dyn_cast<mlir::IntegerType>(
           cast<BaseTensorType>(max.getSelf().getType()).getDtype());
-      if (useUnsignedForMinMax(intType))
+      if (useUnsignedIntegerSemantics(intType))
         return arith::MaxUIOp::create(b, loc, self, result);
       return arith::MaxSIOp::create(b, loc, self, result);
     }
@@ -413,7 +406,7 @@ static Value createLinalgPayloadForReduceOp(OpBuilder &b, Location loc,
     else if (isa<mlir::IntegerType>(resultElementType)) {
       IntegerType intType = dyn_cast<mlir::IntegerType>(
           cast<BaseTensorType>(min.getSelf().getType()).getDtype());
-      if (useUnsignedForMinMax(intType))
+      if (useUnsignedIntegerSemantics(intType))
         return arith::MinUIOp::create(b, loc, self, result);
       return arith::MinSIOp::create(b, loc, self, result);
     }

--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -92,12 +92,12 @@ public:
       return rewriter.notifyMatchFailure(op, "dim is not a valid dim");
 
     Type inElementType = inputType.getElementType();
-    // Torch-dtype IntegerType (carries signedness); null for float inputs.
-    IntegerType torchIntTy;
+    bool useUnsigned = false;
     if (!isa<mlir::FloatType>(inElementType)) {
       if (isa<mlir::IntegerType>(inElementType)) {
-        torchIntTy = dyn_cast<mlir::IntegerType>(
+        auto torchIntTy = dyn_cast<mlir::IntegerType>(
             cast<BaseTensorType>(op.getSelf().getType()).getDtype());
+        useUnsigned = useUnsignedIntegerSemantics(torchIntTy);
       } else {
         return rewriter.notifyMatchFailure(
             op, opName + " to linalg.* requires Float or Integer "
@@ -132,7 +132,7 @@ public:
     } else {
       auto width = cast<mlir::IntegerType>(inElementType).getWidth();
       APInt init;
-      if (useUnsignedIntegerSemantics(torchIntTy)) {
+      if (useUnsigned) {
         init = isMax ? APInt::getMinValue(width) : APInt::getMaxValue(width);
       } else {
         init = isMax ? APSInt::getSignedMinValue(width)
@@ -197,7 +197,6 @@ public:
                                               newValue, oldValue);
           } else {
             arith::CmpIPredicate predType;
-            bool useUnsigned = useUnsignedIntegerSemantics(torchIntTy);
             if (isMax) {
               predType = useUnsigned ? arith::CmpIPredicate::ugt
                                      : arith::CmpIPredicate::sgt;
@@ -321,9 +320,10 @@ static Value createInitElementForReduceOp(OpBuilder &b, Location loc,
     else if (isa<mlir::IntegerType>(elementType) &&
              elementType.getIntOrFloatBitWidth() != 8) {
       unsigned width = elementType.getIntOrFloatBitWidth();
-      // i1 (bool): initial value for max is false (0); use unsigned min.
-      auto init = (width == 1) ? APInt::getMinValue(width)
-                               : APSInt::getSignedMinValue(width);
+      auto init =
+          useUnsignedIntegerSemantics(cast<mlir::IntegerType>(elementType))
+              ? APInt::getMinValue(width)
+              : APSInt::getSignedMinValue(width);
       return arith::ConstantOp::create(b, loc,
                                        b.getIntegerAttr(elementType, init));
     }
@@ -339,9 +339,10 @@ static Value createInitElementForReduceOp(OpBuilder &b, Location loc,
     else if (isa<mlir::IntegerType>(elementType) &&
              elementType.getIntOrFloatBitWidth() != 8) {
       unsigned width = elementType.getIntOrFloatBitWidth();
-      // i1 (bool): initial value for min is true (1); use unsigned max.
-      auto init = (width == 1) ? APInt::getMaxValue(width)
-                               : APSInt::getSignedMaxValue(width);
+      auto init =
+          useUnsignedIntegerSemantics(cast<mlir::IntegerType>(elementType))
+              ? APInt::getMaxValue(width)
+              : APSInt::getSignedMaxValue(width);
       return arith::ConstantOp::create(b, loc,
                                        b.getIntegerAttr(elementType, init));
     }

--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -27,6 +27,13 @@ using namespace mlir::torch;
 using namespace mlir::torch::Torch;
 
 namespace {
+// i1 is signless but must use unsigned semantics for max/min reductions:
+// under signed compare, `true` (bit 1) is -1, so e.g. maxsi([false,true])
+// picks false.
+bool useUnsignedForMinMax(IntegerType intType) {
+  return intType.isUnsigned() || intType.getWidth() == 1;
+}
+
 // Aten max.dim (min.dim) lowering represents the MaxDimOp (MinDimOp) as an
 // linalg.indexed_generic op, producing two output buffers.
 //
@@ -92,12 +99,12 @@ public:
       return rewriter.notifyMatchFailure(op, "dim is not a valid dim");
 
     Type inElementType = inputType.getElementType();
-    bool isUnsigned = false;
+    // Torch-dtype IntegerType (carries signedness); null for float inputs.
+    IntegerType torchIntTy;
     if (!isa<mlir::FloatType>(inElementType)) {
       if (isa<mlir::IntegerType>(inElementType)) {
-        auto integerTy = dyn_cast<mlir::IntegerType>(
+        torchIntTy = dyn_cast<mlir::IntegerType>(
             cast<BaseTensorType>(op.getSelf().getType()).getDtype());
-        isUnsigned = integerTy.isUnsigned();
       } else {
         return rewriter.notifyMatchFailure(
             op, opName + " to linalg.* requires Float or Integer "
@@ -129,15 +136,15 @@ public:
               inElementType,
               getFloatInf(cast<mlir::FloatType>(inElementType),
                           /*Negative=*/isMax, this->allowNonFinites)));
-    } else if (!isUnsigned) {
+    } else {
       auto width = cast<mlir::IntegerType>(inElementType).getWidth();
-      auto init = isMax ? APSInt::getSignedMinValue(width)
-                        : APSInt::getSignedMaxValue(width);
-      fillValue = arith::ConstantOp::create(
-          rewriter, loc, rewriter.getIntegerAttr(inElementType, init));
-    } else if (isUnsigned) {
-      auto width = cast<mlir::IntegerType>(inElementType).getWidth();
-      auto init = isMax ? APInt::getMinValue(width) : APInt::getMaxValue(width);
+      APInt init;
+      if (useUnsignedForMinMax(torchIntTy)) {
+        init = isMax ? APInt::getMinValue(width) : APInt::getMaxValue(width);
+      } else {
+        init = isMax ? APSInt::getSignedMinValue(width)
+                     : APSInt::getSignedMaxValue(width);
+      }
       fillValue = arith::ConstantOp::create(
           rewriter, loc, rewriter.getIntegerAttr(inElementType, init));
     }
@@ -197,10 +204,11 @@ public:
                                               newValue, oldValue);
           } else {
             arith::CmpIPredicate predType;
+            bool useUnsigned = useUnsignedForMinMax(torchIntTy);
             if (isMax) {
-              predType = isUnsigned ? arith::CmpIPredicate::ugt
-                                    : arith::CmpIPredicate::sgt;
-              if (isUnsigned) {
+              predType = useUnsigned ? arith::CmpIPredicate::ugt
+                                     : arith::CmpIPredicate::sgt;
+              if (useUnsigned) {
                 resultVal = arith::MaxUIOp::create(rewriter, nestedLoc,
                                                    newValue, oldValue);
               } else {
@@ -208,9 +216,9 @@ public:
                                                    newValue, oldValue);
               }
             } else {
-              predType = isUnsigned ? arith::CmpIPredicate::ult
-                                    : arith::CmpIPredicate::slt;
-              if (isUnsigned) {
+              predType = useUnsigned ? arith::CmpIPredicate::ult
+                                     : arith::CmpIPredicate::slt;
+              if (useUnsigned) {
                 resultVal = arith::MinUIOp::create(rewriter, nestedLoc,
                                                    newValue, oldValue);
               } else {
@@ -318,12 +326,14 @@ static Value createInitElementForReduceOp(OpBuilder &b, Location loc,
                          getFloatInf(cast<mlir::FloatType>(elementType),
                                      /*Negative=*/true, allowNonFinites)));
     else if (isa<mlir::IntegerType>(elementType) &&
-             elementType.getIntOrFloatBitWidth() != 8)
-      return arith::ConstantOp::create(
-          b, loc,
-          b.getIntegerAttr(
-              elementType,
-              APSInt::getSignedMinValue(elementType.getIntOrFloatBitWidth())));
+             elementType.getIntOrFloatBitWidth() != 8) {
+      unsigned width = elementType.getIntOrFloatBitWidth();
+      // i1 (bool): initial value for max is false (0); use unsigned min.
+      auto init = (width == 1) ? APInt::getMinValue(width)
+                               : APSInt::getSignedMinValue(width);
+      return arith::ConstantOp::create(b, loc,
+                                       b.getIntegerAttr(elementType, init));
+    }
   }
 
   if (isa<AtenMinOp>(op)) {
@@ -334,12 +344,14 @@ static Value createInitElementForReduceOp(OpBuilder &b, Location loc,
                          getFloatInf(cast<mlir::FloatType>(elementType),
                                      /*Negative=*/false, allowNonFinites)));
     else if (isa<mlir::IntegerType>(elementType) &&
-             elementType.getIntOrFloatBitWidth() != 8)
-      return arith::ConstantOp::create(
-          b, loc,
-          b.getIntegerAttr(
-              elementType,
-              APSInt::getSignedMaxValue(elementType.getIntOrFloatBitWidth())));
+             elementType.getIntOrFloatBitWidth() != 8) {
+      unsigned width = elementType.getIntOrFloatBitWidth();
+      // i1 (bool): initial value for min is true (1); use unsigned max.
+      auto init = (width == 1) ? APInt::getMaxValue(width)
+                               : APSInt::getSignedMaxValue(width);
+      return arith::ConstantOp::create(b, loc,
+                                       b.getIntegerAttr(elementType, init));
+    }
   }
 
   if (isa<AtenLinalgVectorNormOp>(op) || isa<AtenFrobeniusNormDimOp>(op) ||
@@ -388,10 +400,9 @@ static Value createLinalgPayloadForReduceOp(OpBuilder &b, Location loc,
     else if (isa<mlir::IntegerType>(resultElementType)) {
       IntegerType intType = dyn_cast<mlir::IntegerType>(
           cast<BaseTensorType>(max.getSelf().getType()).getDtype());
-      if (intType.isUnsigned())
+      if (useUnsignedForMinMax(intType))
         return arith::MaxUIOp::create(b, loc, self, result);
-      if (intType.isSigned())
-        return arith::MaxSIOp::create(b, loc, self, result);
+      return arith::MaxSIOp::create(b, loc, self, result);
     }
   } else if (auto min = dyn_cast<AtenMinOp>(op)) {
     Value self =
@@ -402,10 +413,9 @@ static Value createLinalgPayloadForReduceOp(OpBuilder &b, Location loc,
     else if (isa<mlir::IntegerType>(resultElementType)) {
       IntegerType intType = dyn_cast<mlir::IntegerType>(
           cast<BaseTensorType>(min.getSelf().getType()).getDtype());
-      if (intType.isUnsigned())
+      if (useUnsignedForMinMax(intType))
         return arith::MinUIOp::create(b, loc, self, result);
-      if (intType.isSigned())
-        return arith::MinSIOp::create(b, loc, self, result);
+      return arith::MinSIOp::create(b, loc, self, result);
     }
   } else if (isa<AtenNormScalarOp>(op)) {
     // This creates payload for only the first of the two linalg.generic ops.

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -18,6 +18,10 @@ using namespace mlir;
 using namespace mlir::torch;
 using namespace mlir::torch::Torch;
 
+bool Torch::useUnsignedIntegerSemantics(IntegerType intType) {
+  return intType.isUnsigned() || intType.getWidth() == 1;
+}
+
 int64_t Torch::toPositiveDim(int64_t dim, int64_t inputRank) {
   return dim >= 0 ? dim : dim + inputRank;
 }

--- a/test/Conversion/TorchToLinalg/basic.mlir
+++ b/test/Conversion/TorchToLinalg/basic.mlir
@@ -1121,3 +1121,57 @@ func.func @torch.aten.cat$rank1_empty(%arg0: !torch.vtensor<[1,8,?,128],f16>, %a
   %1 = torch.aten.cat %0, %int-2 : !torch.list<vtensor>, !torch.int -> !torch.vtensor<[1,8,?,128],f16>
   return %1 : !torch.vtensor<[1,8,?,128],f16>
 }
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.max$bool
+// CHECK:         %[[INIT:.+]] = arith.constant false
+// CHECK:         linalg.fill ins(%[[INIT]] : i1)
+// CHECK:         linalg.generic
+// CHECK:         ^bb0(%[[IN:.+]]: i1, %[[OUT:.+]]: i1):
+// CHECK-NEXT:      %[[RES:.+]] = arith.maxui %[[IN]], %[[OUT]] : i1
+func.func @torch.aten.max$bool(%arg0: !torch.vtensor<[4],i1>) -> !torch.vtensor<[],i1> {
+  %0 = torch.aten.max %arg0 : !torch.vtensor<[4],i1> -> !torch.vtensor<[],i1>
+  return %0 : !torch.vtensor<[],i1>
+}
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.min$bool
+// CHECK:         %[[INIT:.+]] = arith.constant true
+// CHECK:         linalg.fill ins(%[[INIT]] : i1)
+// CHECK:         linalg.generic
+// CHECK:         ^bb0(%[[IN:.+]]: i1, %[[OUT:.+]]: i1):
+// CHECK-NEXT:      %[[RES:.+]] = arith.minui %[[IN]], %[[OUT]] : i1
+func.func @torch.aten.min$bool(%arg0: !torch.vtensor<[4],i1>) -> !torch.vtensor<[],i1> {
+  %0 = torch.aten.min %arg0 : !torch.vtensor<[4],i1> -> !torch.vtensor<[],i1>
+  return %0 : !torch.vtensor<[],i1>
+}
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.max.dim$bool
+// CHECK:         %[[INIT:.+]] = arith.constant false
+// CHECK:         linalg.fill ins(%[[INIT]] : i1)
+// CHECK:         linalg.generic
+// CHECK:         ^bb0(%[[IN:.+]]: i1, {{.*}}: i1, {{.*}}: i64):
+// CHECK:           arith.maxui %[[IN]], {{.*}} : i1
+// CHECK:           arith.cmpi ugt, {{.*}} : i1
+func.func @torch.aten.max.dim$bool(%arg0: !torch.vtensor<[3,4],i1>) -> !torch.vtensor<[3],i1> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %values, %indices = torch.aten.max.dim %arg0, %int1, %false : !torch.vtensor<[3,4],i1>, !torch.int, !torch.bool -> !torch.vtensor<[3],i1>, !torch.vtensor<[3],si64>
+  return %values : !torch.vtensor<[3],i1>
+}
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.min.dim$bool
+// CHECK:         %[[INIT:.+]] = arith.constant true
+// CHECK:         linalg.fill ins(%[[INIT]] : i1)
+// CHECK:         linalg.generic
+// CHECK:         ^bb0(%[[IN:.+]]: i1, {{.*}}: i1, {{.*}}: i64):
+// CHECK:           arith.minui %[[IN]], {{.*}} : i1
+// CHECK:           arith.cmpi ult, {{.*}} : i1
+func.func @torch.aten.min.dim$bool(%arg0: !torch.vtensor<[3,4],i1>) -> !torch.vtensor<[3],i1> {
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %values, %indices = torch.aten.min.dim %arg0, %int1, %false : !torch.vtensor<[3,4],i1>, !torch.int, !torch.bool -> !torch.vtensor<[3],i1>, !torch.vtensor<[3],si64>
+  return %values : !torch.vtensor<[3],i1>
+}


### PR DESCRIPTION
This PR fixes `i1` legalization for max/min ops.

`aten.max`, `aten.min`, `aten.max.dim`, and `aten.min.dim` on bool (`i1`) tensors produced incorrect results or lowering failures. `i1` is signless, so it fell through both `isUnsigned()` and `isSigned()` checks; and even where it didn't fall through, signed compare treats bit `1` as `-1`, so `maxsi([false, true])` returns `false`.
