### PR TITLE
[fx-importer] Add uint32 support

### DIFF
--- a/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
@@ -115,7 +115,8 @@ enum class TypeKind {
   _(c10::Float8_e4m3fnuz, Float8_e4m3fnuz)   /* 26 */                          \
   _(c10::qint16, QInt16)                     /* 27 */                          \
   _(c10::Float8_e8m0fnu, Float8_e8m0fnu)     /* 28 */                          \
-  _(c10::Float4_e2m1fn_x2, Float4_e2m1fn_x2) /* 29 */
+  _(c10::Float4_e2m1fn_x2, Float4_e2m1fn_x2) /* 29 */                          \
+  _(uint32_t, UInt32)                        /* 30 */
 
 enum class ScalarType : int8_t {
 #define DEFINE_ENUM(_1, n) n,

--- a/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/TorchUpstream.h
@@ -113,17 +113,36 @@ enum class TypeKind {
   _(c10::Float8_e4m3fn, Float8_e4m3fn)       /* 24 */                          \
   _(c10::Float8_e5m2fnuz, Float8_e5m2fnuz)   /* 25 */                          \
   _(c10::Float8_e4m3fnuz, Float8_e4m3fnuz)   /* 26 */                          \
-  _(c10::qint16, QInt16)                     /* 27 */                          \
-  _(c10::Float8_e8m0fnu, Float8_e8m0fnu)     /* 28 */                          \
-  _(c10::Float4_e2m1fn_x2, Float4_e2m1fn_x2) /* 29 */                          \
-  _(uint32_t, UInt32)                        /* 30 */
+  _(uint16_t, UInt16)                        /* 27 */                          \
+  _(uint32_t, UInt32)                        /* 28 */                          \
+  _(uint64_t, UInt64)                        /* 29 */                          \
+  _(c10::dummy_uint1_7_t<1>, UInt1)          /* 30 */                          \
+  _(c10::dummy_uint1_7_t<2>, UInt2)          /* 31 */                          \
+  _(c10::dummy_uint1_7_t<3>, UInt3)          /* 32 */                          \
+  _(c10::dummy_uint1_7_t<4>, UInt4)          /* 33 */                          \
+  _(c10::dummy_uint1_7_t<5>, UInt5)          /* 34 */                          \
+  _(c10::dummy_uint1_7_t<6>, UInt6)          /* 35 */                          \
+  _(c10::dummy_uint1_7_t<7>, UInt7)          /* 36 */                          \
+  _(c10::dummy_int1_7_t<1>, Int1)            /* 37 */                          \
+  _(c10::dummy_int1_7_t<2>, Int2)            /* 38 */                          \
+  _(c10::dummy_int1_7_t<3>, Int3)            /* 39 */                          \
+  _(c10::dummy_int1_7_t<4>, Int4)            /* 40 */                          \
+  _(c10::dummy_int1_7_t<5>, Int5)            /* 41 */                          \
+  _(c10::dummy_int1_7_t<6>, Int6)            /* 42 */                          \
+  _(c10::dummy_int1_7_t<7>, Int7)            /* 43 */                          \
+  _(c10::Float8_e8m0fnu, Float8_e8m0fnu)     /* 44 */                          \
+  _(c10::Float4_e2m1fn_x2, Float4_e2m1fn_x2) /* 45 */                          \
+  _(c10::complex<c10::BFloat16>, BComplex32) /* 46 */
 
 enum class ScalarType : int8_t {
 #define DEFINE_ENUM(_1, n) n,
   AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(DEFINE_ENUM)
 #undef DEFINE_ENUM
       Undefined,
-  NumOptions
+  NumOptions,
+
+  // torch-mlir-specific types use negative values to preserve upstream IDs.
+  QInt16 = -1,
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -48,6 +48,8 @@ inline torch_upstream::ScalarType getScalarTypeForType(Type type) {
     return torch_upstream::ScalarType::Half;
   if (type.isUnsignedInteger(8))
     return torch_upstream::ScalarType::Byte;
+  if (type.isUnsignedInteger(32))
+    return torch_upstream::ScalarType::UInt32;
   if (type.isSignedInteger(8))
     return torch_upstream::ScalarType::Char;
   if (isa<QUInt8Type>(type))
@@ -125,6 +127,8 @@ getTypeForScalarType(MLIRContext *context,
     return mlir::Float16Type::get(context);
   case torch_upstream::ScalarType::Byte:
     return mlir::IntegerType::get(context, 8, mlir::IntegerType::Unsigned);
+  case torch_upstream::ScalarType::UInt32:
+    return mlir::IntegerType::get(context, 32, mlir::IntegerType::Unsigned);
   case torch_upstream::ScalarType::Char:
     return mlir::IntegerType::get(context, 8, mlir::IntegerType::Signed);
   case torch_upstream::ScalarType::QUInt8:

--- a/lib/Dialect/Torch/Utils/TorchUpstream.cpp
+++ b/lib/Dialect/Torch/Utils/TorchUpstream.cpp
@@ -24,6 +24,11 @@ static inline bool isQIntType(ScalarType t) {
          t == ScalarType::QUInt2x4 || t == ScalarType::QInt16;
 }
 
+static inline bool isFloatingType(ScalarType t) {
+  return (t == ScalarType::Double || t == ScalarType::Float ||
+          t == ScalarType::Half || t == ScalarType::BFloat16);
+}
+
 //===----------------------------------------------------------------------===//
 // Type promotion related code are copied from
 // aten/src/ATen/native/TypeProperties.*.
@@ -56,6 +61,15 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
   // Preserve UInt32 on exact match, it has no entry in the promotion table.
   if (a == ScalarType::UInt32 && b == ScalarType::UInt32) {
     return a;
+  }
+
+  // Mixed UInt32 promotion is supported only with floating-point types.
+  if (a == ScalarType::UInt32 || b == ScalarType::UInt32) {
+    if (isFloatingType(a))
+      return a;
+    if (isFloatingType(b))
+      return b;
+    return ScalarType::Undefined;
   }
 
   // Private dtypes have no promotion rule.
@@ -93,11 +107,6 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
       /* bf */ {bf, bf, bf, bf, bf, f4, f4, f8, ud, c4, c8, bf, ud, ud, ud, bf},
   };
   return _promoteTypesLookup[static_cast<int>(a)][static_cast<int>(b)];
-}
-
-static inline bool isFloatingType(ScalarType t) {
-  return (t == ScalarType::Double || t == ScalarType::Float ||
-          t == ScalarType::Half || t == ScalarType::BFloat16);
 }
 
 static inline bool isComplexType(ScalarType t) {

--- a/lib/Dialect/Torch/Utils/TorchUpstream.cpp
+++ b/lib/Dialect/Torch/Utils/TorchUpstream.cpp
@@ -53,6 +53,11 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
     return a;
   }
 
+  // Preserve UInt32 on exact match, it has no entry in the promotion table.
+  if (a == ScalarType::UInt32 && b == ScalarType::UInt32) {
+    return a;
+  }
+
   // Private dtypes have no promotion rule.
   // Never use their negative encodings to index the upstream lookup table.
   if (static_cast<int>(a) < 0 || static_cast<int>(b) < 0) {

--- a/lib/Dialect/Torch/Utils/TorchUpstream.cpp
+++ b/lib/Dialect/Torch/Utils/TorchUpstream.cpp
@@ -53,6 +53,12 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
     return a;
   }
 
+  // Private dtypes have no promotion rule.
+  // Never use their negative encodings to index the upstream lookup table.
+  if (static_cast<int>(a) < 0 || static_cast<int>(b) < 0) {
+    return ScalarType::Undefined;
+  }
+
   if (isQIntType(a) || isQIntType(b)) {
     assert(false && "promoteTypes with quantized numbers is not handled yet; "
                     "figure out what the correct rules should be");

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -157,6 +157,7 @@ TORCH_DTYPE_TO_MLIR_TYPE_ASM = {
     torch.float32: "f32",
     torch.float64: "f64",
     torch.uint8: "ui8",
+    torch.uint32: "ui32",
     torch.int8: "si8",
     torch.int16: "si16",
     torch.int32: "si32",
@@ -187,6 +188,7 @@ TORCH_DTYPE_TO_MLIR_TYPE: Dict[torch.dtype, Callable[[], IrType]] = {
     torch.float32: lambda: F32Type.get(),
     torch.float64: lambda: F64Type.get(),
     torch.uint8: lambda: IntegerType.get_unsigned(8),
+    torch.uint32: lambda: IntegerType.get_unsigned(32),
     torch.int8: lambda: IntegerType.get_signed(8),
     torch.int16: lambda: IntegerType.get_signed(16),
     torch.int32: lambda: IntegerType.get_signed(32),
@@ -215,6 +217,7 @@ TORCH_DTYPE_TO_NPY_TYPE = {
     # torch.qint8: None, # no equivalent np datatype
     # torch.quint8: None,
     torch.uint8: np.uint8,
+    torch.uint32: np.uint32,
     torch.int8: np.int8,
     torch.int16: np.int16,
     torch.int32: np.int32,
@@ -252,6 +255,7 @@ TORCH_DTYPE_TO_INT = {
     # torch.quint8: 13,
     # torch.qint32 14
     torch.bfloat16: 15,
+    torch.uint32: 30,
 }
 # Type entries added only in torch with higher version
 OPTIONAL_TORCH_DTYPE_TO_INT = {

--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -255,7 +255,7 @@ TORCH_DTYPE_TO_INT = {
     # torch.quint8: 13,
     # torch.qint32 14
     torch.bfloat16: 15,
-    torch.uint32: 30,
+    torch.uint32: 28,
 }
 # Type entries added only in torch with higher version
 OPTIONAL_TORCH_DTYPE_TO_INT = {
@@ -263,8 +263,8 @@ OPTIONAL_TORCH_DTYPE_TO_INT = {
     "float8_e4m3fn": 24,
     "float8_e5m2fnuz": 25,
     "float8_e4m3fnuz": 26,
-    "float8_e8m0fnu": 28,
-    "float4_e2m1fn_x2": 29,
+    "float8_e8m0fnu": 44,
+    "float4_e2m1fn_x2": 45,
 }
 for dtype_str, dtype_int in OPTIONAL_TORCH_DTYPE_TO_INT.items():
     if hasattr(torch, dtype_str):

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -91,7 +91,7 @@ func.func @test_quantizelinear_per_channel_ui8(%arg0: !torch.vtensor<[4,3,7,7],f
 
 // CHECK-LABEL: @test_quantizelinear_per_channel_si16
 func.func @test_quantizelinear_per_channel_si16(%arg0: !torch.vtensor<[4,3,7,7],f32>, %arg1: !torch.vtensor<[4],f32>, %arg2: !torch.vtensor<[4],si16>) -> !torch.vtensor<[4,3,7,7],si16> attributes {torch.onnx_meta.ir_version = 10 : si64, torch.onnx_meta.opset_version = 19 : si64} {
-  // CHECK: %[[DTYPE:.+]] = torch.constant.int 27
+  // CHECK: %[[DTYPE:.+]] = torch.constant.int -1
   // CHECK: %[[AXIS:.+]] = torch.constant.int 1
   // CHECK: %[[QUANT:.+]] = torch.aten.quantize_per_channel %arg0, %arg1, %arg2, %[[AXIS]], %[[DTYPE]]
   // CHECK: %[[REPR:.+]] = torch.aten.int_repr %[[QUANT]]

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -40,6 +40,17 @@ func.func @torch.aten.assert_tensor_metadata() {
   return
 }
 
+// CHECK-LABEL:   func.func @torch.aten.assert_tensor_metadata$uint32
+// CHECK-NEXT:      return
+func.func @torch.aten.assert_tensor_metadata$uint32() {
+  %int30 = torch.constant.int 30
+  %none = torch.constant.none
+  %0 = tensor.empty() : tensor<1x1x128x128xui32>
+  %1 = torch_c.from_builtin_tensor %0 : tensor<1x1x128x128xui32> -> !torch.vtensor<[1,1,128,128],ui32>
+  torch.aten._assert_tensor_metadata %1, %none, %none, %int30, %none, %none : !torch.vtensor<[1,1,128,128],ui32>, !torch.none, !torch.none, !torch.int, !torch.none, !torch.none
+  return
+}
+
 // CHECK-LABEL:   func.func @torch.aten.ones_item
 // CHECK:           %[[CONST:.*]] = torch.constant.int 1
 // CHECK:           return %[[CONST]] : !torch.int
@@ -1361,6 +1372,15 @@ func.func @torch.aten.pow.int_float() -> !torch.float {
 // CHECK:           return %[[CST]] : !torch.int
 func.func @torch.prim.dtype$bfloat16(%t : !torch.tensor<*,bf16>) -> !torch.int {
     %ret = torch.prim.dtype %t: !torch.tensor<*,bf16> -> !torch.int
+    return %ret : !torch.int
+}
+
+// CHECK-LABEL:   func.func @torch.prim.dtype$uint32(
+// CHECK-SAME:             %[[T:.*]]: !torch.tensor<*,ui32>) -> !torch.int {
+// CHECK:           %[[CST:.*]] = torch.constant.int 30
+// CHECK:           return %[[CST]] : !torch.int
+func.func @torch.prim.dtype$uint32(%t : !torch.tensor<*,ui32>) -> !torch.int {
+    %ret = torch.prim.dtype %t: !torch.tensor<*,ui32> -> !torch.int
     return %ret : !torch.int
 }
 

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -43,11 +43,11 @@ func.func @torch.aten.assert_tensor_metadata() {
 // CHECK-LABEL:   func.func @torch.aten.assert_tensor_metadata$uint32
 // CHECK-NEXT:      return
 func.func @torch.aten.assert_tensor_metadata$uint32() {
-  %int30 = torch.constant.int 30
+  %int28 = torch.constant.int 28
   %none = torch.constant.none
   %0 = tensor.empty() : tensor<1x1x128x128xui32>
   %1 = torch_c.from_builtin_tensor %0 : tensor<1x1x128x128xui32> -> !torch.vtensor<[1,1,128,128],ui32>
-  torch.aten._assert_tensor_metadata %1, %none, %none, %int30, %none, %none : !torch.vtensor<[1,1,128,128],ui32>, !torch.none, !torch.none, !torch.int, !torch.none, !torch.none
+  torch.aten._assert_tensor_metadata %1, %none, %none, %int28, %none, %none : !torch.vtensor<[1,1,128,128],ui32>, !torch.none, !torch.none, !torch.int, !torch.none, !torch.none
   return
 }
 
@@ -1377,7 +1377,7 @@ func.func @torch.prim.dtype$bfloat16(%t : !torch.tensor<*,bf16>) -> !torch.int {
 
 // CHECK-LABEL:   func.func @torch.prim.dtype$uint32(
 // CHECK-SAME:             %[[T:.*]]: !torch.tensor<*,ui32>) -> !torch.int {
-// CHECK:           %[[CST:.*]] = torch.constant.int 30
+// CHECK:           %[[CST:.*]] = torch.constant.int 28
 // CHECK:           return %[[CST]] : !torch.int
 func.func @torch.prim.dtype$uint32(%t : !torch.tensor<*,ui32>) -> !torch.int {
     %ret = torch.prim.dtype %t: !torch.tensor<*,ui32> -> !torch.int

--- a/test/Dialect/Torch/qint16-dtype.mlir
+++ b/test/Dialect/Torch/qint16-dtype.mlir
@@ -1,0 +1,55 @@
+// RUN: torch-mlir-opt --torch-simplification-pipeline='shape-dtype-refine=true' --split-input-file %s | FileCheck %s
+
+// QInt16's negative dtype encoding must round-trip through dtype refinement.
+// CHECK-LABEL: func.func @qint16_relu
+// CHECK: torch.aten.relu {{.*}} -> !torch.vtensor<[4],!torch.qint16>
+func.func @qint16_relu(%arg0: !torch.vtensor<[4],!torch.qint16>) -> !torch.vtensor<[4],unk> {
+  %result = torch.aten.relu %arg0 : !torch.vtensor<[4],!torch.qint16> -> !torch.vtensor<[4],unk>
+  return %result : !torch.vtensor<[4],unk>
+}
+
+// -----
+
+// Same-type promotion must preserve QInt16 without indexing the lookup table.
+// CHECK-LABEL: func.func @promote_qint16_pair
+// CHECK: %[[DTYPE:.*]] = torch.constant.int -1
+// CHECK: return %[[DTYPE]] : !torch.int
+func.func @promote_qint16_pair(%arg0: !torch.vtensor<[4],!torch.qint16>) -> !torch.int {
+  %rank = torch.constant.int 1
+  %dtype = torch.prim.dtype %arg0 : !torch.vtensor<[4],!torch.qint16> -> !torch.int
+  %ranks = torch.prim.ListConstruct %rank, %rank : (!torch.int, !torch.int) -> !torch.list<optional<int>>
+  %dtypes = torch.prim.ListConstruct %dtype, %dtype : (!torch.int, !torch.int) -> !torch.list<int>
+  %result = torch.promote_dtypes %ranks, %dtypes : (!torch.list<optional<int>>, !torch.list<int>) -> !torch.int
+  return %result : !torch.int
+}
+
+// -----
+
+// Unsupported mixed promotion returns Undefined, rather than indexing at -1.
+// CHECK-LABEL: func.func @promote_qint16_float
+// CHECK: %[[DTYPE:.*]] = torch.constant.int 47
+// CHECK: return %[[DTYPE]] : !torch.int
+func.func @promote_qint16_float(%arg0: !torch.vtensor<[4],!torch.qint16>) -> !torch.int {
+  %rank = torch.constant.int 1
+  %qint16 = torch.prim.dtype %arg0 : !torch.vtensor<[4],!torch.qint16> -> !torch.int
+  %float = torch.constant.int 6
+  %ranks = torch.prim.ListConstruct %rank, %rank : (!torch.int, !torch.int) -> !torch.list<optional<int>>
+  %dtypes = torch.prim.ListConstruct %qint16, %float : (!torch.int, !torch.int) -> !torch.list<int>
+  %result = torch.promote_dtypes %ranks, %dtypes : (!torch.list<optional<int>>, !torch.list<int>) -> !torch.int
+  return %result : !torch.int
+}
+
+// -----
+
+// CHECK-LABEL: func.func @promote_float_qint16
+// CHECK: %[[DTYPE:.*]] = torch.constant.int 47
+// CHECK: return %[[DTYPE]] : !torch.int
+func.func @promote_float_qint16(%arg0: !torch.vtensor<[4],!torch.qint16>) -> !torch.int {
+  %rank = torch.constant.int 1
+  %qint16 = torch.prim.dtype %arg0 : !torch.vtensor<[4],!torch.qint16> -> !torch.int
+  %float = torch.constant.int 6
+  %ranks = torch.prim.ListConstruct %rank, %rank : (!torch.int, !torch.int) -> !torch.list<optional<int>>
+  %dtypes = torch.prim.ListConstruct %float, %qint16 : (!torch.int, !torch.int) -> !torch.list<int>
+  %result = torch.promote_dtypes %ranks, %dtypes : (!torch.list<optional<int>>, !torch.list<int>) -> !torch.int
+  return %result : !torch.int
+}

--- a/test/Dialect/Torch/simplify-dtype-calculations.mlir
+++ b/test/Dialect/Torch/simplify-dtype-calculations.mlir
@@ -24,6 +24,22 @@ func.func @basic(%arg0: !torch.vtensor<*,f32>) -> !torch.vtensor {
 
 // -----
 
+// Same-type promotion must preserve UInt32.
+// CHECK-LABEL: func.func @promote_dtypes$tensor_tensor_uint32
+// CHECK: %[[DTYPE:.*]] = torch.constant.int 28
+// CHECK: return %[[DTYPE]] : !torch.int
+func.func @promote_dtypes$tensor_tensor_uint32(%arg0: !torch.vtensor<[4],ui32>, %arg1: !torch.vtensor<[4],ui32>) -> !torch.int {
+  %rank = torch.constant.int 1
+  %dtype0 = torch.prim.dtype %arg0 : !torch.vtensor<[4],ui32> -> !torch.int
+  %dtype1 = torch.prim.dtype %arg1 : !torch.vtensor<[4],ui32> -> !torch.int
+  %ranks = torch.prim.ListConstruct %rank, %rank : (!torch.int, !torch.int) -> !torch.list<optional<int>>
+  %dtypes = torch.prim.ListConstruct %dtype0, %dtype1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %result = torch.promote_dtypes %ranks, %dtypes : (!torch.list<optional<int>>, !torch.list<int>) -> !torch.int
+  return %result : !torch.int
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @promote_dtypes$tensor_tensor_same_category_different_width(
 // CHECK:             {{.*}} = torch.aten.add.Tensor {{.*}} -> !torch.vtensor<[1],f64>
 func.func @promote_dtypes$tensor_tensor_same_category_different_width(%arg0: !torch.vtensor<[1],f32>, %arg1: !torch.vtensor<[1],f64>, %arg2: !torch.float) {

--- a/test/Dialect/Torch/simplify-dtype-calculations.mlir
+++ b/test/Dialect/Torch/simplify-dtype-calculations.mlir
@@ -40,6 +40,68 @@ func.func @promote_dtypes$tensor_tensor_uint32(%arg0: !torch.vtensor<[4],ui32>, 
 
 // -----
 
+// Mixed UInt32/Float promotion preserves Float in either operand order.
+// CHECK-LABEL: func.func @promote_dtypes$tensor_tensor_uint32_float
+// CHECK: %[[DTYPE:.*]] = torch.constant.int 6
+// CHECK: return %[[DTYPE]] : !torch.int
+func.func @promote_dtypes$tensor_tensor_uint32_float(%arg0: !torch.vtensor<[4],ui32>, %arg1: !torch.vtensor<[4],f32>) -> !torch.int {
+  %rank = torch.constant.int 1
+  %dtype0 = torch.prim.dtype %arg0 : !torch.vtensor<[4],ui32> -> !torch.int
+  %dtype1 = torch.prim.dtype %arg1 : !torch.vtensor<[4],f32> -> !torch.int
+  %ranks = torch.prim.ListConstruct %rank, %rank : (!torch.int, !torch.int) -> !torch.list<optional<int>>
+  %dtypes = torch.prim.ListConstruct %dtype0, %dtype1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %result = torch.promote_dtypes %ranks, %dtypes : (!torch.list<optional<int>>, !torch.list<int>) -> !torch.int
+  return %result : !torch.int
+}
+
+// -----
+
+// CHECK-LABEL: func.func @promote_dtypes$tensor_tensor_float_uint32
+// CHECK: %[[DTYPE:.*]] = torch.constant.int 6
+// CHECK: return %[[DTYPE]] : !torch.int
+func.func @promote_dtypes$tensor_tensor_float_uint32(%arg0: !torch.vtensor<[4],f32>, %arg1: !torch.vtensor<[4],ui32>) -> !torch.int {
+  %rank = torch.constant.int 1
+  %dtype0 = torch.prim.dtype %arg0 : !torch.vtensor<[4],f32> -> !torch.int
+  %dtype1 = torch.prim.dtype %arg1 : !torch.vtensor<[4],ui32> -> !torch.int
+  %ranks = torch.prim.ListConstruct %rank, %rank : (!torch.int, !torch.int) -> !torch.list<optional<int>>
+  %dtypes = torch.prim.ListConstruct %dtype0, %dtype1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %result = torch.promote_dtypes %ranks, %dtypes : (!torch.list<optional<int>>, !torch.list<int>) -> !torch.int
+  return %result : !torch.int
+}
+
+// -----
+
+// Mixed UInt32/Long promotion is unsupported in either operand order.
+// CHECK-LABEL: func.func @promote_dtypes$tensor_tensor_uint32_long
+// CHECK: %[[DTYPE:.*]] = torch.constant.int 47
+// CHECK: return %[[DTYPE]] : !torch.int
+func.func @promote_dtypes$tensor_tensor_uint32_long(%arg0: !torch.vtensor<[4],ui32>, %arg1: !torch.vtensor<[4],si64>) -> !torch.int {
+  %rank = torch.constant.int 1
+  %dtype0 = torch.prim.dtype %arg0 : !torch.vtensor<[4],ui32> -> !torch.int
+  %dtype1 = torch.prim.dtype %arg1 : !torch.vtensor<[4],si64> -> !torch.int
+  %ranks = torch.prim.ListConstruct %rank, %rank : (!torch.int, !torch.int) -> !torch.list<optional<int>>
+  %dtypes = torch.prim.ListConstruct %dtype0, %dtype1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %result = torch.promote_dtypes %ranks, %dtypes : (!torch.list<optional<int>>, !torch.list<int>) -> !torch.int
+  return %result : !torch.int
+}
+
+// -----
+
+// CHECK-LABEL: func.func @promote_dtypes$tensor_tensor_long_uint32
+// CHECK: %[[DTYPE:.*]] = torch.constant.int 47
+// CHECK: return %[[DTYPE]] : !torch.int
+func.func @promote_dtypes$tensor_tensor_long_uint32(%arg0: !torch.vtensor<[4],si64>, %arg1: !torch.vtensor<[4],ui32>) -> !torch.int {
+  %rank = torch.constant.int 1
+  %dtype0 = torch.prim.dtype %arg0 : !torch.vtensor<[4],si64> -> !torch.int
+  %dtype1 = torch.prim.dtype %arg1 : !torch.vtensor<[4],ui32> -> !torch.int
+  %ranks = torch.prim.ListConstruct %rank, %rank : (!torch.int, !torch.int) -> !torch.list<optional<int>>
+  %dtypes = torch.prim.ListConstruct %dtype0, %dtype1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %result = torch.promote_dtypes %ranks, %dtypes : (!torch.list<optional<int>>, !torch.list<int>) -> !torch.int
+  return %result : !torch.int
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @promote_dtypes$tensor_tensor_same_category_different_width(
 // CHECK:             {{.*}} = torch.aten.add.Tensor {{.*}} -> !torch.vtensor<[1],f64>
 func.func @promote_dtypes$tensor_tensor_same_category_different_width(%arg0: !torch.vtensor<[1],f32>, %arg1: !torch.vtensor<[1],f64>, %arg2: !torch.float) {

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -240,6 +240,56 @@ def test_full():
 
 
 @run
+# CHECK-LABEL: test_empty_uint32
+# CHECK: func.func @empty_uint32() -> !torch.vtensor<[2,3],ui32>
+# CHECK: %[[DTYPE:.+]] = torch.constant.int 30
+# CHECK: torch.aten.empty.memory_format
+# CHECK-SAME: %[[DTYPE]]
+# CHECK-SAME: -> !torch.vtensor<[2,3],ui32>
+def test_empty_uint32():
+    class Module(torch.nn.Module):
+        def forward(self):
+            return torch.empty((2, 3), dtype=torch.uint32)
+
+    module = fx.export_and_import(Module(), func_name="empty_uint32")
+    print(module)
+
+
+@run
+# CHECK-LABEL: test_uint32_tensor_literal
+# CHECK: func.func @uint32_tensor_literal() -> !torch.vtensor<[2],ui32>
+# CHECK: torch.vtensor.literal
+# CHECK-SAME: tensor<2xui32>
+# CHECK-SAME: !torch.vtensor<[2],ui32>
+def test_uint32_tensor_literal():
+    class Module(torch.nn.Module):
+        def forward(self):
+            return torch.tensor([1, 2], dtype=torch.uint32)
+
+    module = fx.export_and_import(Module(), func_name="uint32_tensor_literal")
+    print(module)
+
+
+@run
+# CHECK-LABEL: test_view_uint32
+# CHECK: func.func @view_uint32(%[[ARG:.+]]: !torch.vtensor<[8],f32>)
+# CHECK-SAME: -> !torch.vtensor<[8],ui32>
+# CHECK: %[[DTYPE:.+]] = torch.constant.int 30
+# CHECK: torch.aten.view.dtype %[[ARG]], %[[DTYPE]]
+# CHECK-SAME: !torch.vtensor<[8],f32>, !torch.int
+# CHECK-SAME: -> !torch.vtensor<[8],ui32>
+def test_view_uint32():
+    class Module(torch.nn.Module):
+        def forward(self, value):
+            return value.view(torch.uint32)
+
+    module = fx.export_and_import(
+        Module(), torch.ones(8, dtype=torch.float32), func_name="view_uint32"
+    )
+    print(module)
+
+
+@run
 # CHECK-LABEL: test_while_loop_two_returns
 # Check that helper functions are emitted first
 # CHECK: func.func private @while_loop_cond_graph_{{[0-9]+}}(%arg0: !torch.vtensor<[],si64>, %arg1: !torch.vtensor<[4,4],f32>) -> !torch.vtensor<[],i1>

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -240,22 +240,6 @@ def test_full():
 
 
 @run
-# CHECK-LABEL: test_empty_uint32
-# CHECK: func.func @empty_uint32() -> !torch.vtensor<[2,3],ui32>
-# CHECK: %[[DTYPE:.+]] = torch.constant.int 30
-# CHECK: torch.aten.empty.memory_format
-# CHECK-SAME: %[[DTYPE]]
-# CHECK-SAME: -> !torch.vtensor<[2,3],ui32>
-def test_empty_uint32():
-    class Module(torch.nn.Module):
-        def forward(self):
-            return torch.empty((2, 3), dtype=torch.uint32)
-
-    module = fx.export_and_import(Module(), func_name="empty_uint32")
-    print(module)
-
-
-@run
 # CHECK-LABEL: test_uint32_tensor_literal
 # CHECK: func.func @uint32_tensor_literal() -> !torch.vtensor<[2],ui32>
 # CHECK: torch.vtensor.literal
@@ -274,7 +258,7 @@ def test_uint32_tensor_literal():
 # CHECK-LABEL: test_view_uint32
 # CHECK: func.func @view_uint32(%[[ARG:.+]]: !torch.vtensor<[8],f32>)
 # CHECK-SAME: -> !torch.vtensor<[8],ui32>
-# CHECK: %[[DTYPE:.+]] = torch.constant.int 30
+# CHECK: %[[DTYPE:.+]] = torch.constant.int 28
 # CHECK: torch.aten.view.dtype %[[ARG]], %[[DTYPE]]
 # CHECK-SAME: !torch.vtensor<[8],f32>, !torch.int
 # CHECK-SAME: -> !torch.vtensor<[8],ui32>

--- a/test/python/fx_importer/scaled_mm_test.py
+++ b/test/python/fx_importer/scaled_mm_test.py
@@ -262,7 +262,7 @@ def test_import_scaled_mm_v2_out_dtype_none_fp4():
 # CHECK: %[[SWIZZLE_B_VALUE:.*]] = torch.constant.int 0
 # CHECK: %[[SWIZZLE_B:.*]] = torch.prim.ListConstruct %[[SWIZZLE_B_VALUE]]
 # CHECK: %[[BIAS_NONE:.*]] = torch.constant.none
-# CHECK: %[[OUT_DTYPE:.*]] = torch.constant.int 29
+# CHECK: %[[OUT_DTYPE:.*]] = torch.constant.int 45
 # CHECK: %[[CONTRACTION:.*]] = torch.prim.ListConstruct
 # CHECK: %[[FALSE:.*]] = torch.constant.bool false
 # CHECK: %[[MM:.*]] = torch.aten._scaled_mm_v2 %arg0, %arg1, %[[SCALE_A]], %[[RECIPE_A]], %[[SWIZZLE_A]], %[[SCALE_B]], %[[RECIPE_B]], %[[SWIZZLE_B]], %[[BIAS_NONE]], %[[OUT_DTYPE]], %[[CONTRACTION]], %[[FALSE]]


### PR DESCRIPTION
Represent torch.uint32 tensors as ui32 in the FX importer. Handle uint32 tensor literals and map torch.uint32 to its corresponding ScalarType value.

Add the Torch dialect type conversions and regression tests for tensor creation, literals, and dtype views.