### PR TITLE
[CI] Fix auditwheel failure for abi3-tagged wheels on Python >= 3.12

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -463,7 +463,19 @@ function build_torch_mlir_ext() {
 function run_audit_wheel() {
   local wheel_basename="$1"
   local python_version="$2"
-  generic_wheel="/wheelhouse/${wheel_basename}-${TORCH_MLIR_PYTHON_PACKAGE_VERSION}-${python_version}-linux_${arch}.whl"
+  # The ABI tag may be 'abi3' instead of the cpXYZ-cpXYZ form when
+  # MLIR_ENABLE_PYTHON_STABLE_ABI is ON (Python >= 3.12). Anchor on the
+  # interpreter tag (e.g. cp312) so the glob matches both cases.
+  local cp_tag="${python_version%%-*}"
+  local matches
+  matches=$(ls /wheelhouse/${wheel_basename}-${TORCH_MLIR_PYTHON_PACKAGE_VERSION}-${cp_tag}-*-linux_${arch}.whl 2>/dev/null)
+  local count
+  count=$(echo "$matches" | grep -c . 2>/dev/null || echo 0)
+  if [ "$count" -ne 1 ]; then
+    echo "ERROR: Expected exactly 1 wheel for ${wheel_basename} ${cp_tag}, found ${count}: ${matches}"
+    exit 1
+  fi
+  local generic_wheel="$matches"
   echo ":::: Auditwheel $generic_wheel"
   auditwheel repair -w /wheelhouse "$generic_wheel"
   rm "$generic_wheel"
@@ -484,7 +496,10 @@ function clean_wheels() {
   local wheel_basename="$1"
   local python_version="$2"
   echo ":::: Clean wheels $wheel_basename $python_version"
-  rm -f /wheelhouse/"${wheel_basename}"-*-"${python_version}"-*.whl
+  # Use only the interpreter tag (e.g. cp312) so the glob covers both
+  # cp312-cp312 and cp312-abi3 filenames.
+  local cp_tag="${python_version%%-*}"
+  rm -f /wheelhouse/"${wheel_basename}"-*-"${cp_tag}"-*.whl
 }
 
 # Trampoline to the docker container if running on the host.


### PR DESCRIPTION
PR #4639 enabled MLIR_ENABLE_PYTHON_STABLE_ABI for Python >= 3.12, causing pip wheel to produce cp312-abi3 tagged wheels instead of cp312-cp312. `run_audit_wheel` hardcodes the python_version string (e.g. cp312-cp312) as the ABI tag in the filename, so auditwheel could not find the wheel and exited with "No such file".

This PR modifies `run_audit_wheel` to glob using only the interpreter tag (`cp312`) so it matches both `cp312-cp312` and `cp312-abi3` filenames. Add a count check to fail loudly if the glob matches 0 or >1 wheels. We still produce 310/311 wheels which are named `cp310(11)-cp310(11)`.

Fixes `clean_wheels` the same way so it also removes abi3-tagged wheels.

Fixes https://github.com/llvm/torch-mlir-release/issues/33#issue-5017721615