### PR TITLE
add j2kun to packaging code owners

### DIFF
--- a/docs/code_owners.md
+++ b/docs/code_owners.md
@@ -31,6 +31,7 @@ and Clang's
 ### CI / Build system / Packaging / [Release](https://github.com/llvm/torch-mlir-release)
 
 - Anush Elangovan (@powderluv)
+- Jeremy Kun (@j2kun)
 - Maybe you!*
 
 ### TorchToTOSA


### PR DESCRIPTION
Cf. https://github.com/llvm/torch-mlir/pull/4639, https://github.com/llvm/torch-mlir/pull/4694, https://discourse.llvm.org/t/rfc-torch-mlir-refresh-and-modernize-pypi-release-workflows/91514, and more generally https://github.com/llvm/torch-mlir/pulls?q=is%3Apr+author%3Aj2kun


