### PR TITLE
[TorchOnnxToTorch] Support valid auto pad in onnx.ConvInteger

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
@@ -1627,10 +1627,11 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         std::string autoPad;
         if (binder.customOpNameStringAttr(autoPad, "auto_pad", "NOTSET"))
           return failure();
-        if (autoPad != "NOTSET")
-          // TODO: Add support for `auto_pad` != "NOTSET"
+        if (autoPad != "NOTSET" && autoPad != "VALID")
+          // TODO: Add support for "SAME_UPPER" and "SAME_LOWER" auto_pad
           return rewriter.notifyMatchFailure(
-              binder.op, "unsupported conversion: auto_pad != NOTSET");
+              binder.op, "unsupported conversion: only NOTSET and VALID "
+                         "auto_pad supported");
 
         Torch::ValueTensorType resultType;
         Value input, weight, inputZp, weightZp;
@@ -1683,11 +1684,16 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         // x2_begin…x1_end, x2_end,…], where xi_begin the number of pixels added
         // at the beginning of axis i and xi_end, the number of pixels added at
         // the end of axis i.
-        if (binder.s64IntegerArrayAttr(padding, "pads", defaultPadding))
-          return failure();
-        if (padding.size() != rank - 2 && padding.size() != 2 * (rank - 2))
-          return rewriter.notifyMatchFailure(
-              binder.op, "padding list size does not match the number of axes");
+        if (autoPad == "VALID")
+          padding = defaultPadding;
+        else if (autoPad == "NOTSET") {
+          if (binder.s64IntegerArrayAttr(padding, "pads", defaultPadding))
+            return failure();
+          if (padding.size() != rank - 2 && padding.size() != 2 * (rank - 2))
+            return rewriter.notifyMatchFailure(
+                binder.op,
+                "padding list size does not match the number of axes");
+        }
         if (binder.s64IntegerArrayAttr(dilations, "dilations",
                                        defaultDilations))
           return failure();

--- a/test/Conversion/TorchOnnxToTorch/convinteger_diagnostics.mlir
+++ b/test/Conversion/TorchOnnxToTorch/convinteger_diagnostics.mlir
@@ -1,0 +1,15 @@
+// RUN: torch-mlir-opt %s -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch
+
+func.func @test_convinteger_invalid_padding_size(
+    %arg0: !torch.vtensor<[1,1,3,3],ui8>,
+    %arg1: !torch.vtensor<[1,1,2,2],ui8>)
+    -> !torch.vtensor<[1,1,2,2],si32>
+    attributes {torch.onnx_meta.opset_version = 17 : si64} {
+  // expected-error @below {{failed to legalize operation 'torch.operator' that was explicitly marked illegal}}
+  %0 = torch.operator "onnx.ConvInteger"(%arg0, %arg1) {
+    torch.onnx.pads = [0 : si64, 0 : si64, 0 : si64]
+  } : (!torch.vtensor<[1,1,3,3],ui8>,
+       !torch.vtensor<[1,1,2,2],ui8>)
+       -> !torch.vtensor<[1,1,2,2],si32>
+  return %0 : !torch.vtensor<[1,1,2,2],si32>
+}

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_a_to_f.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_a_to_f.mlir
@@ -1217,6 +1217,37 @@ func.func @test_convinteger_without_padding(%arg0: !torch.vtensor<[1,1,3,3],ui8>
 
 // -----
 
+// CHECK-LABEL: @test_convinteger_with_valid_autopad
+func.func @test_convinteger_with_valid_autopad(%arg0: !torch.vtensor<[1,1,3,3],ui8>, %arg1: !torch.vtensor<[1,1,2,2],ui8>, %arg2: !torch.vtensor<[],ui8>, %arg3: !torch.vtensor<[1],ui8>) -> !torch.vtensor<[1,1,2,2],si32> attributes {torch.onnx_meta.ir_version = 5 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %[[NONE:.*]] = torch.constant.none
+  // CHECK: %[[SCALE:.*]] = torch.constant.float 1.000000e+00
+  // CHECK: %[[INPUT_ZP:.*]] = torch.aten.item %arg2 : !torch.vtensor<[],ui8> -> !torch.int
+  // CHECK: %[[WEIGHT_ZP:.*]] = torch.aten.item %arg3 : !torch.vtensor<[1],ui8> -> !torch.int
+  // CHECK: %[[C0:.*]] = torch.constant.int 0
+  // CHECK: %[[C0_0:.*]] = torch.constant.int 0
+  // CHECK: %[[PADDING:.*]] = torch.prim.ListConstruct %[[C0]], %[[C0_0]] : (!torch.int, !torch.int) -> !torch.list<int>
+  // CHECK: %[[C1_0:.*]] = torch.constant.int 1
+  // CHECK: %[[C1_1:.*]] = torch.constant.int 1
+  // CHECK: %[[DILATIONS:.*]] = torch.prim.ListConstruct %[[C1_0]], %[[C1_1]] : (!torch.int, !torch.int) -> !torch.list<int>
+  // CHECK: %[[C1_2:.*]] = torch.constant.int 1
+  // CHECK: %[[C1_3:.*]] = torch.constant.int 1
+  // CHECK: %[[STRIDE:.*]] = torch.prim.ListConstruct %[[C1_2]], %[[C1_3]] : (!torch.int, !torch.int) -> !torch.list<int>
+  // CHECK: %[[C0_1:.*]] = torch.constant.int 0
+  // CHECK: %[[C0_2:.*]] = torch.constant.int 0
+  // CHECK: %[[OUTPUT_PADDING:.*]] = torch.prim.ListConstruct %[[C0_1]], %[[C0_2]] : (!torch.int, !torch.int) -> !torch.list<int>
+  // CHECK: %[[TRANSPOSED:.*]] = torch.constant.bool false
+  // CHECK: %[[BIAS:.*]] = torch.constant.none
+  // CHECK: %[[GROUPS:.*]] = torch.constant.int 1
+  // CHECK: %[[INPUT:.*]] = torch.aten._make_per_tensor_quantized_tensor %arg0, %[[SCALE]], %[[INPUT_ZP]] : !torch.vtensor<[1,1,3,3],ui8>, !torch.float, !torch.int -> !torch.vtensor<[1,1,3,3],!torch.quint8>
+  // CHECK: %[[WEIGHT:.*]] = torch.aten._make_per_tensor_quantized_tensor %arg1, %[[SCALE]], %[[WEIGHT_ZP]] : !torch.vtensor<[1,1,2,2],ui8>, !torch.float, !torch.int -> !torch.vtensor<[1,1,2,2],!torch.quint8>
+  // CHECK: torch.aten.convolution %[[INPUT]], %[[WEIGHT]], %[[BIAS]], %[[STRIDE]], %[[PADDING]], %[[DILATIONS]], %[[TRANSPOSED]], %[[OUTPUT_PADDING]], %[[GROUPS]] : !torch.vtensor<[1,1,3,3],!torch.quint8>, !torch.vtensor<[1,1,2,2],!torch.quint8>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[1,1,2,2],si32>
+  %none = torch.constant.none
+  %0 = torch.operator "onnx.ConvInteger"(%arg0, %arg1, %arg2, %arg3) {torch.onnx.auto_pad = "VALID"} : (!torch.vtensor<[1,1,3,3],ui8>, !torch.vtensor<[1,1,2,2],ui8>, !torch.vtensor<[],ui8>, !torch.vtensor<[1],ui8>) -> !torch.vtensor<[1,1,2,2],si32>
+  return %0 : !torch.vtensor<[1,1,2,2],si32>
+}
+
+// -----
+
 // CHECK-LABEL: @test_convinteger_with_padding
 func.func @test_convinteger_with_padding(%arg0: !torch.vtensor<[1,1,3,3],ui8>, %arg1: !torch.vtensor<[1,1,2,2],ui8>, %arg2: !torch.vtensor<[],ui8>) -> !torch.vtensor<[1,1,4,4],si32> attributes {torch.onnx_meta.ir_version = 5 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
   // CHECK: %[[NONE:.*]] = torch.constant.none


### PR DESCRIPTION
Enable VALID auto_pad attribute for [onnx.ConvInteger](https://onnx.ai/onnx/operators/onnx__ConvInteger.html). If auto_pad is VALID, then 0 padding size should be used.

Such nodes are seen in the int8 quantized vision encoders of [SmolVLM2](https://huggingface.co/HuggingFaceTB/SmolVLM2-500M-Video-Instruct/tree/main/onnx) and [Florence-2](https://huggingface.co/onnx-community/Florence-2-base/tree/main/onnx)