### PR TITLE
Add @AGindinson to code owners

### DIFF
--- a/docs/code_owners.md
+++ b/docs/code_owners.md
@@ -28,6 +28,7 @@ and Clang's
 - Ramiro Leal-Cavazos (@ramiro050) - emeritus
 - Zach Garvey (@zjgarvey)
 - Renato Golin (@rengolin)
+- Artem Gindinson (@AGindinson)
 
 ### CI / Build system / Packaging / [Release](https://github.com/llvm/torch-mlir-release)
 
@@ -58,6 +59,7 @@ and Clang's
 
 - Sambhav Jain (@sjain-stanford)
 - Ahmed Taei (@asaadaldien)
+- Artem Gindinson (@AGindinson)
 - Maybe you!*
 
 ### LLVM Integrate


### PR DESCRIPTION
Adding myself as one of the code owners for TorchToLinalg and Bazel.

My history of contributions to both components is admittedly limited. As an active maintainer of IREE, which is a big user of Torch-MLIR, I'd be happy to share review responsibilities for TorchToLinalg as our key path for PyTorch and ONNX imports. As Bazel users, we are also keen to help review PRs in the overlay component and help more actively with maintaining the setup here and in upstream MLIR.

Signed-off-by: Artem Gindinson <gindinson@roofline.ai>