### PR TITLE
[TorchToTosa] Lower MXFP4 aten._scaled_mm_v2 to TOSA

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -26,9 +26,11 @@
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchTypes.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
 #include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/MathExtras.h"
 #include <array>
@@ -111,6 +113,10 @@ static bool isSupportedScaledMmDataElementType(Type type) {
   return isa<Float8E4M3FNType, Float8E5M2Type>(type);
 }
 
+static bool isSupportedScaledMmV2DataElementType(Type type) {
+  return isa<Float4E2M1FNType>(type);
+}
+
 static bool isSupportedStaticScaledMmScaleElementType(Type type) {
   return type.isF32();
 }
@@ -160,6 +166,38 @@ static Value transposeTensor(Value input, ArrayRef<int64_t> inputShape,
                                    typeConverter->convertType(resultTy), input,
                                    rewriter.getDenseI32ArrayAttr(permutation))
       .getResult();
+}
+
+static FailureOr<Value> getSingleListConstructElement(Value value) {
+  auto listConstruct = value.getDefiningOp<PrimListConstructOp>();
+  if (!listConstruct || listConstruct.getElements().size() != 1)
+    return failure();
+  return listConstruct.getElements().front();
+}
+
+static FailureOr<Value> convertSingleTensorListConstructElement(
+    Value value, const TypeConverter *converter,
+    ConversionPatternRewriter &rewriter, Location loc) {
+  FailureOr<Value> element = getSingleListConstructElement(value);
+  if (failed(element))
+    return failure();
+
+  auto convertedTy = dyn_cast_or_null<RankedTensorType>(
+      converter->convertType(element->getType()));
+  if (!convertedTy)
+    return failure();
+
+  return TorchConversion::ToBuiltinTensorOp::create(rewriter, loc, convertedTy,
+                                                    *element)
+      .getResult();
+}
+
+static FailureOr<int64_t> getSingleConstantIntListValue(Value value) {
+  SmallVector<int64_t> values;
+  if (!matchPattern(value, m_TorchListOfConstantInts(values)) ||
+      values.size() != 1)
+    return failure();
+  return values.front();
 }
 
 static std::optional<Value>
@@ -397,12 +435,8 @@ reshapeFlatBlockedScale(Value scale, RankedTensorType scaleTy, int64_t rows,
       .getResult();
 }
 
-static FailureOr<ArrayRef<char>> getDenseConstantRawByteData(Value value) {
-  auto constOp = value.getDefiningOp<tosa::ConstOp>();
-  if (!constOp)
-    return failure();
-
-  ElementsAttr attr = constOp.getValues();
+static FailureOr<ArrayRef<char>>
+getDenseElementsRawByteData(ElementsAttr attr) {
   if (auto denseAttr = dyn_cast<DenseElementsAttr>(attr))
     return denseAttr.getRawData();
 
@@ -412,6 +446,23 @@ static FailureOr<ArrayRef<char>> getDenseConstantRawByteData(Value value) {
       return failure();
     return blob->getData();
   }
+
+  return failure();
+}
+
+static FailureOr<ArrayRef<char>> getDenseConstantRawByteData(Value value) {
+  if (auto toBuiltin =
+          value.getDefiningOp<TorchConversion::ToBuiltinTensorOp>())
+    value = toBuiltin.getOperand();
+  if (auto fromBuiltin =
+          value.getDefiningOp<TorchConversion::FromBuiltinTensorOp>())
+    value = fromBuiltin.getOperand();
+
+  if (auto constOp = value.getDefiningOp<tosa::ConstOp>())
+    return getDenseElementsRawByteData(constOp.getValues());
+
+  if (auto literalOp = value.getDefiningOp<ValueTensorLiteralOp>())
+    return getDenseElementsRawByteData(literalOp.getValueAttr());
 
   return failure();
 }
@@ -433,11 +484,13 @@ getDenseConstantRawByteData(Value value, int64_t numElements) {
 
 // PyTorch accepts blocked scales in two encodings:
 //   FlatPadded: a runtime value already padded to ceil(rows, 128) x
-//     ceil(K / 32, 4), either rank-2 or flattened. Lowering reshapes it and
-//     slices away padding that is outside the true M/N extent.
-//   SwizzledConstant: a compile-time constant stored as 32x16 byte tiles. This
-//     is reordered at compile time into the compact [1, rows, K / 32] TOSA
-//     layout because TOSA does not model the swizzled storage format.
+//     ceil(K / 32, 4), either rank-1, rank-2, or rank-3 with a leading batch
+//     dimension. Lowering reshapes it and slices away padding that is outside
+//     the true M/N extent.
+//   SwizzledConstant: a compile-time constant stored as 32x16 byte tiles,
+//     either as a 2-D tile grid or a flattened list of tiles. This is reordered
+//     at compile time into the compact [1, rows, K / 32] TOSA layout because
+//     TOSA does not model the swizzled storage format.
 enum class BlockedScaleLayout {
   Invalid,
   FlatPadded,
@@ -466,6 +519,12 @@ static BlockedScaleLayout classifyFlatBlockedScale(RankedTensorType scaleTy,
                ? BlockedScaleLayout::FlatPadded
                : BlockedScaleLayout::Invalid;
 
+  if (scaleTy.getRank() == 3)
+    return scaleTy.getDimSize(0) == 1 && scaleTy.getDimSize(1) == paddedRows &&
+                   scaleTy.getDimSize(2) == paddedCols
+               ? BlockedScaleLayout::FlatPadded
+               : BlockedScaleLayout::Invalid;
+
   if (scaleTy.getRank() != 1)
     return BlockedScaleLayout::Invalid;
 
@@ -481,9 +540,15 @@ static bool hasSwizzledBlockedScaleShape(RankedTensorType scaleTy, int64_t rows,
 
   int64_t rowBlocks = llvm::divideCeil(rows, kTosaBlockedScaleRowBlock);
   int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
-  return scaleTy.getDimSize(0) ==
-             rowBlocks * colBlocks * kTosaBlockedScaleSwizzleTileRows &&
-         scaleTy.getDimSize(1) == kTosaBlockedScaleSwizzleTileCols;
+  SmallVector<int64_t, 2> gridShape{
+      rowBlocks * kTosaBlockedScaleSwizzleTileRows,
+      colBlocks * kTosaBlockedScaleSwizzleTileCols};
+  SmallVector<int64_t, 2> flatTileShape{rowBlocks * colBlocks *
+                                            kTosaBlockedScaleSwizzleTileRows,
+                                        kTosaBlockedScaleSwizzleTileCols};
+  ArrayRef<int64_t> shape = scaleTy.getShape();
+  return shape == ArrayRef<int64_t>(gridShape) ||
+         shape == ArrayRef<int64_t>(flatTileShape);
 }
 
 static FailureOr<SmallVector<char>>
@@ -522,13 +587,26 @@ static FailureOr<Value> reorderSwizzledBlockedScaleConstant(
   if (!hasSwizzledBlockedScaleShape(scaleTy, rows, scaleCols))
     return failure();
 
+  int64_t rowBlocks = llvm::divideCeil(rows, kTosaBlockedScaleRowBlock);
   int64_t colBlocks = llvm::divideCeil(scaleCols, kTosaBlockedScaleColBlock);
+  SmallVector<int64_t, 2> gridShape{
+      rowBlocks * kTosaBlockedScaleSwizzleTileRows,
+      colBlocks * kTosaBlockedScaleSwizzleTileCols};
+  SmallVector<int64_t, 2> flatTileShape{rowBlocks * colBlocks *
+                                            kTosaBlockedScaleSwizzleTileRows,
+                                        kTosaBlockedScaleSwizzleTileCols};
+  ArrayRef<int64_t> shape = scaleTy.getShape();
+  bool isGridShape = shape == ArrayRef<int64_t>(gridShape);
+  bool isFlatTileShape = shape == ArrayRef<int64_t>(flatTileShape);
+  if (!isGridShape && !isFlatTileShape)
+    return failure();
 
   // E8M0 scale values are layout-reordered byte payloads here, not numerically
-  // transformed. The swizzled storage is [rowBlocks * colBlocks * 32, 16],
-  // where each 32x16 tile stores one 128-row by 4-column padded scale block.
-  // For constants with this exact layout, reorder the raw bytes at compile time
-  // into TOSA's compact [1, rows, K/32] scale layout.
+  // transformed. The swizzled storage is made of 32x16 tiles, each holding one
+  // 128-row by 4-column padded scale block. Constants can expose those tiles as
+  // a 2-D grid or as a flattened list of tiles, but both carry the same
+  // block-major raw byte stream. Reorder it at compile time into TOSA's compact
+  // [1, rows, K/32] scale layout.
   if (static_cast<int64_t>(rawData.size()) != scaleTy.getNumElements())
     return failure();
 
@@ -536,19 +614,15 @@ static FailureOr<Value> reorderSwizzledBlockedScaleConstant(
   for (int64_t row = 0; row < rows; ++row) {
     int64_t rowBlock = row / kTosaBlockedScaleRowBlock;
     int64_t rowInBlock = row % kTosaBlockedScaleRowBlock;
+    int64_t rowTile = rowInBlock / kTosaBlockedScaleSwizzleTileRows;
+    int64_t rowTileOffset = rowInBlock % kTosaBlockedScaleSwizzleTileRows;
     for (int64_t col = 0; col < scaleCols; ++col) {
       int64_t colBlock = col / kTosaBlockedScaleColBlock;
       int64_t colInBlock = col % kTosaBlockedScaleColBlock;
       int64_t block = rowBlock * colBlocks + colBlock;
-      // Within each 32x16 tile, rows are grouped by row % 32 and columns by
-      // four-row sub-blocks, so compact [row, col] maps to:
-      //   tileBase + (row % 32) * 16 + (row / 32) * 4 + (col % 4).
       int64_t srcIndex = block * kTosaBlockedScaleSwizzleTileSize +
-                         (rowInBlock % kTosaBlockedScaleSwizzleTileRows) *
-                             kTosaBlockedScaleSwizzleTileCols +
-                         (rowInBlock / kTosaBlockedScaleSwizzleTileRows) *
-                             kTosaBlockedScaleColBlock +
-                         colInBlock;
+                         rowTileOffset * kTosaBlockedScaleSwizzleTileCols +
+                         rowTile * kTosaBlockedScaleColBlock + colInBlock;
       compactData[row * scaleCols + col] = rawData[srcIndex];
     }
   }
@@ -3477,6 +3551,396 @@ public:
     return rewriteBlockedScaledMmToMatmulTBlockScaledOp(
         op, lhs, rhs, scaleA, scaleB, bias, lhsTy, rhsTy, scaleATy, scaleBTy,
         resultTy, rewriter, loc);
+  }
+};
+
+static Value unwrapBuiltinTensorRoundTrip(Value value) {
+  if (auto toBuiltin =
+          value.getDefiningOp<TorchConversion::ToBuiltinTensorOp>()) {
+    if (auto fromBuiltin =
+            toBuiltin.getOperand()
+                .getDefiningOp<TorchConversion::FromBuiltinTensorOp>())
+      return fromBuiltin.getOperand();
+  }
+  return value;
+}
+
+static FailureOr<Value>
+getLogicalFp4Activation(Value value, int64_t m, int64_t logicalK,
+                        Type elementTy, ConversionPatternRewriter &rewriter,
+                        Location loc) {
+  value = unwrapBuiltinTensorRoundTrip(value);
+  SmallVector<int64_t> logicalRank3Shape = {1, m, logicalK};
+  SmallVector<int64_t> logicalRank2Shape = {m, logicalK};
+  auto hasLogicalRank3Shape = [&](Value candidate) {
+    auto ty = dyn_cast<RankedTensorType>(candidate.getType());
+    return ty && ty.getElementType() == elementTy && ty.hasStaticShape() &&
+           ty.getShape() == ArrayRef<int64_t>(logicalRank3Shape);
+  };
+  auto hasLogicalRank2Shape = [&](Value candidate) {
+    auto ty = dyn_cast<RankedTensorType>(candidate.getType());
+    return ty && ty.getElementType() == elementTy && ty.hasStaticShape() &&
+           ty.getShape() == ArrayRef<int64_t>(logicalRank2Shape);
+  };
+
+  if (hasLogicalRank3Shape(value))
+    return value;
+  if (hasLogicalRank2Shape(value))
+    return reshapeTensor(value, logicalRank3Shape, elementTy, rewriter, loc);
+
+  if (auto reshape = value.getDefiningOp<tosa::ReshapeOp>()) {
+    Value input = reshape.getInput1();
+    if (hasLogicalRank3Shape(input))
+      return input;
+    if (hasLogicalRank2Shape(input))
+      return reshapeTensor(input, logicalRank3Shape, elementTy, rewriter, loc);
+  }
+
+  return failure();
+}
+
+static FailureOr<Value> getLogicalFp4ActivationFromScale(Value scale, int64_t m,
+                                                         int64_t logicalK,
+                                                         Type elementTy) {
+  scale = unwrapBuiltinTensorRoundTrip(scale);
+  while (true) {
+    if (auto pad = scale.getDefiningOp<tosa::PadOp>()) {
+      scale = pad.getInput1();
+      continue;
+    }
+    if (auto reshape = scale.getDefiningOp<tosa::ReshapeOp>()) {
+      scale = reshape.getInput1();
+      continue;
+    }
+    break;
+  }
+
+  auto castToBlockScaled = scale.getDefiningOp<tosa::CastToBlockScaledOp>();
+  if (!castToBlockScaled)
+    return failure();
+
+  Value data = castToBlockScaled.getOutputData();
+  SmallVector<int64_t> logicalShape = {1, m, logicalK};
+  auto dataTy = dyn_cast<RankedTensorType>(data.getType());
+  if (!dataTy || dataTy.getElementType() != elementTy ||
+      !dataTy.hasStaticShape() ||
+      dataTy.getShape() != ArrayRef<int64_t>(logicalShape))
+    return failure();
+  return data;
+}
+
+static Value unwrapScaledMmV2TransparentTensorOp(Value value) {
+  while (true) {
+    if (auto alias = value.getDefiningOp<AtenAliasOp>()) {
+      value = alias.getSelf();
+      continue;
+    }
+    if (auto detach = value.getDefiningOp<AtenDetachOp>()) {
+      value = detach.getSelf();
+      continue;
+    }
+    if (auto toCopy = value.getDefiningOp<Aten_ToCopyOp>()) {
+      value = toCopy.getSelf();
+      continue;
+    }
+    if (auto toDtype = value.getDefiningOp<AtenToDtypeOp>()) {
+      value = toDtype.getSelf();
+      continue;
+    }
+    return value;
+  }
+}
+
+static void collectPackedFp4WeightProducerTree(
+    Value value, llvm::SmallPtrSetImpl<Operation *> &producers) {
+  SmallVector<Operation *> worklist;
+  if (Operation *op = value.getDefiningOp())
+    worklist.push_back(op);
+
+  while (!worklist.empty()) {
+    Operation *op = worklist.pop_back_val();
+    if (!op || !producers.insert(op).second)
+      continue;
+    for (Value operand : op->getOperands())
+      if (Operation *definingOp = operand.getDefiningOp())
+        worklist.push_back(definingOp);
+  }
+}
+
+static void eraseDeadPackedFp4WeightProducers(
+    ConversionPatternRewriter &rewriter,
+    llvm::SmallPtrSetImpl<Operation *> &producers) {
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    SmallVector<Operation *> deadOps;
+    for (Operation *op : producers)
+      if (op->use_empty())
+        deadOps.push_back(op);
+    for (Operation *op : deadOps) {
+      if (producers.erase(op)) {
+        rewriter.eraseOp(op);
+        changed = true;
+      }
+    }
+  }
+}
+
+static bool isPackedFp4ScaledMmV2WeightView(AtenViewDtypeOp view) {
+  auto resultTy = dyn_cast<ValueTensorType>(view.getType());
+  if (!resultTy || !resultTy.hasDtype() ||
+      !isa<Float4E2M1FNType>(resultTy.getDtype()))
+    return false;
+
+  Value source = unwrapScaledMmV2TransparentTensorOp(view.getSelf());
+  if (!source.getDefiningOp<ValueTensorLiteralOp>())
+    return false;
+
+  Value value = view.getResult();
+  while (value.hasOneUse()) {
+    Operation *user = *value.getUsers().begin();
+    if (isa<AtenAliasOp, AtenDetachOp, Aten_ToCopyOp, AtenToDtypeOp,
+            AtenPermuteOp>(user)) {
+      if (user->getNumResults() != 1)
+        return false;
+      value = user->getResult(0);
+      continue;
+    }
+    if (auto scaledMm = dyn_cast<Aten_ScaledMmV2Op>(user))
+      return scaledMm.getMat2() == value;
+    return false;
+  }
+  return false;
+}
+
+static SmallVector<char> unpackFp4X2ToDenseBytes(ArrayRef<char> packed) {
+  SmallVector<char> unpacked;
+  unpacked.reserve(packed.size() * 2);
+  for (char value : packed) {
+    uint8_t byte = static_cast<uint8_t>(value);
+    unpacked.push_back(static_cast<char>(byte & 0x0f));
+    unpacked.push_back(static_cast<char>((byte >> 4) & 0x0f));
+  }
+  return unpacked;
+}
+
+static FailureOr<Value> createLogicalFp4RhsFromPackedConstant(
+    Aten_ScaledMmV2Op op, RankedTensorType rhsTy, int64_t n, int64_t storageK,
+    int64_t logicalK, ConversionPatternRewriter &rewriter, Location loc) {
+  Value mat2 = unwrapScaledMmV2TransparentTensorOp(op.getMat2());
+  auto permute = mat2.getDefiningOp<AtenPermuteOp>();
+  if (!permute)
+    return failure();
+
+  SmallVector<int64_t> dims;
+  if (!matchPattern(permute.getDims(), m_TorchListOfConstantInts(dims)) ||
+      dims.size() != 2 || dims[0] != 1 || dims[1] != 0)
+    return failure();
+
+  Value packedWeight = unwrapScaledMmV2TransparentTensorOp(permute.getSelf());
+  auto fp4View = packedWeight.getDefiningOp<AtenViewDtypeOp>();
+  if (!fp4View)
+    return failure();
+
+  Value literalValue = unwrapScaledMmV2TransparentTensorOp(fp4View.getSelf());
+  auto literal = literalValue.getDefiningOp<ValueTensorLiteralOp>();
+  if (!literal)
+    return failure();
+
+  int64_t expectedBytes = n * storageK;
+  FailureOr<ArrayRef<char>> rawData =
+      getDenseElementsRawByteData(literal.getValueAttr());
+  if (failed(rawData))
+    return failure();
+  SmallVector<char> packed = expandRawByteData(*rawData, expectedBytes);
+  if (static_cast<int64_t>(packed.size()) != expectedBytes)
+    return failure();
+
+  SmallVector<char> unpacked = unpackFp4X2ToDenseBytes(packed);
+  if (static_cast<int64_t>(unpacked.size()) != n * logicalK)
+    return failure();
+
+  auto rhsLogicalTy =
+      RankedTensorType::get({1, n, logicalK}, rhsTy.getElementType());
+  auto attr = DenseElementsAttr::getFromRawBuffer(rhsLogicalTy, unpacked);
+  return tosa::ConstOp::create(rewriter, loc, rhsLogicalTy, attr).getResult();
+}
+
+class ConvertAtenScaledMmV2Op
+    : public TorchToTosaOpConversionPattern<Aten_ScaledMmV2Op> {
+public:
+  using TorchToTosaOpConversionPattern<
+      Aten_ScaledMmV2Op>::TorchToTosaOpConversionPattern;
+  using OpAdaptor = typename Aten_ScaledMmV2Op::Adaptor;
+
+  LogicalResult
+  matchAndRewriteImpl(Aten_ScaledMmV2Op op, OpAdaptor adaptor,
+                      ConversionPatternRewriter &rewriter) const override {
+    constexpr int64_t kScalingTypeBlockWise1x32 = 3;
+    constexpr int64_t kSwizzle32x4x4 = 1;
+    constexpr int64_t kTosaBlockScaledMmBlockSize = 32;
+
+    SmallVector<int64_t> contractionDims;
+    if (!matchPattern(op.getContractionDim(),
+                      m_TorchListOfConstantInts(contractionDims)))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires constant contraction_dim");
+    bool hasDefaultContractionDims =
+        contractionDims.empty() ||
+        (contractionDims.size() == 2 && contractionDims[0] == 1 &&
+         contractionDims[1] == 0);
+    if (!hasDefaultContractionDims)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 only supports default contraction dims");
+
+    // TOSA exposes one block-scaled matmul accumulation behavior. Ignore the
+    // PyTorch knob just like the aten._scaled_mm lowering does.
+    (void)op.getUseFastAccum();
+
+    FailureOr<int64_t> recipeA = getSingleConstantIntListValue(op.getRecipeA());
+    FailureOr<int64_t> recipeB = getSingleConstantIntListValue(op.getRecipeB());
+    FailureOr<int64_t> swizzleA =
+        getSingleConstantIntListValue(op.getSwizzleA());
+    FailureOr<int64_t> swizzleB =
+        getSingleConstantIntListValue(op.getSwizzleB());
+    if (failed(recipeA) || failed(recipeB) || failed(swizzleA) ||
+        failed(swizzleB))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires constant single-element recipes "
+              "and swizzles");
+    if (*recipeA != kScalingTypeBlockWise1x32 ||
+        *recipeB != kScalingTypeBlockWise1x32 || *swizzleA != kSwizzle32x4x4 ||
+        *swizzleB != kSwizzle32x4x4)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 only supports MXFP4 BlockWise1x32 scales "
+              "with SWIZZLE_32_4_4");
+
+    // The TOSA result uses an unpacked constant, so the original packed RHS
+    // producer tree should become dead when _scaled_mm_v2 is replaced.
+    llvm::SmallPtrSet<Operation *, 16> packedWeightProducers;
+    collectPackedFp4WeightProducerTree(op.getMat2(), packedWeightProducers);
+    collectPackedFp4WeightProducerTree(adaptor.getMat2(),
+                                       packedWeightProducers);
+
+    Value lhs = adaptor.getSelf();
+    Value rhs = adaptor.getMat2();
+    Value bias = adaptor.getBias();
+    auto lhsTy = dyn_cast<RankedTensorType>(lhs.getType());
+    auto rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
+    auto resultTy = dyn_cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getType()));
+    if (!lhsTy || !rhsTy || !resultTy)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires ranked tensor operands and result");
+
+    Type lhsElemTy = lhsTy.getElementType();
+    Type rhsElemTy = rhsTy.getElementType();
+    if (!isSupportedScaledMmV2DataElementType(lhsElemTy) ||
+        !isSupportedScaledMmV2DataElementType(rhsElemTy))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects FP4 input types");
+    if (lhsElemTy != rhsElemTy)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects matching FP4 input types");
+    if (!isSupportedStaticScaledMmResultElementType(resultTy.getElementType()))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects f32, f16 or bf16 result type");
+    if (lhsTy.getRank() != 2 || rhsTy.getRank() != 2 || resultTy.getRank() != 2)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects rank-2 input/result tensors");
+    if (!lhsTy.hasStaticShape() || !rhsTy.hasStaticShape() ||
+        !resultTy.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires static shapes for TOSA lowering");
+
+    int64_t m = lhsTy.getDimSize(0);
+    int64_t lhsK = lhsTy.getDimSize(1);
+    int64_t storageK = rhsTy.getDimSize(0);
+    int64_t n = rhsTy.getDimSize(1);
+    int64_t logicalK = storageK * 2;
+    if (lhsK != storageK && lhsK != logicalK)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires lhs K to match packed or logical "
+              "rhs contracting dim");
+    if (logicalK % kTosaBlockScaledMmBlockSize != 0)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects logical K divisible by 32");
+    if (resultTy.getDimSize(0) != m || resultTy.getDimSize(1) != n)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects result shape [M, N]");
+    if (!isValidScaledMmBias(bias, n))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 expects bias to be None or rank-1 [N]");
+
+    Location loc = op.getLoc();
+    FailureOr<Value> scaleA = convertSingleTensorListConstructElement(
+        op.getScaleA(), this->getTypeConverter(), rewriter, loc);
+    FailureOr<Value> scaleB = convertSingleTensorListConstructElement(
+        op.getScaleB(), this->getTypeConverter(), rewriter, loc);
+    if (failed(scaleA) || failed(scaleB)) {
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires single tensor scale lists");
+    }
+    auto scaleATy = dyn_cast<RankedTensorType>(scaleA->getType());
+    auto scaleBTy = dyn_cast<RankedTensorType>(scaleB->getType());
+    if (!scaleATy || !scaleBTy || !scaleATy.hasStaticShape() ||
+        !scaleBTy.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires static ranked scale tensors");
+
+    int64_t scaleCols = logicalK / kTosaBlockScaledMmBlockSize;
+    BlockedScaleClassification scaleAClassification =
+        classifyBlockedScale(*scaleA, scaleATy, m, scaleCols);
+    BlockedScaleClassification scaleBClassification =
+        classifyBlockedScale(*scaleB, scaleBTy, n, scaleCols);
+    if (scaleAClassification.layout == BlockedScaleLayout::Invalid ||
+        scaleBClassification.layout == BlockedScaleLayout::Invalid)
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 failed to validate MXFP4 blocked scales");
+
+    auto scaleAOr = getBlockedScale(*scaleA, scaleATy, m, scaleCols,
+                                    scaleAClassification, rewriter, loc);
+    auto scaleBOr = getBlockedScale(*scaleB, scaleBTy, n, scaleCols,
+                                    scaleBClassification, rewriter, loc);
+    if (failed(scaleAOr) || failed(scaleBOr)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to reshape aten._scaled_mm_v2 blocked scales");
+    }
+
+    FailureOr<Value> lhsLogical =
+        getLogicalFp4Activation(lhs, m, logicalK, lhsElemTy, rewriter, loc);
+    if (failed(lhsLogical)) {
+      lhsLogical =
+          getLogicalFp4ActivationFromScale(*scaleA, m, logicalK, lhsElemTy);
+    }
+    if (failed(lhsLogical))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires logical FP4 activation produced by "
+              "MX fusion");
+    lhs = *lhsLogical;
+    FailureOr<Value> rhsConst = createLogicalFp4RhsFromPackedConstant(
+        op, rhsTy, n, storageK, logicalK, rewriter, loc);
+    if (failed(rhsConst))
+      return rewriter.notifyMatchFailure(
+          op, "aten._scaled_mm_v2 requires constant packed MXFP4 rhs weights");
+    rhs = *rhsConst;
+
+    auto blockedResultTy =
+        RankedTensorType::get({1, m, n}, resultTy.getElementType());
+    auto blockedResultOr = createScaledMmMatmulTBlockScaledResult(
+        op, lhs, rhs, *scaleAOr, *scaleBOr, bias, blockedResultTy, rewriter,
+        loc);
+    if (failed(blockedResultOr))
+      return failure();
+
+    Value result =
+        tosa::ReshapeOp::create(
+            rewriter, loc, resultTy, *blockedResultOr,
+            tosa::getTosaConstShape(rewriter, loc, getTensorShape(resultTy)))
+            .getResult();
+    rewriter.replaceOp(op, {result});
+    eraseDeadPackedFp4WeightProducers(rewriter, packedWeightProducers);
+    return success();
   }
 };
 
@@ -11750,6 +12214,17 @@ public:
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
+    llvm::SmallPtrSet<Operation *, 4> packedFp4WeightViews;
+    llvm::SmallPtrSet<Operation *, 4> packedFp4WeightLiterals;
+    getOperation()->walk([&](AtenViewDtypeOp view) {
+      if (!isPackedFp4ScaledMmV2WeightView(view))
+        return;
+      packedFp4WeightViews.insert(view);
+      Value source = unwrapScaledMmV2TransparentTensorOp(view.getSelf());
+      packedFp4WeightLiterals.insert(
+          source.getDefiningOp<ValueTensorLiteralOp>());
+    });
+
     ConversionTarget target(*context);
     target.addLegalDialect<tosa::TosaDialect, tensor::TensorDialect,
                            arith::ArithDialect>();
@@ -11759,7 +12234,6 @@ public:
     } else {
       target.addLegalDialect<Torch::TorchDialect>();
     }
-
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
     TorchConversion::setupBackendTypeConversion(target, typeConverter);
@@ -11797,12 +12271,49 @@ public:
       target.addIllegalOp(OperationName(op, context));
     }
 
+    target.addDynamicallyLegalOp<AtenViewDtypeOp>(
+        [&](AtenViewDtypeOp op) { return packedFp4WeightViews.contains(op); });
+    target.addDynamicallyLegalOp<ValueTensorLiteralOp>(
+        [&](ValueTensorLiteralOp op) {
+          return packedFp4WeightLiterals.contains(op);
+        });
+
     auto frozenPatterns = FrozenRewritePatternSet(
         std::move(patterns), this->disabledPatterns, this->enabledPatterns);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(frozenPatterns))))
       return signalPassFailure();
+
+    if (!packedFp4WeightViews.empty()) {
+      bool changed = true;
+      while (changed) {
+        changed = false;
+        SmallVector<Operation *> deadPackedStorageOps;
+        getOperation()->walk([&](Operation *op) {
+          if ((packedFp4WeightViews.contains(op) ||
+               packedFp4WeightLiterals.contains(op)) &&
+              op->use_empty())
+            deadPackedStorageOps.push_back(op);
+        });
+        for (Operation *op : deadPackedStorageOps) {
+          op->erase();
+          changed = true;
+        }
+      }
+
+      bool hasResidualPackedFp4StorageOp = false;
+      getOperation()->walk([&](Operation *op) {
+        hasResidualPackedFp4StorageOp |= packedFp4WeightViews.contains(op) ||
+                                         packedFp4WeightLiterals.contains(op);
+      });
+      if (hasResidualPackedFp4StorageOp) {
+        getOperation()->emitError(
+            "failed to remove packed MXFP4 storage operations after "
+            "aten._scaled_mm_v2 conversion");
+        return signalPassFailure();
+      }
+    }
   }
 };
 } // namespace
@@ -12026,6 +12537,10 @@ std::set<StringRef> populateTorchToTosaConversionPatternsAndIllegalOps(
   illegalOps.insert(Aten_ScaledMmOp::getOperationName());
   patterns.addWithLabel<ConvertAtenScaledMmOp<Aten_ScaledMmOp>>(
       Aten_ScaledMmOp::getOperationName(), typeConverter, context);
+
+  illegalOps.insert(Aten_ScaledMmV2Op::getOperationName());
+  patterns.addWithLabel<ConvertAtenScaledMmV2Op>(
+      Aten_ScaledMmV2Op::getOperationName(), typeConverter, context);
 
 #define INSERT_ADAPTIVE_POOLING_ATENOP_PATTERN(AtenOp, TosaOpT)                \
   illegalOps.insert(AtenOp::getOperationName());                               \

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -7067,8 +7067,8 @@ verifyScaledMmV2MatrixShapes(Aten_ScaledMmV2Op op) {
       mat2Type.hasDtype() && isa<Float4E2M1FNType>(mat2Type.getDtype());
   // `k` is the statically visible storage dimension. For FP4, the
   // float4_e2m1fn_x2 representation packs two logical FP4 values into each
-  // storage element. PyTorch _scaled_mm_v2 applies that packed-K multiplier
-  // only when both matrix operands are FP4.
+  // storage element. PyTorch _scaled_mm_v2 requires both FP4 matrix operands
+  // to use this packed representation.
   info.logicalK = info.k;
   int64_t mat2LogicalK = mat2K;
   if (selfIsFp4 && mat2IsFp4) {
@@ -7146,7 +7146,6 @@ verifyScaledMmV2ScaleNumel(Aten_ScaledMmV2Op op,
     return success();
 
   int64_t m = matrixInfo.m;
-  int64_t k = matrixInfo.k;
   int64_t n = matrixInfo.n;
   int64_t logicalK = matrixInfo.logicalK;
   ScaledMmV2RecipeMode mode = recipeInfo.mode;
@@ -7223,7 +7222,9 @@ verifyScaledMmV2ScaleNumel(Aten_ScaledMmV2Op op,
 
   int64_t blockSizeMN = 128;
   int64_t blockSizeK = 32;
-  int64_t numKBlocks = llvm::divideCeil(k, blockSizeK);
+  // MX blockwise scales are defined over the logical contracting dimension.
+  // For packed FP4 this is twice the visible storage K.
+  int64_t numKBlocks = llvm::divideCeil(logicalK, blockSizeK);
   int64_t paddedNumKBlocks = llvm::divideCeil(numKBlocks, int64_t{4}) * 4;
   int64_t expectedScaleANumel =
       blockSizeMN * llvm::divideCeil(m, blockSizeMN) * paddedNumKBlocks;

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -6159,6 +6159,406 @@ func.func @torch.aten._scaled_mm$block_scaled_fp8_swizzled_resource_scales(%arg0
 #-}
 
 // -----
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_packed_weight(
+// CHECK-SAME:      %arg0: tensor<1x3x32xf32>, %arg1: !torch.vtensor<[3,16],f4E2M1FN>) -> !torch.vtensor<[3,16],bf16> {
+// CHECK:           %[[LHS:.*]], %[[SCALE_A_COMPACT:.*]] = tosa.cast_to_block_scaled %arg0 {block_size = BLOCK_SIZE_32}
+// CHECK:           %[[SCALE_A_SOURCE_PADDED:.*]] = tosa.pad %[[SCALE_A_COMPACT]], %{{.*}}, %{{.*}} : (tensor<1x3x1xf8E8M0FNU>, !tosa.shape<6>, tensor<1xf8E8M0FNU>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_FLAT:.*]] = tosa.reshape %[[SCALE_A_SOURCE_PADDED]], %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<1>) -> tensor<512xf8E8M0FNU>
+// CHECK:           %[[SCALE_A_PADDED:.*]] = tosa.reshape %{{.*}}, %{{.*}} : (tensor<512xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A:.*]] = tosa.slice %[[SCALE_A_PADDED]], %{{.*}}, %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x3x1xf8E8M0FNU>
+// CHECK:           %[[SCALE_B:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x16x1xf8E8M0FNU>}>
+// CHECK:           %[[RHS:.*]] = "tosa.const"() <{values = dense<"0x0102{{.*}}"> : tensor<1x16x32xf4E2M1FN>}>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A]], %[[RHS]], %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x16x32xf4E2M1FN>, tensor<1x16x1xf8E8M0FNU>) -> tensor<1x3x16xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[MATMUL]] : (tensor<1x3x16xf32>) -> tensor<1x3x16xbf16>
+// CHECK:           tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x3x16xbf16>, !tosa.shape<2>) -> tensor<3x16xbf16>
+// CHECK-NOT:       torch.aten.view.dtype
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_packed_weight(%arg0: tensor<1x3x32xf32>, %arg1: !torch.vtensor<[3,16],f4E2M1FN>) -> !torch.vtensor<[3,16],bf16> {
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %int29 = torch.constant.int 29
+  %none = torch.constant.none
+  %activation, %activation_scale = tosa.cast_to_block_scaled %arg0 {block_size = #tosa.block_size<BLOCK_SIZE_32>} : (tensor<1x3x32xf32>) -> (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>)
+  %scale_padding = tosa.const_shape {values = dense<[0, 0, 0, 125, 0, 3]> : tensor<6xindex>} : () -> !tosa.shape<6>
+  %scale_pad_value = "tosa.const"() <{values = dense<0x00> : tensor<1xf8E8M0FNU>}> : () -> tensor<1xf8E8M0FNU>
+  %activation_scale_padded = tosa.pad %activation_scale, %scale_padding, %scale_pad_value : (tensor<1x3x1xf8E8M0FNU>, !tosa.shape<6>, tensor<1xf8E8M0FNU>) -> tensor<1x128x4xf8E8M0FNU>
+  %scale_flat_shape = tosa.const_shape {values = dense<512> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %activation_scale_flat = tosa.reshape %activation_scale_padded, %scale_flat_shape : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<1>) -> tensor<512xf8E8M0FNU>
+  %activation_scale_torch = torch_c.from_builtin_tensor %activation_scale_flat : tensor<512xf8E8M0FNU> -> !torch.vtensor<[512],f8E8M0FNU>
+  %weight_storage = torch.vtensor.literal(dense<33> : tensor<16x16xui8>) : !torch.vtensor<[16,16],ui8>
+  %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,16],ui8>, !torch.int -> !torch.vtensor<[16,16],f4E2M1FN>
+  %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[16,16],f4E2M1FN>
+  %scale_b_value = torch.vtensor.literal(dense<0x00> : tensor<32x16xf8E8M0FNU>) : !torch.vtensor<[32,16],f8E8M0FNU>
+  %scale_a = torch.prim.ListConstruct %activation_scale_torch : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %scale_b = torch.prim.ListConstruct %scale_b_value : (!torch.vtensor<[32,16],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg1, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],bf16>
+  return %0 : !torch.vtensor<[3,16],bf16>
+}
+
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank3_padded_scales(
+// CHECK-SAME:      %arg0: tensor<1x130x128xf32>, %arg1: !torch.vtensor<[130,64],f4E2M1FN>, %arg2: !torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.vtensor<[130,80],bf16> {
+// CHECK:           %[[LHS:.*]], %[[SCALE_A_COMPACT:.*]] = tosa.cast_to_block_scaled %arg0 {block_size = BLOCK_SIZE_32}
+// CHECK:           %[[SCALE_A_PADDED:.*]] = tosa.reshape %{{.*}}, %{{.*}} : (tensor<1x256x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x256x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_A:.*]] = tosa.slice %[[SCALE_A_PADDED]], %{{.*}}, %{{.*}} : (tensor<1x256x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x130x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B_PADDED:.*]] = tosa.reshape %{{.*}}, %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>) -> tensor<1x128x4xf8E8M0FNU>
+// CHECK:           %[[SCALE_B:.*]] = tosa.slice %[[SCALE_B_PADDED]], %{{.*}}, %{{.*}} : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<1x80x4xf8E8M0FNU>
+// CHECK:           %[[RHS:.*]] = "tosa.const"() <{values = dense<{{.*}}> : tensor<1x80x128xf4E2M1FN>}>
+// CHECK:           tosa.matmul_t_block_scaled %[[LHS]], %[[SCALE_A]], %[[RHS]], %[[SCALE_B]] {block_size = BLOCK_SIZE_32} : (tensor<1x130x128xf4E2M1FN>, tensor<1x130x4xf8E8M0FNU>, tensor<1x80x128xf4E2M1FN>, tensor<1x80x4xf8E8M0FNU>) -> tensor<1x130x80xf32>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_rank3_padded_scales(%arg0: tensor<1x130x128xf32>, %arg1: !torch.vtensor<[130,64],f4E2M1FN>, %arg2: !torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.vtensor<[130,80],bf16> {
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %int29 = torch.constant.int 29
+  %none = torch.constant.none
+  %activation, %activation_scale = tosa.cast_to_block_scaled %arg0 {block_size = #tosa.block_size<BLOCK_SIZE_32>} : (tensor<1x130x128xf32>) -> (tensor<1x130x128xf4E2M1FN>, tensor<1x130x4xf8E8M0FNU>)
+  %scale_padding = tosa.const_shape {values = dense<[0, 0, 0, 126, 0, 0]> : tensor<6xindex>} : () -> !tosa.shape<6>
+  %scale_pad_value = "tosa.const"() <{values = dense<0x00> : tensor<1xf8E8M0FNU>}> : () -> tensor<1xf8E8M0FNU>
+  %activation_scale_padded = tosa.pad %activation_scale, %scale_padding, %scale_pad_value : (tensor<1x130x4xf8E8M0FNU>, !tosa.shape<6>, tensor<1xf8E8M0FNU>) -> tensor<1x256x4xf8E8M0FNU>
+  %activation_scale_torch = torch_c.from_builtin_tensor %activation_scale_padded : tensor<1x256x4xf8E8M0FNU> -> !torch.vtensor<[1,256,4],f8E8M0FNU>
+  %weight_storage = torch.vtensor.literal(dense<0> : tensor<80x64xui8>) : !torch.vtensor<[80,64],ui8>
+  %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[80,64],ui8>, !torch.int -> !torch.vtensor<[80,64],f4E2M1FN>
+  %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[80,64],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[64,80],f4E2M1FN>
+  %scale_a = torch.prim.ListConstruct %activation_scale_torch : (!torch.vtensor<[1,256,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[1,128,4],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg1, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[130,64],f4E2M1FN>, !torch.vtensor<[64,80],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[130,80],bf16>
+  return %0 : !torch.vtensor<[130,80],bf16>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_bias(
+// CHECK-SAME:      %arg3: !torch.vtensor<[16],bf16>) -> !torch.vtensor<[3,16],bf16> {
+// CHECK-DAG:       %[[BIAS:.*]] = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[16],bf16> -> tensor<16xbf16>
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x16x32xf4E2M1FN>, tensor<1x16x1xf8E8M0FNU>) -> tensor<1x3x16xf32>
+// CHECK:           %[[BIAS_F32:.*]] = tosa.cast %[[BIAS]] : (tensor<16xbf16>) -> tensor<16xf32>
+// CHECK:           %[[BIAS_3D:.*]] = tosa.reshape %[[BIAS_F32]], %{{.*}} : (tensor<16xf32>, !tosa.shape<3>) -> tensor<1x1x16xf32>
+// CHECK:           %[[WITH_BIAS:.*]] = tosa.add %[[MATMUL]], %[[BIAS_3D]] : (tensor<1x3x16xf32>, tensor<1x1x16xf32>) -> tensor<1x3x16xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[WITH_BIAS]] : (tensor<1x3x16xf32>) -> tensor<1x3x16xbf16>
+// CHECK:           tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x3x16xbf16>, !tosa.shape<2>) -> tensor<3x16xbf16>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_bias(%arg0: tensor<1x3x32xf32>, %arg1: !torch.vtensor<[3,16],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[16],bf16>) -> !torch.vtensor<[3,16],bf16> {
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %int29 = torch.constant.int 29
+  %activation, %activation_scale = tosa.cast_to_block_scaled %arg0 {block_size = #tosa.block_size<BLOCK_SIZE_32>} : (tensor<1x3x32xf32>) -> (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>)
+  %scale_padding = tosa.const_shape {values = dense<[0, 0, 0, 125, 0, 3]> : tensor<6xindex>} : () -> !tosa.shape<6>
+  %scale_pad_value = "tosa.const"() <{values = dense<0x00> : tensor<1xf8E8M0FNU>}> : () -> tensor<1xf8E8M0FNU>
+  %activation_scale_padded = tosa.pad %activation_scale, %scale_padding, %scale_pad_value : (tensor<1x3x1xf8E8M0FNU>, !tosa.shape<6>, tensor<1xf8E8M0FNU>) -> tensor<1x128x4xf8E8M0FNU>
+  %scale_flat_shape = tosa.const_shape {values = dense<512> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %activation_scale_flat = tosa.reshape %activation_scale_padded, %scale_flat_shape : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<1>) -> tensor<512xf8E8M0FNU>
+  %activation_scale_torch = torch_c.from_builtin_tensor %activation_scale_flat : tensor<512xf8E8M0FNU> -> !torch.vtensor<[512],f8E8M0FNU>
+  %weight_storage = torch.vtensor.literal(dense<0> : tensor<16x16xui8>) : !torch.vtensor<[16,16],ui8>
+  %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,16],ui8>, !torch.int -> !torch.vtensor<[16,16],f4E2M1FN>
+  %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[16,16],f4E2M1FN>
+  %scale_a = torch.prim.ListConstruct %activation_scale_torch : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg1, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %arg3, %int15, %contraction_dim, %false : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.vtensor<[16],bf16>, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],bf16>
+  return %0 : !torch.vtensor<[3,16],bf16>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_f16_result(
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x16x32xf4E2M1FN>, tensor<1x16x1xf8E8M0FNU>) -> tensor<1x3x16xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[MATMUL]] : (tensor<1x3x16xf32>) -> tensor<1x3x16xf16>
+// CHECK:           tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x3x16xf16>, !tosa.shape<2>) -> tensor<3x16xf16>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_f16_result(%arg0: tensor<1x3x32xf32>, %arg1: !torch.vtensor<[3,16],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,16],f16> {
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int5 = torch.constant.int 5
+  %int29 = torch.constant.int 29
+  %none = torch.constant.none
+  %activation, %activation_scale = tosa.cast_to_block_scaled %arg0 {block_size = #tosa.block_size<BLOCK_SIZE_32>} : (tensor<1x3x32xf32>) -> (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>)
+  %scale_padding = tosa.const_shape {values = dense<[0, 0, 0, 125, 0, 3]> : tensor<6xindex>} : () -> !tosa.shape<6>
+  %scale_pad_value = "tosa.const"() <{values = dense<0x00> : tensor<1xf8E8M0FNU>}> : () -> tensor<1xf8E8M0FNU>
+  %activation_scale_padded = tosa.pad %activation_scale, %scale_padding, %scale_pad_value : (tensor<1x3x1xf8E8M0FNU>, !tosa.shape<6>, tensor<1xf8E8M0FNU>) -> tensor<1x128x4xf8E8M0FNU>
+  %scale_flat_shape = tosa.const_shape {values = dense<512> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %activation_scale_flat = tosa.reshape %activation_scale_padded, %scale_flat_shape : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<1>) -> tensor<512xf8E8M0FNU>
+  %activation_scale_torch = torch_c.from_builtin_tensor %activation_scale_flat : tensor<512xf8E8M0FNU> -> !torch.vtensor<[512],f8E8M0FNU>
+  %weight_storage = torch.vtensor.literal(dense<0> : tensor<16x16xui8>) : !torch.vtensor<[16,16],ui8>
+  %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,16],ui8>, !torch.int -> !torch.vtensor<[16,16],f4E2M1FN>
+  %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[16,16],f4E2M1FN>
+  %scale_a = torch.prim.ListConstruct %activation_scale_torch : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg1, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int5, %contraction_dim, %false : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],f16>
+  return %0 : !torch.vtensor<[3,16],f16>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_f32_result(
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x16x32xf4E2M1FN>, tensor<1x16x1xf8E8M0FNU>) -> tensor<1x3x16xf32>
+// CHECK-NOT:       tosa.cast %[[MATMUL]]
+// CHECK:           tosa.reshape %[[MATMUL]], %{{.*}} : (tensor<1x3x16xf32>, !tosa.shape<2>) -> tensor<3x16xf32>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_f32_result(%arg0: tensor<1x3x32xf32>, %arg1: !torch.vtensor<[3,16],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,16],f32> {
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int6 = torch.constant.int 6
+  %int29 = torch.constant.int 29
+  %none = torch.constant.none
+  %activation, %activation_scale = tosa.cast_to_block_scaled %arg0 {block_size = #tosa.block_size<BLOCK_SIZE_32>} : (tensor<1x3x32xf32>) -> (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>)
+  %scale_padding = tosa.const_shape {values = dense<[0, 0, 0, 125, 0, 3]> : tensor<6xindex>} : () -> !tosa.shape<6>
+  %scale_pad_value = "tosa.const"() <{values = dense<0x00> : tensor<1xf8E8M0FNU>}> : () -> tensor<1xf8E8M0FNU>
+  %activation_scale_padded = tosa.pad %activation_scale, %scale_padding, %scale_pad_value : (tensor<1x3x1xf8E8M0FNU>, !tosa.shape<6>, tensor<1xf8E8M0FNU>) -> tensor<1x128x4xf8E8M0FNU>
+  %scale_flat_shape = tosa.const_shape {values = dense<512> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %activation_scale_flat = tosa.reshape %activation_scale_padded, %scale_flat_shape : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<1>) -> tensor<512xf8E8M0FNU>
+  %activation_scale_torch = torch_c.from_builtin_tensor %activation_scale_flat : tensor<512xf8E8M0FNU> -> !torch.vtensor<[512],f8E8M0FNU>
+  %weight_storage = torch.vtensor.literal(dense<0> : tensor<16x16xui8>) : !torch.vtensor<[16,16],ui8>
+  %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,16],ui8>, !torch.int -> !torch.vtensor<[16,16],f4E2M1FN>
+  %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[16,16],f4E2M1FN>
+  %scale_a = torch.prim.ListConstruct %activation_scale_torch : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg1, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int6, %contraction_dim, %false : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],f32>
+  return %0 : !torch.vtensor<[3,16],f32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_use_fast_accum(
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x16x32xf4E2M1FN>, tensor<1x16x1xf8E8M0FNU>) -> tensor<1x3x16xf32>
+// CHECK:           tosa.cast %[[MATMUL]] : (tensor<1x3x16xf32>) -> tensor<1x3x16xbf16>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_use_fast_accum(%arg0: tensor<1x3x32xf32>, %arg1: !torch.vtensor<[3,16],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,16],bf16> {
+  %true = torch.constant.bool true
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %int29 = torch.constant.int 29
+  %none = torch.constant.none
+  %activation, %activation_scale = tosa.cast_to_block_scaled %arg0 {block_size = #tosa.block_size<BLOCK_SIZE_32>} : (tensor<1x3x32xf32>) -> (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>)
+  %scale_padding = tosa.const_shape {values = dense<[0, 0, 0, 125, 0, 3]> : tensor<6xindex>} : () -> !tosa.shape<6>
+  %scale_pad_value = "tosa.const"() <{values = dense<0x00> : tensor<1xf8E8M0FNU>}> : () -> tensor<1xf8E8M0FNU>
+  %activation_scale_padded = tosa.pad %activation_scale, %scale_padding, %scale_pad_value : (tensor<1x3x1xf8E8M0FNU>, !tosa.shape<6>, tensor<1xf8E8M0FNU>) -> tensor<1x128x4xf8E8M0FNU>
+  %scale_flat_shape = tosa.const_shape {values = dense<512> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %activation_scale_flat = tosa.reshape %activation_scale_padded, %scale_flat_shape : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<1>) -> tensor<512xf8E8M0FNU>
+  %activation_scale_torch = torch_c.from_builtin_tensor %activation_scale_flat : tensor<512xf8E8M0FNU> -> !torch.vtensor<[512],f8E8M0FNU>
+  %weight_storage = torch.vtensor.literal(dense<0> : tensor<16x16xui8>) : !torch.vtensor<[16,16],ui8>
+  %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,16],ui8>, !torch.int -> !torch.vtensor<[16,16],f4E2M1FN>
+  %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[16,16],f4E2M1FN>
+  %scale_a = torch.prim.ListConstruct %activation_scale_torch : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg1, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %true : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],bf16>
+  return %0 : !torch.vtensor<[3,16],bf16>
+}
+
+// -----
+module {
+  func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_non_constant_weight_rejected(%arg0: !torch.vtensor<[3,16],f4E2M1FN>, %arg1: !torch.vtensor<[16,16],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,16],bf16> {
+    %false = torch.constant.bool false
+    %int1 = torch.constant.int 1
+    %int3 = torch.constant.int 3
+    %int15 = torch.constant.int 15
+    %none = torch.constant.none
+    %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],bf16>
+    return %0 : !torch.vtensor<[3,16],bf16>
+  }
+}
+
+// -----
+module {
+  func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_k_not_divisible_by_32_rejected(%arg0: !torch.vtensor<[3,24],f4E2M1FN>, %arg1: !torch.vtensor<[512],f8E8M0FNU>, %arg2: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,16],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int3 = torch.constant.int 3
+    %int15 = torch.constant.int 15
+    %int29 = torch.constant.int 29
+    %none = torch.constant.none
+    %weight_storage = torch.vtensor.literal(dense<0> : tensor<16x24xui8>) : !torch.vtensor<[16,24],ui8>
+    %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,24],ui8>, !torch.int -> !torch.vtensor<[16,24],f4E2M1FN>
+    %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+    %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,24],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[24,16],f4E2M1FN>
+    %scale_a = torch.prim.ListConstruct %arg1 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[3,24],f4E2M1FN>, !torch.vtensor<[24,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],bf16>
+    return %0 : !torch.vtensor<[3,16],bf16>
+  }
+}
+
+// -----
+module {
+  func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_unsupported_recipe_rejected(%arg0: !torch.vtensor<[3,16],f4E2M1FN>, %arg1: !torch.vtensor<[],f32>, %arg2: !torch.vtensor<[],f32>) -> !torch.vtensor<[3,16],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int15 = torch.constant.int 15
+    %int29 = torch.constant.int 29
+    %none = torch.constant.none
+    %weight_storage = torch.vtensor.literal(dense<0> : tensor<16x16xui8>) : !torch.vtensor<[16,16],ui8>
+    %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,16],ui8>, !torch.int -> !torch.vtensor<[16,16],f4E2M1FN>
+    %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+    %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[16,16],f4E2M1FN>
+    %scale_a = torch.prim.ListConstruct %arg1 : (!torch.vtensor<[],f32>) -> !torch.list<vtensor>
+    %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[],f32>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %recipe_b = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int0 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],bf16>
+    return %0 : !torch.vtensor<[3,16],bf16>
+  }
+}
+
+// -----
+module {
+  func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_noncanonical_scale_shape_rejected(%arg0: !torch.vtensor<[3,16],f4E2M1FN>, %arg1: !torch.vtensor<[2,256],f8E8M0FNU>, %arg2: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,16],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int3 = torch.constant.int 3
+    %int15 = torch.constant.int 15
+    %int29 = torch.constant.int 29
+    %none = torch.constant.none
+    %weight_storage = torch.vtensor.literal(dense<0> : tensor<16x16xui8>) : !torch.vtensor<[16,16],ui8>
+    %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,16],ui8>, !torch.int -> !torch.vtensor<[16,16],f4E2M1FN>
+    %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+    %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[16,16],f4E2M1FN>
+    %scale_a = torch.prim.ListConstruct %arg1 : (!torch.vtensor<[2,256],f8E8M0FNU>) -> !torch.list<vtensor>
+    %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],bf16>
+    return %0 : !torch.vtensor<[3,16],bf16>
+  }
+}
+
+// -----
+module {
+  func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_non_constant_swizzled_scale_rejected(%arg0: !torch.vtensor<[3,16],f4E2M1FN>, %arg1: !torch.vtensor<[32,16],f8E8M0FNU>, %arg2: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,16],bf16> {
+    %false = torch.constant.bool false
+    %int0 = torch.constant.int 0
+    %int1 = torch.constant.int 1
+    %int3 = torch.constant.int 3
+    %int15 = torch.constant.int 15
+    %int29 = torch.constant.int 29
+    %none = torch.constant.none
+    %weight_storage = torch.vtensor.literal(dense<0> : tensor<16x16xui8>) : !torch.vtensor<[16,16],ui8>
+    %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,16],ui8>, !torch.int -> !torch.vtensor<[16,16],f4E2M1FN>
+    %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+    %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[16,16],f4E2M1FN>
+    %scale_a = torch.prim.ListConstruct %arg1 : (!torch.vtensor<[32,16],f8E8M0FNU>) -> !torch.list<vtensor>
+    %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+    %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+    %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+    %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm_v2' that was explicitly marked illegal}}
+    %0 = torch.aten._scaled_mm_v2 %arg0, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],bf16>
+    return %0 : !torch.vtensor<[3,16],bf16>
+  }
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_explicit_contraction_dims(
+// CHECK:           %[[MATMUL:.*]] = tosa.matmul_t_block_scaled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {block_size = BLOCK_SIZE_32} : (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>, tensor<1x16x32xf4E2M1FN>, tensor<1x16x1xf8E8M0FNU>) -> tensor<1x3x16xf32>
+// CHECK:           %[[CAST:.*]] = tosa.cast %[[MATMUL]] : (tensor<1x3x16xf32>) -> tensor<1x3x16xbf16>
+// CHECK:           tosa.reshape %[[CAST]], %{{.*}} : (tensor<1x3x16xbf16>, !tosa.shape<2>) -> tensor<3x16xbf16>
+// CHECK-NOT:       torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$block_scaled_fp4_explicit_contraction_dims(%arg0: tensor<1x3x32xf32>, %arg1: !torch.vtensor<[3,16],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[3,16],bf16> {
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %int29 = torch.constant.int 29
+  %none = torch.constant.none
+  %activation, %activation_scale = tosa.cast_to_block_scaled %arg0 {block_size = #tosa.block_size<BLOCK_SIZE_32>} : (tensor<1x3x32xf32>) -> (tensor<1x3x32xf4E2M1FN>, tensor<1x3x1xf8E8M0FNU>)
+  %scale_padding = tosa.const_shape {values = dense<[0, 0, 0, 125, 0, 3]> : tensor<6xindex>} : () -> !tosa.shape<6>
+  %scale_pad_value = "tosa.const"() <{values = dense<0x00> : tensor<1xf8E8M0FNU>}> : () -> tensor<1xf8E8M0FNU>
+  %activation_scale_padded = tosa.pad %activation_scale, %scale_padding, %scale_pad_value : (tensor<1x3x1xf8E8M0FNU>, !tosa.shape<6>, tensor<1xf8E8M0FNU>) -> tensor<1x128x4xf8E8M0FNU>
+  %scale_flat_shape = tosa.const_shape {values = dense<512> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %activation_scale_flat = tosa.reshape %activation_scale_padded, %scale_flat_shape : (tensor<1x128x4xf8E8M0FNU>, !tosa.shape<1>) -> tensor<512xf8E8M0FNU>
+  %activation_scale_torch = torch_c.from_builtin_tensor %activation_scale_flat : tensor<512xf8E8M0FNU> -> !torch.vtensor<[512],f8E8M0FNU>
+  %weight_storage = torch.vtensor.literal(dense<0> : tensor<16x16xui8>) : !torch.vtensor<[16,16],ui8>
+  %weight_fp4 = torch.aten.view.dtype %weight_storage, %int29 : !torch.vtensor<[16,16],ui8>, !torch.int -> !torch.vtensor<[16,16],f4E2M1FN>
+  %transpose_dims = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %weight = torch.aten.permute %weight_fp4, %transpose_dims : !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<int> -> !torch.vtensor<[16,16],f4E2M1FN>
+  %scale_a = torch.prim.ListConstruct %activation_scale_torch : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %scale_b = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten._scaled_mm_v2 %arg1, %weight, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[3,16],f4E2M1FN>, !torch.vtensor<[16,16],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,16],bf16>
+  return %0 : !torch.vtensor<[3,16],bf16>
+}
+
+// -----
 module {
   // scale_result is verifier-valid as a scalar, but this TOSA lowering does
   // not yet model the extra output scaling semantics.
@@ -6183,20 +6583,6 @@ module {
     %none = torch.constant.none
     // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
     %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,48],f8E4M3FN>, !torch.vtensor<[48,128],f8E4M3FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
-    return %0 : !torch.vtensor<[128,128],bf16>
-  }
-}
-
-// -----
-module {
-  // Block-scaled FP4 imports through Torch, but this TOSA lowering is currently
-  // scoped to MXFP8 data with E8M0 scales.
-  func.func @torch.aten._scaled_mm$block_scaled_fp4_rejected(%arg0: !torch.vtensor<[128,64],f4E2M1FN>, %arg1: !torch.vtensor<[64,128],f4E2M1FN>, %arg2: !torch.vtensor<[512],f8E8M0FNU>, %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
-    %false = torch.constant.bool false
-    %int15 = torch.constant.int 15
-    %none = torch.constant.none
-    // expected-error @below {{failed to legalize operation 'torch.aten._scaled_mm' that was explicitly marked illegal}}
-    %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,64],f4E2M1FN>, !torch.vtensor<[64,128],f4E2M1FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
     return %0 : !torch.vtensor<[128,128],bf16>
   }
 }

--- a/test/Dialect/Torch/invalid.mlir
+++ b/test/Dialect/Torch/invalid.mlir
@@ -498,16 +498,50 @@ func.func @torch.aten._scaled_mm$invalid_mixed_scale_dtype(
 
 // -----
 
-func.func @torch.aten._scaled_mm$invalid_fp4_blockwise_scale_numel(
+func.func @torch.aten._scaled_mm_v2$invalid_mxfp4_mixed_logical_lhs_packed_rhs(
+    %arg0: !torch.vtensor<[128,256],f4E2M1FN>,
+    %arg1: !torch.vtensor<[128,128],f4E2M1FN>,
+    %arg2: !torch.vtensor<[1024],f8E8M0FNU>,
+    %arg3: !torch.vtensor<[1024],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
+  %int15 = torch.constant.int 15
+  %none = torch.constant.none
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[1024],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[1024],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct %int1, %int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  // expected-error @+1 {{'torch.aten._scaled_mm_v2' op expected self and mat2 contraction_dim-selected dimensions to match, but got 256 and 128}}
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,256],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// -----
+
+func.func @torch.aten._scaled_mm_v2$invalid_mxfp4_blockwise_packed_k128_scale_numel(
     %arg0: !torch.vtensor<[128,128],f4E2M1FN>,
     %arg1: !torch.vtensor<[128,128],f4E2M1FN>,
     %arg2: !torch.vtensor<[512],f8E8M0FNU>,
     %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
   %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int3 = torch.constant.int 3
   %int15 = torch.constant.int 15
   %none = torch.constant.none
-  // expected-error @+1 {{'torch.aten._scaled_mm' op invalid blockwise scaling configuration: expected scale_a to have 1024 elements and scale_b to have 1024 elements, but got 512 and 512}}
-  %0 = torch.aten._scaled_mm %arg0, %arg1, %arg2, %arg3, %none, %none, %int15, %false : !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[512],f8E8M0FNU>, !torch.vtensor<[512],f8E8M0FNU>, !torch.none, !torch.none, !torch.int, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  %scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_a = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_a = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %recipe_b = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %swizzle_b = torch.prim.ListConstruct %int1 : (!torch.int) -> !torch.list<int>
+  %contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  // expected-error @+1 {{'torch.aten._scaled_mm_v2' op invalid blockwise scaling configuration: expected scale_a to have 1024 elements and scale_b to have 1024 elements, but got 512 and 512}}
+  %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scale_a, %recipe_a, %swizzle_a, %scale_b, %recipe_b, %swizzle_b, %none, %int15, %contraction_dim, %false : !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
   return %0 : !torch.vtensor<[128,128],bf16>
 }
 

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -355,22 +355,69 @@ func.func @torch.aten._scaled_mm_v2$blockwise_128x128_1x128_scales(
 func.func @torch.aten._scaled_mm_v2$mxfp4_blockwise_packed_k128_scales(
     %arg0: !torch.vtensor<[128,128],f4E2M1FN>,
     %arg1: !torch.vtensor<[128,128],f4E2M1FN>,
-    %arg2: !torch.vtensor<[512],f8E8M0FNU>,
-    %arg3: !torch.vtensor<[512],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+    %arg2: !torch.vtensor<[1024],f8E8M0FNU>,
+    %arg3: !torch.vtensor<[1024],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
   %scaled_mm_v2_false = torch.constant.bool false
   %scaled_mm_v2_int1 = torch.constant.int 1
   %scaled_mm_v2_int3 = torch.constant.int 3
   %scaled_mm_v2_int15 = torch.constant.int 15
   %scaled_mm_v2_none = torch.constant.none
-  %scaled_mm_v2_scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %scaled_mm_v2_scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[1024],f8E8M0FNU>) -> !torch.list<vtensor>
   %scaled_mm_v2_recipe_a = torch.prim.ListConstruct %scaled_mm_v2_int3 : (!torch.int) -> !torch.list<int>
   %scaled_mm_v2_swizzle_a = torch.prim.ListConstruct %scaled_mm_v2_int1 : (!torch.int) -> !torch.list<int>
-  %scaled_mm_v2_scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[512],f8E8M0FNU>) -> !torch.list<vtensor>
+  %scaled_mm_v2_scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[1024],f8E8M0FNU>) -> !torch.list<vtensor>
   %scaled_mm_v2_recipe_b = torch.prim.ListConstruct %scaled_mm_v2_int3 : (!torch.int) -> !torch.list<int>
   %scaled_mm_v2_swizzle_b = torch.prim.ListConstruct %scaled_mm_v2_int1 : (!torch.int) -> !torch.list<int>
   %scaled_mm_v2_contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
   %0 = torch.aten._scaled_mm_v2 %arg0, %arg1, %scaled_mm_v2_scale_a, %scaled_mm_v2_recipe_a, %scaled_mm_v2_swizzle_a, %scaled_mm_v2_scale_b, %scaled_mm_v2_recipe_b, %scaled_mm_v2_swizzle_b, %scaled_mm_v2_none, %scaled_mm_v2_int15, %scaled_mm_v2_contraction_dim, %scaled_mm_v2_false : !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
   return %0 : !torch.vtensor<[128,128],bf16>
+}
+
+// CHECK-LABEL: func.func @torch.aten._scaled_mm_v2$mxfp4_blockwise_packed_k128_explicit_contraction_dims(
+// CHECK: torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$mxfp4_blockwise_packed_k128_explicit_contraction_dims(
+    %arg0: !torch.vtensor<[128,128],f4E2M1FN>,
+    %arg1: !torch.vtensor<[128,128],f4E2M1FN>,
+    %arg2: !torch.vtensor<[1024],f8E8M0FNU>,
+    %arg3: !torch.vtensor<[1024],f8E8M0FNU>) -> !torch.vtensor<[128,128],bf16> {
+  %mxfp4_explicit_false = torch.constant.bool false
+  %mxfp4_explicit_int0 = torch.constant.int 0
+  %mxfp4_explicit_int1 = torch.constant.int 1
+  %mxfp4_explicit_int3 = torch.constant.int 3
+  %mxfp4_explicit_int15 = torch.constant.int 15
+  %mxfp4_explicit_none = torch.constant.none
+  %mxfp4_explicit_scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[1024],f8E8M0FNU>) -> !torch.list<vtensor>
+  %mxfp4_explicit_recipe_a = torch.prim.ListConstruct %mxfp4_explicit_int3 : (!torch.int) -> !torch.list<int>
+  %mxfp4_explicit_swizzle_a = torch.prim.ListConstruct %mxfp4_explicit_int1 : (!torch.int) -> !torch.list<int>
+  %mxfp4_explicit_scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[1024],f8E8M0FNU>) -> !torch.list<vtensor>
+  %mxfp4_explicit_recipe_b = torch.prim.ListConstruct %mxfp4_explicit_int3 : (!torch.int) -> !torch.list<int>
+  %mxfp4_explicit_swizzle_b = torch.prim.ListConstruct %mxfp4_explicit_int1 : (!torch.int) -> !torch.list<int>
+  %mxfp4_explicit_contraction_dim = torch.prim.ListConstruct %mxfp4_explicit_int1, %mxfp4_explicit_int0 : (!torch.int, !torch.int) -> !torch.list<int>
+  %mxfp4_explicit_result = torch.aten._scaled_mm_v2 %arg0, %arg1, %mxfp4_explicit_scale_a, %mxfp4_explicit_recipe_a, %mxfp4_explicit_swizzle_a, %mxfp4_explicit_scale_b, %mxfp4_explicit_recipe_b, %mxfp4_explicit_swizzle_b, %mxfp4_explicit_none, %mxfp4_explicit_int15, %mxfp4_explicit_contraction_dim, %mxfp4_explicit_false : !torch.vtensor<[128,128],f4E2M1FN>, !torch.vtensor<[128,128],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[128,128],bf16>
+  return %mxfp4_explicit_result : !torch.vtensor<[128,128],bf16>
+}
+
+// CHECK-LABEL: func.func @torch.aten._scaled_mm_v2$mxfp4_blockwise_padded_mn(
+// CHECK: torch.aten._scaled_mm_v2
+func.func @torch.aten._scaled_mm_v2$mxfp4_blockwise_padded_mn(
+    %arg0: !torch.vtensor<[130,128],f4E2M1FN>,
+    %arg1: !torch.vtensor<[128,80],f4E2M1FN>,
+    %arg2: !torch.vtensor<[2048],f8E8M0FNU>,
+    %arg3: !torch.vtensor<[1024],f8E8M0FNU>) -> !torch.vtensor<[130,80],bf16> {
+  %mxfp4_padded_false = torch.constant.bool false
+  %mxfp4_padded_int1 = torch.constant.int 1
+  %mxfp4_padded_int3 = torch.constant.int 3
+  %mxfp4_padded_int15 = torch.constant.int 15
+  %mxfp4_padded_none = torch.constant.none
+  %mxfp4_padded_scale_a = torch.prim.ListConstruct %arg2 : (!torch.vtensor<[2048],f8E8M0FNU>) -> !torch.list<vtensor>
+  %mxfp4_padded_recipe_a = torch.prim.ListConstruct %mxfp4_padded_int3 : (!torch.int) -> !torch.list<int>
+  %mxfp4_padded_swizzle_a = torch.prim.ListConstruct %mxfp4_padded_int1 : (!torch.int) -> !torch.list<int>
+  %mxfp4_padded_scale_b = torch.prim.ListConstruct %arg3 : (!torch.vtensor<[1024],f8E8M0FNU>) -> !torch.list<vtensor>
+  %mxfp4_padded_recipe_b = torch.prim.ListConstruct %mxfp4_padded_int3 : (!torch.int) -> !torch.list<int>
+  %mxfp4_padded_swizzle_b = torch.prim.ListConstruct %mxfp4_padded_int1 : (!torch.int) -> !torch.list<int>
+  %mxfp4_padded_contraction_dim = torch.prim.ListConstruct : () -> !torch.list<int>
+  %mxfp4_padded_result = torch.aten._scaled_mm_v2 %arg0, %arg1, %mxfp4_padded_scale_a, %mxfp4_padded_recipe_a, %mxfp4_padded_swizzle_a, %mxfp4_padded_scale_b, %mxfp4_padded_recipe_b, %mxfp4_padded_swizzle_b, %mxfp4_padded_none, %mxfp4_padded_int15, %mxfp4_padded_contraction_dim, %mxfp4_padded_false : !torch.vtensor<[130,128],f4E2M1FN>, !torch.vtensor<[128,80],f4E2M1FN>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.list<vtensor>, !torch.list<int>, !torch.list<int>, !torch.none, !torch.int, !torch.list<int>, !torch.bool -> !torch.vtensor<[130,80],bf16>
+  return %mxfp4_padded_result : !torch.vtensor<[130,80],bf16>
 }
 
 // CHECK-LABEL: func.func @torch.aten._scaled_mm_v2$nv_blockwise_1x16_scales(


### PR DESCRIPTION
Adds TorchToTosa legalization for block-scaled MXFP4 aten._scaled_mm_v2