### PR TITLE
[CI] Fix ccache reuse on Windows and Linux

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -3,24 +3,6 @@ name: "Setup build environment"
 description: "Setup the build environment. An action so that it can be shared between in-tree/out-of-tree jobs"
 
 inputs:
-  cache-enabled:
-    required: true
-    default: true
-
-  cache-suffix:
-    description: |
-      Additional string that is used to compute the ccache hash.
-      Different jobs running the action need distinct values for this key,
-      but the content is irrelevant.
-    required: false
-    default: ''
-  torch-version:
-    description: |
-      Additional string to determine wether to test against a stable
-      torch release or against the nightly build
-    required: false
-    default: 'nightly'
-
   python-version:
     description: 'Python version to use'
     required: false
@@ -58,24 +40,3 @@ runs:
         pip install ninja
         choco install ccache --yes
       shell: bash
-
-    - name: Configure ccache
-      if: ${{ inputs.cache-enabled == 'true' }}
-      run: |
-        rm -rf ${{ github.workspace }}/.ccache
-        mkdir -p ${{ github.workspace }}/.ccache
-        ccache --set-config "cache_dir=${{ github.workspace }}/.ccache"
-        ccache --set-config "compression=true"
-        ccache --set-config "max_size=300M"
-        ccache --zero-stats
-      shell: bash
-
-    - name: Enable ccache
-      if: ${{ inputs.cache-enabled == 'true' }}
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-      with:
-        path: ${{ github.workspace }}/.ccache
-        key: ${{ runner.os }}-${{ inputs.cache-suffix }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache-suffix }}-
-          ${{ runner.os }}-

--- a/.github/workflows/RollPyTorch.yml
+++ b/.github/workflows/RollPyTorch.yml
@@ -41,8 +41,6 @@ jobs:
 
       - name: Setup ccache
         uses: ./.github/actions/setup-build
-        with:
-          cache-suffix: 'rollPyTorch'
 
       - name: Determine nightly PyTorch version
         run: |

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -34,8 +34,6 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-build
-        with:
-          cache-enabled: 'false'
       - name: Build Python wheels and smoke test.
         run: |
           cd $GITHUB_WORKSPACE
@@ -102,8 +100,6 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-build
-        with:
-          cache-enabled: 'false'
       - name: Build Python wheels and smoke test.
         run: |
           cd $GITHUB_WORKSPACE
@@ -160,8 +156,6 @@ jobs:
         with:
           submodules: 'true'
       - uses: ./.github/actions/setup-build
-        with:
-          cache-enabled: 'false'
       - name: Build Python wheels and smoke test.
         run: |
           cd $GITHUB_WORKSPACE
@@ -220,8 +214,6 @@ jobs:
         with:
           submodules: 'true'
       - uses: ./.github/actions/setup-build
-        with:
-          cache-enabled: 'false'
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,22 +33,16 @@ jobs:
         with:
           submodules: true
 
-      - name: Enable cache
+      - name: Setup workspace and python
+        uses: ./.github/actions/setup-build
+
+      - name: Restore cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.CACHE_DIR }}
           key: build-test-cpp-asserts-manylinux-${{ matrix.torch-version }}-v2-${{ github.sha }}
           restore-keys: |
             build-test-cpp-asserts-manylinux-${{ matrix.torch-version }}-v2-
-
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
-        with:
-          key: ${{ github.job }}-${{ matrix.torch-version }}
-          save: ${{ needs.setup.outputs.write-caches == 1 }}
-
-      - name: Setup workspace and python
-        uses: ./.github/actions/setup-build
 
       - name: Display Python version and path
         run: |

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -27,7 +27,7 @@ jobs:
       run:
         shell: bash
     env:
-      CACHE_DIR: ${{ github.workspace }}\.container-cache
+      CACHE_DIR: ${{ github.workspace }}/.container-cache
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,7 +37,7 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-build
 
-      - name: Enable cache
+      - name: Restore cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.CACHE_DIR }}
@@ -52,12 +52,6 @@ jobs:
       - name: Install python deps (torch-${{ matrix.torch-version }})
         run: |
           ./build_tools/ci/install_python_deps.sh ${{ matrix.torch-version }}
-
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
-        with:
-          key: ${{ github.job }}-${{ matrix.torch-version }}
-          save: ${{ needs.setup.outputs.write-caches == 1 }}
 
       - name: Build project
         run: |

--- a/build_tools/ci/build_posix.sh
+++ b/build_tools/ci/build_posix.sh
@@ -27,7 +27,8 @@ export CMAKE_TOOLCHAIN_FILE="$this_dir/linux_default_toolchain.cmake"
 export CC=clang
 export CXX=clang++
 export CCACHE_DIR="${cache_dir}/ccache"
-export CCACHE_MAXSIZE="350M"
+export CCACHE_MAXSIZE="700M"
+export CCACHE_SLOPPINESS="pch_defines,time_macros"
 export CMAKE_C_COMPILER_LAUNCHER=ccache
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 

--- a/build_tools/python_deploy/build_windows_ci.sh
+++ b/build_tools/python_deploy/build_windows_ci.sh
@@ -19,7 +19,8 @@ mkdir -p "${cache_dir}/ccache"
 mkdir -p "${cache_dir}/pip"
 
 export CCACHE_DIR="${cache_dir}/ccache"
-export CCACHE_MAXSIZE="350M"
+export CCACHE_MAXSIZE="700M"
+export CCACHE_SLOPPINESS="pch_defines,time_macros"
 
 # Clear ccache stats.
 ccache -z
@@ -27,6 +28,8 @@ ccache -z
 echo "::group::CMake configure"
 cmake -GNinja -Bbuild \
   -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang-cl \
+  -DCMAKE_CXX_COMPILER=clang-cl \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DLLVM_ENABLE_PROJECTS=mlir \


### PR DESCRIPTION
Fix ccache to cache all compilations

Add CCACHE_SLOPPINESS=pch_defines,time_macros which is
required for ccache to cache PCH-using compilations.
Without it, only ~150/3100 files went through ccache
on both Linux and Windows.

Also switch Windows to clang-cl for stable compiler
hashes on ephemeral runners, remove the broken
hendrikmuhs/ccache-action step, and clean up unused
cache inputs from the setup-build action.

The removed cache-suffix and cache-enabled inputs from
setup-build were only consumed by the cache steps that
are now deleted. RollPyTorch passed cache-suffix but
its build runs inside a Docker container
(build_linux_packages.sh), so the host-level ccache
persisted by setup-build was never used. buildRelease
only passed cache-enabled: false to skip caching.

Windows CI: 2h32m -> ~10min with warm cache.

Assisted by: Claude Opus 4.6