### PR TITLE
[Torch] Fix aten.linalg_vector_norm for ord = 0 and ord = +/-inf

### DIFF
--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -678,16 +678,6 @@ private:
     // Cast `ord` to float so that we can readily pass it math.powf.
     Value ordValue = convertScalarToDtype(rewriter, loc, ordOp, elemType);
 
-    // TODO: Add support for ord = {0, +inf, -inf}.
-    auto epsilon = 1e-5;
-    auto ordLiteral = 0.0;
-    if (matchPattern(ordValue, m_TorchConstantFloat(&ordLiteral)) &&
-        fabs(ordLiteral) < epsilon)
-      return rewriter.notifyMatchFailure(op, "unimplemented: L0 norm");
-
-    if (std::isinf(ordLiteral))
-      return rewriter.notifyMatchFailure(op, "unimplemented: ord = +/- inf");
-
     // Raise each summed value to the inverse of the order of the norm.
     TypedAttr oneAttr = rewriter.getFloatAttr(elemType, 1.0);
     auto oneValue = arith::ConstantOp::create(rewriter, loc, oneAttr);
@@ -758,6 +748,26 @@ public:
     if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
       return rewriter.notifyMatchFailure(
           op, "invalid operand or result types to use with linalg on tensors");
+
+    // ord = 0 (count of nonzeros, imported as an int) and ord = +/-inf (min/max
+    // of absolute values, imported as a float) are handled by
+    // DecomposeAtenLinalgVectorNormOp; the generic (sum |x|^ord)^(1/ord)
+    // lowering is undefined for them. Decline before creating any IR so that a
+    // miscompile cannot slip through if decomposition is disabled. Match on the
+    // original `ord` scalar; a non-constant ord is left to the generic path.
+    if (auto normOp = dyn_cast<AtenLinalgVectorNormOp>(op)) {
+      double ordLiteral;
+      int64_t ordInt;
+      bool isConstOrd = true;
+      if (matchPattern(normOp.getOrd(), m_TorchConstantInt(&ordInt)))
+        ordLiteral = static_cast<double>(ordInt);
+      else if (!matchPattern(normOp.getOrd(),
+                             m_TorchConstantFloat(&ordLiteral)))
+        isConstOrd = false;
+      if (isConstOrd && (ordLiteral == 0.0 || std::isinf(ordLiteral)))
+        return rewriter.notifyMatchFailure(
+            op, "ord = 0 / +/-inf are handled by decomposition");
+    }
 
     FailureOr<torch_to_linalg::ReductionOpInfo> opInfo =
         computeReductionOpInfo(op, operands, rewriter);

--- a/lib/Conversion/TorchToStablehlo/Reduction.cpp
+++ b/lib/Conversion/TorchToStablehlo/Reduction.cpp
@@ -910,6 +910,23 @@ LogicalResult ConvertAtenReductionOp<AtenLinalgVectorNormOp>::matchAndRewrite(
   }
   int64_t inputRank = inputType.getRank();
 
+  // ord = 0 (count of nonzeros, imported as an int) and ord = +/-inf (min/max
+  // of absolute values, imported as a float) are handled by
+  // DecomposeAtenLinalgVectorNormOp; the generic (sum |x|^ord)^(1/ord) lowering
+  // below is undefined for them. Decline before creating any IR so that a
+  // miscompile cannot slip through if decomposition is disabled. Match on the
+  // original `ord` scalar; a non-constant ord is left to the generic path.
+  double ordFloat;
+  int64_t ordInt;
+  bool isConstOrd = true;
+  if (matchPattern(op.getOrd(), m_TorchConstantInt(&ordInt)))
+    ordFloat = static_cast<double>(ordInt);
+  else if (!matchPattern(op.getOrd(), m_TorchConstantFloat(&ordFloat)))
+    isConstOrd = false;
+  if (isConstOrd && (ordFloat == 0.0 || std::isinf(ordFloat)))
+    return rewriter.notifyMatchFailure(
+        op, "ord = 0 / +/-inf are handled by decomposition");
+
   auto outType =
       cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
   auto outElemType = outType.getElementType();

--- a/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
+++ b/lib/Conversion/TorchToTosa/TosaLegalizeCommon.cpp
@@ -1121,44 +1121,46 @@ convertLinalgVectorNormOp(PatternRewriter &rewriter, Operation *op,
   }
 
   auto linalgVectorNormOp = cast<AtenLinalgVectorNormOp>(op);
-  // TODO: Add support for ord = {0, +inf, -inf}.
-  auto epsilon = 1e-5;
   double ordLiteralFloat = 1.0;
   int64_t ordLiteralInt = 1;
-  Value ordVal;
-  if (matchPattern(linalgVectorNormOp.getOrd(),
-                   torch::Torch::m_TorchConstantFloat(&ordLiteralFloat))) {
-    ordVal = tosa::getConstTensor<float>(rewriter, op,
-                                         {static_cast<float>(ordLiteralFloat)},
-                                         {}, elemType)
-                 .value();
-  } else if (matchPattern(linalgVectorNormOp.getOrd(),
-                          torch::Torch::m_TorchConstantInt(&ordLiteralInt))) {
-    ordVal = tosa::getConstTensor<float>(rewriter, op,
-                                         {static_cast<float>(ordLiteralInt)},
-                                         {}, elemType)
-                 .value();
-  } else {
+  bool ordIsFloat =
+      matchPattern(linalgVectorNormOp.getOrd(),
+                   torch::Torch::m_TorchConstantFloat(&ordLiteralFloat));
+  bool ordIsInt =
+      !ordIsFloat &&
+      matchPattern(linalgVectorNormOp.getOrd(),
+                   torch::Torch::m_TorchConstantInt(&ordLiteralInt));
+  if (!ordIsFloat && !ordIsInt) {
     op->emitOpError("only support FP or INT type ord parameter");
     return std::nullopt;
   }
 
+  // ord = 0 (count of nonzeros) and ord = +/-inf (min/max of absolute values)
+  // are handled by DecomposeAtenLinalgVectorNormOp; the generic
+  // (sum |x|^ord)^(1/ord) lowering below is undefined for them. Decline before
+  // creating any IR so that a miscompile cannot slip through if decomposition
+  // is disabled.
+  double ordLiteral =
+      ordIsFloat ? ordLiteralFloat : static_cast<double>(ordLiteralInt);
+  if (ordLiteral == 0.0) {
+    (void)rewriter.notifyMatchFailure(op,
+                                      "ord = 0 is handled by decomposition");
+    return std::nullopt;
+  }
+  if (std::isinf(ordLiteral)) {
+    (void)rewriter.notifyMatchFailure(
+        op, "ord = +/-inf are handled by decomposition");
+    return std::nullopt;
+  }
+
+  Value ordVal = tosa::getConstTensor<float>(rewriter, op,
+                                             {static_cast<float>(ordLiteral)},
+                                             {}, elemType)
+                     .value();
   Value ordValRank0 = ordVal;
   if (mlir::tosa::EqualizeRanks(rewriter, op->getLoc(), input_value, ordVal)
           .failed())
     return std::nullopt;
-
-  if (fabs(ordLiteralFloat) < epsilon ||
-      fabs(static_cast<double>(ordLiteralInt)) < epsilon) {
-    op->emitOpError("unimplemented: L0 norm");
-    return std::nullopt;
-  }
-
-  if (std::isinf(ordLiteralFloat) ||
-      std::isinf(static_cast<double>(ordLiteralInt))) {
-    op->emitOpError("unimplemented: ord = +/- inf");
-    return std::nullopt;
-  }
 
   auto input_value_casted =
       tosa::tosaCastTensorToType(rewriter, input_value, output_type).value();

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -10678,6 +10678,82 @@ public:
 } // namespace
 
 namespace {
+// Decompose `aten.linalg_vector_norm` for the `ord` values where the generic
+// `(sum |x|^ord)^(1/ord)` lowering is undefined: `ord = +inf` is `max(|x|)`,
+// `ord = -inf` is `min(|x|)`, and `ord = 0` is the count of nonzero elements
+// `sum(|x| != 0)`. Handling these here makes every backend correct through the
+// already-supported `aten.amax`/`aten.amin`/`aten.sum.dim_IntList` ops. Finite,
+// nonzero `ord` (and non-constant `ord`) are left for the backends' generic
+// lowering.
+class DecomposeAtenLinalgVectorNormOp
+    : public OpRewritePattern<AtenLinalgVectorNormOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(AtenLinalgVectorNormOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    // `ord` is an `AnyTorchScalarType`, so an integer `ord` (e.g. `ord = 0`)
+    // imports as a `torch.constant.int`, not a `torch.constant.float`.
+    double ordLiteral;
+    int64_t ordInt;
+    if (matchPattern(op.getOrd(), m_TorchConstantInt(&ordInt)))
+      ordLiteral = static_cast<double>(ordInt);
+    else if (!matchPattern(op.getOrd(), m_TorchConstantFloat(&ordLiteral)))
+      return rewriter.notifyMatchFailure(op, "non-constant `ord` unsupported");
+
+    bool isInf = std::isinf(ordLiteral);
+    bool isZero = ordLiteral == 0.0;
+    if (!isInf && !isZero)
+      return rewriter.notifyMatchFailure(
+          op, "only ord = 0 / +/-inf are decomposed; finite ord is lowered by "
+              "the backends");
+
+    Value self = op.getSelf();
+    auto selfType = dyn_cast<BaseTensorType>(self.getType());
+    if (!selfType || !selfType.hasSizes())
+      return rewriter.notifyMatchFailure(op, "expected input with known rank");
+
+    // `dim = None` means reduce over all dimensions.
+    Value dim = op.getDim();
+    if (isa<Torch::NoneType>(dim.getType())) {
+      SmallVector<Value> allDims;
+      for (int64_t i = 0, rank = selfType.getSizes().size(); i < rank; ++i)
+        allDims.push_back(ConstantIntOp::create(rewriter, loc,
+                                                rewriter.getI64IntegerAttr(i)));
+      dim = PrimListConstructOp::create(
+          rewriter, loc,
+          Torch::ListType::get(Torch::IntType::get(op.getContext())), allDims);
+    }
+
+    Value abs = AtenAbsOp::create(rewriter, loc, self.getType(), self);
+
+    // `ord = +/-inf` are the max/min of the absolute values.
+    if (isInf) {
+      if (ordLiteral > 0)
+        rewriter.replaceOpWithNewOp<AtenAmaxOp>(op, op.getType(), abs, dim,
+                                                op.getKeepdim());
+      else
+        rewriter.replaceOpWithNewOp<AtenAminOp>(op, op.getType(), abs, dim,
+                                                op.getKeepdim());
+      return success();
+    }
+
+    // `ord = 0` is the count of nonzero elements: `sum(|x| != 0)`.
+    Value zero =
+        ConstantFloatOp::create(rewriter, loc, rewriter.getF64FloatAttr(0.0));
+    auto boolType = selfType.getWithSizesAndDtype(selfType.getOptionalSizes(),
+                                                  rewriter.getI1Type());
+    Value nonzero = AtenNeScalarOp::create(rewriter, loc, boolType, abs, zero);
+    Value none = ConstantNoneOp::create(rewriter, loc);
+    rewriter.replaceOpWithNewOp<AtenSumDimIntListOp>(
+        op, op.getType(), nonzero, dim, op.getKeepdim(), /*dtype=*/none);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class DecomposeAtenRandintLowOp : public OpRewritePattern<AtenRandintLowOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -13842,6 +13918,7 @@ public:
     addPatternIfTargetOpIsIllegal<DecomposeAtenMseLossOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenL1LossOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenNormScalarOptDimOp>(patterns);
+    addPatternIfTargetOpIsIllegal<DecomposeAtenLinalgVectorNormOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenRandintOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenRandintLowOp>(patterns);
     addPatternIfTargetOpIsIllegal<DecomposeAtenVarMeanCorrectionOp>(patterns);

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/reduction.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/reduction.py
@@ -2069,6 +2069,149 @@ def ReduceLN3NormModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ReduceLInfNormModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1], torch.float32, True),
+        ]
+    )
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=0, ord=float("inf"))
+
+
+@register_test_case(module_factory=lambda: ReduceLInfNormModule())
+def ReduceLInfNormModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5))
+
+
+# ==============================================================================
+
+
+class ReduceLNegInfNormModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1], torch.float32, True),
+        ]
+    )
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=0, ord=float("-inf"))
+
+
+@register_test_case(module_factory=lambda: ReduceLNegInfNormModule())
+def ReduceLNegInfNormModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5))
+
+
+# ==============================================================================
+
+
+class ReduceL0NormModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1], torch.float32, True),
+        ]
+    )
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=0, ord=0)
+
+
+@register_test_case(module_factory=lambda: ReduceL0NormModule())
+def ReduceL0NormModule_basic(module, tu: TestUtils):
+    # Include exact zeros so the nonzero-count semantics are exercised.
+    module.forward(torch.tensor([0.0, 1.5, 0.0, -2.0, 3.0]))
+
+
+# ==============================================================================
+
+
+# ord = +inf over a single dim of a multidim input, with keepdim.
+class ReduceLInfNormKeepDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=1, keepdim=True, ord=float("inf"))
+
+
+@register_test_case(module_factory=lambda: ReduceLInfNormKeepDimModule())
+def ReduceLInfNormKeepDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+
+
+# ==============================================================================
+
+
+# ord = -inf reducing over all dims (dim=None) of a multidim input.
+class ReduceLNegInfNormNoneDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=None, ord=float("-inf"))
+
+
+@register_test_case(module_factory=lambda: ReduceLNegInfNormNoneDimModule())
+def ReduceLNegInfNormNoneDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4))
+
+
+# ==============================================================================
+
+
+# ord = 0 over multiple dims, with keepdim, of a multidim input.
+class ReduceL0NormMultiDimKeepDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, a):
+        return torch.linalg.vector_norm(a, dim=[0, 1], keepdim=True, ord=0)
+
+
+@register_test_case(module_factory=lambda: ReduceL0NormMultiDimKeepDimModule())
+def ReduceL0NormMultiDimKeepDimModule_basic(module, tu: TestUtils):
+    # Include exact zeros so the nonzero-count semantics are exercised.
+    module.forward(torch.tensor([[0.0, 1.5, 0.0], [-2.0, 0.0, 3.0]]))
+
+
+# ==============================================================================
+
+
 class ReduceL3NormAllDimsModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Conversion/TorchToLinalg/vector_norm.mlir
+++ b/test/Conversion/TorchToLinalg/vector_norm.mlir
@@ -1,0 +1,96 @@
+// RUN: torch-mlir-opt <%s -convert-torch-to-linalg -split-input-file -verify-diagnostics | FileCheck %s
+
+// A finite, nonzero ord is lowered by this pass with the generic
+// (sum |x|^ord)^(1/ord) formula: a reduction that accumulates |x|^ord, followed
+// by raising the sum to the 1/ord power.
+// CHECK-LABEL:   func.func @torch.aten.linalg_vector_norm$finite(
+// CHECK:           %[[REDUCE:.*]] = linalg.generic
+// CHECK-SAME:        iterator_types = ["parallel", "reduction"]
+// CHECK:             %[[ABS:.*]] = math.absf
+// CHECK:             %[[POW:.*]] = math.powf %[[ABS]],
+// CHECK:             %[[ACC:.*]] = arith.addf %[[POW]],
+// CHECK:             linalg.yield %[[ACC]]
+// CHECK:           %[[ROOT:.*]] = linalg.generic
+// CHECK-SAME:        iterator_types = ["parallel"]
+// CHECK:             math.powf
+// CHECK:             linalg.yield
+func.func @torch.aten.linalg_vector_norm$finite(%arg0: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3],f32> {
+  %ord = torch.constant.float 2.000000e+00
+  %dim = torch.constant.int 1
+  %dimlist = torch.prim.ListConstruct %dim : (!torch.int) -> !torch.list<int>
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dimlist, %keepdim, %dtype : !torch.vtensor<[3,4],f32>, !torch.float, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[3],f32>
+  return %0 : !torch.vtensor<[3],f32>
+}
+
+// -----
+
+// Reducing over multiple dims with keepdim = true: the reduction op has one
+// reduction iterator per reduced dim, and the reduced dims are kept as size-1
+// (the output indexing map pins them to 0), so the result rank matches the
+// input rank.
+// CHECK-LABEL:   func.func @torch.aten.linalg_vector_norm$keepdim_multidim(
+// CHECK:           %[[REDUCE:.*]] = linalg.generic
+// CHECK-SAME:        iterator_types = ["parallel", "reduction", "reduction"]
+// CHECK:             %[[ABS:.*]] = math.absf
+// CHECK:             %[[POW:.*]] = math.powf %[[ABS]],
+// CHECK:             %[[ACC:.*]] = arith.addf %[[POW]],
+// CHECK:             linalg.yield %[[ACC]]
+// CHECK:           %[[ROOT:.*]] = linalg.generic
+// CHECK-SAME:        iterator_types = ["parallel", "parallel", "parallel"]
+// CHECK:             math.powf
+// CHECK:             linalg.yield
+func.func @torch.aten.linalg_vector_norm$keepdim_multidim(%arg0: !torch.vtensor<[2,3,4],f32>) -> !torch.vtensor<[2,1,1],f32> {
+  %ord = torch.constant.float 2.000000e+00
+  %d0 = torch.constant.int 1
+  %d1 = torch.constant.int 2
+  %dimlist = torch.prim.ListConstruct %d0, %d1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %keepdim = torch.constant.bool true
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dimlist, %keepdim, %dtype : !torch.vtensor<[2,3,4],f32>, !torch.float, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[2,1,1],f32>
+  return %0 : !torch.vtensor<[2,1,1],f32>
+}
+
+// -----
+
+// The ord = 0 / +-inf vector norms are handled by
+// DecomposeAtenLinalgVectorNormOp before this conversion runs; the generic
+// (sum |x|^ord)^(1/ord) lowering here is undefined for them. If the op reaches
+// this pass undecomposed (e.g. decomposition disabled), the conversion declines
+// rather than miscompiling, so the op fails to legalize.
+
+func.func @torch.aten.linalg_vector_norm$pos_inf(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.float 0x7FF0000000000000
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.linalg_vector_norm'}}
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.float, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+func.func @torch.aten.linalg_vector_norm$neg_inf(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.float 0xFFF0000000000000
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.linalg_vector_norm'}}
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.float, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+// ord is a Scalar, so an integer ord = 0 imports as a torch.constant.int.
+func.func @torch.aten.linalg_vector_norm$zero_int(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.int 0
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.linalg_vector_norm'}}
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.int, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}

--- a/test/Conversion/TorchToStablehlo/reduction.mlir
+++ b/test/Conversion/TorchToStablehlo/reduction.mlir
@@ -31,3 +31,52 @@ func.func @torch.aten.prod.intdim_negative_dim(%arg0: !torch.vtensor<[?,?,?,?],f
   // CHECK: return %[[VAL_3]] : !torch.vtensor<[?,?,?],f32>
   return %0 : !torch.vtensor<[?,?,?],f32>
 }
+
+// -----
+
+// A finite, nonzero ord uses the generic (sum |x|^ord)^(1/ord) formula: raise
+// |x| to the ord power, reduce-add over the reduced dim, then raise the sum to
+// the 1/ord power.
+// CHECK-LABEL:   func.func @torch.aten.linalg_vector_norm$finite(
+// CHECK:           %[[ABS:.*]] = stablehlo.abs
+// CHECK:           %[[POW:.*]] = chlo.broadcast_power %[[ABS]],
+// CHECK:           %[[INIT:.*]] = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK:           %[[SUM:.*]] = stablehlo.reduce(%[[POW]] init: %[[INIT]]) applies stablehlo.add across dimensions = [1]
+// CHECK:           %[[ROOT:.*]] = chlo.broadcast_power %[[SUM]],
+func.func @torch.aten.linalg_vector_norm$finite(%arg0: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3],f32> {
+  %ord = torch.constant.float 2.000000e+00
+  %dim = torch.constant.int 1
+  %dimlist = torch.prim.ListConstruct %dim : (!torch.int) -> !torch.list<int>
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dimlist, %keepdim, %dtype : !torch.vtensor<[3,4],f32>, !torch.float, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[3],f32>
+  return %0 : !torch.vtensor<[3],f32>
+}
+
+// -----
+
+// The ord = 0 / +-inf vector norms are handled by
+// DecomposeAtenLinalgVectorNormOp; the generic (sum |x|^ord)^(1/ord) lowering
+// here is undefined for them. If the op reaches this pass undecomposed the
+// conversion declines, so it fails to legalize.
+func.func @torch.aten.linalg_vector_norm$pos_inf(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.float 0x7FF0000000000000
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.linalg_vector_norm'}}
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.float, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+func.func @torch.aten.linalg_vector_norm$zero_int(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.int 0
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.linalg_vector_norm'}}
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.int, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -6653,3 +6653,31 @@ func.func @torch.aten.avg_pool2d$encoded_stride_with_non_unit_dilation(%arg0: !t
   %0 = torch.aten.avg_pool2d %arg0, %kernel, %stride, %padding, %false, %false, %none : !torch.vtensor<[1,64,16,16],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[1,64,7,7],f32>
   return %0 : !torch.vtensor<[1,64,7,7],f32>
 }
+
+// -----
+
+// The ord = 0 / +-inf vector norms are handled by
+// DecomposeAtenLinalgVectorNormOp; the generic (sum |x|^ord)^(1/ord) lowering
+// here is undefined for them. If the op reaches this pass undecomposed the
+// conversion declines, so it fails to legalize.
+func.func @torch.aten.linalg_vector_norm$pos_inf(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.float 0x7FF0000000000000
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.linalg_vector_norm'}}
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.float, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+func.func @torch.aten.linalg_vector_norm$zero_int(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.int 0
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.linalg_vector_norm'}}
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.int, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1543,3 +1543,126 @@ func.func @addbmm_zero_batch(%arg0: !torch.vtensor<[2,7],f32>, %arg1: !torch.vte
   %0 = torch.aten.addbmm %arg0, %arg1, %arg2, %float1, %float1 : !torch.vtensor<[2,7],f32>, !torch.vtensor<[0,2,9],f32>, !torch.vtensor<[0,9,7],f32>, !torch.float, !torch.float -> !torch.vtensor<[2,7],f32>
   return %0 : !torch.vtensor<[2,7],f32>
 }
+
+// -----
+
+// ord = +inf: linalg_vector_norm decomposes to abs + amax (amax then further
+// decomposes to max.dim within the same pass run).
+// CHECK-LABEL: func.func @torch.aten.linalg_vector_norm$pos_inf(
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %arg0
+// CHECK:         torch.aten.max.dim %[[ABS]]
+// CHECK-NOT:     torch.aten.linalg_vector_norm
+func.func @torch.aten.linalg_vector_norm$pos_inf(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.float 0x7FF0000000000000
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.float, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+// ord = -inf: linalg_vector_norm decomposes to abs + amin (amin then further
+// decomposes to min.dim within the same pass run).
+// CHECK-LABEL: func.func @torch.aten.linalg_vector_norm$neg_inf(
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %arg0
+// CHECK:         torch.aten.min.dim %[[ABS]]
+// CHECK-NOT:     torch.aten.linalg_vector_norm
+func.func @torch.aten.linalg_vector_norm$neg_inf(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.float 0xFFF0000000000000
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.float, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+// ord = 0: linalg_vector_norm decomposes to the count of nonzeros,
+// sum(|x| != 0), via abs + ne.Scalar + sum.dim_IntList.
+// CHECK-LABEL: func.func @torch.aten.linalg_vector_norm$zero(
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %arg0
+// CHECK:         %[[NE:.*]] = torch.aten.ne.Scalar %[[ABS]]
+// CHECK:         torch.aten.sum.dim_IntList %[[NE]]
+// CHECK-NOT:     torch.aten.linalg_vector_norm
+func.func @torch.aten.linalg_vector_norm$zero(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.float 0.0
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.float, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+// ord is a Scalar, so an integer ord = 0 imports as a torch.constant.int; it
+// must still take the count-of-nonzeros decomposition.
+// CHECK-LABEL: func.func @torch.aten.linalg_vector_norm$zero_int(
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %arg0
+// CHECK:         %[[NE:.*]] = torch.aten.ne.Scalar %[[ABS]]
+// CHECK:         torch.aten.sum.dim_IntList %[[NE]]
+// CHECK-NOT:     torch.aten.linalg_vector_norm
+func.func @torch.aten.linalg_vector_norm$zero_int(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.int 0
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.int, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+// Finite ord is left untouched by decomposition (lowered by the backends).
+// CHECK-LABEL: func.func @torch.aten.linalg_vector_norm$finite(
+// CHECK:         torch.aten.linalg_vector_norm
+func.func @torch.aten.linalg_vector_norm$finite(%arg0: !torch.vtensor<[5],f32>) -> !torch.vtensor<[],f32> {
+  %ord = torch.constant.float 3.0
+  %dim = torch.constant.none
+  %keepdim = torch.constant.bool false
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[5],f32>, !torch.float, !torch.none, !torch.bool, !torch.none -> !torch.vtensor<[],f32>
+  return %0 : !torch.vtensor<[],f32>
+}
+
+// -----
+
+// ord = +inf with an explicit dim and keepdim = true: the reduced dim is
+// carried through to max.dim (which keeps it as size-1), so the result keeps
+// the input rank.
+// CHECK-LABEL: func.func @torch.aten.linalg_vector_norm$pos_inf_dim_keepdim(
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %arg0
+// CHECK:         torch.aten.max.dim %[[ABS]], %{{.*}}, %true
+// CHECK-NOT:     torch.aten.linalg_vector_norm
+func.func @torch.aten.linalg_vector_norm$pos_inf_dim_keepdim(%arg0: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,1],f32> {
+  %ord = torch.constant.float 0x7FF0000000000000
+  %d = torch.constant.int 1
+  %dim = torch.prim.ListConstruct %d : (!torch.int) -> !torch.list<int>
+  %keepdim = torch.constant.bool true
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[3,4],f32>, !torch.float, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[3,1],f32>
+  return %0 : !torch.vtensor<[3,1],f32>
+}
+
+// -----
+
+// ord = 0 with an explicit dim and keepdim = true: the dim list and keepdim are
+// forwarded to sum.dim_IntList, so the count of nonzeros keeps the reduced dim
+// as size-1.
+// CHECK-LABEL: func.func @torch.aten.linalg_vector_norm$zero_dim_keepdim(
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %arg0
+// CHECK:         %[[NE:.*]] = torch.aten.ne.Scalar %[[ABS]]
+// CHECK:         torch.aten.sum.dim_IntList %[[NE]], %{{.*}}, %true
+// CHECK-NOT:     torch.aten.linalg_vector_norm
+func.func @torch.aten.linalg_vector_norm$zero_dim_keepdim(%arg0: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,1],f32> {
+  %ord = torch.constant.float 0.0
+  %d = torch.constant.int 1
+  %dim = torch.prim.ListConstruct %d : (!torch.int) -> !torch.list<int>
+  %keepdim = torch.constant.bool true
+  %dtype = torch.constant.none
+  %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[3,4],f32>, !torch.float, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[3,1],f32>
+  return %0 : !torch.vtensor<[3,1],f32>
+}


### PR DESCRIPTION
Fix `aten.linalg_vector_norm` for `ord = 0` and `ord = ±inf`

The generic `(sum |x|^ord)^(1/ord)` lowering is wrong for these:
`±inf` gives `inf^0 = 1` and `ord = 0` gives `pow(N, +inf)`, so
`ord = -inf` was returning `1.0` instead of `min(|x_i|)`.

Instead of patching each backend, I decompose the three cases in
`DecomposeComplexOps` (following `_refs`): `+inf → amax(|x|)`,
`-inf → amin(|x|)`, `0 → sum(|x| != 0)`. This also fixes the ONNX path
(`LpNormalization → aten.norm.ScalarOpt_dim → aten.linalg_vector_norm`),
which never hits the Python `_refs` decomposition. Finite / non-constant
`ord` still go through the backends unchanged, which now decline
`0`/`±inf` cleanly instead of miscompiling.

Also drops the StableHLO XFAILs — the decomposition makes these correct
there too.

