### PR TITLE
[TorchToTosa] Add direct aten.addmm legalization

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -2355,10 +2355,19 @@ public:
                          const TypeConverter *typeConverter) const override {
     if constexpr (!std::is_same_v<AtenOpT, AtenMatmulOp> &&
                   !std::is_same_v<AtenOpT, AtenMmOp> &&
-                  !std::is_same_v<AtenOpT, AtenBmmOp>) {
+                  !std::is_same_v<AtenOpT, AtenBmmOp> &&
+                  !std::is_same_v<AtenOpT, AtenAddmmOp>) {
       return false;
     } else {
-      auto lhs = adaptor.getSelf();
+      Value lhs;
+      if constexpr (std::is_same_v<AtenOpT, AtenAddmmOp>) {
+        lhs = adaptor.getMat1();
+        auto biasTy = dyn_cast<RankedTensorType>(adaptor.getSelf().getType());
+        if (biasTy && mlir::tosa::typeHasZeroDim(biasTy))
+          return false;
+      } else {
+        lhs = adaptor.getSelf();
+      }
       Value rhs;
       if constexpr (std::is_same_v<AtenOpT, AtenMatmulOp>)
         rhs = adaptor.getOther();
@@ -2382,7 +2391,8 @@ public:
   LogicalResult performMatmul(AtenOpT op, OpAdaptor adaptor,
                               ConversionPatternRewriter &rewriter, Value &lhs,
                               Value &rhs, Value &lhsZp, Value &rhsZp,
-                              Value &output) const {
+                              Value &output,
+                              bool keepRank3Result = false) const {
 
     auto lhsTy = cast<RankedTensorType>(lhs.getType());
     auto rhsTy = cast<RankedTensorType>(rhs.getType());
@@ -2828,7 +2838,8 @@ public:
     // Perform the reshape to output shape. This is always required unless max
     // input rank=3 and there was no broadcasting, in which case the tosa.matmul
     // output itself is correctly shaped.
-    bool performOpReshape = !(maxInputRank == 3 && !performBatchDimBroadcast);
+    bool performOpReshape =
+        !(maxInputRank == 3 && !performBatchDimBroadcast) && !keepRank3Result;
 
     if (performOpReshape) {
       // Since the output shape may be unknown, we construct it
@@ -3083,6 +3094,124 @@ public:
           op, "unsupported: aten.mm/aten.bmm with mixed quantization");
     }
 
+    return success();
+  }
+};
+
+// Lowers statically shaped floating-point addmm while retaining the rank-3
+// matmul result so that the bias add can be done before the reshape.
+class ConvertAtenAddmmOp : public ConvertAtenMatmulBaseOp<AtenAddmmOp> {
+  static bool isStaticRanked(RankedTensorType type, int64_t rank) {
+    return type && type.hasStaticShape() && type.getRank() == rank;
+  }
+
+  static std::optional<double> getConstantScalar(Value value) {
+    double floatValue;
+    if (matchPattern(value, m_TorchConstantFloat(&floatValue))) {
+      return floatValue;
+    }
+
+    int64_t intValue;
+    if (matchPattern(value, m_TorchConstantInt(&intValue))) {
+      return static_cast<double>(intValue);
+    }
+    return std::nullopt;
+  }
+
+  static FailureOr<Value> scaleTensor(AtenAddmmOp op, Value tensor,
+                                      Value scalar, double scalarValue,
+                                      ConversionPatternRewriter &rewriter) {
+    if (scalarValue == 1.0) {
+      return tensor;
+    }
+
+    auto tensorTy = cast<RankedTensorType>(tensor.getType());
+    SmallVector<int64_t> scalarShape(tensorTy.getRank(), 1);
+    Value scalarTensor;
+    if (failed(torchScalarToTosaTensor(rewriter, op, scalar, scalarTensor,
+                                       tensorTy.getElementType(),
+                                       scalarShape))) {
+      return failure();
+    }
+    return tosa::createMulOpAndCast(rewriter, op, tensorTy, tensor,
+                                    scalarTensor, /*shift=*/0)
+        .getResult();
+  }
+
+public:
+  using ConvertAtenMatmulBaseOp<AtenAddmmOp>::ConvertAtenMatmulBaseOp;
+  using OpAdaptor = AtenAddmmOp::Adaptor;
+
+  LogicalResult
+  matchAndRewriteImpl(AtenAddmmOp op, OpAdaptor adaptor,
+                      ConversionPatternRewriter &rewriter) const override {
+    Value lhs = adaptor.getMat1();
+    Value rhs = adaptor.getMat2();
+    Value bias = adaptor.getSelf();
+    auto lhsTy = dyn_cast<RankedTensorType>(lhs.getType());
+    auto rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
+    auto biasTy = dyn_cast<RankedTensorType>(bias.getType());
+    auto resultTy = dyn_cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getType()));
+
+    std::optional<double> alpha = getConstantScalar(op.getAlpha());
+    std::optional<double> beta = getConstantScalar(op.getBeta());
+    if (!alpha || !beta) {
+      return rewriter.notifyMatchFailure(op,
+                                         "requires constant alpha and beta");
+    }
+    if (!isStaticRanked(lhsTy, 2) || !isStaticRanked(rhsTy, 2) ||
+        !isStaticRanked(resultTy, 2)) {
+      return rewriter.notifyMatchFailure(
+          op, "requires static rank-2 matrices and result");
+    }
+    if (!biasTy || !biasTy.hasStaticShape() || biasTy.getRank() > 2) {
+      return rewriter.notifyMatchFailure(
+          op, "requires static broadcastable bias of rank at most 2");
+    }
+    if (!isa<FloatType>(lhsTy.getElementType())) {
+      return rewriter.notifyMatchFailure(op, "requires floating-point tensors");
+    }
+
+    Value lhsZp, rhsZp, matmul;
+    if (failed(this->performMatmul(op, adaptor, rewriter, lhs, rhs, lhsZp,
+                                   rhsZp, matmul,
+                                   /*keepRank3Result=*/true))) {
+      return rewriter.notifyMatchFailure(op, "failed to lower addmm matmul");
+    }
+
+    auto matmulTy = cast<RankedTensorType>(matmul.getType());
+    matmul = tosa::tosaCastTensorToType(
+                 rewriter, matmul, matmulTy.clone(resultTy.getElementType()))
+                 .value();
+
+    FailureOr<Value> scaledMatmul =
+        scaleTensor(op, matmul, op.getAlpha(), *alpha, rewriter);
+    if (failed(scaledMatmul)) {
+      return rewriter.notifyMatchFailure(op, "failed to apply addmm alpha");
+    }
+
+    Value result = *scaledMatmul;
+    if (*beta != 0.0) {
+      FailureOr<Value> scaledBias =
+          scaleTensor(op, bias, op.getBeta(), *beta, rewriter);
+      if (failed(scaledBias)) {
+        return rewriter.notifyMatchFailure(op, "failed to apply addmm beta");
+      }
+      bias = *scaledBias;
+
+      if (failed(tosa::EqualizeRanks(rewriter, op.getLoc(), result, bias))) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to broadcast bias to addmm result");
+      }
+      result = tosa::AddOp::create(rewriter, op.getLoc(), result.getType(),
+                                   result, bias)
+                   .getResult();
+    }
+
+    rewriter.replaceOpWithNewOp<tosa::ReshapeOp>(
+        op, resultTy, result,
+        tosa::getTosaConstShape(rewriter, op.getLoc(), resultTy.getShape()));
     return success();
   }
 };
@@ -11863,6 +11992,10 @@ std::set<StringRef> populateTorchToTosaConversionPatternsAndIllegalOps(
   INSERT_MM_ATENOP_PATTERN(AtenMmOp);
   INSERT_MM_ATENOP_PATTERN(AtenBmmOp);
 #undef INSERT_MM_ATENOP_PATTERN
+
+  illegalOps.insert(AtenAddmmOp::getOperationName());
+  patterns.addWithLabel<ConvertAtenAddmmOp>(AtenAddmmOp::getOperationName(),
+                                            typeConverter, context);
 
 #define INSERT_LINEAR_ATENOP_PATTERN(AtenOp)                                   \
   illegalOps.insert(AtenOp::getOperationName());                               \

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -2388,6 +2388,8 @@ public:
     }
   }
 
+  // When keepRank3Result is true, return the native rank-3 TOSA matmul result;
+  // the caller is responsible for reshaping it to the operation's result shape.
   LogicalResult performMatmul(AtenOpT op, OpAdaptor adaptor,
                               ConversionPatternRewriter &rewriter, Value &lhs,
                               Value &rhs, Value &lhsZp, Value &rhsZp,

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -3171,7 +3171,10 @@ public:
       return rewriter.notifyMatchFailure(
           op, "requires static broadcastable bias of rank at most 2");
     }
-    if (!isa<FloatType>(lhsTy.getElementType())) {
+    if (!isa<FloatType>(lhsTy.getElementType()) ||
+        !isa<FloatType>(rhsTy.getElementType()) ||
+        !isa<FloatType>(biasTy.getElementType()) ||
+        !isa<FloatType>(resultTy.getElementType())) {
       return rewriter.notifyMatchFailure(op, "requires floating-point tensors");
     }
 

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -5445,6 +5445,121 @@ func.func @torch.aten.mm$f32(%arg0: !torch.vtensor<[1,22],f32>, %arg1: !torch.vt
 }
 
 // -----
+// CHECK-LABEL: func.func @torch.aten.addmm$f32
+// CHECK: %[[MATMUL:.*]] = tosa.matmul
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK: %[[ADD:.*]] = tosa.add
+// CHECK-SAME: (tensor<1x6x4xf32>, tensor<1x1x4xf32>) -> tensor<1x6x4xf32>
+// CHECK: %[[RESULT:.*]] = tosa.reshape %[[ADD]]
+// CHECK-SAME: -> tensor<6x4xf32>
+// CHECK-NOT: torch.aten.addmm
+func.func @torch.aten.addmm$f32(%bias: !torch.vtensor<[4],f32>, %mat1: !torch.vtensor<[6,8],f32>, %mat2: !torch.vtensor<[8,4],f32>) -> !torch.vtensor<[6,4],f32> {
+  %one = torch.constant.int 1
+  %0 = torch.aten.addmm %bias, %mat1, %mat2, %one, %one : !torch.vtensor<[4],f32>, !torch.vtensor<[6,8],f32>, !torch.vtensor<[8,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[6,4],f32>
+  return %0 : !torch.vtensor<[6,4],f32>
+}
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.addmm$scaled_f32
+// CHECK: %[[MATMUL:.*]] = tosa.matmul
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK-DAG: %[[BETA:.*]] = tosa.mul {{.*}} -> tensor<4xf32>
+// CHECK-DAG: %[[ALPHA:.*]] = tosa.mul %[[MATMUL]]{{.*}} -> tensor<1x6x4xf32>
+// CHECK: %[[ADD:.*]] = tosa.add
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK: tosa.reshape %[[ADD]]
+// CHECK-SAME: -> tensor<6x4xf32>
+// CHECK-NOT: torch.aten.addmm
+func.func @torch.aten.addmm$scaled_f32(%bias: !torch.vtensor<[4],f32>, %mat1: !torch.vtensor<[6,8],f32>, %mat2: !torch.vtensor<[8,4],f32>) -> !torch.vtensor<[6,4],f32> {
+  %two = torch.constant.int 2
+  %three = torch.constant.int 3
+  %0 = torch.aten.addmm %bias, %mat1, %mat2, %three, %two : !torch.vtensor<[4],f32>, !torch.vtensor<[6,8],f32>, !torch.vtensor<[8,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[6,4],f32>
+  return %0 : !torch.vtensor<[6,4],f32>
+}
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.addmm$float_scalars_scalar_bias
+// CHECK: %[[MATMUL:.*]] = tosa.matmul
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK: tosa.mul %[[MATMUL]]
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK: tosa.mul
+// CHECK-SAME: -> tensor<f32>
+// CHECK: %[[ADD:.*]] = tosa.add
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK: tosa.reshape %[[ADD]]
+// CHECK-SAME: -> tensor<6x4xf32>
+// CHECK-NOT: torch.aten.addmm
+func.func @torch.aten.addmm$float_scalars_scalar_bias(%bias: !torch.vtensor<[],f32>, %mat1: !torch.vtensor<[6,8],f32>, %mat2: !torch.vtensor<[8,4],f32>) -> !torch.vtensor<[6,4],f32> {
+  %half = torch.constant.float 5.000000e-01
+  %two = torch.constant.float 2.000000e+00
+  %0 = torch.aten.addmm %bias, %mat1, %mat2, %two, %half : !torch.vtensor<[],f32>, !torch.vtensor<[6,8],f32>, !torch.vtensor<[8,4],f32>, !torch.float, !torch.float -> !torch.vtensor<[6,4],f32>
+  return %0 : !torch.vtensor<[6,4],f32>
+}
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.addmm$beta_zero_f32
+// CHECK: %[[MATMUL:.*]] = tosa.matmul
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK-NOT: tosa.mul
+// CHECK-NOT: tosa.add
+// CHECK: tosa.reshape %[[MATMUL]]
+// CHECK-SAME: -> tensor<6x4xf32>
+// CHECK-NOT: torch.aten.addmm
+func.func @torch.aten.addmm$beta_zero_f32(%bias: !torch.vtensor<[4],f32>, %mat1: !torch.vtensor<[6,8],f32>, %mat2: !torch.vtensor<[8,4],f32>) -> !torch.vtensor<[6,4],f32> {
+  %zero = torch.constant.int 0
+  %one = torch.constant.int 1
+  %0 = torch.aten.addmm %bias, %mat1, %mat2, %zero, %one : !torch.vtensor<[4],f32>, !torch.vtensor<[6,8],f32>, !torch.vtensor<[8,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[6,4],f32>
+  return %0 : !torch.vtensor<[6,4],f32>
+}
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.addmm$f16
+// CHECK: %[[MATMUL:.*]] = tosa.matmul
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK: %[[CAST:.*]] = tosa.cast %[[MATMUL]]
+// CHECK-SAME: -> tensor<1x6x4xf16>
+// CHECK: %[[ADD:.*]] = tosa.add
+// CHECK-SAME: -> tensor<1x6x4xf16>
+// CHECK: tosa.reshape %[[ADD]]
+// CHECK-SAME: -> tensor<6x4xf16>
+// CHECK-NOT: torch.aten.addmm
+func.func @torch.aten.addmm$f16(%bias: !torch.vtensor<[4],f16>, %mat1: !torch.vtensor<[6,8],f16>, %mat2: !torch.vtensor<[8,4],f16>) -> !torch.vtensor<[6,4],f16> {
+  %one = torch.constant.int 1
+  %0 = torch.aten.addmm %bias, %mat1, %mat2, %one, %one : !torch.vtensor<[4],f16>, !torch.vtensor<[6,8],f16>, !torch.vtensor<[8,4],f16>, !torch.int, !torch.int -> !torch.vtensor<[6,4],f16>
+  return %0 : !torch.vtensor<[6,4],f16>
+}
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.addmm$rank2_bias
+// CHECK: %[[MATMUL:.*]] = tosa.matmul
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK: %[[ADD:.*]] = tosa.add
+// CHECK-SAME: -> tensor<1x6x4xf32>
+// CHECK: tosa.reshape %[[ADD]]
+// CHECK-SAME: -> tensor<6x4xf32>
+// CHECK-NOT: torch.aten.addmm
+func.func @torch.aten.addmm$rank2_bias(%bias: !torch.vtensor<[6,4],f32>, %mat1: !torch.vtensor<[6,8],f32>, %mat2: !torch.vtensor<[8,4],f32>) -> !torch.vtensor<[6,4],f32> {
+  %one = torch.constant.int 1
+  %0 = torch.aten.addmm %bias, %mat1, %mat2, %one, %one : !torch.vtensor<[6,4],f32>, !torch.vtensor<[6,8],f32>, !torch.vtensor<[8,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[6,4],f32>
+  return %0 : !torch.vtensor<[6,4],f32>
+}
+
+// -----
+// CHECK-LABEL: func.func @torch.aten.addmm$zero_k
+// CHECK-NOT: tosa.matmul
+// CHECK: %[[ZERO:.*]] = "tosa.const"()
+// CHECK-SAME: tensor<6x4xf32>
+// CHECK: %[[ADD:.*]] = tosa.add
+// CHECK-SAME: (tensor<6x4xf32>, tensor<1x4xf32>) -> tensor<6x4xf32>
+// CHECK-NOT: torch.aten.addmm
+func.func @torch.aten.addmm$zero_k(%bias: !torch.vtensor<[4],f32>, %mat1: !torch.vtensor<[6,0],f32>, %mat2: !torch.vtensor<[0,4],f32>) -> !torch.vtensor<[6,4],f32> {
+  %one = torch.constant.int 1
+  %0 = torch.aten.addmm %bias, %mat1, %mat2, %one, %one : !torch.vtensor<[4],f32>, !torch.vtensor<[6,0],f32>, !torch.vtensor<[0,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[6,4],f32>
+  return %0 : !torch.vtensor<[6,4],f32>
+}
+
+// -----
 // CHECK-LABEL:   func.func @torch.aten.mm$si8
 // CHECK: tosa.matmul
 // CHECK-SAME: (tensor<1x1x22xi8>, tensor<1x22x10xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<1x1x10xi32>


### PR DESCRIPTION
Lower addmm directly over decomposition to retain the rank-3 TOSA matmul result until the final reshape, avoiding unnecessary intermediates.