### PR TITLE
[Torch][Transforms] Dynamic dims in decompose aten nonzero op

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -6643,6 +6643,11 @@ class DecomposeAtenNonzeroOp : public OpRewritePattern<AtenNonzeroOp> {
     int64_t flattenedSize = 1;
     if (inputType.hasSizes()) {
       for (auto size : inputType.getSizes()) {
+        // Any dynamic input dimension makes the flattened size dynamic.
+        if (size == kUnknownSize) {
+          flattenedSize = kUnknownSize;
+          break;
+        }
         flattenedSize *= size;
       }
     } else {
@@ -6724,10 +6729,8 @@ class DecomposeAtenNonzeroOp : public OpRewritePattern<AtenNonzeroOp> {
                                   /*end=*/numNonzero,
                                   /*step=*/constantOne);
 
-    // TODO fix multidim dynamic support. The following code only work for
-    // static multidim. Convert flattened indices back to multi-dimensional
-    // indices original_shape = t.shape input_shape_tensor =
-    // torch.tensor(original_shape)
+    // Convert flattened indices back to multi-dimensional indices using the
+    // input shape queried at runtime.
     auto shapeType = Torch::ValueTensorType::get(
         rewriter.getContext(), SmallVector<int64_t>{inputRank}, intType);
     SmallVector<Value> shapeValues;

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -6654,9 +6654,9 @@ class DecomposeAtenNonzeroOp : public OpRewritePattern<AtenNonzeroOp> {
       flattenedSize = kUnknownSize;
     }
 
-    auto flattendInputShape = SmallVector<int64_t>{flattenedSize};
+    auto flattenedInputShape = SmallVector<int64_t>{flattenedSize};
     auto flattenedInputType = rewriter.getType<Torch::ValueTensorType>(
-        flattendInputShape, inputType.getOptionalDtype());
+        flattenedInputShape, inputType.getOptionalDtype());
 
     // %1 = torch.aten.flatten.using_ints %arg0, %int0, %int0_0 :
     auto inputDimsEnd = ConstantIntOp::create(

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1408,7 +1408,6 @@ func.func @rank2_bool_mask(%input: !torch.vtensor<[4,4],f32>,
         !torch.vtensor<[4],f32>, !torch.bool -> !torch.vtensor<[4,4],f32>
   return %result : !torch.vtensor<[4,4],f32>
 }
-<<<<<<< HEAD
 
 // -----
 
@@ -1453,5 +1452,3 @@ func.func @mixed_int_and_bool(%input: !torch.vtensor<[5,5],f32>,
       -> !torch.vtensor<[5,5],f32>
   return %result : !torch.vtensor<[5,5],f32>
 }
-=======
->>>>>>> dbd9c871 (support dynamic dims in DecomposeAtenNonzeroOp)

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -81,6 +81,25 @@ func.func @repeat_interleave_tensor_oversized_intermediate(%arg0: !torch.vtensor
 
 // -----
 
+// Regression test: any dynamic input dimension must make the flattened
+// intermediate shape dynamic.
+// CHECK-LABEL: func.func @nonzero_dynamic_flattened_shape
+// CHECK:         %[[FLATTEN:.*]] = torch.aten.view %arg0
+// CHECK-SAME:      -> !torch.vtensor<[?],i1>
+// CHECK:         %[[DIM1:.*]] = torch.aten.size.int %arg0
+// CHECK:         %[[DIM2:.*]] = torch.aten.size.int %arg0
+// CHECK:         %[[SHAPE_LIST:.*]] = torch.prim.ListConstruct %{{.*}}, %[[DIM1]], %[[DIM2]], %{{.*}}
+// CHECK:         %[[SHAPE:.*]] = torch.aten.tensor %[[SHAPE_LIST]]
+// CHECK:         %[[DIVIDED:.*]] = torch.aten.div.Tensor_mode
+// CHECK:         %[[RESULT:.*]] = torch.aten.remainder.Tensor %[[DIVIDED]], %[[SHAPE]]
+// CHECK:         return %[[RESULT]]
+func.func @nonzero_dynamic_flattened_shape(%arg0: !torch.vtensor<[2,?,?,4],i1>) -> !torch.vtensor<[?,4],si64> {
+  %0 = torch.aten.nonzero %arg0 : !torch.vtensor<[2,?,?,4],i1> -> !torch.vtensor<[?,4],si64>
+  return %0 : !torch.vtensor<[?,4],si64>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @matmul_no_decompose
 // CHECK:           torch.aten.matmul %arg0, %arg1 : !torch.vtensor<[?,?,?,?,?],f32>, !torch.vtensor<[?,?,?],f32> -> !torch.tensor
 func.func @matmul_no_decompose(%arg0: !torch.vtensor<[?,?,?,?,?],f32>, %arg1: !torch.vtensor<[?,?,?],f32>) -> !torch.tensor {
@@ -1389,6 +1408,7 @@ func.func @rank2_bool_mask(%input: !torch.vtensor<[4,4],f32>,
         !torch.vtensor<[4],f32>, !torch.bool -> !torch.vtensor<[4,4],f32>
   return %result : !torch.vtensor<[4,4],f32>
 }
+<<<<<<< HEAD
 
 // -----
 
@@ -1433,3 +1453,5 @@ func.func @mixed_int_and_bool(%input: !torch.vtensor<[5,5],f32>,
       -> !torch.vtensor<[5,5],f32>
   return %result : !torch.vtensor<[5,5],f32>
 }
+=======
+>>>>>>> dbd9c871 (support dynamic dims in DecomposeAtenNonzeroOp)


### PR DESCRIPTION
Support for dynamic dimensions in DecomposeAtenNonzeroOp

The flattened size calculation was incorrect if size was kUnknownSize:
```cpp
      // If the input is not a 1-d tensor, we need to flatten it
      // to a 1D tensor before applying the strided indexing.
      int64_t flattenedInputSize = 1;
      for (int64_t size : inputSizes) {
        flattenedInputSize *= size; // dynamic dims are mapped to -1, this product would cause a negative dimension
      }
```