### PR TITLE
Remove passing ONNX logsumexp xfails

### DIFF
--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -3047,8 +3047,6 @@ ONNX_XFAIL_SET = {
     "ReduceL1NormComplexModule_basic",
     "ReduceL2NormComplexModule_basic",
     "ReduceL3NormKeepDimComplexModule_basic",
-    "ReduceLogSumExpDimIntListBoolModule_basic",
-    "ReduceLogSumExpDimIntListIntModule_basic",
     "ReflectionPad3dModule_basic",
     "ReflectionPad3dModuleFront_basic",
     "ReflectionPad3dModuleBack_basic",


### PR DESCRIPTION
The ONNX integration job on main reports XPASS for ReduceLogSumExpDimIntListBoolModule_basic and ReduceLogSumExpDimIntListIntModule_basic after logsumexp lowering landed in #4606. Remove those tests from ONNX_XFAIL_SET so the now-passing results are accepted. CI failure: https://github.com/llvm/torch-mlir/actions/runs/32873854121/job/97886999091#step:10:25965. Verification: git diff --check; Python AST parse of projects/pt1/e2e_testing/xfail_sets.py.