### PR TITLE
[TorchToStablehlo] Verify scale/zero-point/axis consistency in fused quantize-dequantize lowering

### DIFF
--- a/lib/Conversion/TorchToStablehlo/Uncategorized.cpp
+++ b/lib/Conversion/TorchToStablehlo/Uncategorized.cpp
@@ -161,8 +161,35 @@ public:
         !isa<AtenDequantizeSelfOp>(opUser)) {
       return failure();
     }
-    // [TODO] verify that zeroPoint and Scale matches with the input operand
-    // type.
+
+    auto *zeroPoint = op.getZeroPoint().getDefiningOp();
+    if (!zeroPoint || !isa<ConstantIntOp>(zeroPoint)) {
+      return failure();
+    }
+
+    auto zeroPointValue =
+        mlir::cast<ConstantIntOp>(zeroPoint).getValueAttr().getInt();
+
+    auto *scale = op.getScale().getDefiningOp();
+    if (!scale || !isa<ConstantFloatOp>(scale)) {
+      return failure();
+    }
+    auto scaleValue = mlir::cast<ConstantFloatOp>(scale)
+                          .getValueAttr()
+                          .getValue()
+                          .convertToDouble();
+
+    auto inputElemType =
+        mlir::cast<RankedTensorType>(adaptor.getOperands().front().getType())
+            .getElementType();
+    auto quantElemType =
+        mlir::dyn_cast<quant::UniformQuantizedType>(inputElemType);
+
+    if (!quantElemType || quantElemType.getScale() != scaleValue ||
+        quantElemType.getZeroPoint() != zeroPointValue) {
+      return failure();
+    }
+
     RankedTensorType outputType = cast<RankedTensorType>(
         getTypeConverter()->convertType(opUser->getResult(0).getType()));
 
@@ -271,8 +298,49 @@ public:
         !isa<AtenDequantizeSelfOp>(opUser)) {
       return failure();
     }
-    // [TODO] verify that zeroPoint and Scale matches with the input operand
-    // type.
+
+    auto *zeroPoints = op.getZeroPoint().getDefiningOp();
+    if (!zeroPoints || !isa<ValueTensorLiteralOp>(zeroPoints)) {
+      return failure();
+    }
+
+    llvm::SmallVector<int64_t, 4> zeroPointsVec;
+    for (auto zp : mlir::cast<ValueTensorLiteralOp>(zeroPoints)
+                       .getValue()
+                       .getValues<llvm::APInt>()) {
+      zeroPointsVec.emplace_back(zp.getSExtValue());
+    }
+
+    auto *scales = op.getScale().getDefiningOp();
+    if (!scales || !isa<ValueTensorLiteralOp>(scales)) {
+      return failure();
+    }
+
+    llvm::SmallVector<double, 4> scalesVec;
+    for (auto scale : mlir::cast<ValueTensorLiteralOp>(scales)
+                          .getValue()
+                          .getValues<llvm::APFloat>()) {
+      scalesVec.emplace_back(scale.convertToDouble());
+    }
+
+    auto *axis = op.getAxis().getDefiningOp();
+    if (!axis || !isa<ConstantIntOp>(axis)) {
+      return failure();
+    }
+    auto axisValue = mlir::cast<ConstantIntOp>(axis).getValueAttr().getInt();
+
+    auto inputElemType =
+        mlir::cast<RankedTensorType>(adaptor.getOperands().front().getType())
+            .getElementType();
+    auto quantElemType =
+        mlir::dyn_cast<quant::UniformQuantizedPerAxisType>(inputElemType);
+    if (!quantElemType || quantElemType.getQuantizedDimension() != axisValue ||
+        quantElemType.getScales() != llvm::ArrayRef<double>(scalesVec) ||
+        quantElemType.getZeroPoints() !=
+            llvm::ArrayRef<int64_t>(zeroPointsVec)) {
+      return failure();
+    }
+
     RankedTensorType outputType = cast<RankedTensorType>(
         getTypeConverter()->convertType(opUser->getResult(0).getType()));
 

--- a/test/Conversion/TorchToStablehlo/quantization.mlir
+++ b/test/Conversion/TorchToStablehlo/quantization.mlir
@@ -158,3 +158,77 @@ func.func @dequantize_per_tensor_dynamic_quant_min(%arg0: !torch.vtensor<[4,8],s
     -> !torch.vtensor<[4,8],f32>
   return %0 : !torch.vtensor<[4,8],f32>
 }
+
+// -----
+
+// aten._make_per_tensor_quantized_tensor's zero point (5) does not match the
+// zero point (0) baked into the quantized type from aten.quantize_per_tensor,
+// so the fused-reuse pattern must reject it instead of silently reusing the
+// mismatched quantized value.
+func.func @make_per_tensor_quantized_tensor_mismatched_zero_point(%arg0: !torch.vtensor<[2,4,4],f32>) -> !torch.vtensor<[2,4,4],f32> {
+  %int12 = torch.constant.int 12
+  %float1.000000e-01 = torch.constant.float 0.1
+  %zero = torch.constant.int 0
+  %five = torch.constant.int 5
+  %0 = torch.aten.quantize_per_tensor %arg0, %float1.000000e-01, %zero, %int12 : !torch.vtensor<[2,4,4],f32>, !torch.float, !torch.int, !torch.int -> !torch.vtensor<[2,4,4],!torch.qint8>
+  %1 = torch.aten.int_repr %0 : !torch.vtensor<[2,4,4],!torch.qint8> -> !torch.vtensor<[2,4,4],si8>
+  // expected-error @+1 {{failed to legalize operation 'torch.aten._make_per_tensor_quantized_tensor' that was explicitly marked illegal}}
+  %2 = torch.aten._make_per_tensor_quantized_tensor %1, %float1.000000e-01, %five : !torch.vtensor<[2,4,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[2,4,4],!torch.qint8>
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[2,4,4],!torch.qint8> -> !torch.vtensor<[2,4,4],f32>
+  return %3 : !torch.vtensor<[2,4,4],f32>
+}
+
+// -----
+
+// Same as above but the scale (0.2) disagrees with the scale (0.1) baked
+// into the quantized type instead of the zero point.
+func.func @make_per_tensor_quantized_tensor_mismatched_scale(%arg0: !torch.vtensor<[2,4,4],f32>) -> !torch.vtensor<[2,4,4],f32> {
+  %int12 = torch.constant.int 12
+  %float1.000000e-01 = torch.constant.float 0.1
+  %float2.000000e-01 = torch.constant.float 0.2
+  %zero = torch.constant.int 0
+  %0 = torch.aten.quantize_per_tensor %arg0, %float1.000000e-01, %zero, %int12 : !torch.vtensor<[2,4,4],f32>, !torch.float, !torch.int, !torch.int -> !torch.vtensor<[2,4,4],!torch.qint8>
+  %1 = torch.aten.int_repr %0 : !torch.vtensor<[2,4,4],!torch.qint8> -> !torch.vtensor<[2,4,4],si8>
+  // expected-error @+1 {{failed to legalize operation 'torch.aten._make_per_tensor_quantized_tensor' that was explicitly marked illegal}}
+  %2 = torch.aten._make_per_tensor_quantized_tensor %1, %float2.000000e-01, %zero : !torch.vtensor<[2,4,4],si8>, !torch.float, !torch.int -> !torch.vtensor<[2,4,4],!torch.qint8>
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[2,4,4],!torch.qint8> -> !torch.vtensor<[2,4,4],f32>
+  return %3 : !torch.vtensor<[2,4,4],f32>
+}
+
+// -----
+
+// aten._make_per_channel_quantized_tensor's scales disagree with the scales
+// baked into the quantized type from aten.quantize_per_channel. Since this
+// op is not itself marked illegal, the mismatch surfaces as a failure to
+// legalize its consumer, aten.dequantize.self, which never gets replaced.
+func.func @make_per_channel_quantized_tensor_mismatched_scale(%arg0: !torch.vtensor<[4,3,7,7],f32>) -> !torch.vtensor<[4,3,7,7],f32> {
+  %scales = torch.vtensor.literal(dense<[4.000000e-01, 1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<4xf32>) : !torch.vtensor<[4],f32>
+  %other_scales = torch.vtensor.literal(dense<[1.000000e-01, 1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<4xf32>) : !torch.vtensor<[4],f32>
+  %zero_points = torch.vtensor.literal(dense<[4, 1, 2, 3]> : tensor<4xsi8>) : !torch.vtensor<[4],si8>
+  %int12 = torch.constant.int 12
+  %zero = torch.constant.int 0
+  %0 = torch.aten.quantize_per_channel %arg0, %scales, %zero_points, %zero, %int12 : !torch.vtensor<[4,3,7,7],f32>, !torch.vtensor<[4],f32>, !torch.vtensor<[4],si8>, !torch.int, !torch.int -> !torch.vtensor<[4,3,7,7],!torch.qint8>
+  %1 = torch.aten.int_repr %0 : !torch.vtensor<[4,3,7,7],!torch.qint8> -> !torch.vtensor<[4,3,7,7],si8>
+  %2 = torch.aten._make_per_channel_quantized_tensor %1, %other_scales, %zero_points, %zero : !torch.vtensor<[4,3,7,7],si8>, !torch.vtensor<[4],f32>, !torch.vtensor<[4],si8>, !torch.int -> !torch.vtensor<[4,3,7,7],!torch.qint8>
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.dequantize.self' that was explicitly marked illegal}}
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[4,3,7,7],!torch.qint8> -> !torch.vtensor<[4,3,7,7],f32>
+  return %3 : !torch.vtensor<[4,3,7,7],f32>
+}
+
+// -----
+
+// aten._make_per_channel_quantized_tensor's axis (1) disagrees with the axis
+// (0) baked into the quantized type from aten.quantize_per_channel.
+func.func @make_per_channel_quantized_tensor_mismatched_axis(%arg0: !torch.vtensor<[4,3,7,7],f32>) -> !torch.vtensor<[4,3,7,7],f32> {
+  %scales = torch.vtensor.literal(dense<[4.000000e-01, 1.000000e-01, 2.000000e-01, 3.000000e-01]> : tensor<4xf32>) : !torch.vtensor<[4],f32>
+  %zero_points = torch.vtensor.literal(dense<[4, 1, 2, 3]> : tensor<4xsi8>) : !torch.vtensor<[4],si8>
+  %int12 = torch.constant.int 12
+  %zero = torch.constant.int 0
+  %one = torch.constant.int 1
+  %0 = torch.aten.quantize_per_channel %arg0, %scales, %zero_points, %zero, %int12 : !torch.vtensor<[4,3,7,7],f32>, !torch.vtensor<[4],f32>, !torch.vtensor<[4],si8>, !torch.int, !torch.int -> !torch.vtensor<[4,3,7,7],!torch.qint8>
+  %1 = torch.aten.int_repr %0 : !torch.vtensor<[4,3,7,7],!torch.qint8> -> !torch.vtensor<[4,3,7,7],si8>
+  %2 = torch.aten._make_per_channel_quantized_tensor %1, %scales, %zero_points, %one : !torch.vtensor<[4,3,7,7],si8>, !torch.vtensor<[4],f32>, !torch.vtensor<[4],si8>, !torch.int -> !torch.vtensor<[4,3,7,7],!torch.qint8>
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.dequantize.self' that was explicitly marked illegal}}
+  %3 = torch.aten.dequantize.self %2 : !torch.vtensor<[4,3,7,7],!torch.qint8> -> !torch.vtensor<[4,3,7,7],f32>
+  return %3 : !torch.vtensor<[4,3,7,7],f32>
+}


### PR DESCRIPTION
## Summary

The `TorchToStablehlo` lowering for `aten._make_per_tensor_quantized_tensor` and `aten._make_per_channel_quantized_tensor` fuses these ops with a following `aten.dequantize.self` by reusing the `quant.UniformQuantizedType` / `quant.UniformQuantizedPerAxisType` produced upstream by `aten.quantize_per_tensor` / `aten.quantize_per_channel`. Previously this reuse was unconditional — there was a `[TODO] verify that zeroPoint and Scale matches with the input operand type` left in both patterns — so if the scale, zero point, or (for per-channel) axis supplied to the `_make_*_quantized_tensor` op didn't actually match what was baked into the quantized type, the pattern would silently reuse the mismatched type anyway, producing an incorrect lowering with no diagnostic.

This PR fills in that verification:

- For the per-tensor pattern, the op's `zero_point`/`scale` operands are required to be `torch.constant.int`/`torch.constant.float` and are compared against `quant::UniformQuantizedType::getZeroPoint()`/`getScale()`.
- For the per-channel pattern, `zero_point`/`scale` are required to be `torch.vtensor.literal` operands and are compared element-wise against `quant::UniformQuantizedPerAxisType::getZeroPoints()`/`getScales()`, and `axis` is compared against `getQuantizedDimension()`.
- On any mismatch (or if the operands aren't constant/literal, so the check can't be statically performed), the pattern now returns `failure()` instead of proceeding, so the mismatch surfaces as a legalization failure on the consumer (`aten.dequantize.self`) rather than silently miscompiling.

## Testing

Adds four new `FileCheck`/`expected-error` cases to `test/Conversion/TorchToStablehlo/quantization.mlir`:

- `make_per_tensor_quantized_tensor_mismatched_zero_point`
- `make_per_tensor_quantized_tensor_mismatched_scale`
- `make_per_channel_quantized_tensor_mismatched_scale`
- `make_per_channel_quantized_tensor_mismatched_axis`

Each constructs a `quantize_per_tensor`/`quantize_per_channel` → `int_repr` → `_make_per_*_quantized_tensor` (with a deliberately mismatched scale/zero-point/axis) → `dequantize.self` chain and expects legalization to fail rather than silently succeed.