### PR TITLE
Adding my name to code ownership for tosa/CI code-paths.

### DIFF
--- a/docs/code_owners.md
+++ b/docs/code_owners.md
@@ -31,12 +31,14 @@ and Clang's
 ### CI / Build system / Packaging / [Release](https://github.com/llvm/torch-mlir-release)
 
 - Anush Elangovan (@powderluv)
+- Sayan Saha (@sahas3)
 - Maybe you!*
 
 ### TorchToTOSA
 
 - Eric Kunze (@eric-k256)
 - Suraj Sudhir (@sjarus)
+- Sayan Saha (@sahas3)
 
 ### TorchToStablehlo
 


### PR DESCRIPTION
Nominating myself as code-owners for TorchToTOSA and CI/Build system sections as I've been contributing and reviewing changes for these paths for a while and want to help maintain the codebase.