### PR TITLE
[TorchOnnxToTorch] Fix LRN dynamic batch reshape

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -2828,8 +2828,30 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
               binder.op, "Unsupported: the second dimension size must be "
                          "statically known");
         }
+        // Collapse the trailing spatial dims (inTyShape[3:]) into a single
+        // dimension. Compute it statically when all trailing dims are known so
+        // that dim0 (the batch dim) stays the only dynamic dim. Falling back to
+        // kUnknownSize here would introduce a second inferred (-1) dimension
+        // when the batch dim is also dynamic, which is an invalid reshape.
+        int64_t trailingDim = 1;
+        for (int64_t d : inTyShape.drop_front(3)) {
+          if (d == Torch::kUnknownSize) {
+            trailingDim = Torch::kUnknownSize;
+            break;
+          }
+          trailingDim *= d;
+        }
         SmallVector<int64_t, 5> viewShapeInt{inTyShape[0], 1, inTyShape[1],
-                                             inTyShape[2], Torch::kUnknownSize};
+                                             inTyShape[2], trailingDim};
+        // aten.view infers at most one dimension (a single -1). The batch dim,
+        // the spatial dim inTyShape[2], and the collapsed trailing dim can each
+        // be dynamic; if more than one is, the reshape has multiple inferred
+        // dimensions and is invalid. Bail out cleanly.
+        if (llvm::count(viewShapeInt, Torch::kUnknownSize) > 1) {
+          return rewriter.notifyMatchFailure(
+              binder.op, "Unsupported: at most one of the batch, spatial, and "
+                         "collapsed trailing dimensions may be dynamic");
+        }
         Torch::ValueTensorType reshapeType =
             rewriter.getType<Torch::ValueTensorType>(viewShapeInt, dtype);
         Value viewShapeListVal =

--- a/test/Conversion/TorchOnnxToTorch/lrn_diagnostics.mlir
+++ b/test/Conversion/TorchOnnxToTorch/lrn_diagnostics.mlir
@@ -1,0 +1,11 @@
+// RUN: torch-mlir-opt %s -split-input-file -verify-diagnostics -convert-torch-onnx-to-torch
+
+// LRN reshapes the input to [N, 1, C, H, W_collapsed]. aten.view infers at most
+// one dimension, so at most one of the batch, spatial (H), and collapsed
+// trailing dims may be dynamic. With both the batch and a trailing dim dynamic
+// the reshape would need two inferred dimensions, so the conversion bails out.
+func.func @test_lrn_multiple_dynamic_dims(%arg0: !torch.vtensor<[?,96,55,?],f32>) -> !torch.vtensor<[?,96,55,?],f32> attributes {torch.onnx_meta.opset_version = 17 : si64} {
+  // expected-error @below {{failed to legalize operation 'torch.operator' that was explicitly marked illegal}}
+  %0 = torch.operator "onnx.LRN"(%arg0) {torch.onnx.size = 5 : si64} : (!torch.vtensor<[?,96,55,?],f32>) -> !torch.vtensor<[?,96,55,?],f32>
+  return %0 : !torch.vtensor<[?,96,55,?],f32>
+}

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_g_to_p.mlir
@@ -434,8 +434,8 @@ func.func @test_lrn_default(%arg0: !torch.vtensor<[20,10,3,50],f32>) -> !torch.v
     // CHECK-DAG: %[[I1:.*]] = torch.constant.int 1
     // CHECK-DAG: %[[I10:.*]] = torch.constant.int 10
     // CHECK-DAG: %[[I3:.+]] = torch.constant.int 3
-    // CHECK-DAG: %[[IMINUS1:.+]] = torch.constant.int -1
-    // CHECK-DAG: %[[VIEWSHAPE:.*]] = torch.prim.ListConstruct %[[I20]], %[[I1]], %[[I10]], %[[I3]], %[[IMINUS1]]
+    // CHECK-DAG: %[[I50:.+]] = torch.constant.int 50
+    // CHECK-DAG: %[[VIEWSHAPE:.*]] = torch.prim.ListConstruct %[[I20]], %[[I1]], %[[I10]], %[[I3]], %[[I50]]
 
     // CHECK-DAG: %[[VIEW1:.*]] = torch.aten.view %[[INSQ]], %[[VIEWSHAPE]]
 
@@ -499,8 +499,8 @@ func.func @test_lrn_with_optionals(%arg0: !torch.vtensor<[13,19,100,200],f32>) -
     // CHECK-DAG: %[[I1:.*]] = torch.constant.int 1
     // CHECK-DAG: %[[I19:.*]] = torch.constant.int 19
     // CHECK-DAG: %[[I100:.+]] = torch.constant.int 100
-    // CHECK-DAG: %[[IMINUS1:.+]] = torch.constant.int -1
-    // CHECK-DAG: %[[VIEWSHAPE:.*]] = torch.prim.ListConstruct %[[I13]], %[[I1]], %[[I19]], %[[I100]], %[[IMINUS1]]
+    // CHECK-DAG: %[[I200:.+]] = torch.constant.int 200
+    // CHECK-DAG: %[[VIEWSHAPE:.*]] = torch.prim.ListConstruct %[[I13]], %[[I1]], %[[I19]], %[[I100]], %[[I200]]
 
     // CHECK-DAG: %[[VIEW1:.*]] = torch.aten.view %[[INSQ]], %[[VIEWSHAPE]]
 
@@ -547,6 +547,25 @@ func.func @test_lrn_with_optionals(%arg0: !torch.vtensor<[13,19,100,200],f32>) -
     %none = torch.constant.none
     %0 = torch.operator "onnx.LRN"(%arg0) {torch.onnx.alpha = 2.000000e-03 : f32, torch.onnx.beta = 6.500000e-01 : f32, torch.onnx.bias = 3.000000e+00 : f32, torch.onnx.size = 5 : si64} : (!torch.vtensor<[13,19,100,200],f32>) -> !torch.vtensor<[13,19,100,200],f32>
     return %0 : !torch.vtensor<[13,19,100,200],f32>
+}
+
+// -----
+
+// With a dynamic batch dim, the 5D reshape must keep dim0 (batch) as the only
+// dynamic dimension. The trailing dim is the static product of the input's
+// trailing dims (55), not an inferred -1 that would create a second dynamic dim
+// and make the reshape invalid.
+// CHECK-LABEL: func.func @test_lrn_dynamic_batch
+func.func @test_lrn_dynamic_batch(%arg0: !torch.vtensor<[?,96,55,55],f32>) -> !torch.vtensor<[?,96,55,55],f32> attributes {torch.onnx_meta.opset_version = 17 : si64} {
+    // CHECK-DAG: %[[IMINUS1:.+]] = torch.constant.int -1
+    // CHECK-DAG: %[[I1:.*]] = torch.constant.int 1
+    // CHECK-DAG: %[[I96:.*]] = torch.constant.int 96
+    // CHECK-DAG: %[[I55:.*]] = torch.constant.int 55
+    // CHECK-DAG: %[[I55_2:.*]] = torch.constant.int 55
+    // CHECK-DAG: %[[VIEWSHAPE:.*]] = torch.prim.ListConstruct %[[IMINUS1]], %[[I1]], %[[I96]], %[[I55]], %[[I55_2]]
+    // CHECK-DAG: %[[VIEW1:.*]] = torch.aten.view %{{.*}}, %[[VIEWSHAPE]] : !torch.vtensor<[?,96,55,55],f32>, !torch.list<int> -> !torch.vtensor<[?,1,96,55,55],f32>
+    %0 = torch.operator "onnx.LRN"(%arg0) {torch.onnx.size = 5 : si64} : (!torch.vtensor<[?,96,55,55],f32>) -> !torch.vtensor<[?,96,55,55],f32>
+    return %0 : !torch.vtensor<[?,96,55,55],f32>
 }
 
 // -----


### PR DESCRIPTION
The ONNX LRN lowering reshapes the input to a 5D tensor [N, 1, C, d0, ...] for a 3D average pool over the channel dim. The trailing dimension was always set to -1 (inferred), which is fine when only that dimension is dynamic. But when the batch dim N is also dynamic, the reshape target ends up with two inferred dimensions, which is invalid: downstream reshape legalization emits an unconditional 'cf.assert %false, "must have at most one inferred (negative) dimension"' that always fails at runtime.

Compute the trailing dimension as the static product of the input's trailing dims when they are known, so the batch dim remains the only dynamic dimension. Falls back to -1 only if a trailing dim is itself dynamic, preserving prior behavior for the static-batch case.

The reshape can still hit multiple inferred dimensions when more than one of the batch, spatial (H), and collapsed trailing dims is dynamic. Guard against that and bail out with a clean match failure instead of emitting the always-failing runtime assert.