### PR TITLE
[onnx-e2e] Add ONNX-native op e2e test framework

### DIFF
--- a/build_tools/ci/test_posix.sh
+++ b/build_tools/ci/test_posix.sh
@@ -8,8 +8,16 @@ torch_version="${1:-unknown}"
 
 export PYTHONPATH="$repo_root/build/tools/torch-mlir/python_packages/torch_mlir:$repo_root/projects/pt1"
 
-echo "::group::Run ONNX e2e integration tests"
+echo "::group::Run ONNX exported from torch authored op e2e integration tests"
 python3 -m e2e_testing.main --config=onnx -v
+echo "::endgroup::"
+
+echo "::group::Run ONNX authored op e2e integration tests (linalg)"
+python3 -m onnx_e2e_test.main --config linalg -v
+echo "::endgroup::"
+
+echo "::group::Run ONNX authored op e2e integration tests (TOSA)"
+python3 -m onnx_e2e_test.main --config tosa -v
 echo "::endgroup::"
 
 case $torch_version in

--- a/projects/pt1/python/CMakeLists.txt
+++ b/projects/pt1/python/CMakeLists.txt
@@ -42,6 +42,9 @@ if(TORCH_MLIR_ENABLE_JIT_IR_IMPORTER)
   add_subdirectory(torch_mlir/jit_ir_importer)
   add_subdirectory(torch_mlir/csrc/jit_ir_importer)
   add_subdirectory(torch_mlir_e2e_test)
+  # onnx_e2e_test reuses the torch_mlir_e2e_test harness (framework,
+  # reporting, backends), so it is only built when that suite is.
+  add_subdirectory(onnx_e2e_test)
 endif()
 
 ################################################################################
@@ -60,6 +63,7 @@ if(TORCH_MLIR_ENABLE_JIT_IR_IMPORTER)
     TorchMLIRJITIRImporter
     TorchMLIRJITIRImporterPybind
     TorchMLIRE2ETestPythonModules
+    OnnxE2ETestPythonModules
   )
 endif()
 

--- a/projects/pt1/python/onnx_e2e_test/CMakeLists.txt
+++ b/projects/pt1/python/onnx_e2e_test/CMakeLists.txt
@@ -1,0 +1,14 @@
+declare_mlir_python_sources(OnnxE2ETestPythonSources)
+
+declare_mlir_python_sources(OnnxE2ETestPythonSources.Core
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+  ADD_TO_PARENT OnnxE2ETestPythonSources
+  SOURCES_GLOB
+    *.py
+)
+
+add_mlir_python_modules(OnnxE2ETestPythonModules
+  ROOT_PREFIX "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/onnx_e2e_test"
+  INSTALL_PREFIX "python_packages/torch_mlir/onnx_e2e_test"
+  DECLARED_SOURCES OnnxE2ETestPythonSources
+  )

--- a/projects/pt1/python/onnx_e2e_test/__init__.py
+++ b/projects/pt1/python/onnx_e2e_test/__init__.py
@@ -1,0 +1,12 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+from .framework import (
+    OnnxTest,
+    OnnxTestCase,
+    annotate_inputs,
+    build_model,
+)
+from .registry import GLOBAL_ONNX_TEST_REGISTRY, register_onnx_test

--- a/projects/pt1/python/onnx_e2e_test/config.py
+++ b/projects/pt1/python/onnx_e2e_test/config.py
@@ -1,0 +1,262 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""
+Golden-vs-backend evaluation for ONNX-native end-to-end tests.
+
+Provides two functions:
+  - run_golden: run an onnx.ModelProto through onnx.reference.ReferenceEvaluator
+  - run_backend: compile the same ModelProto through a torch-mlir backend
+
+Both return a list of torch.Tensor so the existing torch_mlir_e2e_test
+reporting/compare layer (torch.allclose) can be reused.
+"""
+
+from typing import List
+
+import numpy as np
+import onnx
+import torch
+
+import onnx.reference
+
+from torch_mlir.compiler_utils import (
+    OutputType,
+    TensorPlaceholder,
+    lower_mlir_module,
+    run_pipeline_with_repro_report,
+)
+from torch_mlir_e2e_test.configs.onnx_backend import import_onnx
+from torch_mlir_e2e_test.configs.utils import recursively_convert_from_numpy
+
+from .framework import _INPUT_RANGE_ATTR
+
+# Torch-MLIR execution backends
+from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import (
+    RefBackendLinalgOnTensorsBackend,
+)
+from torch_mlir_e2e_test.tosa_backends.linalg_on_tensors import (
+    LinalgOnTensorsTosaBackend,
+)
+
+# ---------------------------------------------------------------------------
+# Input materialisation
+# ---------------------------------------------------------------------------
+
+_DYNAMIC_DIM_PLACEHOLDER = 2
+
+
+def _numpy_dtype_for_torch(dtype: torch.dtype) -> np.dtype:
+    """Map a torch.dtype to a numpy dtype for seeding input arrays."""
+    try:
+        return torch.empty((), dtype=dtype).numpy().dtype
+    except TypeError as e:
+        raise ValueError(
+            f"Unsupported torch dtype for input generation: {dtype}"
+        ) from e
+
+
+def _is_integer_dtype(np_dtype: np.dtype) -> bool:
+    return np.issubdtype(np_dtype, np.integer) or np_dtype == np.bool_
+
+
+def materialize_inputs(
+    inputs: List[TensorPlaceholder],
+    seed: int = 0,
+) -> List[np.ndarray]:
+    """Materialise seeded numpy arrays from a list of TensorPlaceholder specs.
+
+    Dynamic dimensions (shape element == -1) are replaced with
+    ``_DYNAMIC_DIM_PLACEHOLDER`` (2) so BOTH golden and SUT receive the same
+    concrete tensors.
+
+    A placeholder may carry an optional ``(low, high)`` range (set by
+    ``@annotate_inputs``) overriding the default sampling range for float and
+    integer inputs; bool inputs ignore it.
+
+    Args:
+        inputs: Ordered list of TensorPlaceholder input specs.
+        seed: RNG seed (default 0) — MUST be the same for golden and SUT.
+
+    Returns:
+        A list of numpy arrays, one per placeholder, in the same order.
+    """
+    rng = np.random.default_rng(seed)
+    arrays: List[np.ndarray] = []
+    for placeholder in inputs:
+        shape = tuple(
+            d if d >= 0 else _DYNAMIC_DIM_PLACEHOLDER for d in placeholder.shape
+        )
+        np_dtype = _numpy_dtype_for_torch(placeholder.dtype)
+        value_range = getattr(placeholder, _INPUT_RANGE_ATTR, None)
+        # Default to torch_mlir_e2e_test.TestUtils defaults: floats uniform
+        # [0, 1), ints uniform [0, 10), bools [0, 2).
+        if np_dtype == np.bool_:
+            arr = rng.integers(0, 2, size=shape, dtype=np.bool_)
+        elif _is_integer_dtype(np_dtype):
+            low, high = value_range if value_range is not None else (0, 10)
+            arr = rng.integers(low, high, size=shape, dtype=np_dtype)
+        else:
+            low, high = value_range if value_range is not None else (0.0, 1.0)
+            arr = rng.uniform(low, high, size=shape).astype(np_dtype)
+        arrays.append(arr)
+    return arrays
+
+
+# ---------------------------------------------------------------------------
+# Golden evaluation via onnx.reference
+# ---------------------------------------------------------------------------
+
+
+def run_golden(
+    model_proto: onnx.ModelProto,
+    numpy_inputs: List[np.ndarray],
+) -> List[torch.Tensor]:
+    """Run *model_proto* through ``onnx.reference.ReferenceEvaluator``.
+
+    Args:
+        model_proto: The ONNX model.
+        numpy_inputs: Concrete input arrays, one per graph input, in order.
+
+    Returns:
+        A list of torch.Tensor outputs.
+    """
+    input_names = [inp.name for inp in model_proto.graph.input]
+    feed = {name: arr for name, arr in zip(input_names, numpy_inputs)}
+    sess = onnx.reference.ReferenceEvaluator(model_proto)
+    raw_outputs = sess.run(None, feed)
+    return [recursively_convert_from_numpy(out) for out in raw_outputs]
+
+
+# ---------------------------------------------------------------------------
+# SUT evaluation via a torch-mlir Linalg backend
+# ---------------------------------------------------------------------------
+
+_BACKEND_LEGAL_OPS = [
+    "aten.flatten.using_ints",
+    "aten.adaptive_avg_pool1d",
+    "aten.unflatten.int",
+]
+_ONNX_TO_TORCH_PIPELINE = (
+    "builtin.module(torch-onnx-to-torch-backend-pipeline"
+    "{backend-legal-ops=" + ",".join(_BACKEND_LEGAL_OPS) + "})"
+)
+
+
+def run_backend(
+    model_proto: onnx.ModelProto,
+    numpy_inputs: List[np.ndarray],
+    output_type: str = "linalg-on-tensors",
+    backend=None,
+) -> List[torch.Tensor]:
+    """Compile *model_proto* through a torch-mlir backend and run it.
+
+    The ModelProto is serialised, imported via ``import_onnx``, lowered from
+    the ONNX dialect to the Torch backend contract, then to *output_type*
+    (``"linalg-on-tensors"`` or ``"tosa"``).  The resulting module is compiled
+    and executed through *backend* (a ``compile``/``load`` backend whose
+    ``load`` returns an object exposing a ``main_graph`` invoker).  Both the
+    Linalg and the TOSA backend ultimately execute on linalg via RefBackend,
+    so numeric results are directly comparable to the golden.
+
+    Args:
+        model_proto: The ONNX model.
+        numpy_inputs: Concrete input arrays matching the model inputs.
+        output_type: torch-mlir OutputType to lower to.
+        backend: Backend instance; defaults to the Linalg backend.
+
+    Returns:
+        A list of torch.Tensor outputs.
+    """
+    if backend is None:
+        backend = RefBackendLinalgOnTensorsBackend()
+
+    # Serialise once.
+    serialized = model_proto.SerializeToString()
+
+    # Import to MLIR.
+    mlir_module = import_onnx(serialized)
+
+    # Lower ONNX dialect -> Torch backend contract.
+    run_pipeline_with_repro_report(
+        mlir_module,
+        _ONNX_TO_TORCH_PIPELINE,
+        "Lowering ONNX Raw IR -> Torch Backend IR",
+    )
+
+    # Lower Torch backend contract -> requested backend dialect.
+    backend_module = lower_mlir_module(
+        verbose=False, output_type=OutputType.get(output_type), module=mlir_module
+    )
+
+    # Compile and run.
+    compiled = backend.compile(backend_module)
+    invoker = backend.load(compiled)
+
+    raw_outputs = invoker.main_graph(*numpy_inputs)
+
+    # Normalise: a backend may return a single ndarray or a tuple.
+    if isinstance(raw_outputs, np.ndarray):
+        raw_outputs = (raw_outputs,)
+
+    return [recursively_convert_from_numpy(out) for out in raw_outputs]
+
+
+# ---------------------------------------------------------------------------
+# Test configs — pair golden (onnx.reference) with a SUT backend
+# ---------------------------------------------------------------------------
+
+
+class OnnxLinalgTestConfig:
+    """Golden (onnx.reference) + SUT lowered to linalg-on-tensors on the Linalg backend.
+
+    Usage::
+
+        cfg = OnnxLinalgTestConfig()
+        golden_outputs = cfg.run_golden(model_proto, numpy_inputs)
+        sut_outputs = cfg.run_backend(model_proto, numpy_inputs)
+        # compare with torch.allclose …
+    """
+
+    def run_golden(
+        self,
+        model_proto: onnx.ModelProto,
+        numpy_inputs: List[np.ndarray],
+    ) -> List[torch.Tensor]:
+        return run_golden(model_proto, numpy_inputs)
+
+    def run_backend(
+        self,
+        model_proto: onnx.ModelProto,
+        numpy_inputs: List[np.ndarray],
+    ) -> List[torch.Tensor]:
+        return run_backend(model_proto, numpy_inputs)
+
+
+class OnnxTosaBackendTestConfig:
+    """Golden (onnx.reference) + SUT lowered to TOSA, executed via linalg.
+
+    Lowers the imported model to the ``tosa`` dialect, then compiles it with
+    ``LinalgOnTensorsTosaBackend`` (TOSA -> linalg -> RefBackend) so numeric
+    results are comparable to the golden.
+    """
+
+    def run_golden(
+        self,
+        model_proto: onnx.ModelProto,
+        numpy_inputs: List[np.ndarray],
+    ) -> List[torch.Tensor]:
+        return run_golden(model_proto, numpy_inputs)
+
+    def run_backend(
+        self,
+        model_proto: onnx.ModelProto,
+        numpy_inputs: List[np.ndarray],
+    ) -> List[torch.Tensor]:
+        return run_backend(
+            model_proto,
+            numpy_inputs,
+            output_type="tosa",
+            backend=LinalgOnTensorsTosaBackend(),
+        )

--- a/projects/pt1/python/onnx_e2e_test/framework.py
+++ b/projects/pt1/python/onnx_e2e_test/framework.py
@@ -1,0 +1,257 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""
+End-to-end testing framework for ONNX-native tests.
+
+A test in this framework is described by an ``OnnxTest`` — a stable name,
+a zero-argument factory that builds an ``onnx.ModelProto``, and a list of
+``TensorPlaceholder`` input specs.
+"""
+
+from typing import Callable, List, NamedTuple, Optional, Tuple
+
+import torch
+import onnx
+import onnx.helper
+
+from torch_mlir.compiler_utils import TensorPlaceholder
+
+
+# ---------------------------------------------------------------------------
+# OnnxTest — the fundamental test descriptor
+# ---------------------------------------------------------------------------
+
+
+class OnnxTest(NamedTuple):
+    """A description of an ONNX end-to-end test case.
+
+    Attributes:
+        unique_name: Stable identifier used for error reporting and registry
+            deduplication.
+        model_factory: Zero-argument callable that builds and returns an
+            ``onnx.ModelProto``.  Only invoked when the runner executes the
+            test, so imports stay cheap and ``--filter`` skips building
+            unselected models (each build runs the reference evaluator).
+        inputs: Ordered list of ``TensorPlaceholder`` instances describing
+            the shape and dtype of each model input.  Step 3 (golden
+            generation) materialises seeded numpy arrays from these specs.
+    """
+
+    unique_name: str
+    model_factory: Callable[[], onnx.ModelProto]
+    inputs: List[TensorPlaceholder]
+
+
+# ---------------------------------------------------------------------------
+# build_model — convenience helper
+# ---------------------------------------------------------------------------
+
+# Opset 17 / IR version 8: a broadly supported, stable baseline.  Single-sourced
+# so the probe and final models can't declare mismatched versions.
+_DEFAULT_OPSET = 17
+_DEFAULT_IR_VERSION = 8
+
+
+def build_model(
+    nodes: list,
+    inputs: list,
+    outputs: list,
+    initializers: Optional[list] = None,
+    opset: int = _DEFAULT_OPSET,
+    ir_version: int = _DEFAULT_IR_VERSION,
+    validate: bool = True,
+) -> onnx.ModelProto:
+    """Build an ``onnx.ModelProto`` with the graph name hard-coded to
+    ``"main_graph"``.
+
+    The ``"main_graph"`` name is required because the RefBackend invocation
+    calls the compiled symbol by that name.
+
+    Args:
+        nodes: List of ``onnx.NodeProto`` objects (from
+            ``onnx.helper.make_node``).
+        inputs: List of ``onnx.ValueInfoProto`` objects describing graph
+            inputs (from ``onnx.helper.make_tensor_value_info``).
+        outputs: List of ``onnx.ValueInfoProto`` objects describing graph
+            outputs.
+        initializers: Optional list of ``onnx.TensorProto`` weight tensors.
+        opset: ONNX opset version (default ``_DEFAULT_OPSET``).
+        ir_version: ONNX IR version (default ``_DEFAULT_IR_VERSION``).
+        validate: Run ``onnx.checker.check_model`` (default True).  Set False
+            for the pass-1 probe model, whose outputs are intentionally
+            shapeless (the checker requires a shape).
+
+    Returns:
+        An ``onnx.ModelProto`` (validated unless ``validate`` is False).
+    """
+    graph = onnx.helper.make_graph(
+        nodes=nodes,
+        name="main_graph",
+        inputs=inputs,
+        outputs=outputs,
+        initializer=initializers or [],
+    )
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[onnx.helper.make_opsetid("", opset)],
+        ir_version=ir_version,
+    )
+    if validate:
+        onnx.checker.check_model(model)
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Class-based authoring API (mirrors the torch e2e suite's Module + decorators)
+# ---------------------------------------------------------------------------
+
+# Maps a torch.dtype to its ONNX TensorProto element type, so an input is
+# described exactly once (as a torch.dtype) and reused for both the ONNX
+# value_info and the runtime TensorPlaceholder.
+_TORCH_TO_ONNX_DTYPE = {
+    torch.float16: onnx.TensorProto.FLOAT16,
+    # bfloat16 omitted: onnx.reference can't evaluate bf16 arithmetic and
+    # np_dtype_to_tensor_dtype can't round-trip ml_dtypes.bfloat16.
+    torch.float32: onnx.TensorProto.FLOAT,
+    torch.float64: onnx.TensorProto.DOUBLE,
+    torch.int8: onnx.TensorProto.INT8,
+    torch.int16: onnx.TensorProto.INT16,
+    torch.int32: onnx.TensorProto.INT32,
+    torch.int64: onnx.TensorProto.INT64,
+    torch.uint8: onnx.TensorProto.UINT8,
+    torch.bool: onnx.TensorProto.BOOL,
+}
+
+# Attribute the @annotate_inputs decorator stashes on graph(); read by
+# OnnxTestCase to build the input value_infos and TensorPlaceholders.
+_INPUT_ANNOTATIONS_ATTR = "_onnx_input_annotations"
+
+# Type of a single input annotation: (name, torch.dtype, shape) with an
+# optional 4th element (low, high) giving the value range to sample from.
+InputAnnotation = Tuple[str, torch.dtype, List[int]]
+
+# Attribute name under which input_placeholders() stashes an input's optional
+# (low, high) range on its TensorPlaceholder; read by materialize_inputs.
+_INPUT_RANGE_ATTR = "_onnx_input_range"
+
+
+def annotate_inputs(annotations: List[InputAnnotation]):
+    """Declare the runtime inputs of a test's ``graph`` method.
+
+    Each entry is ``(name, dtype, shape)`` or, to override the default sampling
+    range, ``(name, dtype, shape, (low, high))``.  The name is the ONNX tensor
+    name used inside the graph; dtype/shape are written **once** here and reused
+    to build both the ONNX input ``value_info`` and the runtime
+    ``TensorPlaceholder``.  ``(low, high)`` mirrors the ``low``/``high``
+    arguments authors pass to ``TestUtils.rand``/``randint`` in the torch e2e
+    suite; when omitted, the framework default range is used.
+    """
+
+    def decorator(fn):
+        setattr(fn, _INPUT_ANNOTATIONS_ATTR, annotations)
+        return fn
+
+    return decorator
+
+
+class OnnxTestCase:
+    """Base class for class-based ONNX e2e tests.
+
+    Subclass it, decorate ``graph`` with ``@annotate_inputs`` and register the
+    class with ``@register_onnx_test``.  The subclass name is the test's
+    ``unique_name``.  ``graph`` returns ``(nodes, output_names[, initializers])``
+    where ``output_names`` is the list of graph output tensor names.  The base
+    infers each output's shape and dtype by running the model once through
+    ``onnx.reference`` — authors never declare output shapes.  Example::
+
+        @register_onnx_test
+        class OnnxAdd_f32_basic(OnnxTestCase):
+            @annotate_inputs([
+                ("x", torch.float32, [4, 4]),
+                ("y", torch.float32, [4, 4]),
+            ])
+            def graph(self):
+                return [onnx.helper.make_node("Add", ["x", "y"], ["z"])], ["z"]
+    """
+
+    def graph(self):
+        raise NotImplementedError
+
+    @classmethod
+    def _input_annotations(cls) -> List[InputAnnotation]:
+        annotations = getattr(cls.graph, _INPUT_ANNOTATIONS_ATTR, None)
+        if annotations is None:
+            raise ValueError(
+                f"{cls.__name__}.graph must be decorated with @annotate_inputs"
+            )
+        return annotations
+
+    @classmethod
+    def input_placeholders(cls) -> List[TensorPlaceholder]:
+        placeholders = []
+        for annotation in cls._input_annotations():
+            _name, dtype, shape = annotation[:3]
+            placeholder = TensorPlaceholder(shape, dtype)
+            if len(annotation) > 3:
+                setattr(placeholder, _INPUT_RANGE_ATTR, annotation[3])
+            placeholders.append(placeholder)
+        return placeholders
+
+    @classmethod
+    def build(cls) -> onnx.ModelProto:
+        # Local imports so that the pure descriptor path (registration) does not
+        # pull in the reference evaluator / numpy input machinery.
+        import onnx.reference
+
+        from .config import materialize_inputs
+
+        annotations = cls._input_annotations()
+        # A -1 in an annotation shape marks a dynamic dim: TensorPlaceholder /
+        # materialize_inputs read it as -1 (substituting a concrete size at
+        # runtime), but ONNX expects None for a symbolic dim -- a literal -1
+        # would import as a static dim of -1 instead of a `?`.
+        input_infos = [
+            onnx.helper.make_tensor_value_info(
+                name,
+                _TORCH_TO_ONNX_DTYPE[dtype],
+                [d if d >= 0 else None for d in shape],
+            )
+            for (name, dtype, shape, *_range) in annotations
+        ]
+
+        instance = cls()
+        result = instance.graph()
+        if len(result) == 3:
+            nodes, output_names, initializers = result
+        else:
+            nodes, output_names = result
+            initializers = None
+
+        # Pass 1: build a model with shapeless outputs and run onnx.reference to
+        # learn each output's concrete shape and dtype.  This model is not
+        # validated (check_model requires a shape); it exists only to be run.
+        probe_outputs = [
+            onnx.helper.make_empty_tensor_value_info(name) for name in output_names
+        ]
+        probe_model = build_model(
+            nodes, input_infos, probe_outputs, initializers=initializers, validate=False
+        )
+        numpy_inputs = materialize_inputs(cls.input_placeholders(), seed=0)
+        feed = {
+            annotation[0]: arr for (annotation, arr) in zip(annotations, numpy_inputs)
+        }
+        golden = onnx.reference.ReferenceEvaluator(probe_model).run(None, feed)
+
+        # Pass 2: rebuild with concrete, inferred output value_infos so the
+        # importer sees correct result types (and check_model passes).
+        output_infos = [
+            onnx.helper.make_tensor_value_info(
+                name,
+                onnx.helper.np_dtype_to_tensor_dtype(arr.dtype),
+                list(arr.shape),
+            )
+            for name, arr in zip(output_names, golden)
+        ]
+        return build_model(nodes, input_infos, output_infos, initializers=initializers)

--- a/projects/pt1/python/onnx_e2e_test/main.py
+++ b/projects/pt1/python/onnx_e2e_test/main.py
@@ -1,0 +1,249 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""
+Entry point for the ONNX-native end-to-end test suite.
+
+Runs every ``OnnxTest`` in ``GLOBAL_ONNX_TEST_REGISTRY`` through the
+selected config, compares outputs against the ONNX reference evaluator, and
+reports results using the existing ``torch_mlir_e2e_test.reporting`` layer.
+
+Usage::
+
+    python -m onnx_e2e_test.main --config linalg -v --filter Add
+"""
+
+import argparse
+import re
+import sys
+import traceback
+from typing import List
+
+import torch
+
+from torch_mlir_e2e_test.framework import TestResult, TraceItem
+from torch_mlir_e2e_test.reporting import report_results
+
+from .config import (
+    OnnxLinalgTestConfig,
+    OnnxTosaBackendTestConfig,
+    materialize_inputs,
+)
+from .registry import GLOBAL_ONNX_TEST_REGISTRY
+from .xfail_sets import (
+    ONNX_E2E_LINALG_CRASHING_SET,
+    ONNX_E2E_TOSA_CRASHING_SET,
+    ONNX_E2E_TOSA_XFAIL_SET,
+    ONNX_E2E_LINALG_XFAIL_SET,
+)
+
+# Register built-in test cases (side-effecting import).
+from .test_suite import register_all_tests as _register_all_tests
+
+_register_all_tests()
+
+# ---------------------------------------------------------------------------
+# Run loop
+# ---------------------------------------------------------------------------
+
+_SYMBOL = "main_graph"
+
+
+def _run_one(test, config: OnnxLinalgTestConfig) -> TestResult:
+    """Run a single OnnxTest and return a TestResult.
+
+    The comparison is delegated to report_results (via TraceItem / golden_trace),
+    which uses torch.allclose with rtol=1e-03, atol=1e-07 like the rest of the
+    e2e suite.
+    """
+    # Build the model (may raise if the factory is broken).
+    try:
+        model_proto = test.model_factory()
+    except Exception:
+        return TestResult(
+            unique_name=test.unique_name,
+            compilation_error=traceback.format_exc(),
+            runtime_error=None,
+            trace=None,
+            golden_trace=None,
+        )
+
+    # Materialise inputs with seed=0 — identical for golden and SUT.
+    numpy_inputs = materialize_inputs(test.inputs, seed=0)
+
+    # --- golden ---
+    try:
+        golden_outputs: List[torch.Tensor] = config.run_golden(
+            model_proto, numpy_inputs
+        )
+    except Exception:
+        return TestResult(
+            unique_name=test.unique_name,
+            compilation_error=None,
+            runtime_error="Golden evaluation failed:\n" + traceback.format_exc(),
+            trace=None,
+            golden_trace=None,
+        )
+
+    # --- SUT (compile + run) ---
+    try:
+        sut_outputs: List[torch.Tensor] = config.run_backend(model_proto, numpy_inputs)
+    except Exception:
+        tb = traceback.format_exc()
+        # Heuristic: distinguish compile vs runtime failures by the presence of
+        # typical compilation exception text.  A false-positive here is
+        # harmless — it just determines which error field is populated.
+        if "compilation" in tb.lower() or "lowering" in tb.lower():
+            return TestResult(
+                unique_name=test.unique_name,
+                compilation_error=tb,
+                runtime_error=None,
+                trace=None,
+                golden_trace=None,
+            )
+        return TestResult(
+            unique_name=test.unique_name,
+            compilation_error=None,
+            runtime_error=tb,
+            trace=None,
+            golden_trace=None,
+        )
+
+    # Build trace / golden_trace — one TraceItem per call (just one here).
+    # inputs are the numpy arrays converted to torch tensors so ValueReport
+    # can compare them if needed; they should always match since it's the same
+    # seed.
+    torch_inputs = [torch.from_numpy(a) for a in numpy_inputs]
+
+    # A mismatched output count would make the compare below silently align
+    # the wrong tensors; surface it as a runtime error instead.
+    if len(sut_outputs) != len(golden_outputs):
+        return TestResult(
+            unique_name=test.unique_name,
+            compilation_error=None,
+            runtime_error=(
+                f"Output count mismatch: SUT returned {len(sut_outputs)}, "
+                f"golden returned {len(golden_outputs)}."
+            ),
+            trace=None,
+            golden_trace=None,
+        )
+
+    # Wrap multiple outputs as a tuple (single output stays as-is).
+    if len(sut_outputs) == 1:
+        sut_out = sut_outputs[0]
+        golden_out = golden_outputs[0]
+    else:
+        sut_out = tuple(sut_outputs)
+        golden_out = tuple(golden_outputs)
+
+    trace = [TraceItem(symbol=_SYMBOL, inputs=torch_inputs, output=sut_out)]
+    golden_trace = [TraceItem(symbol=_SYMBOL, inputs=torch_inputs, output=golden_out)]
+
+    return TestResult(
+        unique_name=test.unique_name,
+        compilation_error=None,
+        runtime_error=None,
+        trace=trace,
+        golden_trace=golden_trace,
+    )
+
+
+def run_tests(
+    tests,
+    config: OnnxLinalgTestConfig,
+    verbose: bool = False,
+) -> List[TestResult]:
+    results = []
+    for test in tests:
+        if verbose:
+            print(f'  Running "{test.unique_name}"...')
+        result = _run_one(test, config)
+        results.append(result)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _get_argparse() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run ONNX-native end-to-end tests.")
+    parser.add_argument(
+        "-c",
+        "--config",
+        choices=["linalg", "tosa"],
+        default="linalg",
+        help="Backend to lower to and execute (default: linalg).",
+    )
+    parser.add_argument(
+        "-f",
+        "--filter",
+        default=".*",
+        help="Regular expression to select tests by unique_name.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        default=False,
+        action="store_true",
+        help="Report test results with additional detail.",
+    )
+    parser.add_argument(
+        "--ignore_failures",
+        default=False,
+        action="store_true",
+        help="Return exit code 0 even if tests fail (unblocks pipelines).",
+    )
+    return parser
+
+
+def main():
+    args = _get_argparse().parse_args()
+
+    # Resolve config.
+    if args.config == "linalg":
+        config = OnnxLinalgTestConfig()
+        xfail_set = ONNX_E2E_LINALG_XFAIL_SET
+        crashing_set = ONNX_E2E_LINALG_CRASHING_SET
+    elif args.config == "tosa":
+        config = OnnxTosaBackendTestConfig()
+        xfail_set = ONNX_E2E_TOSA_XFAIL_SET
+        crashing_set = ONNX_E2E_TOSA_CRASHING_SET
+    else:
+        print(f"ERROR: unknown config {args.config!r}", file=sys.stderr)
+        sys.exit(1)
+
+    # Skip known crashers.
+    available_tests = [
+        t for t in GLOBAL_ONNX_TEST_REGISTRY if t.unique_name not in crashing_set
+    ]
+
+    # Apply filter.
+    tests = [t for t in available_tests if re.match(args.filter, t.unique_name)]
+    if not tests:
+        print(f"ERROR: filter {args.filter!r} matched no tests. Available tests:")
+        for t in available_tests:
+            print(f"  {t.unique_name}")
+        sys.exit(1)
+
+    # Run.
+    results = run_tests(tests, config, verbose=args.verbose)
+
+    # Report — reuses torch_mlir_e2e_test.reporting.report_results unchanged.
+    failed = report_results(
+        results,
+        expected_failures=xfail_set,
+        verbose=args.verbose,
+        config=args.config,
+    )
+
+    if args.ignore_failures:
+        sys.exit(0)
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/pt1/python/onnx_e2e_test/registry.py
+++ b/projects/pt1/python/onnx_e2e_test/registry.py
@@ -1,0 +1,48 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+from typing import Callable, List
+
+import onnx
+
+from torch_mlir.compiler_utils import TensorPlaceholder
+
+from .framework import OnnxTest
+
+# The global registry of ONNX end-to-end tests.
+GLOBAL_ONNX_TEST_REGISTRY: List[OnnxTest] = []
+# Ensure that there are no duplicate names in the global registry.
+_SEEN_UNIQUE_NAMES: set = set()
+
+
+def register_onnx_test(cls):
+    """Class-based registration for ONNX end-to-end test cases.
+
+    Decorate an ``OnnxTestCase`` subclass; its name is the ``unique_name``, its
+    ``build`` classmethod is the model factory, and its input placeholders are
+    derived from the ``@annotate_inputs`` on ``graph``.  See ``OnnxTestCase``.
+    """
+    _register(cls.__name__, cls.build, cls.input_placeholders())
+    return cls
+
+
+def _register(
+    unique_name: str,
+    model_factory: Callable[[], onnx.ModelProto],
+    inputs: List[TensorPlaceholder],
+):
+    if unique_name in _SEEN_UNIQUE_NAMES:
+        raise Exception(
+            f"Duplicate test name: '{unique_name}'. Please make sure that "
+            "each registered ONNX test has a unique name."
+        )
+    _SEEN_UNIQUE_NAMES.add(unique_name)
+    GLOBAL_ONNX_TEST_REGISTRY.append(
+        OnnxTest(
+            unique_name=unique_name,
+            model_factory=model_factory,
+            inputs=inputs,
+        )
+    )

--- a/projects/pt1/python/onnx_e2e_test/test_suite/__init__.py
+++ b/projects/pt1/python/onnx_e2e_test/test_suite/__init__.py
@@ -1,0 +1,20 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""Seed op test suite for the ONNX-native e2e framework.
+
+Importing this package triggers the side-effecting registrations in each
+sub-module so that ``GLOBAL_ONNX_TEST_REGISTRY`` is populated before the
+runner queries it.
+"""
+
+
+def register_all_tests():
+    """Register all built-in ONNX e2e tests."""
+    # Imported only to run their @register_onnx_test side effects.
+    from . import elementwise  # noqa: F401
+    from . import linear  # noqa: F401
+    from . import recurrent  # noqa: F401
+    from . import signal  # noqa: F401
+    from . import reduction  # noqa: F401

--- a/projects/pt1/python/onnx_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/onnx_e2e_test/test_suite/elementwise.py
@@ -1,0 +1,137 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""Elementwise ONNX op tests."""
+
+import torch
+import onnx.helper
+
+from onnx_e2e_test.framework import OnnxTestCase, annotate_inputs
+from onnx_e2e_test.registry import register_onnx_test
+
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxAdd_f32_basic(OnnxTestCase):
+    @annotate_inputs(
+        [
+            ("x", torch.float32, [4, 4]),
+            ("y", torch.float32, [4, 4]),
+        ]
+    )
+    def graph(self):
+        node = onnx.helper.make_node("Add", ["x", "y"], ["z"])
+        return [node], ["z"]
+
+
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxRelu_f32_basic(OnnxTestCase):
+    @annotate_inputs([("x", torch.float32, [3, 4])])
+    def graph(self):
+        node = onnx.helper.make_node("Relu", ["x"], ["y"])
+        return [node], ["y"]
+
+
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxRelu_negrange_basic(OnnxTestCase):
+    # Sample from [-1, 1) so Relu sees negative inputs to clamp.
+    @annotate_inputs([("x", torch.float32, [3, 4], (-1.0, 1.0))])
+    def graph(self):
+        node = onnx.helper.make_node("Relu", ["x"], ["y"])
+        return [node], ["y"]
+
+
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxAdd_i64_basic(OnnxTestCase):
+    @annotate_inputs(
+        [
+            ("x", torch.int64, [4, 4]),
+            ("y", torch.int64, [4, 4]),
+        ]
+    )
+    def graph(self):
+        node = onnx.helper.make_node("Add", ["x", "y"], ["z"])
+        return [node], ["z"]
+
+
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxSplit_f32_twoOutputs(OnnxTestCase):
+    # Split along axis 0 into two equal halves -> two graph outputs, exercising
+    # the multi-output trace/compare path.
+    @annotate_inputs([("x", torch.float32, [4, 4])])
+    def graph(self):
+        node = onnx.helper.make_node("Split", ["x"], ["a", "b"], axis=0)
+        return [node], ["a", "b"]
+
+
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxAnd_bool_basic(OnnxTestCase):
+    # Bool inputs exercise the boolean branch of materialize_inputs (the only
+    # input-generation path that samples with rng.integers(0, 2) and ignores
+    # any value_range).
+    @annotate_inputs(
+        [
+            ("x", torch.bool, [4, 4]),
+            ("y", torch.bool, [4, 4]),
+        ]
+    )
+    def graph(self):
+        node = onnx.helper.make_node("And", ["x", "y"], ["z"])
+        return [node], ["z"]
+
+
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxAdd_i32_customRange(OnnxTestCase):
+    # Integer input with an explicit (low, high) range exercises the custom
+    # value_range branch for integers in materialize_inputs (elsewhere only
+    # floats carry a custom range).
+    @annotate_inputs(
+        [
+            ("x", torch.int32, [4, 4], (-5, 5)),
+            ("y", torch.int32, [4, 4], (-5, 5)),
+        ]
+    )
+    def graph(self):
+        node = onnx.helper.make_node("Add", ["x", "y"], ["z"])
+        return [node], ["z"]
+
+
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxAdd_f32_dynamicInput(OnnxTestCase):
+    # A -1 dim marks a dynamic INPUT: it imports as `?` and materialize_inputs
+    # substitutes a concrete size at runtime for both golden and SUT.  The
+    # output value_info is still concrete (pass-2 infers it from the probe run),
+    # so this exercises dynamic-input handling in the lowering, not a dynamic
+    # result dim.
+    @annotate_inputs(
+        [
+            ("x", torch.float32, [-1, 4]),
+            ("y", torch.float32, [-1, 4]),
+        ]
+    )
+    def graph(self):
+        node = onnx.helper.make_node("Add", ["x", "y"], ["z"])
+        return [node], ["z"]

--- a/projects/pt1/python/onnx_e2e_test/test_suite/linear.py
+++ b/projects/pt1/python/onnx_e2e_test/test_suite/linear.py
@@ -1,0 +1,50 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""Linear / weight-carrying ONNX op tests.
+
+Exercises the shared-weights design: concrete weight and bias tensors are
+embedded as ONNX initializers (returned as the third element of ``graph``),
+not runtime inputs.  Only the activation ``x`` is an annotated input.
+"""
+
+import numpy as np
+import torch
+import onnx.helper
+import onnx.numpy_helper
+
+from onnx_e2e_test.framework import OnnxTestCase, annotate_inputs
+from onnx_e2e_test.registry import register_onnx_test
+
+# ==============================================================================
+# Gemm with embedded weight + bias initializers
+#
+#   x [4, 8]  --\
+#   W [8, 16]    >--> Gemm --> y [4, 16]
+#   b [16]    --/
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxGemm_withWeights_basic(OnnxTestCase):
+    def __init__(self):
+        self._W = np.random.default_rng(42).standard_normal((8, 16)).astype(np.float32)
+        self._b = np.random.default_rng(43).standard_normal((16,)).astype(np.float32)
+
+    @annotate_inputs([("x", torch.float32, [4, 8])])
+    def graph(self):
+        node = onnx.helper.make_node(
+            "Gemm",
+            ["x", "W", "b"],
+            ["y"],
+            alpha=1.0,
+            beta=1.0,
+            transA=0,
+            transB=0,
+        )
+        initializers = [
+            onnx.numpy_helper.from_array(self._W, name="W"),
+            onnx.numpy_helper.from_array(self._b, name="b"),
+        ]
+        return [node], ["y"], initializers

--- a/projects/pt1/python/onnx_e2e_test/test_suite/recurrent.py
+++ b/projects/pt1/python/onnx_e2e_test/test_suite/recurrent.py
@@ -1,0 +1,53 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""Recurrent ONNX op tests (LSTM)."""
+
+import numpy as np
+import torch
+import onnx.helper
+import onnx.numpy_helper
+
+from onnx_e2e_test.framework import OnnxTestCase, annotate_inputs
+from onnx_e2e_test.registry import register_onnx_test
+
+# ==============================================================================
+# LSTM — single-direction; seq=5, batch=1, input_size=4, hidden_size=8.
+# X is the only runtime input; W/R/B are baked in as initializers.
+#   Outputs: Y [seq, num_dir, batch, H] and Y_h [num_dir, batch, H].
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxLSTM_forward_basic(OnnxTestCase):
+    _SEQ, _BATCH, _INPUT, _HIDDEN = 5, 1, 4, 8
+    _NUM_DIR = 1
+
+    def __init__(self):
+        rng = np.random.default_rng(7)
+        self._W = rng.standard_normal(
+            (self._NUM_DIR, 4 * self._HIDDEN, self._INPUT)
+        ).astype(np.float32)
+        self._R = rng.standard_normal(
+            (self._NUM_DIR, 4 * self._HIDDEN, self._HIDDEN)
+        ).astype(np.float32)
+        self._B = rng.standard_normal((self._NUM_DIR, 8 * self._HIDDEN)).astype(
+            np.float32
+        )
+
+    @annotate_inputs([("X", torch.float32, [_SEQ, _BATCH, _INPUT])])
+    def graph(self):
+        node = onnx.helper.make_node(
+            "LSTM",
+            ["X", "W", "R", "B"],
+            ["Y", "Y_h"],
+            hidden_size=self._HIDDEN,
+            direction="forward",
+        )
+        initializers = [
+            onnx.numpy_helper.from_array(self._W, name="W"),
+            onnx.numpy_helper.from_array(self._R, name="R"),
+            onnx.numpy_helper.from_array(self._B, name="B"),
+        ]
+        return [node], ["Y", "Y_h"], initializers

--- a/projects/pt1/python/onnx_e2e_test/test_suite/reduction.py
+++ b/projects/pt1/python/onnx_e2e_test/test_suite/reduction.py
@@ -1,0 +1,26 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""Reduction ONNX op tests (HardMax)."""
+
+import torch
+import onnx.helper
+
+from onnx_e2e_test.framework import OnnxTestCase, annotate_inputs
+from onnx_e2e_test.registry import register_onnx_test
+
+# ==============================================================================
+# HardMax — opset 13+
+#
+# HardMax(x, axis=1) returns a one-hot tensor where 1.0 marks the argmax
+# position along the given axis.
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxHardmax_axis1_basic(OnnxTestCase):
+    @annotate_inputs([("x", torch.float32, [3, 5])])
+    def graph(self):
+        node = onnx.helper.make_node("Hardmax", ["x"], ["y"], axis=1)
+        return [node], ["y"]

--- a/projects/pt1/python/onnx_e2e_test/test_suite/signal.py
+++ b/projects/pt1/python/onnx_e2e_test/test_suite/signal.py
@@ -1,0 +1,50 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""Signal-processing ONNX op tests (STFT)."""
+
+import numpy as np
+import torch
+import onnx.helper
+import onnx.numpy_helper
+
+from onnx_e2e_test.framework import OnnxTestCase, annotate_inputs
+from onnx_e2e_test.registry import register_onnx_test
+
+# ==============================================================================
+# STFT — opset 17
+#
+# signal is the only runtime input; frame_step, window and frame_length are
+# baked in as initializers.
+#   signal_length = 64, frame_step = 8, window_length = 16
+#   frames = (64 - 16) // 8 + 1 = 7 ; freq_bins = 16 // 2 + 1 = 9
+# ==============================================================================
+
+
+@register_onnx_test
+class OnnxSTFT_onesided_basic(OnnxTestCase):
+    _SIGNAL_LEN = 64
+    _FRAME_STEP = 8
+    _WIN_LEN = 16
+    _BATCH = 1
+
+    def __init__(self):
+        self._window = np.hanning(self._WIN_LEN).astype(np.float32)
+        self._frame_step_arr = np.array(self._FRAME_STEP, dtype=np.int64)
+        self._frame_length_arr = np.array(self._WIN_LEN, dtype=np.int64)
+
+    @annotate_inputs([("signal", torch.float32, [_BATCH, _SIGNAL_LEN, 1])])
+    def graph(self):
+        node = onnx.helper.make_node(
+            "STFT",
+            ["signal", "frame_step", "window", "frame_length"],
+            ["output"],
+            onesided=1,
+        )
+        initializers = [
+            onnx.numpy_helper.from_array(self._frame_step_arr, name="frame_step"),
+            onnx.numpy_helper.from_array(self._window, name="window"),
+            onnx.numpy_helper.from_array(self._frame_length_arr, name="frame_length"),
+        ]
+        return [node], ["output"], initializers

--- a/projects/pt1/python/onnx_e2e_test/xfail_sets.py
+++ b/projects/pt1/python/onnx_e2e_test/xfail_sets.py
@@ -1,0 +1,43 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+"""
+Expected-failure sets for the ONNX-native e2e test suite.
+
+Named ``ONNX_E2E_<CONFIG>_<KIND>_SET`` where CONFIG is LINALG or TOSA:
+
+- ``*_XFAIL_SET`` — tests known to fail (XFAIL); unexpected passes are errors.
+- ``*_CRASHING_SET`` — tests that crash the process; they are skipped entirely.
+
+Sets are per-config: a name belongs in whichever config's set it fails under.
+Add a test's ``unique_name`` (the decorated function name) to the appropriate
+set when filing a bug, and remove it when the bug is fixed.
+"""
+
+# Tests expected to fail.  Add names here when a bug is filed.
+ONNX_E2E_LINALG_XFAIL_SET = {
+    # OnnxLSTM_forward_basic: RefBackend bufferization fails with
+    # "Yield operand #1 is not equivalent to the corresponding iter bbArg"
+    # during linalg-on-tensors -> LLVM lowering.
+    "OnnxLSTM_forward_basic",
+}
+
+# Tests that crash the interpreter and cannot be XFAILed safely.
+# These are skipped (not attempted) by the runner.
+ONNX_E2E_LINALG_CRASHING_SET = set()
+
+# --- TOSA backend (onnx_tosa config) ---
+# TOSA has different op coverage than linalg; tests unsupported on the
+# torch -> tosa path go here.
+ONNX_E2E_TOSA_XFAIL_SET = {
+    # OnnxLSTM_forward_basic: LSTM has no torch -> tosa lowering.
+    "OnnxLSTM_forward_basic",
+    # OnnxSTFT_onesided_basic: STFT has no torch -> tosa lowering.
+    "OnnxSTFT_onesided_basic",
+    # OnnxAdd_f32_dynamicInput: TOSA -> linalg -> RefBackend fails to bufferize
+    # a dynamic-shaped tensor ("bufferization.dealloc ... marked illegal").
+    "OnnxAdd_f32_dynamicInput",
+}
+
+ONNX_E2E_TOSA_CRASHING_SET = set()


### PR DESCRIPTION
The existing "onnx" e2e config exports models from a torch nn.Module via torch.onnx and reimports them, so its op coverage is bounded by what torch's ONNX exporter emits. ONNX ops, attributes, and op variants that torch never produces (and ONNX domains outside torch's export set) are therefore never exercised end to end, leaving gaps in the ONNX -> Torch -> {linalg, tosa} lowering that only surface on real models.

This suite authors ONNX models directly instead of exporting them from torch, so any ONNX op or construct can be covered regardless of torch exporter support, and validates the lowering against onnx.reference goldens.

Framework:
- OnnxTestCase / @annotate_inputs / @register_onnx_test authoring API, mirroring the torch e2e suite's Module + decorator style.
- Two-pass model build: a shapeless probe run through onnx.reference infers concrete output value_infos so authors don't have to declare them.
- Seeded numpy input materialization matching TestUtils defaults (float [0,1), int [0,10), bool [0,2)), with optional per-input (low, high) ranges and dynamic-dim support (-1 imports as ?, with a concrete size substituted at runtime).
- OnnxLinalgTestConfig and OnnxTosaBackendTestConfig reuse the existing torch_mlir_e2e_test reporting/compare layer; per-config xfail sets.

Tests cover elementwise (Add f32/i64/i32-range, Relu, And bool, Split multi-output, dynamic input), Gemm, Hardmax, STFT, and LSTM to test a few ops mentioned in https://github.com/llvm/torch-mlir/issues/3520

Wire the suite into CI (test_posix.sh, linalg + tosa configs) and the build (built only when the JIT IR importer / torch_mlir_e2e_test is building).