### PR TITLE
Preserve tensor dispatch mode in as_strided rewrite

### DIFF
--- a/python/torch_mlir/extras/fx_as_strided.py
+++ b/python/torch_mlir/extras/fx_as_strided.py
@@ -87,9 +87,8 @@ def _rewrite(g: fx.Graph, node: fx.Node) -> fx.Node:
     with g.inserting_before(node):
         replacement = g.call_function(_INDEX, args=(base, index_nodes))
     replacement.meta.update(node.meta)
-    replacement.meta["val"] = torch.empty(
-        tuple(size), dtype=_tensor(node, "result").dtype
-    )
+    result_value = _tensor(node, "result")
+    replacement.meta["val"] = result_value.new_empty(tuple(size))
     return replacement
 
 

--- a/test/python/fx_importer/as_strided_test.py
+++ b/test/python/fx_importer/as_strided_test.py
@@ -7,9 +7,11 @@
 
 import torch
 import torch.nn as nn
+from torch._subclasses.fake_tensor import FakeTensor, unset_fake_temporarily
 from torch.export import Dim
 
 from torch_mlir import fx
+from torch_mlir.extras.fx_as_strided import rewrite_as_strided
 
 
 def run(f):
@@ -41,6 +43,43 @@ def expect_reject(module, *args, **kwargs):
         print(f"ValueError: {e}")
         return
     raise AssertionError("expected aten.as_strided.default import to fail")
+
+
+@run
+# CHECK-LABEL: test_as_strided_rewrite_preserves_fake_tensor_metadata
+# CHECK: original is FakeTensor: True
+# CHECK: rewrite applied: True
+# CHECK: replacement is FakeTensor: True
+# CHECK: same FakeTensorMode: True
+def test_as_strided_rewrite_preserves_fake_tensor_metadata():
+    class M(nn.Module):
+        def forward(self, x):
+            return torch.ops.aten.as_strided.default(x, [2, 2], [4, 1], 0)
+
+    program = torch.export.export(
+        M(), (torch.arange(12, dtype=torch.float32).reshape(3, 4),)
+    )
+    original = program.graph.find_nodes(
+        op="call_function", target=torch.ops.aten.as_strided.default
+    )[0]
+    original_value = original.meta["val"]
+    print("original is FakeTensor:", isinstance(original_value, FakeTensor))
+
+    with original_value.fake_mode:
+        with unset_fake_temporarily():
+            rewritten = rewrite_as_strided(program.graph)
+    print("rewrite applied:", rewritten)
+
+    replacement = program.graph.find_nodes(
+        op="call_function", target=torch.ops.aten.index.Tensor
+    )[0]
+    replacement_value = replacement.meta["val"]
+    replacement_is_fake = isinstance(replacement_value, FakeTensor)
+    print("replacement is FakeTensor:", replacement_is_fake)
+    same_fake_mode = (
+        replacement_is_fake and replacement_value.fake_mode is original_value.fake_mode
+    )
+    print("same FakeTensorMode:", same_fake_mode)
 
 
 @run


### PR DESCRIPTION
Create the replacement value with new_empty on the original result tensor. 
This  tensor creation through the original tensor's dispatch behavior,  e.g. preserving FakeTensor mode.