### PR TITLE
[TorchOnnxToTorch] Accept LayerNormalization without optional bias

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -2663,7 +2663,6 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         float epsilon;
         if (binder.tensorOperandAtIndex(x, 0) ||
             binder.tensorOperandAtIndex(scale, 1) ||
-            binder.tensorOperandAtIndex(b, 2) ||
             binder.tensorResultTypeAtIndex(yType, 0) ||
             binder.s64IntegerAttr(axis, "axis", -1) ||
             binder.f32FloatAttr(epsilon, "epsilon", 0.00001f) ||
@@ -2697,6 +2696,10 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
               /*non_blocking=*/cstFalse, /*copy=*/cstFalse,
               /*memory_format=*/none);
         }
+
+        // The bias operand B is optional and defaults to no bias.
+        if (binder.tensorOperandAtIndex(b, 2))
+          b = none;
 
         Value constEpsilon = Torch::ConstantFloatOp::create(
             rewriter, binder.getLoc(), rewriter.getType<Torch::FloatType>(),

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -1684,6 +1684,7 @@ STABLEHLO_PASS_SET = {
     "IndexTensorStaticNonContiguousWithNoneModule_basic",
     "LayerNormLastDimModule_basic",
     "LayerNormModule_basic",
+    "LayerNormNoBiasModule_basic",
     "LayerNormNormalizeOverAllDimsModule_basic",
     "MaxPool2dWithIndicesStaticModule_basic",
     "MeanDimAllReduceKeepdimModule_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/norm_like.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/norm_like.py
@@ -620,6 +620,36 @@ def LayerNormModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class LayerNormNoBiasModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.ly = torch.nn.LayerNorm([2, 2, 3], bias=False)
+        self.ly.eval()
+        self.ly.weight = torch.nn.Parameter(
+            torch.tensor(
+                [[[3.0, 2.0, 4.0], [2.0, 3.0, 3.0]], [[3.0, 2.0, 4.0], [2.0, 3.0, 3.0]]]
+            )
+        )
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([2, 5, 2, 2, 3], torch.float32, True),
+        ]
+    )
+    def forward(self, x):
+        return self.ly(x)
+
+
+@register_test_case(module_factory=lambda: LayerNormNoBiasModule())
+def LayerNormNoBiasModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 5, 2, 2, 3))
+
+
+# ==============================================================================
+
+
 class LayerNormLastDimModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
@@ -396,6 +396,20 @@ func.func @test_layer_norm_single_result(%arg0: !torch.vtensor<[1,4,768],f32>, %
 
 // -----
 
+// CHECK-LABEL : func.func @test_layer_norm_optional_bias
+func.func @test_layer_norm_optional_bias(%arg0: !torch.vtensor<[1,4,768],f32>, %arg1: !torch.vtensor<[768],f32>) -> (!torch.vtensor<[1,4,768], f32>)
+                           attributes {torch.onnx_meta.ir_version = 6 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %none = torch.constant.none
+  // CHECK: %float9.999990e-06 = torch.constant.float 9.9999997473787516E-6
+  // CHECK: %int768 = torch.constant.int 768
+  // CHECK: %0 = torch.prim.ListConstruct %int768 : (!torch.int) -> !torch.list<int>
+  // CHECK: %result0, %result1, %result2 = torch.aten.native_layer_norm %arg0, %0, %arg1, %none
+  %0 = torch.operator "onnx.LayerNormalization"(%arg0, %arg1) {torch.onnx.axis = -1 : si64, torch.onnx.epsilon = 9.99999974E-6 : f32} : (!torch.vtensor<[1,4,768],f32>, !torch.vtensor<[768],f32>) -> !torch.vtensor<[1,4,768],f32>
+  return %0 : !torch.vtensor<[1,4,768],f32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @test_leaky_relu
 func.func @test_leaky_relu(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],f32> attributes {torch.onnx_meta.opset_version = 16 : si64} {
   // CHECK-DAG: %[[F2:.+]] = torch.constant.float 2


### PR DESCRIPTION
The ONNX spec defines LayerNormalization's third input B (bias) as optional [[ref](https://onnx.ai/onnx/operators/onnx__LayerNormalization.html#inputs)], with a missing value being equivalent to a zero bias. The problem is that the `torch.onnx` dynamo exporter emits the two-operand form `LayerNormalization(X, Scale)` for bias-less layernorms (e.g. `torch.nn.LayerNorm(..., bias=False)`), and the lowering through `TorchOnnxToTorch` fails the pattern match when B is missing:

```
failed to legalize operation 'torch.operator' ... onnx.LayerNormalization
```

The fix is to fall back to a `none` value for B when the operand is not given. The `aten.native_layer_norm` op's bias operand is defined as `Tensor?` [[ref](https://github.com/llvm/torch-mlir/blob/df3b95787d698f2236412c688783b1d5176c91e1/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td#L7799-L7811)], and a `none` bias means "no bias", which matches the ONNX default. This is the same method the file already uses for `NegativeLogLikelihoodLoss`'s optional weight operand.

For testing, this PR adds FileCheck coverage and an e2e test explicitly covering a no-bias LayerNorm module.