### PR TITLE
[TorchOnnxToTorch] Lower ReverseSequence using torch.prim.Loop

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -3999,52 +3999,74 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         flipShape[timeAxis] = Torch::kUnknownSize;
         auto flipType =
             rewriter.getType<Torch::ValueTensorType>(flipShape, dtype);
-        auto scalarTensorType = rewriter.getType<Torch::ValueTensorType>(
-            ArrayRef<int64_t>{1}, rewriter.getIntegerType(64, /*signed*/ 1));
+        // iterate over the batch dimension at runtime.
+        Value batchSize = Torch::AtenSizeIntOp::create(
+            rewriter, binder.getLoc(),
+            rewriter.getType<Torch::IntType>(), input, batchAxisVal);
 
-        for (int i = 0; i < inputShape[batchAxis]; i++) {
-          // slice i iterating on batch axis
-          Value k = Torch::ConstantIntOp::create(rewriter, binder.getLoc(),
-                                                 rewriter.getI64IntegerAttr(i));
-          Value end =
-              Torch::AtenAddIntOp::create(rewriter, binder.getLoc(), k, cstOne);
+        Value loopConditionTrue = Torch::ConstantBoolOp::create(
+            rewriter, binder.getLoc(), rewriter.getBoolAttr(true));
+        Type loopIndexType = rewriter.getType<Torch::IntType>();
+        auto sequenceLensTy =
+            cast<Torch::ValueTensorType>(sequenceLens.getType());
+        auto sequenceLengthTensorType = rewriter.getType<Torch::ValueTensorType>(
+            ArrayRef<int64_t>{}, sequenceLensTy.getDtype());
+
+        auto loop = Torch::PrimLoopOp::create(
+            rewriter, binder.getLoc(), TypeRange({resultType}), batchSize,
+            loopConditionTrue, ValueRange({input}));
+        {
+          PatternRewriter::InsertionGuard guard(rewriter);
+          Block *loopBody =
+              rewriter.createBlock(&loop.getRegion(), loop.getRegion().begin(),
+                                   TypeRange({loopIndexType, resultType}),
+                                   {binder.getLoc(), binder.getLoc()});
+
+          Value k = loopBody->getArgument(0);
+          Value currInput = loopBody->getArgument(1);
+
+          // slice k iterating on batch axis
+          Value end = Torch::AtenAddIntOp::create(rewriter, binder.getLoc(), k,
+                                                  cstOne);
+
           Value sliceBatch = Torch::AtenSliceTensorOp::create(
-              rewriter, binder.getLoc(), sliceType, input, batchAxisVal, k, end,
-              cstOne);
+              rewriter, binder.getLoc(), sliceType, currInput, batchAxisVal, k,
+              end, cstOne);
 
           // get sequence length and slice the reversing part
-          Value kTensor = Torch::PrimNumToTensorScalarOp::create(
-              rewriter, binder.getLoc(), scalarTensorType, k);
-          Value sel = Torch::AtenIndexSelectOp::create(
-              rewriter, binder.getLoc(), scalarTensorType, sequenceLens,
-              cstZero, kTensor);
+          Value sel = Torch::AtenSelectIntOp::create(
+              rewriter, binder.getLoc(), sequenceLengthTensorType, sequenceLens,
+              cstZero, k);
           Value len = Torch::AtenItemOp::create(
               rewriter, binder.getLoc(), rewriter.getType<Torch::IntType>(),
               sel);
           Value sliceTime = Torch::AtenSliceTensorOp::create(
               rewriter, binder.getLoc(), flipType, sliceBatch, timeAxisVal,
               cstZero, len, cstOne);
+
           // flip the sliced reversing tensor
           Value dims = Torch::PrimListConstructOp::create(
               rewriter, binder.getLoc(),
               rewriter.getType<Torch::ListType>(
                   rewriter.getType<Torch::IntType>()),
               SmallVector<Value>{timeAxisVal});
-          Value flip = Torch::AtenFlipOp::create(rewriter, binder.getLoc(),
-                                                 flipType, sliceTime, dims);
+          Value flip = Torch::AtenFlipOp::create(
+              rewriter, binder.getLoc(), flipType, sliceTime, dims);
 
           // embeds the reversed tensor to the input
           Value embedTime = Torch::AtenSliceScatterOp::create(
               rewriter, binder.getLoc(), sliceType, sliceBatch, flip,
-              timeAxisVal,
-              /*start=*/cstZero, /*end=*/len, /*step=*/cstOne);
-          input = Torch::AtenSliceScatterOp::create(
-              rewriter, binder.getLoc(), resultType, input, embedTime,
-              batchAxisVal,
-              /*start=*/k, /*end=*/end, /*step=*/cstOne);
+              timeAxisVal, /*start=*/cstZero, /*end=*/len, /*step=*/cstOne);
+          Value updatedInput = Torch::AtenSliceScatterOp::create(
+              rewriter, binder.getLoc(), resultType, currInput, embedTime,
+              batchAxisVal, /*start=*/k, /*end=*/end, /*step=*/cstOne);
+
+          Torch::PrimLoopConditionOp::create(
+              rewriter, binder.getLoc(), loopConditionTrue,
+              ValueRange({updatedInput}));
         }
 
-        rewriter.replaceOp(binder.op, input);
+        rewriter.replaceOp(binder.op, loop.getResult(0));
         return success();
       });
   patterns.onOp(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -3999,18 +3999,19 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
         flipShape[timeAxis] = Torch::kUnknownSize;
         auto flipType =
             rewriter.getType<Torch::ValueTensorType>(flipShape, dtype);
-        // iterate over the batch dimension at runtime.
+        // iterate over the batch dimension at runtime
         Value batchSize = Torch::AtenSizeIntOp::create(
-            rewriter, binder.getLoc(),
-            rewriter.getType<Torch::IntType>(), input, batchAxisVal);
+            rewriter, binder.getLoc(), rewriter.getType<Torch::IntType>(),
+            input, batchAxisVal);
 
         Value loopConditionTrue = Torch::ConstantBoolOp::create(
             rewriter, binder.getLoc(), rewriter.getBoolAttr(true));
         Type loopIndexType = rewriter.getType<Torch::IntType>();
         auto sequenceLensTy =
             cast<Torch::ValueTensorType>(sequenceLens.getType());
-        auto sequenceLengthTensorType = rewriter.getType<Torch::ValueTensorType>(
-            ArrayRef<int64_t>{}, sequenceLensTy.getDtype());
+        auto sequenceLengthTensorType =
+            rewriter.getType<Torch::ValueTensorType>(ArrayRef<int64_t>{},
+                                                     sequenceLensTy.getDtype());
 
         auto loop = Torch::PrimLoopOp::create(
             rewriter, binder.getLoc(), TypeRange({resultType}), batchSize,
@@ -4026,17 +4027,17 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
           Value currInput = loopBody->getArgument(1);
 
           // slice k iterating on batch axis
-          Value end = Torch::AtenAddIntOp::create(rewriter, binder.getLoc(), k,
-                                                  cstOne);
+          Value end =
+              Torch::AtenAddIntOp::create(rewriter, binder.getLoc(), k, cstOne);
 
           Value sliceBatch = Torch::AtenSliceTensorOp::create(
               rewriter, binder.getLoc(), sliceType, currInput, batchAxisVal, k,
               end, cstOne);
 
           // get sequence length and slice the reversing part
-          Value sel = Torch::AtenSelectIntOp::create(
-              rewriter, binder.getLoc(), sequenceLengthTensorType, sequenceLens,
-              cstZero, k);
+          Value sel = Torch::AtenSelectIntOp::create(rewriter, binder.getLoc(),
+                                                     sequenceLengthTensorType,
+                                                     sequenceLens, cstZero, k);
           Value len = Torch::AtenItemOp::create(
               rewriter, binder.getLoc(), rewriter.getType<Torch::IntType>(),
               sel);
@@ -4050,8 +4051,8 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
               rewriter.getType<Torch::ListType>(
                   rewriter.getType<Torch::IntType>()),
               SmallVector<Value>{timeAxisVal});
-          Value flip = Torch::AtenFlipOp::create(
-              rewriter, binder.getLoc(), flipType, sliceTime, dims);
+          Value flip = Torch::AtenFlipOp::create(rewriter, binder.getLoc(),
+                                                 flipType, sliceTime, dims);
 
           // embeds the reversed tensor to the input
           Value embedTime = Torch::AtenSliceScatterOp::create(
@@ -4061,9 +4062,9 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
               rewriter, binder.getLoc(), resultType, currInput, embedTime,
               batchAxisVal, /*start=*/k, /*end=*/end, /*step=*/cstOne);
 
-          Torch::PrimLoopConditionOp::create(
-              rewriter, binder.getLoc(), loopConditionTrue,
-              ValueRange({updatedInput}));
+          Torch::PrimLoopConditionOp::create(rewriter, binder.getLoc(),
+                                             loopConditionTrue,
+                                             ValueRange({updatedInput}));
         }
 
         rewriter.replaceOp(binder.op, loop.getResult(0));

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3262,8 +3262,8 @@ func.func @test_reversesequence_time(%arg0: !torch.vtensor<[4,4],f32>, %arg1: !t
 
 // -----
 
-// CHECK-LABEL: @test_reversesequence_dynamic_batch
-func.func @test_reversesequence_dynamic_batch(%arg0: !torch.vtensor<[?,4],f32>, %arg1: !torch.vtensor<[?],si64>) -> !torch.vtensor<[?,4],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+// CHECK-LABEL: @test_reversesequence_dynamic_batch_dim
+func.func @test_reversesequence_dynamic_batch_dim(%arg0: !torch.vtensor<[?,4],f32>, %arg1: !torch.vtensor<[?],si64>) -> !torch.vtensor<[?,4],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
   // CHECK: %[[C0:.*]] = torch.constant.int 0
   // CHECK: %[[C1:.*]] = torch.constant.int 1
   // CHECK: %[[BATCH_AXIS:.*]] = torch.constant.int 0

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3210,12 +3210,24 @@ func.func @test_stft_with_window_and_framelen(%arg0: !torch.vtensor<[1,128,1],f3
 
 // CHECK-LABEL: @test_reversesequence_batch
 func.func @test_reversesequence_batch(%arg0: !torch.vtensor<[4,4],f32>, %arg1: !torch.vtensor<[4],si64>) -> !torch.vtensor<[4,4],f32> attributes {torch.onnx_meta.ir_version = 5 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-  // CHECK: %[[BATCH_SIZE:.*]] = torch.aten.size.int %arg0
-  // CHECK: %[[LOOP:.*]] = torch.prim.Loop %[[BATCH_SIZE]]
-  // CHECK: torch.aten.select.int %arg1
-  // CHECK: torch.aten.flip
-  // CHECK: torch.aten.slice_scatter
-  // CHECK: torch.prim.Loop.condition
+  // CHECK: %[[C0:.*]] = torch.constant.int 0
+  // CHECK: %[[C1:.*]] = torch.constant.int 1
+  // CHECK: %[[BATCH_AXIS:.*]] = torch.constant.int 0
+  // CHECK: %[[TIME_AXIS:.*]] = torch.constant.int 1
+  // CHECK: %[[BATCH_SIZE:.*]] = torch.aten.size.int %arg0, %[[BATCH_AXIS]]
+  // CHECK: %[[TRUE:.*]] = torch.constant.bool true
+  // CHECK: %[[LOOP:.*]] = torch.prim.Loop %[[BATCH_SIZE]], %[[TRUE]], init(%arg0)
+  // CHECK: ^bb0(%[[K:.*]]: !torch.int, %[[CURRENT:.*]]: !torch.vtensor<[4,4],f32>):
+  // CHECK: %[[END:.*]] = torch.aten.add.int %[[K]], %[[C1]]
+  // CHECK: %[[BATCH_SLICE:.*]] = torch.aten.slice.Tensor %[[CURRENT]], %[[BATCH_AXIS]], %[[K]], %[[END]], %[[C1]]
+  // CHECK: %[[LENGTH_TENSOR:.*]] = torch.aten.select.int %arg1, %[[C0]], %[[K]]
+  // CHECK: %[[LENGTH:.*]] = torch.aten.item %[[LENGTH_TENSOR]]
+  // CHECK: %[[TIME_SLICE:.*]] = torch.aten.slice.Tensor %[[BATCH_SLICE]], %[[TIME_AXIS]], %[[C0]], %[[LENGTH]], %[[C1]]
+  // CHECK: %[[DIMS:.*]] = torch.prim.ListConstruct %[[TIME_AXIS]]
+  // CHECK: %[[FLIPPED:.*]] = torch.aten.flip %[[TIME_SLICE]], %[[DIMS]]
+  // CHECK: %[[UPDATED_BATCH:.*]] = torch.aten.slice_scatter %[[BATCH_SLICE]], %[[FLIPPED]], %[[TIME_AXIS]], %[[C0]], %[[LENGTH]], %[[C1]]
+  // CHECK: %[[UPDATED_INPUT:.*]] = torch.aten.slice_scatter %[[CURRENT]], %[[UPDATED_BATCH]], %[[BATCH_AXIS]], %[[K]], %[[END]], %[[C1]]
+  // CHECK: torch.prim.Loop.condition %[[TRUE]], iter(%[[UPDATED_INPUT]]
   // CHECK: return %[[LOOP]]
   %0 = torch.operator "onnx.ReverseSequence"(%arg0, %arg1) {torch.onnx.batch_axis = 0 : si64, torch.onnx.time_axis = 1 : si64} : (!torch.vtensor<[4,4],f32>, !torch.vtensor<[4],si64>) -> !torch.vtensor<[4,4],f32>
   return %0 : !torch.vtensor<[4,4],f32>
@@ -3225,12 +3237,24 @@ func.func @test_reversesequence_batch(%arg0: !torch.vtensor<[4,4],f32>, %arg1: !
 
 // CHECK-LABEL: @test_reversesequence_time
 func.func @test_reversesequence_time(%arg0: !torch.vtensor<[4,4],f32>, %arg1: !torch.vtensor<[4],si64>) -> !torch.vtensor<[4,4],f32> attributes {torch.onnx_meta.ir_version = 5 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-  // CHECK: %[[BATCH_SIZE:.*]] = torch.aten.size.int %arg0
-  // CHECK: %[[LOOP:.*]] = torch.prim.Loop %[[BATCH_SIZE]]
-  // CHECK: torch.aten.select.int %arg1
-  // CHECK: torch.aten.flip
-  // CHECK: torch.aten.slice_scatter
-  // CHECK: torch.prim.Loop.condition
+  // CHECK: %[[C0:.*]] = torch.constant.int 0
+  // CHECK: %[[C1:.*]] = torch.constant.int 1
+  // CHECK: %[[BATCH_AXIS:.*]] = torch.constant.int 1
+  // CHECK: %[[TIME_AXIS:.*]] = torch.constant.int 0
+  // CHECK: %[[BATCH_SIZE:.*]] = torch.aten.size.int %arg0, %[[BATCH_AXIS]]
+  // CHECK: %[[TRUE:.*]] = torch.constant.bool true
+  // CHECK: %[[LOOP:.*]] = torch.prim.Loop %[[BATCH_SIZE]], %[[TRUE]], init(%arg0)
+  // CHECK: ^bb0(%[[K:.*]]: !torch.int, %[[CURRENT:.*]]: !torch.vtensor<[4,4],f32>):
+  // CHECK: %[[END:.*]] = torch.aten.add.int %[[K]], %[[C1]]
+  // CHECK: %[[BATCH_SLICE:.*]] = torch.aten.slice.Tensor %[[CURRENT]], %[[BATCH_AXIS]], %[[K]], %[[END]], %[[C1]]
+  // CHECK: %[[LENGTH_TENSOR:.*]] = torch.aten.select.int %arg1, %[[C0]], %[[K]]
+  // CHECK: %[[LENGTH:.*]] = torch.aten.item %[[LENGTH_TENSOR]]
+  // CHECK: %[[TIME_SLICE:.*]] = torch.aten.slice.Tensor %[[BATCH_SLICE]], %[[TIME_AXIS]], %[[C0]], %[[LENGTH]], %[[C1]]
+  // CHECK: %[[DIMS:.*]] = torch.prim.ListConstruct %[[TIME_AXIS]]
+  // CHECK: %[[FLIPPED:.*]] = torch.aten.flip %[[TIME_SLICE]], %[[DIMS]]
+  // CHECK: %[[UPDATED_BATCH:.*]] = torch.aten.slice_scatter %[[BATCH_SLICE]], %[[FLIPPED]], %[[TIME_AXIS]], %[[C0]], %[[LENGTH]], %[[C1]]
+  // CHECK: %[[UPDATED_INPUT:.*]] = torch.aten.slice_scatter %[[CURRENT]], %[[UPDATED_BATCH]], %[[BATCH_AXIS]], %[[K]], %[[END]], %[[C1]]
+  // CHECK: torch.prim.Loop.condition %[[TRUE]], iter(%[[UPDATED_INPUT]]
   // CHECK: return %[[LOOP]]
   %0 = torch.operator "onnx.ReverseSequence"(%arg0, %arg1) {torch.onnx.batch_axis = 1 : si64, torch.onnx.time_axis = 0 : si64} : (!torch.vtensor<[4,4],f32>, !torch.vtensor<[4],si64>) -> !torch.vtensor<[4,4],f32>
   return %0 : !torch.vtensor<[4,4],f32>
@@ -3240,12 +3264,24 @@ func.func @test_reversesequence_time(%arg0: !torch.vtensor<[4,4],f32>, %arg1: !t
 
 // CHECK-LABEL: @test_reversesequence_dynamic_batch
 func.func @test_reversesequence_dynamic_batch(%arg0: !torch.vtensor<[?,4],f32>, %arg1: !torch.vtensor<[?],si64>) -> !torch.vtensor<[?,4],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-  // CHECK: %[[BATCH_SIZE:.*]] = torch.aten.size.int %arg0
-  // CHECK: %[[LOOP:.*]] = torch.prim.Loop %[[BATCH_SIZE]]
-  // CHECK: torch.aten.select.int %arg1
-  // CHECK: torch.aten.flip
-  // CHECK: torch.aten.slice_scatter
-  // CHECK: torch.prim.Loop.condition
+  // CHECK: %[[C0:.*]] = torch.constant.int 0
+  // CHECK: %[[C1:.*]] = torch.constant.int 1
+  // CHECK: %[[BATCH_AXIS:.*]] = torch.constant.int 0
+  // CHECK: %[[TIME_AXIS:.*]] = torch.constant.int 1
+  // CHECK: %[[BATCH_SIZE:.*]] = torch.aten.size.int %arg0, %[[BATCH_AXIS]]
+  // CHECK: %[[TRUE:.*]] = torch.constant.bool true
+  // CHECK: %[[LOOP:.*]] = torch.prim.Loop %[[BATCH_SIZE]], %[[TRUE]], init(%arg0)
+  // CHECK: ^bb0(%[[K:.*]]: !torch.int, %[[CURRENT:.*]]: !torch.vtensor<[?,4],f32>):
+  // CHECK: %[[END:.*]] = torch.aten.add.int %[[K]], %[[C1]]
+  // CHECK: %[[BATCH_SLICE:.*]] = torch.aten.slice.Tensor %[[CURRENT]], %[[BATCH_AXIS]], %[[K]], %[[END]], %[[C1]]
+  // CHECK: %[[LENGTH_TENSOR:.*]] = torch.aten.select.int %arg1, %[[C0]], %[[K]]
+  // CHECK: %[[LENGTH:.*]] = torch.aten.item %[[LENGTH_TENSOR]]
+  // CHECK: %[[TIME_SLICE:.*]] = torch.aten.slice.Tensor %[[BATCH_SLICE]], %[[TIME_AXIS]], %[[C0]], %[[LENGTH]], %[[C1]]
+  // CHECK: %[[DIMS:.*]] = torch.prim.ListConstruct %[[TIME_AXIS]]
+  // CHECK: %[[FLIPPED:.*]] = torch.aten.flip %[[TIME_SLICE]], %[[DIMS]]
+  // CHECK: %[[UPDATED_BATCH:.*]] = torch.aten.slice_scatter %[[BATCH_SLICE]], %[[FLIPPED]], %[[TIME_AXIS]], %[[C0]], %[[LENGTH]], %[[C1]]
+  // CHECK: %[[UPDATED_INPUT:.*]] = torch.aten.slice_scatter %[[CURRENT]], %[[UPDATED_BATCH]], %[[BATCH_AXIS]], %[[K]], %[[END]], %[[C1]]
+  // CHECK: torch.prim.Loop.condition %[[TRUE]], iter(%[[UPDATED_INPUT]]
   // CHECK: return %[[LOOP]]
   %0 = torch.operator "onnx.ReverseSequence"(%arg0, %arg1) {torch.onnx.batch_axis = 0 : si64, torch.onnx.time_axis = 1 : si64} : (!torch.vtensor<[?,4],f32>, !torch.vtensor<[?],si64>) -> !torch.vtensor<[?,4],f32>
   return %0 : !torch.vtensor<[?,4],f32>

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -3210,54 +3210,13 @@ func.func @test_stft_with_window_and_framelen(%arg0: !torch.vtensor<[1,128,1],f3
 
 // CHECK-LABEL: @test_reversesequence_batch
 func.func @test_reversesequence_batch(%arg0: !torch.vtensor<[4,4],f32>, %arg1: !torch.vtensor<[4],si64>) -> !torch.vtensor<[4,4],f32> attributes {torch.onnx_meta.ir_version = 5 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-  // CHECK: %[[C0:.*]] = torch.constant.int 0
-  // CHECK: %[[C1:.*]] = torch.constant.int 1
-  // CHECK: %[[C0_0:.*]] = torch.constant.int 0
-  // CHECK: %[[C1_0:.*]] = torch.constant.int 1
-  // CHECK: %[[C0_1:.*]] = torch.constant.int 0
-  // CHECK: %[[ADD:.*]] = torch.aten.add.int %[[C0_1]], %[[C1]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[SLICE:.*]] = torch.aten.slice.Tensor %arg0, %[[C0_0]], %[[C0_1]], %[[ADD]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,4],f32>
-  // CHECK: %[[INDEX:.*]] = torch.prim.NumToTensor.Scalar %[[C0_1]] : !torch.int -> !torch.vtensor<[1],si64>
-  // CHECK: %[[SELECT:.*]] = torch.aten.index_select %arg1, %[[C0]], %[[INDEX]] : !torch.vtensor<[4],si64>, !torch.int, !torch.vtensor<[1],si64> -> !torch.vtensor<[1],si64>
-  // CHECK: %[[ITEM:.*]] = torch.aten.item %[[SELECT]] : !torch.vtensor<[1],si64> -> !torch.int
-  // CHECK: %[[SLICE_0:.*]] = torch.aten.slice.Tensor %[[SLICE]], %[[C1_0]], %[[C0]], %[[ITEM]], %[[C1]] : !torch.vtensor<[1,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,?],f32>
-  // CHECK: %[[DIM:.*]] = torch.prim.ListConstruct %[[C1_0]] : (!torch.int) -> !torch.list<int>
-  // CHECK: %[[FLIP:.*]] = torch.aten.flip %[[SLICE_0]], %[[DIM]] : !torch.vtensor<[1,?],f32>, !torch.list<int> -> !torch.vtensor<[1,?],f32>
-  // CHECK: %[[EMBED:.*]] = torch.aten.slice_scatter %[[SLICE]], %[[FLIP]], %[[C1_0]], %[[C0]], %[[ITEM]], %[[C1]] : !torch.vtensor<[1,4],f32>, !torch.vtensor<[1,?],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,4],f32>
-  // CHECK: %[[EMBED_0:.*]] = torch.aten.slice_scatter %arg0, %[[EMBED]], %[[C0_0]], %[[C0_1]], %[[ADD]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.vtensor<[1,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,4],f32>
-  // CHECK: %[[C1_1:.*]] = torch.constant.int 1
-  // CHECK: %[[ADD_0:.*]] = torch.aten.add.int %[[C1_1]], %[[C1]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[SLICE_1:.*]] = torch.aten.slice.Tensor %[[EMBED_0]], %[[C0_0]], %[[C1_1]], %[[ADD_0]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,4],f32>
-  // CHECK: %[[INDEX_0:.*]] = torch.prim.NumToTensor.Scalar %[[C1_1]] : !torch.int -> !torch.vtensor<[1],si64>
-  // CHECK: %[[SELECT_0:.*]] = torch.aten.index_select %arg1, %[[C0]], %[[INDEX_0]] : !torch.vtensor<[4],si64>, !torch.int, !torch.vtensor<[1],si64> -> !torch.vtensor<[1],si64>
-  // CHECK: %[[ITEM_0:.*]] = torch.aten.item %[[SELECT_0]] : !torch.vtensor<[1],si64> -> !torch.int
-  // CHECK: %[[SLICE_2:.*]] = torch.aten.slice.Tensor %[[SLICE_1]], %[[C1_0]], %[[C0]], %[[ITEM_0]], %[[C1]] : !torch.vtensor<[1,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,?],f32>
-  // CHECK: %[[DIM_0:.*]] = torch.prim.ListConstruct %[[C1_0]] : (!torch.int) -> !torch.list<int>
-  // CHECK: %[[FLIP_0:.*]] = torch.aten.flip %[[SLICE_2]], %[[DIM_0]] : !torch.vtensor<[1,?],f32>, !torch.list<int> -> !torch.vtensor<[1,?],f32>
-  // CHECK: %[[EMBED_1:.*]] = torch.aten.slice_scatter %[[SLICE_1]], %[[FLIP_0]], %[[C1_0]], %[[C0]], %[[ITEM_0]], %[[C1]] : !torch.vtensor<[1,4],f32>, !torch.vtensor<[1,?],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,4],f32>
-  // CHECK: %[[EMBED_2:.*]] = torch.aten.slice_scatter %[[EMBED_0]], %[[EMBED_1]], %[[C0_0]], %[[C1_1]], %[[ADD_0]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.vtensor<[1,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,4],f32>
-  // CHECK: %[[C2:.*]] = torch.constant.int 2
-  // CHECK: %[[ADD_1:.*]] = torch.aten.add.int %[[C2]], %[[C1]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[SLICE_3:.*]] = torch.aten.slice.Tensor %[[EMBED_2]], %[[C0_0]], %[[C2]], %[[ADD_1]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,4],f32>
-  // CHECK: %[[INDEX_1:.*]] = torch.prim.NumToTensor.Scalar %[[C2]] : !torch.int -> !torch.vtensor<[1],si64>
-  // CHECK: %[[SELECT_1:.*]] = torch.aten.index_select %arg1, %[[C0]], %[[INDEX_1]] : !torch.vtensor<[4],si64>, !torch.int, !torch.vtensor<[1],si64> -> !torch.vtensor<[1],si64>
-  // CHECK: %[[ITEM_1:.*]] = torch.aten.item %[[SELECT_1]] : !torch.vtensor<[1],si64> -> !torch.int
-  // CHECK: %[[SLICE_4:.*]] = torch.aten.slice.Tensor %[[SLICE_3]], %[[C1_0]], %[[C0]], %[[ITEM_1]], %[[C1]] : !torch.vtensor<[1,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,?],f32>
-  // CHECK: %[[DIM_1:.*]] = torch.prim.ListConstruct %[[C1_0]] : (!torch.int) -> !torch.list<int>
-  // CHECK: %[[FLIP_1:.*]] = torch.aten.flip %[[SLICE_4]], %[[DIM_1]] : !torch.vtensor<[1,?],f32>, !torch.list<int> -> !torch.vtensor<[1,?],f32>
-  // CHECK: %[[EMBED_3:.*]] = torch.aten.slice_scatter %[[SLICE_3]], %[[FLIP_1]], %[[C1_0]], %[[C0]], %[[ITEM_1]], %[[C1]] : !torch.vtensor<[1,4],f32>, !torch.vtensor<[1,?],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,4],f32>
-  // CHECK: %[[EMBED_4:.*]] = torch.aten.slice_scatter %[[EMBED_2]], %[[EMBED_3]], %[[C0_0]], %[[C2]], %[[ADD_1]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.vtensor<[1,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,4],f32>
-  // CHECK: %[[C3:.*]] = torch.constant.int 3
-  // CHECK: %[[ADD_2:.*]] = torch.aten.add.int %[[C3]], %[[C1]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[SLICE_5:.*]] = torch.aten.slice.Tensor %[[EMBED_4]], %[[C0_0]], %[[C3]], %[[ADD_2]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,4],f32>
-  // CHECK: %[[INDEX_2:.*]] = torch.prim.NumToTensor.Scalar %[[C3]] : !torch.int -> !torch.vtensor<[1],si64>
-  // CHECK: %[[SELECT_2:.*]] = torch.aten.index_select %arg1, %[[C0]], %[[INDEX_2]] : !torch.vtensor<[4],si64>, !torch.int, !torch.vtensor<[1],si64> -> !torch.vtensor<[1],si64>
-  // CHECK: %[[ITEM_2:.*]] = torch.aten.item %[[SELECT_2]] : !torch.vtensor<[1],si64> -> !torch.int
-  // CHECK: %[[SLICE_6:.*]] = torch.aten.slice.Tensor %[[SLICE_5]], %[[C1_0]], %[[C0]], %[[ITEM_2]], %[[C1]] : !torch.vtensor<[1,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,?],f32>
-  // CHECK: %[[DIM_2:.*]] = torch.prim.ListConstruct %[[C1_0]] : (!torch.int) -> !torch.list<int>
-  // CHECK: %[[FLIP_2:.*]] = torch.aten.flip %[[SLICE_6]], %[[DIM_2]] : !torch.vtensor<[1,?],f32>, !torch.list<int> -> !torch.vtensor<[1,?],f32>
-  // CHECK: %[[EMBED_5:.*]] = torch.aten.slice_scatter %[[SLICE_5]], %[[FLIP_2]], %[[C1_0]], %[[C0]], %[[ITEM_2]], %[[C1]] : !torch.vtensor<[1,4],f32>, !torch.vtensor<[1,?],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[1,4],f32>
-  // CHECK: torch.aten.slice_scatter %[[EMBED_4]], %[[EMBED_5]], %[[C0_0]], %[[C3]], %[[ADD_2]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.vtensor<[1,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,4],f32>
+  // CHECK: %[[BATCH_SIZE:.*]] = torch.aten.size.int %arg0
+  // CHECK: %[[LOOP:.*]] = torch.prim.Loop %[[BATCH_SIZE]]
+  // CHECK: torch.aten.select.int %arg1
+  // CHECK: torch.aten.flip
+  // CHECK: torch.aten.slice_scatter
+  // CHECK: torch.prim.Loop.condition
+  // CHECK: return %[[LOOP]]
   %0 = torch.operator "onnx.ReverseSequence"(%arg0, %arg1) {torch.onnx.batch_axis = 0 : si64, torch.onnx.time_axis = 1 : si64} : (!torch.vtensor<[4,4],f32>, !torch.vtensor<[4],si64>) -> !torch.vtensor<[4,4],f32>
   return %0 : !torch.vtensor<[4,4],f32>
 }
@@ -3266,56 +3225,30 @@ func.func @test_reversesequence_batch(%arg0: !torch.vtensor<[4,4],f32>, %arg1: !
 
 // CHECK-LABEL: @test_reversesequence_time
 func.func @test_reversesequence_time(%arg0: !torch.vtensor<[4,4],f32>, %arg1: !torch.vtensor<[4],si64>) -> !torch.vtensor<[4,4],f32> attributes {torch.onnx_meta.ir_version = 5 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-  // CHECK: %[[C0:.*]] = torch.constant.int 0
-  // CHECK: %[[C1:.*]] = torch.constant.int 1
-  // CHECK: %[[C1_0:.*]] = torch.constant.int 1
-  // CHECK: %[[C0_0:.*]] = torch.constant.int 0
-  // CHECK: %[[C0_1:.*]] = torch.constant.int 0
-  // CHECK: %[[ADD:.*]] = torch.aten.add.int %[[C0_1]], %[[C1]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[SLICE:.*]] = torch.aten.slice.Tensor %arg0, %[[C1_0]], %[[C0_1]], %[[ADD]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,1],f32>
-  // CHECK: %[[INDEX:.*]] = torch.prim.NumToTensor.Scalar %[[C0_1]] : !torch.int -> !torch.vtensor<[1],si64>
-  // CHECK: %[[SELECT:.*]] = torch.aten.index_select %arg1, %[[C0]], %[[INDEX]] : !torch.vtensor<[4],si64>, !torch.int, !torch.vtensor<[1],si64> -> !torch.vtensor<[1],si64>
-  // CHECK: %[[ITEM:.*]] = torch.aten.item %[[SELECT]] : !torch.vtensor<[1],si64> -> !torch.int
-  // CHECK: %[[SLICE_0:.*]] = torch.aten.slice.Tensor %[[SLICE]], %[[C0_0]], %[[C0]], %[[ITEM]], %[[C1]] : !torch.vtensor<[4,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[?,1],f32>
-  // CHECK: %[[DIM:.*]] = torch.prim.ListConstruct %[[C0_0]] : (!torch.int) -> !torch.list<int>
-  // CHECK: %[[FLIP:.*]] = torch.aten.flip %[[SLICE_0]], %[[DIM]] : !torch.vtensor<[?,1],f32>, !torch.list<int> -> !torch.vtensor<[?,1],f32>
-  // CHECK: %[[EMBED:.*]] = torch.aten.slice_scatter %[[SLICE]], %[[FLIP]], %[[C0_0]], %[[C0]], %[[ITEM]], %[[C1]] : !torch.vtensor<[4,1],f32>, !torch.vtensor<[?,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,1],f32>
-  // CHECK: %[[EMBED_0:.*]] = torch.aten.slice_scatter %arg0, %[[EMBED]], %[[C1_0]], %[[C0_1]], %[[ADD]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.vtensor<[4,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,4],f32>
-  // CHECK: %[[C1_1:.*]] = torch.constant.int 1
-  // CHECK: %[[ADD_0:.*]] = torch.aten.add.int %[[C1_1]], %[[C1]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[SLICE_1:.*]] = torch.aten.slice.Tensor %[[EMBED_0]], %[[C1_0]], %[[C1_1]], %[[ADD_0]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,1],f32>
-  // CHECK: %[[INDEX_0:.*]] = torch.prim.NumToTensor.Scalar %[[C1_1]] : !torch.int -> !torch.vtensor<[1],si64>
-  // CHECK: %[[SELECT_0:.*]] = torch.aten.index_select %arg1, %[[C0]], %[[INDEX_0]] : !torch.vtensor<[4],si64>, !torch.int, !torch.vtensor<[1],si64> -> !torch.vtensor<[1],si64>
-  // CHECK: %[[ITEM_0:.*]] = torch.aten.item %[[SELECT_0]] : !torch.vtensor<[1],si64> -> !torch.int
-  // CHECK: %[[SLICE_2:.*]] = torch.aten.slice.Tensor %[[SLICE_1]], %[[C0_0]], %[[C0]], %[[ITEM_0]], %[[C1]] : !torch.vtensor<[4,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[?,1],f32>
-  // CHECK: %[[DIM_0:.*]] = torch.prim.ListConstruct %[[C0_0]] : (!torch.int) -> !torch.list<int>
-  // CHECK: %[[FLIP_0:.*]] = torch.aten.flip %[[SLICE_2]], %[[DIM_0]] : !torch.vtensor<[?,1],f32>, !torch.list<int> -> !torch.vtensor<[?,1],f32>
-  // CHECK: %[[EMBED_1:.*]] = torch.aten.slice_scatter %[[SLICE_1]], %[[FLIP_0]], %[[C0_0]], %[[C0]], %[[ITEM_0]], %[[C1]] : !torch.vtensor<[4,1],f32>, !torch.vtensor<[?,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,1],f32>
-  // CHECK: %[[EMBED_2:.*]] = torch.aten.slice_scatter %[[EMBED_0]], %[[EMBED_1]], %[[C1_0]], %[[C1_1]], %[[ADD_0]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.vtensor<[4,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,4],f32>
-  // CHECK: %[[C2:.*]] = torch.constant.int 2
-  // CHECK: %[[ADD_1:.*]] = torch.aten.add.int %[[C2]], %[[C1]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[SLICE_3:.*]] = torch.aten.slice.Tensor %[[EMBED_2]], %[[C1_0]], %[[C2]], %[[ADD_1]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,1],f32>
-  // CHECK: %[[INDEX_1:.*]] = torch.prim.NumToTensor.Scalar %[[C2]] : !torch.int -> !torch.vtensor<[1],si64>
-  // CHECK: %[[SELECT_1:.*]] = torch.aten.index_select %arg1, %[[C0]], %[[INDEX_1]] : !torch.vtensor<[4],si64>, !torch.int, !torch.vtensor<[1],si64> -> !torch.vtensor<[1],si64>
-  // CHECK: %[[ITEM_1:.*]] = torch.aten.item %[[SELECT_1]] : !torch.vtensor<[1],si64> -> !torch.int
-  // CHECK: %[[SLICE_4:.*]] = torch.aten.slice.Tensor %[[SLICE_3]], %[[C0_0]], %[[C0]], %[[ITEM_1]], %[[C1]] : !torch.vtensor<[4,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[?,1],f32>
-  // CHECK: %[[DIM_1:.*]] = torch.prim.ListConstruct %[[C0_0]] : (!torch.int) -> !torch.list<int>
-  // CHECK: %[[FLIP_1:.*]] = torch.aten.flip %[[SLICE_4]], %[[DIM_1]] : !torch.vtensor<[?,1],f32>, !torch.list<int> -> !torch.vtensor<[?,1],f32>
-  // CHECK: %[[EMBED_3:.*]] = torch.aten.slice_scatter %[[SLICE_3]], %[[FLIP_1]], %[[C0_0]], %[[C0]], %[[ITEM_1]], %[[C1]] : !torch.vtensor<[4,1],f32>, !torch.vtensor<[?,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,1],f32>
-  // CHECK: %[[EMBED_4:.*]] = torch.aten.slice_scatter %[[EMBED_2]], %[[EMBED_3]], %[[C1_0]], %[[C2]], %[[ADD_1]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.vtensor<[4,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,4],f32>
-  // CHECK: %[[C3:.*]] = torch.constant.int 3
-  // CHECK: %[[ADD_2:.*]] = torch.aten.add.int %[[C3]], %[[C1]] : !torch.int, !torch.int -> !torch.int
-  // CHECK: %[[SLICE_5:.*]] = torch.aten.slice.Tensor %[[EMBED_4]], %[[C1_0]], %[[C3]], %[[ADD_2]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,1],f32>
-  // CHECK: %[[INDEX_2:.*]] = torch.prim.NumToTensor.Scalar %[[C3]] : !torch.int -> !torch.vtensor<[1],si64>
-  // CHECK: %[[SELECT_2:.*]] = torch.aten.index_select %arg1, %[[C0]], %[[INDEX_2]] : !torch.vtensor<[4],si64>, !torch.int, !torch.vtensor<[1],si64> -> !torch.vtensor<[1],si64>
-  // CHECK: %[[ITEM_2:.*]] = torch.aten.item %[[SELECT_2]] : !torch.vtensor<[1],si64> -> !torch.int
-  // CHECK: %[[SLICE_6:.*]] = torch.aten.slice.Tensor %[[SLICE_5]], %[[C0_0]], %[[C0]], %[[ITEM_2]], %[[C1]] : !torch.vtensor<[4,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[?,1],f32>
-  // CHECK: %[[DIM_2:.*]] = torch.prim.ListConstruct %[[C0_0]] : (!torch.int) -> !torch.list<int>
-  // CHECK: %[[FLIP_2:.*]] = torch.aten.flip %[[SLICE_6]], %[[DIM_2]] : !torch.vtensor<[?,1],f32>, !torch.list<int> -> !torch.vtensor<[?,1],f32>
-  // CHECK: %[[EMBED_5:.*]] = torch.aten.slice_scatter %[[SLICE_5]], %[[FLIP_2]], %[[C0_0]], %[[C0]], %[[ITEM_2]], %[[C1]] : !torch.vtensor<[4,1],f32>, !torch.vtensor<[?,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,1],f32>
-  // CHECK: torch.aten.slice_scatter %[[EMBED_4]], %[[EMBED_5]], %[[C1_0]], %[[C3]], %[[ADD_2]], %[[C1]] : !torch.vtensor<[4,4],f32>, !torch.vtensor<[4,1],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[4,4],f32>
+  // CHECK: %[[BATCH_SIZE:.*]] = torch.aten.size.int %arg0
+  // CHECK: %[[LOOP:.*]] = torch.prim.Loop %[[BATCH_SIZE]]
+  // CHECK: torch.aten.select.int %arg1
+  // CHECK: torch.aten.flip
+  // CHECK: torch.aten.slice_scatter
+  // CHECK: torch.prim.Loop.condition
+  // CHECK: return %[[LOOP]]
   %0 = torch.operator "onnx.ReverseSequence"(%arg0, %arg1) {torch.onnx.batch_axis = 1 : si64, torch.onnx.time_axis = 0 : si64} : (!torch.vtensor<[4,4],f32>, !torch.vtensor<[4],si64>) -> !torch.vtensor<[4,4],f32>
   return %0 : !torch.vtensor<[4,4],f32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_reversesequence_dynamic_batch
+func.func @test_reversesequence_dynamic_batch(%arg0: !torch.vtensor<[?,4],f32>, %arg1: !torch.vtensor<[?],si64>) -> !torch.vtensor<[?,4],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 17 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
+  // CHECK: %[[BATCH_SIZE:.*]] = torch.aten.size.int %arg0
+  // CHECK: %[[LOOP:.*]] = torch.prim.Loop %[[BATCH_SIZE]]
+  // CHECK: torch.aten.select.int %arg1
+  // CHECK: torch.aten.flip
+  // CHECK: torch.aten.slice_scatter
+  // CHECK: torch.prim.Loop.condition
+  // CHECK: return %[[LOOP]]
+  %0 = torch.operator "onnx.ReverseSequence"(%arg0, %arg1) {torch.onnx.batch_axis = 0 : si64, torch.onnx.time_axis = 1 : si64} : (!torch.vtensor<[?,4],f32>, !torch.vtensor<[?],si64>) -> !torch.vtensor<[?,4],f32>
+  return %0 : !torch.vtensor<[?,4],f32>
 }
 
 // -----


### PR DESCRIPTION
Updated the ONNX `ReverseSequence` conversion to use a runtime `torch.prim.Loop` over the batch dimension.

 The previous implementation statically unrolled the operation based off the compile-time batch size, so it failed to apply the operation for dynamic batch dimensions.

The new implementation obtains the batch size at runtime and iterates over each batch element using `torch.prim.Loop`. It emits the same set of operations to reverse the selected portion and can now support both static and dynamic batch dimensions.

Tests:
  - Updated the existing batch-axis and time-axis `ReverseSequence` tests to check for the new operations
  - Added a regression test in `simple_ops_q_to_z.mlir` for a dynamic batch dimension
