### PR TITLE
[TorchOnnxToTorch] Fix unsqueeze type mismatch

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1286,8 +1286,14 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           result = Torch::AtenUnsqueezeOp::create(rewriter, loc, unsqueezeType,
                                                   result, cstDim);
         }
-        rewriter.replaceOpWithNewOp<Torch::TensorStaticInfoCastOp>(
-            binder.op, resultType, result);
+        if (result.getType() != resultType &&
+            Torch::isValidSubtype(result.getType(), resultType)) {
+          // "downcast" if the unsqueeze result type is strictly less precise
+          // than the input type
+          result = Torch::TensorStaticInfoCastOp::create(rewriter, loc,
+                                                         resultType, result);
+        }
+        rewriter.replaceOp(binder.op, result);
         return success();
       });
   patterns.onOp(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -1286,7 +1286,8 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           result = Torch::AtenUnsqueezeOp::create(rewriter, loc, unsqueezeType,
                                                   result, cstDim);
         }
-        rewriter.replaceOp(binder.op, result);
+        rewriter.replaceOpWithNewOp<Torch::TensorStaticInfoCastOp>(
+            binder.op, resultType, result);
         return success();
       });
   patterns.onOp(

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -711,6 +711,27 @@ func.func @test_unsqueeze_three_axes(%arg0: !torch.vtensor<[3,4,5],f32>, %arg1: 
 
 // -----
 
+// CHECK-LABEL: func.func @unsqueeze_type_mismatch
+func.func @unsqueeze_type_mismatch(%arg0: !torch.vtensor<[1,?,16],f32>, %arg1: !torch.vtensor<[3,4,5],f32>) -> (!torch.vtensor<[?,?,16,1],f32>, !torch.vtensor<[3,4,1,5,1,?],f32>) attributes {torch.onnx_meta.opset_version = 18 : si64} {
+  %0 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<-1> : tensor<1xsi64>} : () -> !torch.vtensor<[1],si64>
+  %1 = torch.operator "onnx.Unsqueeze"(%arg0, %0) : (!torch.vtensor<[1,?,16],f32>, !torch.vtensor<[1],si64>) -> !torch.vtensor<[?,?,16,1],f32>
+  // CHECK: %[[INT3:.*]] = torch.constant.int 3
+  // CHECK: %[[UNSQ:.*]] = torch.aten.unsqueeze %arg0, %[[INT3]] : !torch.vtensor<[1,?,16],f32>, !torch.int -> !torch.vtensor<[1,?,16,1],f32>
+  // CHECK: torch.tensor_static_info_cast %[[UNSQ]] : !torch.vtensor<[1,?,16,1],f32> to !torch.vtensor<[?,?,16,1],f32>
+  %2 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<[2, 4, 5]> : tensor<3xsi64>} : () -> !torch.vtensor<[3],si64>
+  %3 = torch.operator "onnx.Unsqueeze"(%arg1, %2) : (!torch.vtensor<[3,4,5],f32>, !torch.vtensor<[3],si64>) -> !torch.vtensor<[3,4,1,5,1,?],f32>
+  // CHECK: %[[INT2:.*]] = torch.constant.int 2
+  // CHECK: %[[UNSQ0:.*]] = torch.aten.unsqueeze %arg1, %[[INT2]] : !torch.vtensor<[3,4,5],f32>, !torch.int -> !torch.vtensor<[3,4,1,5],f32>
+  // CHECK: %[[INT4:.*]] = torch.constant.int 4
+  // CHECK: %[[UNSQ1:.*]] = torch.aten.unsqueeze %[[UNSQ0]], %[[INT4]] : !torch.vtensor<[3,4,1,5],f32>, !torch.int -> !torch.vtensor<[3,4,1,5,1],f32>
+  // CHECK: %[[INT5:.*]] = torch.constant.int 5
+  // CHECK: %[[UNSQ2:.*]] = torch.aten.unsqueeze %[[UNSQ1]], %[[INT5]] : !torch.vtensor<[3,4,1,5,1],f32>, !torch.int -> !torch.vtensor<[3,4,1,5,1,1],f32>
+  // CHECK: torch.tensor_static_info_cast %[[UNSQ2]] : !torch.vtensor<[3,4,1,5,1,1],f32> to !torch.vtensor<[3,4,1,5,1,?],f32>
+  return %1, %3 : !torch.vtensor<[?,?,16,1],f32>, !torch.vtensor<[3,4,1,5,1,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @test_softmax_axis_0
 func.func @test_softmax_axis_0(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[3,4,5],f32> attributes {torch.onnx_meta.ir_version = 7 : si64, torch.onnx_meta.opset_version = 13 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
   // CHECK: %[[INT0:.*]] = torch.constant.int 0


### PR DESCRIPTION
In certain cases `onnx.Unsqueeze` lowering causes type mismatch leading to a compilation error.

The problem appears when `onnx.Unsqueeze` input type is more defined than the result type. 
Here is a small reproducer:

```mlir
// repro.mlir
module {
  func.func @repro(%arg0: !torch.vtensor<[1,?,16],f32>) -> !torch.vtensor<[?,?,16,1],f32> attributes {torch.onnx_meta.opset_version = 18 : si64} {
    %18 = torch.operator "onnx.Constant"() {torch.onnx.value = dense<-1> : tensor<1xsi64>} : () -> !torch.vtensor<[1],si64>
    %174 = torch.operator "onnx.Unsqueeze"(%arg0, %18) : (!torch.vtensor<[1,?,16],f32>, !torch.vtensor<[1],si64>) -> !torch.vtensor<[?,?,16,1],f32>
    return %174 : !torch.vtensor<[?,?,16,1],f32>
  }
}
```

During `convert-torch-onnx-to-torch` it lowers to this snippet:

```mlir
// -----// IR Dump After ConvertTorchOnnxToTorch Failed: convert-torch-onnx-to-torch{allow-non-finites=true} //----- //
func.func @repro(%arg0: !torch.vtensor<[1,?,16],f32>) -> !torch.vtensor<[?,?,16,1],f32> attributes {torch.onnx_meta.opset_version = 18 : si64} {
  %0 = torch.vtensor.literal(dense<-1> : tensor<1xsi64>) : !torch.vtensor<[1],si64>
  %int3 = torch.constant.int 3
  %1 = torch.aten.unsqueeze %arg0, %int3 : !torch.vtensor<[1,?,16],f32>, !torch.int -> !torch.vtensor<[1,?,16,1],f32>
  %2 = builtin.unrealized_conversion_cast %1 : !torch.vtensor<[1,?,16,1],f32> to !torch.vtensor<[?,?,16,1],f32>
  return %2 : !torch.vtensor<[?,?,16,1],f32>
}
```

which fails with

```
failed to legalize unresolved materialization from ('!torch.vtensor<[1,?,16,1],f32>') to ('!torch.vtensor<[?,?,16,1],f32>') that remained live after conversion
```

### Alternatives considered

It is possible to derive `torch.aten.unsqueeze` type from the `onnx.Unsqeeze` result type (only for the last unrolled iteration), e.g.:

```cpp
Type unsqueezeType = isLastIteration ? resultType :
    resultType.getWithSizesAndDtype(unsqueezeShape, resultType.getOptionalDtype());
```

which works fine during `convert-torch-onnx-to-torch`:

```
func.func @repro(%arg0: !torch.vtensor<[1,?,16],f32>) -> !torch.vtensor<[?,?,16,1],f32> attributes {torch.onnx_meta.opset_version = 18 : si64} {
  %0 = torch.vtensor.literal(dense<-1> : tensor<1xsi64>) : !torch.vtensor<[1],si64>
  %int3 = torch.constant.int 3
  %1 = torch.aten.unsqueeze %arg0, %int3 : !torch.vtensor<[1,?,16],f32>, !torch.int -> !torch.vtensor<[?,?,16,1],f32>
  return %1 : !torch.vtensor<[?,?,16,1],f32>
}
```

but fails down the stack as the type mismatch reappears at a different place.

### LLM Usage

Claude Code was used to bounce ideas and reduce test cases, but the patch
itself is hand-crafted.


**UPD:**

One open question/note for a future reader: current patch only adds a cast if the input type is more defined than the result type, it is yet unclear if the opposite order could also happen in the wild. If that's the case, then the check should be relaxed and casts should be inserted when the types are not equal.