### PR TITLE
[TorchToTosa] Fix pooling asymmetric padding

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
@@ -554,13 +554,18 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
         ArrayRef<int64_t> spatialShape =
             inputTensorType.getSizes().drop_front(2);
         auto isDynamicDim = [](int64_t d) { return d == Torch::kUnknownSize; };
-        bool anyDynamicSpatial = llvm::any_of(spatialShape, isDynamicDim);
         // In ceil mode ONNX drops any trailing window that would begin entirely
         // inside the padding. The result type reflects that drop (shape
         // inference applied it), so use it as the output extent -- the injected
         // padding below is sized to reproduce it.
         ArrayRef<int64_t> resultSpatialShape =
             resultType.getSizes().drop_front(2);
+        // The static "bake the split into the pad attr" branch below needs both
+        // the input and the result extent of every spatial dim; if either is
+        // unknown, take the runtime `constant_pad_nd` path (buildSplitPadList
+        // handles the mixed case per dim).
+        bool anyDynamicSpatial = llvm::any_of(spatialShape, isDynamicDim) ||
+                                 llvm::any_of(resultSpatialShape, isDynamicDim);
 
         // Expand a collapsed one-value-per-dim padding (used when the input
         // pads are symmetric) into the explicit per-dim begin/end form the ceil
@@ -571,6 +576,23 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
           pads.resize_for_overwrite(2 * spatialRank);
           for (int i = spatialRank - 1; i >= 0; --i)
             pads[i + spatialRank] = pads[i];
+        };
+
+        // Resolve the ONNX ceil split for one static spatial dim: the extra
+        // ceil extent (actualPadded - inDim - pBegin - pEnd) is halved onto the
+        // leading edge and the remainder onto the trailing edge. Updates pBegin
+        // / pEnd in place. Kept as the single source of the static split so the
+        // two static call sites below cannot drift (an earlier divergence
+        // between them was a bug). Requires inDim and outDim to be static.
+        auto staticSplitPad = [](int64_t inDim, int64_t outDim, int64_t stride,
+                                 int64_t dilatedKernel, int64_t &pBegin,
+                                 int64_t &pEnd) {
+          int64_t actualPadded = (outDim - 1) * stride + dilatedKernel;
+          int64_t extra = actualPadded - inDim - pBegin - pEnd;
+          if (extra > 0) {
+            pBegin += extra / 2;
+            pEnd += extra - extra / 2;
+          }
         };
 
         // Build the aten.constant_pad_nd pad list for the ONNX ceil split
@@ -590,14 +612,8 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
             int64_t pEndI = normPad[i + spatialRank];
             if (!isDynamicDim(spatialShape[i]) &&
                 !isDynamicDim(resultSpatialShape[i])) {
-              int64_t inDim = spatialShape[i];
-              int64_t outDim = resultSpatialShape[i];
-              int64_t actualPadded = (outDim - 1) * stride + dilatedKernel;
-              int64_t extra = actualPadded - inDim - pBeginI - pEndI;
-              if (extra > 0) {
-                pBeginI += extra / 2;
-                pEndI += extra - extra / 2;
-              }
+              staticSplitPad(spatialShape[i], resultSpatialShape[i], stride,
+                             dilatedKernel, pBeginI, pEndI);
               padPairsFront.push_back(Torch::ConstantIntOp::create(
                   rewriter, loc, rewriter.getI64IntegerAttr(pBeginI)));
               padPairsFront.push_back(Torch::ConstantIntOp::create(
@@ -706,17 +722,9 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
           // attr, then emit floor mode.
           toBeginEndPadding(padding);
           for (int i = 0; i < spatialRank; ++i) {
-            int64_t inDim = spatialShape[i];
             int64_t dilatedKernel = dilations[i] * (kernel[i] - 1) + 1;
-            int64_t &pBegin = padding[i];
-            int64_t &pEnd = padding[i + spatialRank];
-            int64_t outDim = resultSpatialShape[i];
-            int64_t actualPadded = (outDim - 1) * strides[i] + dilatedKernel;
-            int64_t extra = actualPadded - inDim - pBegin - pEnd;
-            if (extra > 0) {
-              pBegin += extra / 2;
-              pEnd += extra - extra / 2;
-            }
+            staticSplitPad(spatialShape[i], resultSpatialShape[i], strides[i],
+                           dilatedKernel, padding[i], padding[i + spatialRank]);
           }
           ceilMode = false;
         } else if (ceilMode && !countIncludePad) {

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainAtoF.cpp
@@ -547,6 +547,239 @@ void mlir::torch::onnx_c::populateDefaultDomainAtoF(
           }
         }
 
+        // ONNX ceil_mode splits the ceil slack between the leading and trailing
+        // edges; PyTorch (aten.avg_pool) appends it to the trailing edge only,
+        // so passing ceil_mode through is ONNX-wrong when ceil grows the
+        // output. Resolve the split into explicit padding + floor mode instead.
+        ArrayRef<int64_t> spatialShape =
+            inputTensorType.getSizes().drop_front(2);
+        auto isDynamicDim = [](int64_t d) { return d == Torch::kUnknownSize; };
+        bool anyDynamicSpatial = llvm::any_of(spatialShape, isDynamicDim);
+        // In ceil mode ONNX drops any trailing window that would begin entirely
+        // inside the padding. The result type reflects that drop (shape
+        // inference applied it), so use it as the output extent -- the injected
+        // padding below is sized to reproduce it.
+        ArrayRef<int64_t> resultSpatialShape =
+            resultType.getSizes().drop_front(2);
+
+        // Expand a collapsed one-value-per-dim padding (used when the input
+        // pads are symmetric) into the explicit per-dim begin/end form the ceil
+        // split needs: padding[i] = begin, padding[i + spatialRank] = end.
+        auto toBeginEndPadding = [spatialRank](SmallVector<int64_t> &pads) {
+          if (pads.size() != static_cast<size_t>(spatialRank))
+            return;
+          pads.resize_for_overwrite(2 * spatialRank);
+          for (int i = spatialRank - 1; i >= 0; --i)
+            pads[i + spatialRank] = pads[i];
+        };
+
+        // Build the aten.constant_pad_nd pad list for the ONNX ceil split
+        // (begin = p + extra/2, end = p + extra - extra/2), emitted as runtime
+        // arithmetic for dynamic dims and constants otherwise. Order is
+        // innermost spatial dim first.
+        auto buildSplitPadList = [&]() -> Value {
+          Location loc = binder.getLoc();
+          SmallVector<int64_t> normPad(padding);
+          toBeginEndPadding(normPad);
+          // Per spatial dim, outermost first: [beginPad, endPad].
+          SmallVector<Value> padPairsFront;
+          for (int i = 0; i < spatialRank; ++i) {
+            int64_t dilatedKernel = dilations[i] * (kernel[i] - 1) + 1;
+            int64_t stride = strides[i];
+            int64_t pBeginI = normPad[i];
+            int64_t pEndI = normPad[i + spatialRank];
+            if (!isDynamicDim(spatialShape[i]) &&
+                !isDynamicDim(resultSpatialShape[i])) {
+              int64_t inDim = spatialShape[i];
+              int64_t outDim = resultSpatialShape[i];
+              int64_t actualPadded = (outDim - 1) * stride + dilatedKernel;
+              int64_t extra = actualPadded - inDim - pBeginI - pEndI;
+              if (extra > 0) {
+                pBeginI += extra / 2;
+                pEndI += extra - extra / 2;
+              }
+              padPairsFront.push_back(Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(pBeginI)));
+              padPairsFront.push_back(Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(pEndI)));
+            } else {
+              // Dynamic dim: emit the split as runtime int arithmetic.
+              Value cstZeroInt = Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(0));
+              Value cstTwoInt = Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(2));
+              Value cstStride = Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(stride));
+              Value cstDilatedKernel = Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(dilatedKernel));
+              Value cstStaticPad = Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(pBeginI + pEndI));
+              Value pBegin = Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(pBeginI));
+              Value pEnd = Torch::ConstantIntOp::create(
+                  rewriter, loc, rewriter.getI64IntegerAttr(pEndI));
+              Value inDim = Torch::getTensorDimSize(rewriter, operand, i + 2);
+              Value padded = Torch::AtenAddIntOp::create(rewriter, loc, inDim,
+                                                         cstStaticPad);
+              Value numer = Torch::AtenSubIntOp::create(rewriter, loc, padded,
+                                                        cstDilatedKernel);
+              // outDimMinusOne = ceildiv(numer, stride) = (numer+stride-1) /
+              // stride
+              Value strideMinusOne = Torch::AtenSubIntOp::create(
+                  rewriter, loc, cstStride,
+                  Torch::ConstantIntOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(1)));
+              Value ceilNumer = Torch::AtenAddIntOp::create(
+                  rewriter, loc, numer, strideMinusOne);
+              Value outDimMinusOne = Torch::AtenFloordivIntOp::create(
+                  rewriter, loc, ceilNumer, cstStride);
+              // Drop the trailing ceil window when it starts in the padding:
+              // outDimMinusOne -= (outDimMinusOne*stride >= inDim + pBegin).
+              Value startLast = Torch::AtenMulIntOp::create(
+                  rewriter, loc, outDimMinusOne, cstStride);
+              Value inDimPlusPBegin =
+                  Torch::AtenAddIntOp::create(rewriter, loc, inDim, pBegin);
+              Value dropCond = Torch::AtenGeIntOp::create(
+                  rewriter, loc, startLast, inDimPlusPBegin);
+              Value dropInt =
+                  Torch::AtenIntBoolOp::create(rewriter, loc, dropCond);
+              outDimMinusOne = Torch::AtenSubIntOp::create(
+                  rewriter, loc, outDimMinusOne, dropInt);
+              Value actualPadded = Torch::AtenMulIntOp::create(
+                  rewriter, loc, outDimMinusOne, cstStride);
+              actualPadded = Torch::AtenAddIntOp::create(
+                  rewriter, loc, actualPadded, cstDilatedKernel);
+              Value extra = Torch::AtenSubIntOp::create(rewriter, loc,
+                                                        actualPadded, padded);
+              extra =
+                  Torch::PrimMaxIntOp::create(rewriter, loc, extra, cstZeroInt);
+              Value half = Torch::AtenFloordivIntOp::create(rewriter, loc,
+                                                            extra, cstTwoInt);
+              Value newBegin =
+                  Torch::AtenAddIntOp::create(rewriter, loc, pBegin, half);
+              Value otherHalf =
+                  Torch::AtenSubIntOp::create(rewriter, loc, extra, half);
+              Value newEnd =
+                  Torch::AtenAddIntOp::create(rewriter, loc, pEnd, otherHalf);
+              padPairsFront.push_back(newBegin);
+              padPairsFront.push_back(newEnd);
+            }
+          }
+          // Reverse dim order for constant_pad_nd (innermost first).
+          SmallVector<Value> padListVals;
+          for (int i = spatialRank - 1; i >= 0; --i) {
+            padListVals.push_back(padPairsFront[2 * i]);
+            padListVals.push_back(padPairsFront[2 * i + 1]);
+          }
+          Type intListType = Torch::ListType::get(
+              Torch::IntType::get(binder.op->getContext()));
+          return Torch::PrimListConstructOp::create(rewriter, loc, intListType,
+                                                    padListVals);
+        };
+
+        // The ceil-resolution branches below emit rank-specific pools; bail
+        // before creating any IR if the rank is unsupported.
+        if (ceilMode && rank != 3 && rank != 4 && rank != 5)
+          return rewriter.notifyMatchFailure(
+              binder.op, "unsupported rank for AveragePool");
+
+        if (ceilMode && countIncludePad && anyDynamicSpatial) {
+          // Dynamic dim: the split depends on the runtime extent, so
+          // materialize it as an aten.constant_pad_nd (runtime pad amounts) in
+          // front of a floor-mode zero-padded pool. count_include_pad=1 counts
+          // the injected zeros in the divisor, matching ONNX.
+          Location loc = binder.getLoc();
+          Value padList = buildSplitPadList();
+          Value cstZeroFloat = Torch::ConstantFloatOp::create(
+              rewriter, loc, rewriter.getF64FloatAttr(0.0));
+          SmallVector<int64_t> paddedSizes(inputTensorType.getSizes());
+          for (unsigned i = 0; i < spatialRank; ++i)
+            paddedSizes[i + 2] = Torch::kUnknownSize;
+          Type paddedType = inputTensorType.getWithSizesAndDtype(
+              paddedSizes, inputTensorType.getOptionalDtype());
+          operand = Torch::AtenConstantPadNdOp::create(
+              rewriter, loc, paddedType, operand, padList, cstZeroFloat);
+          padding.assign(spatialRank, 0);
+          ceilMode = false;
+        } else if (ceilMode && countIncludePad) {
+          // Static dim: bake the ONNX split into the pool's asymmetric padding
+          // attr, then emit floor mode.
+          toBeginEndPadding(padding);
+          for (int i = 0; i < spatialRank; ++i) {
+            int64_t inDim = spatialShape[i];
+            int64_t dilatedKernel = dilations[i] * (kernel[i] - 1) + 1;
+            int64_t &pBegin = padding[i];
+            int64_t &pEnd = padding[i + spatialRank];
+            int64_t outDim = resultSpatialShape[i];
+            int64_t actualPadded = (outDim - 1) * strides[i] + dilatedKernel;
+            int64_t extra = actualPadded - inDim - pBegin - pEnd;
+            if (extra > 0) {
+              pBegin += extra / 2;
+              pEnd += extra - extra / 2;
+            }
+          }
+          ceilMode = false;
+        } else if (ceilMode && !countIncludePad) {
+          // count_include_pad=0: the divisor is the valid (non-pad) element
+          // count, which
+          // explicit padding cannot express. Decompose into a ones-mask ratio
+          //   avg_pool(pad(input), count_include_pad=1)
+          //     / avg_pool(pad(ones_like), count_include_pad=1)
+          // so the full-kernel divisor cancels, leaving sum_valid/count_valid
+          // (all-pad windows give 0/0 = NaN, matching ONNX).
+          Location loc = binder.getLoc();
+          Value padList = buildSplitPadList();
+          Value cstZeroFloat = Torch::ConstantFloatOp::create(
+              rewriter, loc, rewriter.getF64FloatAttr(0.0));
+          Value cstNoneV = Torch::ConstantNoneOp::create(rewriter, loc);
+          Value cstFalse = Torch::ConstantBoolOp::create(rewriter, loc, false);
+          Value cstTrue = Torch::ConstantBoolOp::create(rewriter, loc, true);
+
+          SmallVector<int64_t> paddedSizes(inputTensorType.getSizes());
+          for (unsigned i = 0; i < spatialRank; ++i)
+            paddedSizes[i + 2] = Torch::kUnknownSize;
+          Type paddedType = inputTensorType.getWithSizesAndDtype(
+              paddedSizes, inputTensorType.getOptionalDtype());
+
+          Value paddedInput = Torch::AtenConstantPadNdOp::create(
+              rewriter, loc, paddedType, operand, padList, cstZeroFloat);
+          Value ones = Torch::AtenOnesLikeOp::create(
+              rewriter, loc, inputTensorType, operand, cstNoneV, cstNoneV,
+              cstNoneV, cstNoneV, cstNoneV);
+          Value paddedOnes = Torch::AtenConstantPadNdOp::create(
+              rewriter, loc, paddedType, ones, padList, cstZeroFloat);
+
+          SmallVector<int64_t> stridesDilations = strides;
+          stridesDilations.append(dilations);
+          Value kernelSizeList =
+              createConstantIntList(binder, rewriter, kernel);
+          Value stridesDilationsList =
+              createConstantIntList(binder, rewriter, stridesDilations);
+          SmallVector<int64_t> zeroPad(spatialRank, 0);
+          Value zeroPadList = createConstantIntList(binder, rewriter, zeroPad);
+
+          auto emitPool = [&](Value in) -> Value {
+            if (rank == 3)
+              return Torch::AtenAvgPool1dOp::create(
+                  rewriter, loc, resultType, in, kernelSizeList,
+                  stridesDilationsList, zeroPadList, cstFalse, cstTrue);
+            if (rank == 4)
+              return Torch::AtenAvgPool2dOp::create(
+                  rewriter, loc, resultType, in, kernelSizeList,
+                  stridesDilationsList, zeroPadList, cstFalse, cstTrue,
+                  /*divisor_override=*/cstNoneV);
+            return Torch::AtenAvgPool3dOp::create(
+                rewriter, loc, resultType, in, kernelSizeList,
+                stridesDilationsList, zeroPadList, cstFalse, cstTrue,
+                /*divisor_override=*/cstNoneV);
+          };
+          Value num = emitPool(paddedInput);
+          Value den = emitPool(paddedOnes);
+          rewriter.replaceOpWithNewOp<Torch::AtenDivTensorOp>(
+              binder.op, resultType, num, den);
+          return success();
+        }
+
         // If the padding is symmetric then we don't need seperate low/high
         // padding values.
         if (padding.size() == static_cast<size_t>(2 * spatialRank)) {

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -8239,7 +8239,10 @@ static LogicalResult getOutputTypeAndPoolingParameters(
     return rewriter.notifyMatchFailure(
         op, "NCHW->NHWC transpose requires 3D or 4D tensor");
 
-  SmallVector<int64_t, 2> kernelSizeInts, strideInts, paddingInts;
+  SmallVector<int64_t, 2> kernelSizeInts, strideInts;
+  // Sized for the asymmetric padding form below, which holds two extents per
+  // spatial dim.
+  SmallVector<int64_t, 4> paddingInts;
   if (!matchPattern(op.getKernelSize(),
                     m_TorchListOfConstantInts(kernelSizeInts)))
     return rewriter.notifyMatchFailure(
@@ -8281,23 +8284,52 @@ static LogicalResult getOutputTypeAndPoolingParameters(
   if (!matchPattern(op.getPadding(), m_TorchListOfConstantInts(paddingInts)))
     return rewriter.notifyMatchFailure(
         op, "Non-const padding factor for pooling op unsupported");
-  expandPoolParams(op, paddingInts, 0);
+
+  // Torch pooling ops carry one symmetric padding extent per spatial dim. The
+  // ONNX importer additionally uses a `2 * spatialRank` form
+  // [begin..., end...] to express asymmetric pads, which the aten schema cannot
+  // represent (see the `AveragePool` legalization in DefaultDomainAtoF.cpp).
+  // Resolve both forms into explicit before/after extents so the rest of this
+  // function is arity-agnostic.
+  constexpr size_t spatialRank = (std::is_same<AtenOpT, AtenMaxPool1dOp>() ||
+                                  std::is_same<AtenOpT, AtenAvgPool1dOp>())
+                                     ? 1
+                                     : 2;
+  SmallVector<int64_t, 2> padBefore, padAfter;
+  if (paddingInts.size() == spatialRank) {
+    padBefore.assign(paddingInts.begin(), paddingInts.end());
+    padAfter.assign(paddingInts.begin(), paddingInts.end());
+  } else if (paddingInts.size() == 2 * spatialRank) {
+    padBefore.assign(paddingInts.begin(), paddingInts.begin() + spatialRank);
+    padAfter.assign(paddingInts.begin() + spatialRank, paddingInts.end());
+  } else {
+    return rewriter.notifyMatchFailure(
+        op, "padding for pooling op must hold one extent per spatial dim, or a "
+            "(begin, end) pair per spatial dim");
+  }
+  // For 1D ops the trailing spatial dim is synthetic, so it takes no padding.
+  expandPoolParams(op, padBefore, 0);
+  expandPoolParams(op, padAfter, 0);
 
   if constexpr (std::is_same<AtenOpT, AtenAvgPool1dOp>() ||
                 std::is_same<AtenOpT, AtenAvgPool2dOp>()) {
+    // Height is at index 0 and width at index 1 of the resolved extents.
+    int64_t padHBefore = padBefore[0], padWBefore = padBefore[1];
+    int64_t padHAfter = padAfter[0], padWAfter = padAfter[1];
+
     // When count_include_pad=true with non-zero padding, we will materialize an
     // explicit pad after transposing to NHWC. Track the padding extents and
     // zero out the TOSA op padding so the divisor matches the full kernel size.
     bool countIncludePad;
-    if ((paddingInts[0] != 0 || paddingInts[1] != 0) &&
+    if ((padHBefore != 0 || padWBefore != 0 || padHAfter != 0 ||
+         padWAfter != 0) &&
         (!matchPattern(op.getCountIncludePad(),
                        m_TorchConstantBool(&countIncludePad)) ||
 
          countIncludePad)) {
       // Remember the spatial padding so we can emit an NHWC tosa.pad right
       // after the transpose.
-      explicitNHWCPad.assign(
-          {paddingInts[0], paddingInts[0], paddingInts[1], paddingInts[1]});
+      explicitNHWCPad.assign({padHBefore, padHAfter, padWBefore, padWAfter});
 
       auto addPad = [](int64_t dim, int64_t before, int64_t after) -> int64_t {
         if (ShapedType::isDynamic(dim))
@@ -8312,19 +8344,20 @@ static LogicalResult getOutputTypeAndPoolingParameters(
       // Height stored at rank-2 and width at rank-1 while the tensor is still
       // in NCHW order; the NHWC transpose happens later.
       paddedShape[inputRank - 2] =
-          addPad(paddedShape[inputRank - 2], paddingInts[0], paddingInts[0]);
+          addPad(paddedShape[inputRank - 2], padHBefore, padHAfter);
       paddedShape[inputRank - 1] =
-          addPad(paddedShape[inputRank - 1], paddingInts[1], paddingInts[1]);
+          addPad(paddedShape[inputRank - 1], padWBefore, padWAfter);
       inputTy = RankedTensorType::get(paddedShape, inputTy.getElementType());
 
       // The TOSA op pad will be zero when we emit explicit NHWC pad.
-      paddingInts.assign(/*Count=*/2, /*Value=*/0);
+      padBefore.assign(/*Count=*/2, /*Value=*/0);
+      padAfter.assign(/*Count=*/2, /*Value=*/0);
     }
   }
 
   // Build the base TOSA pad vector (TOSA expects {top,bottom,left,right}).
-  SmallVector<int64_t, 4> padArr = {paddingInts[0], paddingInts[0],
-                                    paddingInts[1], paddingInts[1]};
+  SmallVector<int64_t, 4> padArr = {padBefore[0], padAfter[0], padBefore[1],
+                                    padAfter[1]};
   kernel = rewriter.getDenseI64ArrayAttr(kernelSizeInts);
   stride = rewriter.getDenseI64ArrayAttr(strideInts);
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2871,10 +2871,24 @@ ONNX_XFAIL_SET = {
     "AtenTopKSmallestModule_basic",
     "Aten_EmbeddingBagExample_basic",
     "AvgPool2dCHWModule_basic",
+    # PyTorch's ONNX exporter emits standard ONNX `ceil_mode`, whose spec
+    # semantics (extra ceil extent split across leading/trailing edges) differ
+    # from PyTorch's own ceil+count_include_pad. The importer is now ONNX-spec
+    # correct (matches onnx.reference), so these round-trip tests -- whose golden
+    # is PyTorch eager -- can no longer pass. The divergence is genuine; see the
+    # AveragePool ceil_mode handling in TorchOnnxToTorch/DefaultDomainAtoF.cpp.
+    "AvgPool2dCeilNoPadStridedIncludePadding_basic",
+    "AvgPool2dCeilPaddingStridedIncludePadding_basic",
     "AvgPool2dSingleIntTupleParamsIncludePadModule_basic",
     "AvgPool2dSingleIntTupleParamsModule_basic",
     "AvgPool2dWithoutPadModule_basic",
     "AvgPool3dSingleIntTupleStrideModule_basic",
+    # For count_include_pad=0 + ceil_mode, ONNX and PyTorch place the ceil
+    # slack differently: for these configs the output shape matches but the
+    # values differ, so the ONNX-correct import cannot match the PyTorch-eager
+    # golden these tests compare against.
+    "AvgPool3dDiffKernelsStridesNoPadCeilPadNotIncluded_basic",
+    "AvgPool3dDiffKernelsStridesPadCeilPadNotIncluded_basic",
     "BatchMlpLayerModule_basic",
     "BincountMinlengthModule_basic",
     "BincountModule_basic",

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_a_to_f.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_a_to_f.mlir
@@ -966,11 +966,87 @@ func.func @test_averagepool_1d_default(%arg0: !torch.vtensor<[1,3,32],f32>) -> !
 
 // -----
 
+// ceil_mode with count_include_pad == 0: the pad-excluding divisor and ONNX's
+// ceil split are resolved by a ones-mask ratio -- pad the input and a ones mask
+// with the ONNX split pads, pool both (count_include_pad, floor mode), then
+// divide. The full-kernel divisor cancels, leaving the valid-element average.
 // CHECK-LABEL: @test_averagepool_2d_ceil
+// CHECK:         %[[PAD_IN:.*]] = torch.aten.constant_pad_nd %arg0, %{{.*}}, %{{.*}} : !torch.vtensor<[1,1,4,4],f32>, !torch.list<int>, !torch.float -> !torch.vtensor<[1,1,?,?],f32>
+// CHECK:         %[[ONES:.*]] = torch.aten.ones_like %arg0
+// CHECK:         %[[PAD_ONES:.*]] = torch.aten.constant_pad_nd %[[ONES]], %{{.*}}, %{{.*}}
+// CHECK:         %[[NUM:.*]] = torch.aten.avg_pool2d %[[PAD_IN]], %{{.*}}, %{{.*}}, %{{.*}}, %false, %true, %none
+// CHECK:         %[[DEN:.*]] = torch.aten.avg_pool2d %[[PAD_ONES]], %{{.*}}, %{{.*}}, %{{.*}}, %false, %true, %none
+// CHECK:         torch.aten.div.Tensor %[[NUM]], %[[DEN]]
 func.func @test_averagepool_2d_ceil(%arg0: !torch.vtensor<[1,1,4,4],f32>) -> !torch.vtensor<[1,1,2,2],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 19 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-  // CHECK: torch.aten.avg_pool2d %arg0, %0, %2, %1, %true, %false, %none : !torch.vtensor<[1,1,4,4],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[1,1,2,2],f32>
   %0 = torch.operator "onnx.AveragePool"(%arg0) {torch.onnx.ceil_mode = 1 : si64, torch.onnx.kernel_shape = [3 : si64, 3 : si64], torch.onnx.strides = [2 : si64, 2 : si64]} : (!torch.vtensor<[1,1,4,4],f32>) -> !torch.vtensor<[1,1,2,2],f32>
   return %0 : !torch.vtensor<[1,1,2,2],f32>
+}
+
+// -----
+
+// ONNX ceil_mode grows the output by splitting the extra extent between the
+// leading and trailing edges, which differs from PyTorch's trailing-only ceil.
+// With count_include_pad set, the divisor is the full kernel area, so the ONNX
+// ceil padding is resolved into explicit (asymmetric) pads and the op is lowered
+// as a plain floor-mode pool -- ceil_mode becomes false and the pad list carries
+// the ONNX split (here H: begin 1, end 2; W: begin/end 1).
+// CHECK-LABEL: @test_averagepool_2d_ceil_count_include_pad
+// CHECK:         %[[PAD:.*]] = torch.prim.ListConstruct %int1, %int1{{.*}}, %int2, %int1{{.*}} : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK:         %[[CEIL:.*]] = torch.constant.bool false
+// CHECK:         %[[CIP:.*]] = torch.constant.bool true
+// CHECK:         torch.aten.avg_pool2d %arg0, %{{.*}}, %{{.*}}, %[[PAD]], %[[CEIL]], %[[CIP]], %none
+func.func @test_averagepool_2d_ceil_count_include_pad(%arg0: !torch.vtensor<[1,2,10,11],f32>) -> !torch.vtensor<[1,2,6,6],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 19 : si64} {
+  %0 = torch.operator "onnx.AveragePool"(%arg0) {torch.onnx.ceil_mode = 1 : si64, torch.onnx.count_include_pad = 1 : si64, torch.onnx.kernel_shape = [3 : si64, 3 : si64], torch.onnx.pads = [1 : si64, 1 : si64, 1 : si64, 1 : si64], torch.onnx.strides = [2 : si64, 2 : si64]} : (!torch.vtensor<[1,2,10,11],f32>) -> !torch.vtensor<[1,2,6,6],f32>
+  return %0 : !torch.vtensor<[1,2,6,6],f32>
+}
+
+// -----
+
+// Same as above but with a dynamic spatial dim: the ONNX ceil split depends on
+// the runtime extent, so it is materialized as a runtime `constant_pad_nd` in
+// front of a zero-padded, floor-mode pool (count_include_pad keeps the injected
+// zeros in the divisor, reproducing ONNX). The pool itself has zero padding and
+// ceil_mode false.
+// CHECK-LABEL: @test_averagepool_2d_ceil_count_include_pad_dynamic
+// The split pads are derived from the runtime extent, including ONNX's
+// trailing-window drop (ge -> Int.bool -> sub) that a plain ceil-div misses.
+// CHECK:         %[[DIM:.*]] = torch.aten.size.int %arg0
+// CHECK:         %[[DROP:.*]] = torch.aten.ge.int %{{.*}}, %{{.*}} : !torch.int, !torch.int -> !torch.bool
+// CHECK:         %[[DROPI:.*]] = torch.aten.Int.bool %[[DROP]]
+// CHECK:         torch.aten.sub.int %{{.*}}, %[[DROPI]]
+// CHECK:         %[[PADLIST:.*]] = torch.prim.ListConstruct %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// CHECK:         %[[PADVAL:.*]] = torch.constant.float 0.000000e+00
+// CHECK:         %[[PADDED:.*]] = torch.aten.constant_pad_nd %arg0, %[[PADLIST]], %[[PADVAL]]
+// CHECK:         %[[ZEROPAD:.*]] = torch.prim.ListConstruct %int0{{.*}}, %int0{{.*}} : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:         %[[CEIL:.*]] = torch.constant.bool false
+// CHECK:         %[[CIP:.*]] = torch.constant.bool true
+// CHECK:         torch.aten.avg_pool2d %[[PADDED]], %{{.*}}, %{{.*}}, %[[ZEROPAD]], %[[CEIL]], %[[CIP]], %none
+func.func @test_averagepool_2d_ceil_count_include_pad_dynamic(%arg0: !torch.vtensor<[1,2,?,?],f32>) -> !torch.vtensor<[1,2,?,?],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 19 : si64} {
+  %0 = torch.operator "onnx.AveragePool"(%arg0) {torch.onnx.ceil_mode = 1 : si64, torch.onnx.count_include_pad = 1 : si64, torch.onnx.kernel_shape = [3 : si64, 3 : si64], torch.onnx.pads = [1 : si64, 1 : si64, 1 : si64, 1 : si64], torch.onnx.strides = [2 : si64, 2 : si64]} : (!torch.vtensor<[1,2,?,?],f32>) -> !torch.vtensor<[1,2,?,?],f32>
+  return %0 : !torch.vtensor<[1,2,?,?],f32>
+}
+
+// -----
+
+// count_include_pad == 0 with a dynamic spatial dim: same ones-mask ratio, but
+// the ONNX split pads are computed with runtime integer arithmetic from the
+// input extent before feeding the two pooled branches.
+// CHECK-LABEL: @test_averagepool_2d_ceil_no_count_include_pad_dynamic
+// The split pads are derived from the runtime extent, including ONNX's
+// trailing-window drop (ge -> Int.bool -> sub) that a plain ceil-div misses.
+// CHECK:         %[[DIM:.*]] = torch.aten.size.int %arg0
+// CHECK:         %[[DROP:.*]] = torch.aten.ge.int %{{.*}}, %{{.*}} : !torch.int, !torch.int -> !torch.bool
+// CHECK:         %[[DROPI:.*]] = torch.aten.Int.bool %[[DROP]]
+// CHECK:         torch.aten.sub.int %{{.*}}, %[[DROPI]]
+// CHECK:         %[[PAD_IN:.*]] = torch.aten.constant_pad_nd %arg0
+// CHECK:         %[[ONES:.*]] = torch.aten.ones_like %arg0
+// CHECK:         %[[PAD_ONES:.*]] = torch.aten.constant_pad_nd %[[ONES]]
+// CHECK:         %[[NUM:.*]] = torch.aten.avg_pool2d %[[PAD_IN]], %{{.*}}, %{{.*}}, %{{.*}}, %false, %true, %none
+// CHECK:         %[[DEN:.*]] = torch.aten.avg_pool2d %[[PAD_ONES]], %{{.*}}, %{{.*}}, %{{.*}}, %false, %true, %none
+// CHECK:         torch.aten.div.Tensor %[[NUM]], %[[DEN]]
+func.func @test_averagepool_2d_ceil_no_count_include_pad_dynamic(%arg0: !torch.vtensor<[1,2,?,?],f32>) -> !torch.vtensor<[1,2,?,?],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 19 : si64} {
+  %0 = torch.operator "onnx.AveragePool"(%arg0) {torch.onnx.ceil_mode = 1 : si64, torch.onnx.count_include_pad = 0 : si64, torch.onnx.kernel_shape = [3 : si64, 3 : si64], torch.onnx.pads = [1 : si64, 1 : si64, 1 : si64, 1 : si64], torch.onnx.strides = [2 : si64, 2 : si64]} : (!torch.vtensor<[1,2,?,?],f32>) -> !torch.vtensor<[1,2,?,?],f32>
+  return %0 : !torch.vtensor<[1,2,?,?],f32>
 }
 
 // -----

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_a_to_f.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_a_to_f.mlir
@@ -1002,6 +1002,31 @@ func.func @test_averagepool_2d_ceil_count_include_pad(%arg0: !torch.vtensor<[1,2
 
 // -----
 
+// Static input but a dynamic result extent: the static "bake the split into the
+// pad attr" path cannot size the split (it would read an unknown result dim), so
+// this must fall through to the runtime `constant_pad_nd` + zero-padded,
+// floor-mode pool path -- the same one used when the input is dynamic. The ONNX
+// split pads are still derived at runtime (size.int / ge / Int.bool / sub), and
+// the pool itself carries zero padding, so the original [1,1] pads must NOT
+// appear as the pool's padding arg on %arg0.
+// The input extent is a compile-time constant here (static input), so the split
+// is derived from constant ints -- but still through the runtime drop logic
+// (ge -> Int.bool -> sub), not the static bake-into-attr path.
+// CHECK-LABEL: @test_averagepool_2d_ceil_count_include_pad_static_in_dynamic_out
+// CHECK:         %[[DROP:.*]] = torch.aten.ge.int %{{.*}}, %{{.*}} : !torch.int, !torch.int -> !torch.bool
+// CHECK:         %[[DROPI:.*]] = torch.aten.Int.bool %[[DROP]]
+// CHECK:         %[[PADDED:.*]] = torch.aten.constant_pad_nd %arg0
+// CHECK:         %[[ZEROPAD:.*]] = torch.prim.ListConstruct %int0{{.*}}, %int0{{.*}} : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK:         %[[CEIL:.*]] = torch.constant.bool false
+// CHECK:         %[[CIP:.*]] = torch.constant.bool true
+// CHECK:         torch.aten.avg_pool2d %[[PADDED]], %{{.*}}, %{{.*}}, %[[ZEROPAD]], %[[CEIL]], %[[CIP]], %none
+func.func @test_averagepool_2d_ceil_count_include_pad_static_in_dynamic_out(%arg0: !torch.vtensor<[1,2,10,11],f32>) -> !torch.vtensor<[1,2,?,?],f32> attributes {torch.onnx_meta.ir_version = 9 : si64, torch.onnx_meta.opset_version = 19 : si64} {
+  %0 = torch.operator "onnx.AveragePool"(%arg0) {torch.onnx.ceil_mode = 1 : si64, torch.onnx.count_include_pad = 1 : si64, torch.onnx.kernel_shape = [3 : si64, 3 : si64], torch.onnx.pads = [1 : si64, 1 : si64, 1 : si64, 1 : si64], torch.onnx.strides = [2 : si64, 2 : si64]} : (!torch.vtensor<[1,2,10,11],f32>) -> !torch.vtensor<[1,2,?,?],f32>
+  return %0 : !torch.vtensor<[1,2,?,?],f32>
+}
+
+// -----
+
 // Same as above but with a dynamic spatial dim: the ONNX ceil split depends on
 // the runtime extent, so it is materialized as a runtime `constant_pad_nd` in
 // front of a zero-padded, floor-mode pool (count_include_pad keeps the injected

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -1230,6 +1230,98 @@ func.func @torch.aten.avg_pool2d$basic(%arg0: !torch.vtensor<[1,512,7,7],f32> ) 
 
 // -----
 
+// A 4-element padding list encodes ONNX-style asymmetric padding
+// [beginH, beginW, endH, endW]. The trailing (end) padding must be honored so
+// the pooled output matches the declared shape; it must not be dropped or
+// turned into an input crop.
+// CHECK-LABEL:   func.func @torch.aten.avg_pool2d$asymmetric_pad(
+// CHECK:           %[[POOL:.*]] = tosa.avg_pool2d %{{.*}} {acc_type = f32, kernel = array<i64: 3, 5>, pad = array<i64: 0, 1, 0, 1>, stride = array<i64: 2, 2>} : (tensor<?x1024x512x3xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x512x255x3xf32>
+// CHECK:           %[[TP:.*]] = tosa.transpose %[[POOL]] {perms = array<i32: 0, 3, 1, 2>} : (tensor<?x512x255x3xf32>) -> tensor<?x3x512x255xf32>
+// CHECK:           tensor.cast %[[TP]] : tensor<?x3x512x255xf32> to tensor<?x3x512x255xf32>
+func.func @torch.aten.avg_pool2d$asymmetric_pad(%arg0: !torch.vtensor<[?,3,1024,512],f32>) -> !torch.vtensor<[?,3,512,255],f32> {
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %int5 = torch.constant.int 5
+  %kernel = torch.prim.ListConstruct %int3, %int5 : (!torch.int, !torch.int) -> !torch.list<int>
+  %stride = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+  %padding = torch.prim.ListConstruct %int0, %int0, %int1, %int1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.avg_pool2d %arg0, %kernel, %stride, %padding, %false, %false, %none : !torch.vtensor<[?,3,1024,512],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,3,512,255],f32>
+  return %0 : !torch.vtensor<[?,3,512,255],f32>
+}
+
+// -----
+
+// count_include_pad=true forces the padding to be materialized as an explicit
+// NHWC tosa.pad so the pool divisor covers the full kernel. The asymmetric
+// extents must survive that detour: the pad grows H and W by only their end
+// padding (8 -> 9 each) and the pool itself is left with pad = 0.
+// CHECK-LABEL:   func.func @torch.aten.avg_pool2d$asymmetric_pad_count_include_pad(
+// CHECK:           %[[PADSHAPE:.*]] = tosa.const_shape  {values = dense<[0, 0, 0, 1, 0, 1, 0, 0]> : tensor<8xindex>} : () -> !tosa.shape<8>
+// CHECK:           %[[PAD:.*]] = tosa.pad %{{.*}}, %[[PADSHAPE]], %{{.*}} : (tensor<?x8x8x3xf32>, !tosa.shape<8>, tensor<1xf32>) -> tensor<?x9x9x3xf32>
+// CHECK:           %[[POOL:.*]] = tosa.avg_pool2d %[[PAD]], %{{.*}}, %{{.*}} {acc_type = f32, kernel = array<i64: 3, 3>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 2, 2>} : (tensor<?x9x9x3xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x4x4x3xf32>
+// CHECK:           %[[TP:.*]] = tosa.transpose %[[POOL]] {perms = array<i32: 0, 3, 1, 2>} : (tensor<?x4x4x3xf32>) -> tensor<?x3x4x4xf32>
+// CHECK:           tensor.cast %[[TP]] : tensor<?x3x4x4xf32> to tensor<?x3x4x4xf32>
+func.func @torch.aten.avg_pool2d$asymmetric_pad_count_include_pad(%arg0: !torch.vtensor<[?,3,8,8],f32>) -> !torch.vtensor<[?,3,4,4],f32> {
+  %none = torch.constant.none
+  %true = torch.constant.bool true
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %kernel = torch.prim.ListConstruct %int3, %int3 : (!torch.int, !torch.int) -> !torch.list<int>
+  %stride = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+  %padding = torch.prim.ListConstruct %int0, %int0, %int1, %int1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.avg_pool2d %arg0, %kernel, %stride, %padding, %false, %true, %none : !torch.vtensor<[?,3,8,8],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,3,4,4],f32>
+  return %0 : !torch.vtensor<[?,3,4,4],f32>
+}
+
+// -----
+
+// The asymmetric form carries a (begin, end) pair per spatial dim, so for a 1D
+// pool it is a 2-element list -- not a 4-element one. Padding only the end of
+// the single spatial axis must land on that axis's pad_after; the synthetic
+// trailing axis added by the 1D->2D expansion stays unpadded.
+// CHECK-LABEL:   func.func @torch.aten.avg_pool1d$asymmetric_pad(
+// CHECK:           tosa.avg_pool2d %{{.*}} {acc_type = f32, kernel = array<i64: 3, 1>, pad = array<i64: 0, 1, 0, 0>, stride = array<i64: 2, 1>} : (tensor<1x10x1x3xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x5x1x3xf32>
+func.func @torch.aten.avg_pool1d$asymmetric_pad(%arg0: !torch.vtensor<[1,3,10],f32>) -> !torch.vtensor<[1,3,5],f32> {
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %kernel = torch.prim.ListConstruct %int3 : (!torch.int) -> !torch.list<int>
+  %stride = torch.prim.ListConstruct %int2 : (!torch.int) -> !torch.list<int>
+  %padding = torch.prim.ListConstruct %int0, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.avg_pool1d %arg0, %kernel, %stride, %padding, %false, %false : !torch.vtensor<[1,3,10],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool -> !torch.vtensor<[1,3,5],f32>
+  return %0 : !torch.vtensor<[1,3,5],f32>
+}
+
+// -----
+
+// A padding list that is neither one extent per spatial dim nor a (begin, end)
+// pair per spatial dim cannot be interpreted, so the lowering must bail rather
+// than silently read the first two entries as the symmetric H/W extents.
+func.func @torch.aten.avg_pool2d$unsupported_pad_arity(%arg0: !torch.vtensor<[1,3,8,8],f32>) -> !torch.vtensor<[1,3,4,4],f32> {
+  %none = torch.constant.none
+  %false = torch.constant.bool false
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %kernel = torch.prim.ListConstruct %int3, %int3 : (!torch.int, !torch.int) -> !torch.list<int>
+  %stride = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+  %padding = torch.prim.ListConstruct %int1, %int1, %int1 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  // expected-error @+1 {{failed to legalize operation 'torch.aten.avg_pool2d'}}
+  %0 = torch.aten.avg_pool2d %arg0, %kernel, %stride, %padding, %false, %false, %none : !torch.vtensor<[1,3,8,8],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[1,3,4,4],f32>
+  return %0 : !torch.vtensor<[1,3,4,4],f32>
+}
+
+// -----
+
 // CHECK-LABEL:   func.func @torch.aten.max.dim$basic(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<3x2x3xf32>) -> tensor<3x2x1xf32> {
 // CHECK:           %[[VAL_1:.*]] = torch_c.from_builtin_tensor %[[VAL_0]] : tensor<3x2x3xf32> -> !torch.vtensor<[3,2,3],f32>
@@ -5306,6 +5398,67 @@ func.func @torch.aten.max_pool2d$full_dim_indivisible_by_stride_with_sliced_inpu
   %false = torch.constant.bool false
   %4 = torch.aten.max_pool2d %arg0, %0, %1, %2, %3, %false : !torch.vtensor<[1,1,75,75],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool -> !torch.vtensor<[1,1,25,25],f32>
   return %4 : !torch.vtensor<[1,1,25,25],f32>
+}
+
+// -----
+
+// A 4-element padding list encodes ONNX-style asymmetric padding
+// [beginH, beginW, endH, endW]. The trailing (end) padding must be honored so
+// the pooled output matches the declared shape; it must not be dropped or
+// turned into an input crop.
+//
+// No importer currently feeds max_pool an asymmetric list -- the ONNX MaxPool
+// legalization materializes those pads as an `aten.constant_pad_nd` and zeroes
+// the padding arg. This covers the shared pad-vector construction so the two
+// pooling families cannot drift.
+// CHECK-LABEL:   func.func @torch.aten.max_pool2d$asymmetric_pad(
+// CHECK:           %[[POOL:.*]] = tosa.max_pool2d %{{.*}} {kernel = array<i64: 3, 5>, pad = array<i64: 0, 1, 0, 1>, stride = array<i64: 2, 2>} : (tensor<?x1024x512x3xf32>) -> tensor<?x512x255x3xf32>
+// CHECK:           %[[TP:.*]] = tosa.transpose %[[POOL]] {perms = array<i32: 0, 3, 1, 2>} : (tensor<?x512x255x3xf32>) -> tensor<?x3x512x255xf32>
+// CHECK:           tensor.cast %[[TP]] : tensor<?x3x512x255xf32> to tensor<?x3x512x255xf32>
+func.func @torch.aten.max_pool2d$asymmetric_pad(%arg0: !torch.vtensor<[?,3,1024,512],f32>) -> !torch.vtensor<[?,3,512,255],f32> {
+  %false = torch.constant.bool false
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %int5 = torch.constant.int 5
+  %kernel = torch.prim.ListConstruct %int3, %int5 : (!torch.int, !torch.int) -> !torch.list<int>
+  %stride = torch.prim.ListConstruct %int2, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+  %padding = torch.prim.ListConstruct %int0, %int0, %int1, %int1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %dilation = torch.prim.ListConstruct %int1, %int1 : (!torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.max_pool2d %arg0, %kernel, %stride, %padding, %dilation, %false : !torch.vtensor<[?,3,1024,512],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool -> !torch.vtensor<[?,3,512,255],f32>
+  return %0 : !torch.vtensor<[?,3,512,255],f32>
+}
+
+// -----
+
+// Asymmetric padding on both spatial dims where one dim (H) additionally needs
+// its trailing region sliced off. H arrives with a non-zero pad_after (1, 2) and
+// a tail that is indivisible by the stride, so the slice crops H (27 -> 26) and
+// consumes H's pad_after entirely, leaving (pad_before=1, pad_after=0) -- still
+// asymmetric, and pad_before must survive untouched. W is asymmetric but
+// stride-aligned, so it keeps its (0, 1) pad and is not cropped.
+// CHECK-LABEL:   func.func @torch.aten.avg_pool2d$asymmetric_pad_with_sliced_input(
+// CHECK-DAG:       %[[SLICE_START:.*]] = tosa.const_shape  {values = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:       %[[SLICE_SHAPE:.*]] = tosa.const_shape  {values = dense<[-1, 26, 512, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK:           %[[SLICE:.*]] = tosa.slice %{{.*}}, %[[SLICE_START]], %[[SLICE_SHAPE]] : (tensor<?x27x512x3xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<?x26x512x3xf32>
+// CHECK:           %[[POOL:.*]] = tosa.avg_pool2d %[[SLICE]], %{{.*}}, %{{.*}} {acc_type = f32, kernel = array<i64: 3, 5>, pad = array<i64: 1, 0, 0, 1>, stride = array<i64: 4, 2>} : (tensor<?x26x512x3xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<?x7x255x3xf32>
+// CHECK:           %[[TP:.*]] = tosa.transpose %[[POOL]] {perms = array<i32: 0, 3, 1, 2>} : (tensor<?x7x255x3xf32>) -> tensor<?x3x7x255xf32>
+// CHECK:           tensor.cast %[[TP]] : tensor<?x3x7x255xf32> to tensor<?x3x7x255xf32>
+func.func @torch.aten.avg_pool2d$asymmetric_pad_with_sliced_input(%arg0: !torch.vtensor<[?,3,27,512],f32>) -> !torch.vtensor<[?,3,7,255],f32> {
+  %false = torch.constant.bool false
+  %none = torch.constant.none
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %int4 = torch.constant.int 4
+  %int5 = torch.constant.int 5
+  %kernel = torch.prim.ListConstruct %int3, %int5 : (!torch.int, !torch.int) -> !torch.list<int>
+  %stride = torch.prim.ListConstruct %int4, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+  %padding = torch.prim.ListConstruct %int1, %int0, %int2, %int1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %0 = torch.aten.avg_pool2d %arg0, %kernel, %stride, %padding, %false, %false, %none : !torch.vtensor<[?,3,27,512],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,3,7,255],f32>
+  return %0 : !torch.vtensor<[?,3,7,255],f32>
 }
 
 // -----


### PR DESCRIPTION
The ONNX AvgPool importer encodes asymmetric padding as a `2 * spatialRank` torch list `[begin..., end...]`, since the aten schema only has room for one symmetric extent per spatial dim. The TOSA pooling lowering assumed the symmetric form and read only `paddingInts[0]`/`[1]`, mirroring the *begin* values as the *end* padding.

For a trailing-only pad (e.g. `[0, 0, 1, 1]` on `avg_pool2d`) the end padding was dropped — the input got cropped instead of padded, producing an output one element short per affected spatial dim. 1D ops fail the same way on a 2-element list, tripping the `tosa.avg_pool2d` pad-vs-kernel verifier.