### PR TITLE
[TorchToTosa] Fix aten.div.Tensor_mode overflow for i64 inputs

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -1495,6 +1495,19 @@ Value truncFloatDiv(PatternRewriter &rewriter, Operation *op,
   return truncFloatDivWithDivResult(rewriter, op, outType, divResult).value();
 }
 
+// tosa.intdiv only legalizes i32 and i64 element types. Pick the element type
+// used for the trunc-divide and its floor/sign correction arithmetic: keep i64
+// inputs in i64 so that neither the divide nor the `input * divisor` products
+// overflow (a large i64 divisor otherwise wraps in i32 and yields a wrong
+// quotient), and widen narrower integer types to i32 as before.
+static RankedTensorType getIntDivComputeType(TensorType outType,
+                                             PatternRewriter &rewriter) {
+  Type computeElemTy = outType.getElementType().isInteger(64)
+                           ? rewriter.getIntegerType(64)
+                           : rewriter.getIntegerType(32);
+  return RankedTensorType::get(outType.getShape(), computeElemTy);
+}
+
 // Function to perform division with floor rounding mode (rounding result
 // down) for integer type inputs.
 std::optional<Value> floorIntDiv(PatternRewriter &rewriter, Operation *op,
@@ -1507,18 +1520,21 @@ std::optional<Value> floorIntDiv(PatternRewriter &rewriter, Operation *op,
   if (mlir::tosa::EqualizeRanks(rewriter, op->getLoc(), lhs, rhs).failed())
     return std::nullopt;
 
-  // TOSA IntDiv requires inputs to be i32
-  auto i32Type =
-      RankedTensorType::get(outType.getShape(), rewriter.getIntegerType(32));
-  lhs = tosa::tosaCastTensorToType(rewriter, lhs, i32Type).value();
-  rhs = tosa::tosaCastTensorToType(rewriter, rhs, i32Type).value();
+  auto computeType = getIntDivComputeType(outType, rewriter);
+  lhs = tosa::tosaCastTensorToType(rewriter, lhs, computeType).value();
+  rhs = tosa::tosaCastTensorToType(rewriter, rhs, computeType).value();
 
   auto intDivOp =
-      tosa::IntDivOp::create(rewriter, op->getLoc(), i32Type, lhs, rhs);
+      tosa::IntDivOp::create(rewriter, op->getLoc(), computeType, lhs, rhs);
 
-  auto zero = tosa::getConstTensor<int32_t>(rewriter, op, 0, {}).value();
-
-  auto one = tosa::getConstTensor<int32_t>(rewriter, op, 1, {}).value();
+  Value zero, one;
+  if (computeType.getElementType().isInteger(64)) {
+    zero = tosa::getConstTensor<int64_t>(rewriter, op, 0, {}).value();
+    one = tosa::getConstTensor<int64_t>(rewriter, op, 1, {}).value();
+  } else {
+    zero = tosa::getConstTensor<int32_t>(rewriter, op, 0, {}).value();
+    one = tosa::getConstTensor<int32_t>(rewriter, op, 1, {}).value();
+  }
 
   if (mlir::tosa::EqualizeRanks(rewriter, op->getLoc(), lhs, one).failed() ||
       mlir::tosa::EqualizeRanks(rewriter, op->getLoc(), lhs, zero).failed())
@@ -1527,14 +1543,14 @@ std::optional<Value> floorIntDiv(PatternRewriter &rewriter, Operation *op,
   auto boolType =
       RankedTensorType::get(outType.getShape(), rewriter.getIntegerType(1));
 
-  auto lhsMulRhs = tosa::createMulOpAndCast(rewriter, op, i32Type, lhs, rhs,
+  auto lhsMulRhs = tosa::createMulOpAndCast(rewriter, op, computeType, lhs, rhs,
                                             /*shift=*/0);
 
   auto lhsRhsDifferentSign = tosa::GreaterOp::create(rewriter, op->getLoc(),
                                                      boolType, zero, lhsMulRhs);
 
-  auto truncMulRhs = tosa::createMulOpAndCast(rewriter, op, i32Type, intDivOp,
-                                              rhs, /*shift=*/0);
+  auto truncMulRhs = tosa::createMulOpAndCast(rewriter, op, computeType,
+                                              intDivOp, rhs, /*shift=*/0);
 
   auto truncMulRhsEqualLhs =
       tosa::EqualOp::create(rewriter, op->getLoc(), boolType, truncMulRhs, lhs);
@@ -1543,14 +1559,14 @@ std::optional<Value> floorIntDiv(PatternRewriter &rewriter, Operation *op,
       rewriter, op->getLoc(), boolType, truncMulRhsEqualLhs);
 
   auto truncMinusOne =
-      tosa::SubOp::create(rewriter, op->getLoc(), i32Type, intDivOp, one);
+      tosa::SubOp::create(rewriter, op->getLoc(), computeType, intDivOp, one);
 
   auto cond =
       tosa::LogicalAndOp::create(rewriter, op->getLoc(), boolType,
                                  lhsRhsDifferentSign, truncMulRhsNotEqualLhs);
 
-  auto selectOp = tosa::SelectOp::create(rewriter, op->getLoc(), i32Type, cond,
-                                         truncMinusOne, intDivOp);
+  auto selectOp = tosa::SelectOp::create(rewriter, op->getLoc(), computeType,
+                                         cond, truncMinusOne, intDivOp);
 
   Value result =
       tosa::tosaCastTensorToType(rewriter, selectOp, outType).value();
@@ -1647,15 +1663,13 @@ public:
         // to C-style integer division.
         // None: no rounding mode.
 
-        // TOSA IntDiv requires inputs to be i32
-        auto i32Type = RankedTensorType::get(outType.getShape(),
-                                             rewriter.getIntegerType(32));
-        lhs = tosa::tosaCastTensorToType(rewriter, lhs, i32Type).value();
-        rhsTensor =
-            tosa::tosaCastTensorToType(rewriter, rhsTensor, i32Type).value();
+        auto computeType = getIntDivComputeType(outType, rewriter);
+        lhs = tosa::tosaCastTensorToType(rewriter, lhs, computeType).value();
+        rhsTensor = tosa::tosaCastTensorToType(rewriter, rhsTensor, computeType)
+                        .value();
 
-        auto intDivOp = tosa::IntDivOp::create(rewriter, op->getLoc(), i32Type,
-                                               lhs, rhsTensor);
+        auto intDivOp = tosa::IntDivOp::create(rewriter, op->getLoc(),
+                                               computeType, lhs, rhsTensor);
 
         result =
             tosa::tosaCastTensorToType(rewriter, intDivOp, outType).value();

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -5275,6 +5275,67 @@ def ElementwiseDivScalarRoundingModeFloorIntStaticModule_basic(module, tu: TestU
 # ==============================================================================
 
 
+# Large i64 divisor: the divisor 2**30 and the operands exceed the i32 range, so
+# any lowering that truncates to i32 (or computes the input*divisor floor/sign
+# correction in i32) overflows and yields the wrong quotient. Keeps computation
+# in i64. Regression test for the div.Tensor_mode i64 overflow bug.
+class ElementwiseDivScalarRoundingModeFloorInt64Module(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([4], torch.int64, True),
+        ]
+    )
+    def forward(self, a):
+        return torch.div(a, 1073741824, rounding_mode="floor")
+
+
+@register_test_case(
+    module_factory=lambda: ElementwiseDivScalarRoundingModeFloorInt64Module()
+)
+def ElementwiseDivScalarRoundingModeFloorInt64Module_basic(module, tu: TestUtils):
+    module.forward(
+        torch.tensor(
+            [9223372036854775806, -9223372036854775807, 1073741824, -3],
+            dtype=torch.int64,
+        )
+    )
+
+
+class ElementwiseDivScalarRoundingModeTruncInt64Module(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([4], torch.int64, True),
+        ]
+    )
+    def forward(self, a):
+        return torch.div(a, 1073741824, rounding_mode="trunc")
+
+
+@register_test_case(
+    module_factory=lambda: ElementwiseDivScalarRoundingModeTruncInt64Module()
+)
+def ElementwiseDivScalarRoundingModeTruncInt64Module_basic(module, tu: TestUtils):
+    module.forward(
+        torch.tensor(
+            [9223372036854775806, -9223372036854775807, 1073741824, -3],
+            dtype=torch.int64,
+        )
+    )
+
+
+# ==============================================================================
+
+
 class ElementwiseDivTensorRoundingModeTruncModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -2398,12 +2398,9 @@ func.func @torch.aten.div.Tensor_mode$float_trunc(%arg0: !torch.vtensor<[?, ?],f
 // CHECK:           %[[VAL_2:.*]] = torch_c.to_builtin_tensor %[[VAL_1]] : !torch.vtensor<[?,?],si64> -> tensor<?x?xi64>
 // CHECK:           %[[VAL_3:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[?,?],si64> -> tensor<?x?xi64>
 // CHECK:           %[[VAL_4:.*]] = torch.constant.str "trunc"
-// CHECK:           %[[VAL_5:.*]] = tosa.cast %[[VAL_3]] : (tensor<?x?xi64>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_6:.*]] = tosa.cast %[[VAL_2]] : (tensor<?x?xi64>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_7:.*]] = tosa.intdiv %[[VAL_5]], %[[VAL_6]] : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_8:.*]] = tosa.cast %[[VAL_7]] : (tensor<?x?xi32>) -> tensor<?x?xi64>
-// CHECK:           %[[VAL_9:.*]] = torch_c.from_builtin_tensor %[[VAL_8]] : tensor<?x?xi64> -> !torch.vtensor<[?,?],si64>
-// CHECK:           return %[[VAL_9]] : !torch.vtensor<[?,?],si64>
+// CHECK:           %[[VAL_5:.*]] = tosa.intdiv %[[VAL_3]], %[[VAL_2]] : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
+// CHECK:           %[[VAL_6:.*]] = torch_c.from_builtin_tensor %[[VAL_5]] : tensor<?x?xi64> -> !torch.vtensor<[?,?],si64>
+// CHECK:           return %[[VAL_6]] : !torch.vtensor<[?,?],si64>
 // CHECK:         }
 func.func @torch.aten.div.Tensor_mode$int_trunc(%arg0: !torch.vtensor<[?, ?],si64>, %arg1: !torch.vtensor<[?, ?],si64>) -> !torch.vtensor<[?, ?],si64> {
   %str = torch.constant.str "trunc"
@@ -2440,33 +2437,65 @@ func.func @torch.aten.div.Tensor_mode$float_floor(%arg0: !torch.vtensor<[?, ?],f
 // CHECK:           %[[VAL_2:.*]] = torch_c.to_builtin_tensor %[[VAL_1]] : !torch.vtensor<[?,?],si64> -> tensor<?x?xi64>
 // CHECK:           %[[VAL_3:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[?,?],si64> -> tensor<?x?xi64>
 // CHECK:           %[[VAL_4:.*]] = torch.constant.str "floor"
-// CHECK:           %[[VAL_5:.*]] = tosa.cast %[[VAL_3]] : (tensor<?x?xi64>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_6:.*]] = tosa.cast %[[VAL_2]] : (tensor<?x?xi64>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_7:.*]] = tosa.intdiv %[[VAL_5]], %[[VAL_6]] : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() <{values = dense<0> : tensor<i32>}> : () -> tensor<i32>
-// CHECK:           %[[VAL_9:.*]] = "tosa.const"() <{values = dense<1> : tensor<i32>}> : () -> tensor<i32>
+// CHECK:           %[[VAL_5:.*]] = tosa.intdiv %[[VAL_3]], %[[VAL_2]] : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
+// CHECK:           %[[VAL_6:.*]] = "tosa.const"() <{values = dense<0> : tensor<i64>}> : () -> tensor<i64>
+// CHECK:           %[[VAL_7:.*]] = "tosa.const"() <{values = dense<1> : tensor<i64>}> : () -> tensor<i64>
+// CHECK:           %[[VAL_8:.*]] = tosa.const_shape  {values = dense<1> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK:           %[[VAL_9:.*]] = tosa.reshape %[[VAL_7]], %[[VAL_8]] : (tensor<i64>, !tosa.shape<2>) -> tensor<1x1xi64>
 // CHECK:           %[[VAL_10:.*]] = tosa.const_shape  {values = dense<1> : tensor<2xindex>} : () -> !tosa.shape<2>
-// CHECK:           %[[VAL_11:.*]] = tosa.reshape %[[VAL_9]], %[[VAL_10]] : (tensor<i32>, !tosa.shape<2>) -> tensor<1x1xi32>
-// CHECK:           %[[VAL_12:.*]] = tosa.const_shape  {values = dense<1> : tensor<2xindex>} : () -> !tosa.shape<2>
-// CHECK:           %[[VAL_13:.*]] = tosa.reshape %[[VAL_8]], %[[VAL_12]] : (tensor<i32>, !tosa.shape<2>) -> tensor<1x1xi32>
-// CHECK:           %[[VAL_14:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
-// CHECK:           %[[VAL_15:.*]] = tosa.mul %[[VAL_5]], %[[VAL_6]], %[[VAL_14]] : (tensor<?x?xi32>, tensor<?x?xi32>, tensor<1xi8>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_16:.*]] = tosa.greater %[[VAL_13]], %[[VAL_15]] : (tensor<1x1xi32>, tensor<?x?xi32>) -> tensor<?x?xi1>
-// CHECK:           %[[VAL_17:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
-// CHECK:           %[[VAL_18:.*]] = tosa.mul %[[VAL_7]], %[[VAL_6]], %[[VAL_17]] : (tensor<?x?xi32>, tensor<?x?xi32>, tensor<1xi8>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_19:.*]] = tosa.equal %[[VAL_18]], %[[VAL_5]] : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x?xi1>
-// CHECK:           %[[VAL_20:.*]] = tosa.logical_not %[[VAL_19]] : (tensor<?x?xi1>) -> tensor<?x?xi1>
-// CHECK:           %[[VAL_21:.*]] = tosa.sub %[[VAL_7]], %[[VAL_11]] : (tensor<?x?xi32>, tensor<1x1xi32>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_22:.*]] = tosa.logical_and %[[VAL_16]], %[[VAL_20]] : (tensor<?x?xi1>, tensor<?x?xi1>) -> tensor<?x?xi1>
-// CHECK:           %[[VAL_23:.*]] = tosa.select %[[VAL_22]], %[[VAL_21]], %[[VAL_7]] : (tensor<?x?xi1>, tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_24:.*]] = tosa.cast %[[VAL_23]] : (tensor<?x?xi32>) -> tensor<?x?xi64>
-// CHECK:           %[[VAL_25:.*]] = torch_c.from_builtin_tensor %[[VAL_24]] : tensor<?x?xi64> -> !torch.vtensor<[?,?],si64>
-// CHECK:           return %[[VAL_25]] : !torch.vtensor<[?,?],si64>
+// CHECK:           %[[VAL_11:.*]] = tosa.reshape %[[VAL_6]], %[[VAL_10]] : (tensor<i64>, !tosa.shape<2>) -> tensor<1x1xi64>
+// CHECK:           %[[VAL_12:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           %[[VAL_13:.*]] = tosa.mul %[[VAL_3]], %[[VAL_2]], %[[VAL_12]] : (tensor<?x?xi64>, tensor<?x?xi64>, tensor<1xi8>) -> tensor<?x?xi64>
+// CHECK:           %[[VAL_14:.*]] = tosa.greater %[[VAL_11]], %[[VAL_13]] : (tensor<1x1xi64>, tensor<?x?xi64>) -> tensor<?x?xi1>
+// CHECK:           %[[VAL_15:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
+// CHECK:           %[[VAL_16:.*]] = tosa.mul %[[VAL_5]], %[[VAL_2]], %[[VAL_15]] : (tensor<?x?xi64>, tensor<?x?xi64>, tensor<1xi8>) -> tensor<?x?xi64>
+// CHECK:           %[[VAL_17:.*]] = tosa.equal %[[VAL_16]], %[[VAL_3]] : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi1>
+// CHECK:           %[[VAL_18:.*]] = tosa.logical_not %[[VAL_17]] : (tensor<?x?xi1>) -> tensor<?x?xi1>
+// CHECK:           %[[VAL_19:.*]] = tosa.sub %[[VAL_5]], %[[VAL_9]] : (tensor<?x?xi64>, tensor<1x1xi64>) -> tensor<?x?xi64>
+// CHECK:           %[[VAL_20:.*]] = tosa.logical_and %[[VAL_14]], %[[VAL_18]] : (tensor<?x?xi1>, tensor<?x?xi1>) -> tensor<?x?xi1>
+// CHECK:           %[[VAL_21:.*]] = tosa.select %[[VAL_20]], %[[VAL_19]], %[[VAL_5]] : (tensor<?x?xi1>, tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
+// CHECK:           %[[VAL_22:.*]] = torch_c.from_builtin_tensor %[[VAL_21]] : tensor<?x?xi64> -> !torch.vtensor<[?,?],si64>
+// CHECK:           return %[[VAL_22]] : !torch.vtensor<[?,?],si64>
 // CHECK:         }
 func.func @torch.aten.div.Tensor_mode$int_floor(%arg0: !torch.vtensor<[?, ?],si64>, %arg1: !torch.vtensor<[?, ?],si64>) -> !torch.vtensor<[?, ?],si64> {
   %str = torch.constant.str "floor"
   %0 = torch.aten.div.Tensor_mode %arg0, %arg1, %str : !torch.vtensor<[?, ?],si64>, !torch.vtensor<[?, ?],si64>, !torch.str -> !torch.vtensor<[?, ?],si64>
   return %0 : !torch.vtensor<[?, ?],si64>
+}
+
+// -----
+
+// An i32 floor div stays in i32: tosa.intdiv only legalizes i32/i64, so narrower
+// types widen to i32 while i32/i64 keep their own width. This guards against the
+// i64-overflow fix accidentally widening i32 work: no tosa.cast is emitted and
+// the intdiv is in i32.
+
+// CHECK-LABEL:   func.func @torch.aten.div.Tensor_mode$int32_floor(
+// CHECK-NOT:       tosa.cast
+// CHECK:           tosa.intdiv %{{.*}}, %{{.*}} : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x?xi32>
+// CHECK-NOT:       tosa.cast
+func.func @torch.aten.div.Tensor_mode$int32_floor(%arg0: !torch.vtensor<[?, ?],si32>, %arg1: !torch.vtensor<[?, ?],si32>) -> !torch.vtensor<[?, ?],si32> {
+  %str = torch.constant.str "floor"
+  %0 = torch.aten.div.Tensor_mode %arg0, %arg1, %str : !torch.vtensor<[?, ?],si32>, !torch.vtensor<[?, ?],si32>, !torch.str -> !torch.vtensor<[?, ?],si32>
+  return %0 : !torch.vtensor<[?, ?],si32>
+}
+
+// -----
+
+// An i8 floor div widens to i32: tosa.intdiv does not legalize sub-i32 integer
+// types, so the operands are cast up to i32, the divide and floor/sign
+// correction run in i32, and the result is cast back down to i8. This is the
+// unchanged widen-to-i32 path that the i64-overflow fix must preserve.
+
+// CHECK-LABEL:   func.func @torch.aten.div.Tensor_mode$int8_floor(
+// CHECK:           %[[LHS:.*]] = tosa.cast %{{.*}} : (tensor<?x?xi8>) -> tensor<?x?xi32>
+// CHECK:           %[[RHS:.*]] = tosa.cast %{{.*}} : (tensor<?x?xi8>) -> tensor<?x?xi32>
+// CHECK:           tosa.intdiv %[[LHS]], %[[RHS]] : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x?xi32>
+// CHECK:           tosa.cast %{{.*}} : (tensor<?x?xi32>) -> tensor<?x?xi8>
+func.func @torch.aten.div.Tensor_mode$int8_floor(%arg0: !torch.vtensor<[?, ?],si8>, %arg1: !torch.vtensor<[?, ?],si8>) -> !torch.vtensor<[?, ?],si8> {
+  %str = torch.constant.str "floor"
+  %0 = torch.aten.div.Tensor_mode %arg0, %arg1, %str : !torch.vtensor<[?, ?],si8>, !torch.vtensor<[?, ?],si8>, !torch.str -> !torch.vtensor<[?, ?],si8>
+  return %0 : !torch.vtensor<[?, ?],si8>
 }
 
 // -----
@@ -2497,12 +2526,9 @@ func.func @torch.aten.div.Tensor_mode$float_basic(%arg0: !torch.vtensor<[?, ?],f
 // CHECK:           %[[VAL_2:.*]] = torch_c.to_builtin_tensor %[[VAL_1]] : !torch.vtensor<[?,?],si64> -> tensor<?x?xi64>
 // CHECK:           %[[VAL_3:.*]] = torch_c.to_builtin_tensor %[[VAL_0]] : !torch.vtensor<[?,?],si64> -> tensor<?x?xi64>
 // CHECK:           %[[VAL_4:.*]] = torch.constant.str ""
-// CHECK:           %[[VAL_5:.*]] = tosa.cast %[[VAL_3]] : (tensor<?x?xi64>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_6:.*]] = tosa.cast %[[VAL_2]] : (tensor<?x?xi64>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_7:.*]] = tosa.intdiv %[[VAL_5]], %[[VAL_6]] : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<?x?xi32>
-// CHECK:           %[[VAL_8:.*]] = tosa.cast %[[VAL_7]] : (tensor<?x?xi32>) -> tensor<?x?xi64>
-// CHECK:           %[[VAL_9:.*]] = torch_c.from_builtin_tensor %[[VAL_8]] : tensor<?x?xi64> -> !torch.vtensor<[?,?],si64>
-// CHECK:           return %[[VAL_9]] : !torch.vtensor<[?,?],si64>
+// CHECK:           %[[VAL_5:.*]] = tosa.intdiv %[[VAL_3]], %[[VAL_2]] : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
+// CHECK:           %[[VAL_6:.*]] = torch_c.from_builtin_tensor %[[VAL_5]] : tensor<?x?xi64> -> !torch.vtensor<[?,?],si64>
+// CHECK:           return %[[VAL_6]] : !torch.vtensor<[?,?],si64>
 // CHECK:         }
 func.func @torch.aten.div.Tensor_mode$int_basic(%arg0: !torch.vtensor<[?, ?],si64>, %arg1: !torch.vtensor<[?, ?],si64>) -> !torch.vtensor<[?, ?],si64> {
   %str = torch.constant.str ""


### PR DESCRIPTION
tosa.intdiv used to require i32, so the lowering cast i64 operands down to i32 before dividing. For i64 inputs that overflows: the divide loses precision and the floor/sign correction products (input * divisor) wrap. tosa.intdiv supports i64 now, so keep i64 inputs in i64 and only widen narrower types to i32 as before.