### PR TITLE
[Torch] Numerically stabilize logaddexp/logaddexp2 and decompose logcumsumexp via a sequential scan

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -3216,12 +3216,136 @@ public:
     if (!isValidDim(dim, inputRank))
       return rewriter.notifyMatchFailure(op, "invalid dim.");
 
-    Value dtypeVal =
-        getDtypeIntValueForType(rewriter, loc, inputType.getDtype());
-    Value expInput = AtenExpOp::create(rewriter, loc, resultType, input);
-    Value cumsum = AtenCumsumOp::create(rewriter, loc, resultType, expInput,
-                                        op.getDim(), dtypeVal);
-    rewriter.replaceOpWithNewOp<AtenLogOp>(op, resultType, cumsum);
+    // logcumsumexp(x)[j] = log(sum_{i<=j} exp(x[i])) is an inclusive prefix
+    // scan whose combiner is logaddexp (associative, commutative, with identity
+    // -inf):
+    //   out[j] = logaddexp_{i<=j} x[i],   out[j] = logaddexp(out[j-1], x[j]).
+    // Each per-step logaddexp is emitted as aten.logaddexp and stabilized by
+    // DecomposeAtenLogAddExpOp to max(a,b) + log1p(exp(-|a-b|)) in this same
+    // pass, so the only exp taken is exp(-|a-b|) in [0,1] -- the shift is
+    // prefix-local, never a single global max over the whole scan. That
+    // locality avoids both the +inf overflow of naive log(cumsum(exp(x))) and
+    // the -inf underflow of a global-max shift M + log(cumsum(exp(x - M)))
+    // when a large value sits late in the scan.
+    Value dimValue =
+        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(dim));
+    Value cstOne =
+        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(1));
+    Value cstNone = ConstantNoneOp::create(rewriter, loc);
+
+    ArrayRef<int64_t> inSizes = inputType.getSizes();
+    int64_t staticDimSize = inSizes[dim];
+
+    // Static scan length: emit a compile-time-unrolled Hillis-Steele inclusive
+    // scan (ceil(log2(L)) doubling steps). Each step shifts the running result
+    // right by `offset` along `dim` -- padding the low side with the -inf
+    // identity via aten.constant_pad_nd, then slicing back to length L -- and
+    // folds it in with an elementwise aten.logaddexp:
+    //   running[k] = logaddexp(running[k], running[k - offset]).
+    // This uses only pad/slice/logaddexp, which legalize to linalg, TOSA and
+    // StableHLO alike (matching how aten.cumsum is lowered on those backends,
+    // which likewise require a static scan dim). logaddexp(a, -inf) == a, so
+    // the padded low end is inert.
+    if (staticDimSize != kUnknownSize) {
+      Value running = AtenCloneOp::create(rewriter, loc, resultType, input,
+                                          /*memory_format=*/cstNone);
+      Value negInf = ConstantFloatOp::create(
+          rewriter, loc,
+          rewriter.getF64FloatAttr(-std::numeric_limits<double>::infinity()));
+      Value cstZero =
+          ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(0));
+      Value cstDimSize = ConstantIntOp::create(
+          rewriter, loc, rewriter.getI64IntegerAttr(staticDimSize));
+      Type intListType =
+          Torch::ListType::get(Torch::IntType::get(op.getContext()));
+
+      for (int64_t offset = 1; offset < staticDimSize; offset <<= 1) {
+        // aten.constant_pad_nd pad list is ordered last-dim-first as
+        // [lastdim_lo, lastdim_hi, ...]; pad `offset` on the low side of `dim`.
+        SmallVector<int64_t> padAmts(2 * inputRank, 0);
+        padAmts[2 * (inputRank - 1 - dim)] = offset;
+        SmallVector<Value> padVals;
+        for (int64_t p : padAmts)
+          padVals.push_back(ConstantIntOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(p)));
+        Value padList =
+            PrimListConstructOp::create(rewriter, loc, intListType, padVals);
+
+        SmallVector<int64_t> paddedSizes(inSizes.begin(), inSizes.end());
+        paddedSizes[dim] = staticDimSize + offset;
+        Type paddedType = inputType.getWithSizesAndDtype(
+            paddedSizes, inputType.getOptionalDtype());
+        Value padded = AtenConstantPadNdOp::create(rewriter, loc, paddedType,
+                                                   running, padList, negInf);
+
+        // shifted = padded[..., 0:L, ...] -- `running` shifted right by
+        // `offset` along `dim`, low end filled with the -inf identity.
+        Value shifted = AtenSliceTensorOp::create(
+            rewriter, loc, resultType, padded, dimValue, /*start=*/cstZero,
+            /*end=*/cstDimSize, /*step=*/cstOne);
+
+        running = AtenLogaddexpOp::create(rewriter, loc, resultType, running,
+                                          shifted);
+      }
+      rewriter.replaceOp(op, running);
+      return success();
+    }
+
+    // Dynamic scan length: the doubling count is not known at compile time, so
+    // materialize the recurrence as a data-dependent torch.prim.Loop (lowers to
+    // scf; linalg only -- TOSA/StableHLO cannot express a dynamic-shape scan,
+    // same as aten.cumsum).
+    //   out[0] = x[0];  out[j] = logaddexp(out[j-1], x[j]) for j >= 1.
+    Value loopCondTrue = ConstantBoolOp::create(rewriter, loc, true);
+
+    // Size-1 slice type along `dim` (dynamic, since indices are runtime ints).
+    SmallVector<int64_t> sliceSizes(inputType.getSizes());
+    sliceSizes[dim] = kUnknownSize;
+    Type sliceType = inputType.getWithSizesAndDtype(
+        sliceSizes, inputType.getOptionalDtype());
+
+    // dimSize = x.size(dim); iterate j = 1 .. dimSize-1  (trip = dimSize - 1).
+    Value dimSize = AtenSizeIntOp::create(rewriter, loc, input, dimValue);
+    Value trip = AtenSubIntOp::create(rewriter, loc, dimSize, cstOne);
+
+    // Seed out = clone(x): out[...,0] already equals logcumsumexp(x)[...,0].
+    Value initOut = AtenCloneOp::create(rewriter, loc, resultType, input,
+                                        /*memory_format=*/cstNone);
+
+    auto scanLoop =
+        PrimLoopOp::create(rewriter, loc, TypeRange({resultType}), trip,
+                           loopCondTrue, ValueRange({initOut}));
+    {
+      PatternRewriter::InsertionGuard guard(rewriter);
+      Type loopIndexType = rewriter.getType<IntType>();
+      Block *body = rewriter.createBlock(
+          &scanLoop.getRegion(), scanLoop.getRegion().begin(),
+          TypeRange({loopIndexType, resultType}), {loc, loc});
+      Value iv = body->getArgument(0);  // 0 .. dimSize-2
+      Value acc = body->getArgument(1); // running output
+      Value j =
+          AtenAddIntOp::create(rewriter, loc, iv, cstOne); // current index
+      Value jp1 = AtenAddIntOp::create(rewriter, loc, j, cstOne);
+
+      // prev = acc[..., j-1] = acc[..., iv];  cur = x[..., j].
+      Value prev = AtenSliceTensorOp::create(rewriter, loc, sliceType, acc,
+                                             dimValue, /*start=*/iv,
+                                             /*end=*/j, /*step=*/cstOne);
+      Value cur = AtenSliceTensorOp::create(rewriter, loc, sliceType, input,
+                                            dimValue, /*start=*/j,
+                                            /*end=*/jp1, /*step=*/cstOne);
+
+      // val = logaddexp(prev, cur)  (stabilized by DecomposeAtenLogAddExpOp).
+      Value val = AtenLogaddexpOp::create(rewriter, loc, sliceType, prev, cur);
+
+      // acc[..., j] = val.
+      Value acc2 = AtenSliceScatterOp::create(rewriter, loc, resultType, acc,
+                                              val, dimValue, /*start=*/j,
+                                              /*end=*/jp1, /*step=*/cstOne);
+      PrimLoopConditionOp::create(rewriter, loc, loopCondTrue,
+                                  ValueRange({acc2}));
+    }
+    rewriter.replaceOp(op, scanLoop.getResults());
     return success();
   }
 };

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -3241,25 +3241,59 @@ public:
 };
 } // namespace
 
+// Numerically stable decomposition of logaddexp / logaddexp2.
+//   logaddexp(a, b)  = log (exp (a) + exp (b))  = m + log1p(exp (-|a - b|))
+//   logaddexp2(a, b) = log2(exp2(a) + exp2(b))  = m + log2(1 + exp2(-|a - b|))
+// where m = max(a, b). Carrying `m` outside the exponential and only ever
+// exponentiating the non-positive value -|a - b| avoids the +inf overflow of
+// the naive `log(exp(a) + exp(b))` form when a or b exceeds ~88 in float32.
+// `useBase2` selects the base-2 variant (exp2/log2); base-e uses log1p
+// directly.
+template <typename OpTy>
+static LogicalResult decomposeLogAddExp(OpTy op, PatternRewriter &rewriter,
+                                        bool useBase2) {
+  Location loc = op.getLoc();
+  Value self = op.getSelf();
+  Value other = op.getOther();
+  auto outTy = cast<BaseTensorType>(op.getType());
+
+  // diff = a - b; |diff|; -|diff|  (broadcast to the result type).
+  Value diff = createTensorSub(rewriter, loc, outTy, self, other);
+  Value absDiff = AtenAbsOp::create(rewriter, loc, outTy, diff);
+  Value negAbsDiff = AtenNegOp::create(rewriter, loc, outTy, absDiff);
+
+  // m = max(a, b).
+  Value maxAB = AtenMaximumOp::create(rewriter, loc, outTy, self, other);
+
+  Value logTerm;
+  if (useBase2) {
+    // log2(1 + exp2(-|a - b|)) -- no log2p1 op, so form 1 + ... explicitly.
+    Value expTerm = AtenExp2Op::create(rewriter, loc, outTy, negAbsDiff);
+    Value one =
+        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(1));
+    Value onePlus = AtenAddScalarOp::create(rewriter, loc, outTy, expTerm,
+                                            /*other=*/one, /*alpha=*/one);
+    logTerm = AtenLog2Op::create(rewriter, loc, outTy, onePlus);
+  } else {
+    // log1p(exp(-|a - b|)).
+    Value expTerm = AtenExpOp::create(rewriter, loc, outTy, negAbsDiff);
+    logTerm = AtenLog1pOp::create(rewriter, loc, outTy, expTerm);
+  }
+
+  Value alpha =
+      ConstantFloatOp::create(rewriter, loc, rewriter.getF64FloatAttr(1));
+  rewriter.replaceOpWithNewOp<AtenAddTensorOp>(op, outTy, maxAB, logTerm,
+                                               alpha);
+  return success();
+}
+
 namespace {
 class DecomposeAtenLogAddExpOp : public OpRewritePattern<AtenLogaddexpOp> {
 public:
   using OpRewritePattern<AtenLogaddexpOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(AtenLogaddexpOp op,
                                 PatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-    Value self = op.getSelf();
-    Value other = op.getOther();
-    auto outTy = op.getType();
-
-    Value constantOne =
-        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(1));
-    Value expSelf = AtenExpOp::create(rewriter, loc, self.getType(), self);
-    Value expOther = AtenExpOp::create(rewriter, loc, other.getType(), other);
-    Value addValue = AtenAddTensorOp::create(rewriter, loc, outTy, expSelf,
-                                             expOther, constantOne);
-    rewriter.replaceOpWithNewOp<AtenLogOp>(op, outTy, addValue);
-    return success();
+    return decomposeLogAddExp(op, rewriter, /*useBase2=*/false);
   }
 };
 } // namespace
@@ -3270,19 +3304,7 @@ public:
   using OpRewritePattern<AtenLogaddexp2Op>::OpRewritePattern;
   LogicalResult matchAndRewrite(AtenLogaddexp2Op op,
                                 PatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-    Value self = op.getSelf();
-    Value other = op.getOther();
-    auto outTy = op.getType();
-
-    Value constantOne =
-        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(1));
-    Value expSelf = AtenExp2Op::create(rewriter, loc, self.getType(), self);
-    Value expOther = AtenExp2Op::create(rewriter, loc, other.getType(), other);
-    Value addValue = AtenAddTensorOp::create(rewriter, loc, outTy, expSelf,
-                                             expOther, constantOne);
-    rewriter.replaceOpWithNewOp<AtenLog2Op>(op, outTy, addValue);
-    return success();
+    return decomposeLogAddExp(op, rewriter, /*useBase2=*/true);
   }
 };
 } // namespace

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2974,6 +2974,12 @@ ONNX_XFAIL_SET = {
     "LinalgNormKeepDimComplexModule_basic",
     "LinalgVectorNormComplexModule_basic",
     "LinalgVectorNormRank0Module_basic",
+    # The ONNX exporter expands logaddexp/logaddexp2 into a form that
+    # overflows fp32 on these large-magnitude inputs before torch-mlir sees
+    # the op; the mismatch is inherent to the exported graph, not the
+    # torch-mlir decomposition.
+    "ElementwiseLogAddExpLargeMagnitudeModule_basic",
+    "ElementwiseLogAddExp2LargeMagnitudeModule_basic",
     "MaxPool1dWithIndicesModule_basic",
     "MaxPool1dCeilModeTrueModule_basic",
     "MaxPool1dModule_basic",

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2980,6 +2980,11 @@ ONNX_XFAIL_SET = {
     # torch-mlir decomposition.
     "ElementwiseLogAddExpLargeMagnitudeModule_basic",
     "ElementwiseLogAddExp2LargeMagnitudeModule_basic",
+    # The ONNX exporter decomposes logcumsumexp into a global-max shift
+    # (M + log(cumsum(exp(x - M)))), which underflows fp32 to -inf on a large
+    # late value before torch-mlir sees the op; the mismatch is inherent to the
+    # exported graph.
+    "LogCumsumExpLargeMagnitudeModule_basic",
     "MaxPool1dWithIndicesModule_basic",
     "MaxPool1dCeilModeTrueModule_basic",
     "MaxPool1dModule_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -5754,6 +5754,39 @@ def LogCumsumExpStaticFloat64DtypeModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class LogCumsumExpLargeMagnitudeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([None, ([-1, -1], torch.float32, True)])
+    def forward(self, x):
+        return torch.ops.aten.logcumsumexp(x, dim=1)
+
+
+@register_test_case(module_factory=lambda: LogCumsumExpLargeMagnitudeModule())
+def LogCumsumExpLargeMagnitudeModule_basic(module, tu: TestUtils):
+    # Regression for the sequential logaddexp scan. Rows exercise both failure
+    # modes of the alternatives along the scan dim:
+    #   - a large late value ([1, 2, 200]) makes a global-max shift
+    #     (M + log(cumsum(exp(x - M)))) underflow early prefixes to log(0) = -inf;
+    #   - large positive values ([100, 101, 102]) overflow the naive
+    #     log(cumsum(exp)) to +inf.
+    # The prefix-local logaddexp scan stays finite and matches eager on both.
+    module.forward(
+        torch.tensor(
+            [
+                [1.0, 2.0, 200.0],
+                [-100.0, 0.0, 50.0],
+                [100.0, 101.0, 102.0],
+            ]
+        )
+    )
+
+
+# ==============================================================================
+
+
 class CumprodModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -3290,6 +3290,37 @@ def ElementwiseLogAddExpBroadcastModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwiseLogAddExpLargeMagnitudeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, x, y):
+        return torch.ops.aten.logaddexp(x, y)
+
+
+@register_test_case(module_factory=lambda: ElementwiseLogAddExpLargeMagnitudeModule())
+def ElementwiseLogAddExpLargeMagnitudeModule_basic(module, tu: TestUtils):
+    # Inputs beyond the fp32 exp overflow threshold (~88). The naive
+    # log(exp(a) + exp(b)) decomposition overflows these to +inf; the stable
+    # max + log1p(exp(-|a - b|)) form used by DecomposeAtenLogAddExpOp stays
+    # finite and matches eager.
+    module.forward(
+        torch.tensor([[100.0, 90.0, -50.0], [120.0, 88.0, 200.0]]),
+        torch.tensor([[95.0, 88.0, 200.0], [119.0, 90.0, 199.0]]),
+    )
+
+
+# ==============================================================================
+
+
 class ElementwiseLogAddExp2Module(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -3333,6 +3364,36 @@ class ElementwiseLogAddExp2BroadcastModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseLogAddExp2BroadcastModule())
 def ElementwiseLogAddExp2BroadcastModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 2, 4), tu.rand(3, 1, 4))
+
+
+# ==============================================================================
+
+
+class ElementwiseLogAddExp2LargeMagnitudeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, x, y):
+        return torch.ops.aten.logaddexp2(x, y)
+
+
+@register_test_case(module_factory=lambda: ElementwiseLogAddExp2LargeMagnitudeModule())
+def ElementwiseLogAddExp2LargeMagnitudeModule_basic(module, tu: TestUtils):
+    # Base-2 analogue: inputs beyond the fp32 exp2 overflow threshold (~127).
+    # The naive log2(2^a + 2^b) form overflows to +inf; the stable
+    # max + log2(1 + 2^(-|a - b|)) form stays finite and matches eager.
+    module.forward(
+        torch.tensor([[130.0, 120.0, -60.0], [150.0, 127.0, 240.0]]),
+        torch.tensor([[125.0, 118.0, 240.0], [149.0, 120.0, 239.0]]),
+    )
 
 
 # ==============================================================================

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1666,3 +1666,46 @@ func.func @torch.aten.linalg_vector_norm$zero_dim_keepdim(%arg0: !torch.vtensor<
   %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[3,4],f32>, !torch.float, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[3,1],f32>
   return %0 : !torch.vtensor<[3,1],f32>
 }
+
+// -----
+
+// logaddexp is decomposed to the numerically stable form
+//   max(a, b) + log1p(exp(-|a - b|))
+// rather than the naive log(exp(a) + exp(b)) (which overflows to +inf in fp32
+// once a or b exceeds ~88). Only ever exponentiating -|a - b| <= 0 avoids this.
+// CHECK-LABEL: func.func @torch.aten.logaddexp(
+// CHECK-SAME:      %[[A:.*]]: !torch.vtensor<[3,4],f32>, %[[B:.*]]: !torch.vtensor<[3,4],f32>
+// CHECK:         %[[SUB:.*]] = torch.aten.sub.Tensor %[[A]], %[[B]]
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %[[SUB]]
+// CHECK:         %[[NEG:.*]] = torch.aten.neg %[[ABS]]
+// CHECK:         %[[MAX:.*]] = torch.aten.maximum %[[A]], %[[B]]
+// CHECK:         %[[EXP:.*]] = torch.aten.exp %[[NEG]]
+// CHECK:         %[[LOG1P:.*]] = torch.aten.log1p %[[EXP]]
+// CHECK:         %[[RES:.*]] = torch.aten.add.Tensor %[[MAX]], %[[LOG1P]]
+// CHECK-NOT:     torch.aten.logaddexp
+// CHECK:         return %[[RES]]
+func.func @torch.aten.logaddexp(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32> {
+  %0 = torch.aten.logaddexp %arg0, %arg1 : !torch.vtensor<[3,4],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor<[3,4],f32>
+  return %0 : !torch.vtensor<[3,4],f32>
+}
+
+// -----
+
+// logaddexp2 uses the base-2 analogue of the stable form:
+//   max(a, b) + log2(1 + 2^(-|a - b|)).
+// CHECK-LABEL: func.func @torch.aten.logaddexp2(
+// CHECK-SAME:      %[[A:.*]]: !torch.vtensor<[3,4],f32>, %[[B:.*]]: !torch.vtensor<[3,4],f32>
+// CHECK:         %[[SUB:.*]] = torch.aten.sub.Tensor %[[A]], %[[B]]
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %[[SUB]]
+// CHECK:         %[[NEG:.*]] = torch.aten.neg %[[ABS]]
+// CHECK:         %[[MAX:.*]] = torch.aten.maximum %[[A]], %[[B]]
+// CHECK:         %[[POW:.*]] = torch.aten.pow.Scalar %{{.*}}, %[[NEG]]
+// CHECK:         %[[ADD1:.*]] = torch.aten.add.Scalar %[[POW]]
+// CHECK:         %[[LOG2:.*]] = torch.aten.log2 %[[ADD1]]
+// CHECK:         %[[RES:.*]] = torch.aten.add.Tensor %[[MAX]], %[[LOG2]]
+// CHECK-NOT:     torch.aten.logaddexp2
+// CHECK:         return %[[RES]]
+func.func @torch.aten.logaddexp2(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32> {
+  %0 = torch.aten.logaddexp2 %arg0, %arg1 : !torch.vtensor<[3,4],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor<[3,4],f32>
+  return %0 : !torch.vtensor<[3,4],f32>
+}

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1709,3 +1709,82 @@ func.func @torch.aten.logaddexp2(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch
   %0 = torch.aten.logaddexp2 %arg0, %arg1 : !torch.vtensor<[3,4],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor<[3,4],f32>
   return %0 : !torch.vtensor<[3,4],f32>
 }
+
+// -----
+
+// logcumsumexp is an inclusive prefix scan with a logaddexp combiner. For a
+// STATIC scan dim it is emitted as a compile-time-unrolled Hillis-Steele scan:
+// ceil(log2(L)) doubling steps, each shifting the running result right by
+// `offset` along `dim` (constant_pad_nd with the -inf identity, then slice back
+// to length L) and folding it in with an elementwise logaddexp (lowered to the
+// stabilized sub/abs/neg/maximum/exp/log1p/add body). No torch.prim.Loop, no
+// global-max shift (aten.amax) and no fused cumsum -- so it lowers to linalg,
+// TOSA and StableHLO alike. Scan dim L=3 -> offsets 1, 2 (two steps).
+// CHECK-LABEL: func.func @torch.aten.logcumsumexp$static(
+// CHECK-SAME:      %[[X:.*]]: !torch.vtensor<[2,3],f32>
+// CHECK-DAG:     %[[ONE:.*]] = torch.constant.int 1
+// CHECK-DAG:     %[[NINF:.*]] = torch.constant.float 0xFFF0000000000000
+// CHECK-DAG:     %[[ZERO:.*]] = torch.constant.int 0
+// CHECK-DAG:     %[[THREE:.*]] = torch.constant.int 3
+// step offset = 1
+// CHECK:         %[[PAD1LIST:.*]] = torch.prim.ListConstruct %[[ONE]], %[[ZERO]], %[[ZERO]], %[[ZERO]]
+// CHECK:         %[[PAD1:.*]] = torch.aten.constant_pad_nd %[[X]], %[[PAD1LIST]], %[[NINF]]
+// CHECK:         %[[SH1:.*]] = torch.aten.slice.Tensor %[[PAD1]], %[[ONE]], %[[ZERO]], %[[THREE]], %[[ONE]]
+// CHECK:           torch.aten.sub.Tensor %[[X]], %[[SH1]]
+// CHECK:           torch.aten.abs
+// CHECK:           torch.aten.neg
+// CHECK:           torch.aten.maximum %[[X]], %[[SH1]]
+// CHECK:           torch.aten.exp
+// CHECK:           torch.aten.log1p
+// CHECK:         %[[R1:.*]] = torch.aten.add.Tensor
+// step offset = 2
+// CHECK:         %[[PAD2LIST:.*]] = torch.prim.ListConstruct %{{.*}}, %[[ZERO]], %[[ZERO]], %[[ZERO]]
+// CHECK:         %[[PAD2:.*]] = torch.aten.constant_pad_nd %[[R1]], %[[PAD2LIST]], %[[NINF]]
+// CHECK:         %[[SH2:.*]] = torch.aten.slice.Tensor %[[PAD2]], %[[ONE]], %[[ZERO]], %[[THREE]], %[[ONE]]
+// CHECK:           torch.aten.maximum %[[R1]], %[[SH2]]
+// CHECK:           torch.aten.log1p
+// CHECK:         %[[R2:.*]] = torch.aten.add.Tensor
+// CHECK-NOT:     torch.prim.Loop
+// CHECK-NOT:     torch.aten.amax
+// CHECK-NOT:     torch.aten.cumsum
+// CHECK-NOT:     torch.aten.logcumsumexp
+// CHECK:         return %[[R2]]
+func.func @torch.aten.logcumsumexp$static(%arg0: !torch.vtensor<[2,3],f32>) -> !torch.vtensor<[2,3],f32> {
+  %dim = torch.constant.int 1
+  %0 = torch.aten.logcumsumexp %arg0, %dim : !torch.vtensor<[2,3],f32>, !torch.int -> !torch.vtensor<[2,3],f32>
+  return %0 : !torch.vtensor<[2,3],f32>
+}
+
+// -----
+
+// For a DYNAMIC scan dim the doubling count is unknown at compile time, so the
+// recurrence out[j] = logaddexp(out[j-1], x[j]) is materialized as a
+// data-dependent torch.prim.Loop (trip = dimSize - 1) whose body slices the
+// running prefix and current element, combines them with the stabilized
+// logaddexp body, and scatters the result back. Lowers to scf (linalg).
+// CHECK-LABEL: func.func @torch.aten.logcumsumexp$dynamic(
+// CHECK-SAME:      %[[X:.*]]: !torch.vtensor<[2,?],f32>
+// CHECK-DAG:     %[[ONE:.*]] = torch.constant.int 1
+// CHECK-DAG:     %[[TRUE:.*]] = torch.constant.bool true
+// CHECK:         %[[DIMSZ:.*]] = torch.aten.size.int %[[X]], %[[ONE]]
+// CHECK:         %[[TRIP:.*]] = torch.aten.sub.int %[[DIMSZ]], %[[ONE]]
+// CHECK:         %[[LOOP:.*]] = torch.prim.Loop %[[TRIP]], %[[TRUE]], init(%[[X]])
+// CHECK:         ^bb0(%[[IV:.*]]: !torch.int, %[[ACC:.*]]: !torch.vtensor<[2,?],f32>):
+// CHECK:           %[[J:.*]] = torch.aten.add.int %[[IV]], %[[ONE]]
+// CHECK:           %[[JP1:.*]] = torch.aten.add.int %[[J]], %[[ONE]]
+// CHECK:           %[[PREV:.*]] = torch.aten.slice.Tensor %[[ACC]], %[[ONE]], %[[IV]], %[[J]], %[[ONE]]
+// CHECK:           %[[CUR:.*]] = torch.aten.slice.Tensor %[[X]], %[[ONE]], %[[J]], %[[JP1]], %[[ONE]]
+// CHECK:           torch.aten.maximum %[[PREV]], %[[CUR]]
+// CHECK:           torch.aten.log1p
+// CHECK:           %[[VAL:.*]] = torch.aten.add.Tensor
+// CHECK:           %[[SCAT:.*]] = torch.aten.slice_scatter %[[ACC]], %[[VAL]], %[[ONE]], %[[J]], %[[JP1]], %[[ONE]]
+// CHECK:           torch.prim.Loop.condition %[[TRUE]], iter(%[[SCAT]]
+// CHECK-NOT:     torch.aten.amax
+// CHECK-NOT:     torch.aten.cumsum
+// CHECK-NOT:     torch.aten.logcumsumexp
+// CHECK:         return %[[LOOP]]
+func.func @torch.aten.logcumsumexp$dynamic(%arg0: !torch.vtensor<[2,?],f32>) -> !torch.vtensor<[2,?],f32> {
+  %dim = torch.constant.int 1
+  %0 = torch.aten.logcumsumexp %arg0, %dim : !torch.vtensor<[2,?],f32>, !torch.int -> !torch.vtensor<[2,?],f32>
+  return %0 : !torch.vtensor<[2,?],f32>
+}


### PR DESCRIPTION
## Summary

Two related numerical-stability fixes in `torch-decompose-complex-ops`:

1. **logaddexp / logaddexp2** — the decompositions computed the naive
   `log(exp(a) + exp(b))`, which overflows fp32 to `+inf` due to the `exp`
   computation once an input exceeds ~88 (~127 for the base-2 form). Rewritten
   to the stable
   `max(a,b) + log1p(exp(-|a-b|))` (and the base-2 analogue), so the only
   `exp` taken is of a value in `[0,1]`.

2. **logcumsumexp** — decomposed to an exact inclusive scan with the
   `logaddexp` combiner (`out[j] = logaddexp(out[j-1], x[j])`), reusing the
   stabilized `logaddexp` above for every step. This prefix-local normalization
   avoids both the `+inf` overflow of naive `log(cumsum(exp(x)))` and the
   `-inf` underflow of a global-max shift `M + log(cumsum(exp(x - M)))` when a
   large value sits late in the scan. For a static scan dim the scan is emitted
   as a compile-time-unrolled Hillis-Steele doubling scan (pad/slice/logaddexp)
   that legalizes to linalg, TOSA, and StableHLO — mirroring how `aten.cumsum`
   lowers on those backends; a dynamic scan dim falls back to a
   `torch.prim.Loop` (linalg only, same limitation `aten.cumsum` already has).

## Details

### logaddexp / logaddexp2

`logaddexp(a, b) = log(exp(a) + exp(b))`. Evaluated literally, `exp(a)`
overflows fp32 (max ≈ `3.4e38`) for `a > ~88`, so any moderately large input
gives `+inf` even when the true result is finite and small.

Factor the larger operand out of the sum before taking the log. Let
`m = max(a, b)`. Pulling `exp(m)` out is exact:

```
exp(a) + exp(b) = exp(m) · (exp(a - m) + exp(b - m))
```

and since one of `a, b` equals `m`, one of `a - m`, `b - m` is `0` and the
other is `-|a - b|`, so the bracket is `1 + exp(-|a - b|)`. Taking the log and
using `log(exp(m) · z) = m + log(z)`:

```
log(exp(a) + exp(b)) = m + log(1 + exp(-|a - b|)) = m + log1p(exp(d)),   d = -|a - b|
```

Now the only exponential is `exp(d)` with `d ∈ (-inf, 0]`, so `exp(d) ∈ (0, 1]`
— it can never overflow, regardless of how large `a` or `b` are; the `m` out
front carries the magnitude losslessly. `log1p` is used instead of `log(1 + …)`
so the correction stays accurate when `exp(d) → 0`. The base-2 variant is
identical with `exp → exp2` and `log1p(t) → log2(1 + t)` (factoring out `2^m`
in place of `exp(m)`):

```
logaddexp2(a, b) = m + log2(1 + 2^(-|a - b|))
```

### logcumsumexp

By definition, along the scan dim:

```
logcumsumexp(x)[j] = log( Σ_{i ≤ j} exp(x[i]) )
```

i.e. the running prefix of exponential sums, in log-space.

**The decomposition.** Rather than form `cumsum(exp(x))` directly, expose the
prefix as a recurrence and fold one element in at a time with `logaddexp`:

```
out[0] = x[0]
out[j] = logaddexp(out[j-1], x[j])      for j ≥ 1
```

This is *exact*, because `out[j-1]` already holds `log(Σ_{i ≤ j-1} exp(x[i]))`,
and

```
log( Σ_{i ≤ j} exp(x[i]) )
    = log( Σ_{i ≤ j-1} exp(x[i]) + exp(x[j]) )
    = logaddexp( log(Σ_{i ≤ j-1} exp(x[i])), x[j] )
    = logaddexp( out[j-1], x[j] )
```

The per-step `aten.logaddexp` is lowered by the stabilized pattern above in the
same pass, so each step's shift is `max(out[j-1], x[j])` — the max over just
*this prefix's result and the current element* ("prefix-local"), never a single
global max over the whole scan.

**How the scan is emitted.** Two forms, chosen by whether the scan dim is
static:

- *Static dim* — a compile-time-unrolled **Hillis-Steele doubling scan**. For
  `offset = 1, 2, 4, … < L`, shift the running result right by `offset` along
  the dim (pad `-inf` on the low side with `aten.constant_pad_nd`, slice back
  to length `L`) and fold with an elementwise `aten.logaddexp`. After
  `⌈log2 L⌉` rounds every position has absorbed all its predecessors. This uses
  only pad / slice / logaddexp, so it legalizes to linalg **and** TOSA **and**
  StableHLO — the same doubling structure `aten.cumsum` already uses on those
  backends.

- *Dynamic dim* — fall back to a `torch.prim.Loop` (trip = dimSize-1; body
  slices the running prefix and current element, combines with
  `aten.logaddexp`, writes back with `aten.slice_scatter`). This lowers through
  `scf` to linalg only; TOSA/StableHLO cannot express a dynamic-shape scan,
  which is the exact same limitation `aten.cumsum` has today, so no backend
  that previously worked regresses.

**Why the obvious alternatives fail.** Two closed-form (loop-free) strategies
are attractive because they lower to a single fused `cumsum`, but each has a
failure mode that the prefix-local scan does not:

- **Naive** `log(cumsum(exp(x)))` — exponentiates every element directly, so a
  single large `x[i]` overflows `exp` to `+inf`, and the `+inf` then poisons
  every prefix at or after it. e.g. `[100, 101, 102]` → `[inf, inf, inf]`.

- **Global-max shift** `M + log(cumsum(exp(x - M)))`, with `M = max(x)` over
  the whole dim. This is the standard trick for a *single* logsumexp and never
  overflows (every `x[i] - M ≤ 0`). But for a cumulative scan the single global
  `M` is wrong for early prefixes: if a large value sits late in the scan, the
  early terms `exp(x[i] - M)` underflow to `0`, so the early prefix sums are
  `log(0) = -inf`. e.g. `[1, 2, 200]` with `M = 200` →
  `exp(1-200) = exp(2-200) = 0` → `[-inf, -inf, 200]`, whereas the true result
  is `[1, 2.31, 200]`.

The prefix-local scan subtracts a bound tied to *each* prefix
(`max(out[j-1], x[j])`) rather than one global bound, so every step stays
finite in both regimes. (This is also what PyTorch's own eager kernel does — a
sequential `log_add_exp` scan on CPU, a Blelloch parallel-prefix scan on CUDA —
so the O(L) recurrence is not a fundamental cost.)

Measured on the two inputs above (fp32):

| input | naive `log(cumsum(exp))` | global-max `M+log(cumsum(exp(x-M)))` | this PR (scan) | eager |
|---|---|---|---|---|
| `[1, 2, 200]` | `[1, 2.31, inf]` | `[-inf, -inf, 200]` | `[1, 2.31, 200]` | `[1, 2.31, 200]` |
| `[100, 101, 102]` | `[inf, inf, inf]` | `[100, 101.3, 102.4]` | `[100, 101.3, 102.4]` | `[100, 101.3, 102.4]` |

## Tests

- Lit: added checks in `decompose-complex-ops.mlir` for `logaddexp`,
  `logaddexp2`, and both `logcumsumexp` forms (`$static` → Hillis-Steele
  pad/slice/logaddexp with no `prim.Loop`; `$dynamic` → `prim.Loop` +
  `slice_scatter`).
- e2e: `ElementwiseLogAddExp{,2}LargeMagnitudeModule` and
  `LogCumsumExpLargeMagnitudeModule` with inputs that produce finite eager
  goldens but break the unstable forms. Pass on `fx_importer`; added to
  `ONNX_XFAIL_SET` because the ONNX exporter decomposes these ops upstream
  (into the naive / global-max forms) before torch-mlir sees them, so the fix
  is unreachable on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
