### PR TITLE
[fx_importer] Lift non-persistent buffers from ExportedProgram.constants

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -960,12 +960,19 @@ class FxImporter:
                     ) from e
                 arg_replacements[input_name] = state_value
 
-        # Always lift buffers.
+        # Always lift buffers. A buffer registered with `persistent=False` is
+        # recorded in `prog.constants` rather than in `prog.state_dict`, but is
+        # still listed in `inputs_to_buffers`, so both have to be consulted.
+        buffer_constants = getattr(prog, "constants", None) or {}
         for input_name, state_name in sig.inputs_to_buffers.items():
-            try:
+            if state_name in state_dict:
                 state_value = state_dict[state_name]
-            except KeyError as e:
-                raise AssertionError("Could not find state mapping for buffer") from e
+            elif state_name in buffer_constants:
+                state_value = buffer_constants[state_name]
+            else:
+                raise AssertionError(
+                    f"Could not find state mapping for buffer '{state_name}'"
+                )
             arg_replacements[input_name] = state_value
 
         # Lift parameters.

--- a/test/python/fx_importer/basic_test.py
+++ b/test/python/fx_importer/basic_test.py
@@ -65,6 +65,33 @@ def test_import_frozen_exported_program():
 
 
 @run
+# CHECK-LABEL: test_import_frozen_exported_program_with_non_persistent_buffer
+# CHECK:     func.func @main(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32>
+# CHECK-DAG: %[[tanh:.+]] = torch.aten.tanh %[[ARG0]]
+# CHECK-DAG: %[[nb:.+]] = torch.vtensor.literal({{.*}}) : !torch.vtensor<[3,1],f32>
+# CHECK-DAG: %[[mul_nb:.+]] = torch.aten.mul.Tensor %[[tanh]], %[[nb]]
+# CHECK-DAG: %[[b:.+]] = torch.vtensor.literal({{.*}}) : !torch.vtensor<[3,1],f32>
+# CHECK-DAG: %[[mul_b:.+]] = torch.aten.mul.Tensor %[[mul_nb]], %[[b]]
+# CHECK:     return %[[mul_b]]
+def test_import_frozen_exported_program_with_non_persistent_buffer():
+    # A buffer registered with persistent=False is recorded in
+    # ExportedProgram.constants rather than in its state_dict, while still
+    # being listed in graph_signature.inputs_to_buffers. Both kinds must be
+    # frozen into literals, leaving the input as the only function argument.
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("nb", torch.randn(3, 1), persistent=False)
+            self.register_buffer("b", torch.randn(3, 1), persistent=True)
+
+        def forward(self, x):
+            return torch.tanh(x) * self.nb * self.b
+
+    m = fx.export_and_import(Basic(), torch.randn(3, 4))
+    print(m)
+
+
+@run
 # CHECK-LABEL: test_import_frozen_exported_program_with_func_name
 # CHECK:     func.func @test_net(%[[ARG0:[a-zA-Z0-9]+]]: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32>
 def test_import_frozen_exported_program_with_func_name():


### PR DESCRIPTION
Fixes #4744.

`torch.export` records a buffer registered with `persistent=False` in `ExportedProgram.constants` rather than in `state_dict`, while still listing it in `graph_signature.inputs_to_buffers`.

Since #4658 ("Always lift buffers when importing frozen programs") the buffer-lifting loop runs unconditionally and consults only `state_dict`, so importing any module owning such a buffer fails with `Could not find state mapping for buffer`. Before that change the loop sat in the `else` branch of `if hasattr(prog, "constants")` and so never ran on a PyTorch new enough to have `constants` — which is what had been keeping this path safe since #2902 ("[fx_importer] Convert non-persistent buffers lifted as tensor constants").

This consults `constants` as well, and names the offending buffer in the assertion so the next such failure is easier to place.

It affects most current LLMs: HuggingFace's RoPE implementations register `rotary_emb.inv_freq` as a non-persistent buffer, so `Qwen/Qwen3-0.6B` cannot be imported without it. With this change it imports and lowers to StableHLO, and `inv_freq` is frozen into a literal rather than left as a dangling `main` argument.

### Testing

Adds `test_import_frozen_exported_program_with_non_persistent_buffer` to `test/python/fx_importer/basic_test.py`, covering a module with one non-persistent and one persistent buffer. It asserts both are frozen into literals and that the input stays the only argument of `main`.

Verified both ways against `401dfc29`:

- Without the fix the new test fails with `AssertionError: Could not find state mapping for buffer`, raised from `fx_importer.py:968`.
- With the fix `basic_test.py` passes `FileCheck` in full.

`black` (24.4.2, per `.pre-commit-config.yaml`) reports both changed files unchanged.
