### PR TITLE
[Torch] Numerically stabilize logaddexp/logaddexp2 decompositions

### DIFF
--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -3241,25 +3241,59 @@ public:
 };
 } // namespace
 
+// Numerically stable decomposition of logaddexp / logaddexp2.
+//   logaddexp(a, b)  = log (exp (a) + exp (b))  = m + log1p(exp (-|a - b|))
+//   logaddexp2(a, b) = log2(exp2(a) + exp2(b))  = m + log2(1 + exp2(-|a - b|))
+// where m = max(a, b). Carrying `m` outside the exponential and only ever
+// exponentiating the non-positive value -|a - b| avoids the +inf overflow of
+// the naive `log(exp(a) + exp(b))` form when a or b exceeds ~88 in float32.
+// `useBase2` selects the base-2 variant (exp2/log2); base-e uses log1p
+// directly.
+template <typename OpTy>
+static LogicalResult decomposeLogAddExp(OpTy op, PatternRewriter &rewriter,
+                                        bool useBase2) {
+  Location loc = op.getLoc();
+  Value self = op.getSelf();
+  Value other = op.getOther();
+  auto outTy = cast<BaseTensorType>(op.getType());
+
+  // diff = a - b; |diff|; -|diff|  (broadcast to the result type).
+  Value diff = createTensorSub(rewriter, loc, outTy, self, other);
+  Value absDiff = AtenAbsOp::create(rewriter, loc, outTy, diff);
+  Value negAbsDiff = AtenNegOp::create(rewriter, loc, outTy, absDiff);
+
+  // m = max(a, b).
+  Value maxAB = AtenMaximumOp::create(rewriter, loc, outTy, self, other);
+
+  Value logTerm;
+  if (useBase2) {
+    // log2(1 + exp2(-|a - b|)) -- no log2p1 op, so form 1 + ... explicitly.
+    Value expTerm = AtenExp2Op::create(rewriter, loc, outTy, negAbsDiff);
+    Value one =
+        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(1));
+    Value onePlus = AtenAddScalarOp::create(rewriter, loc, outTy, expTerm,
+                                            /*other=*/one, /*alpha=*/one);
+    logTerm = AtenLog2Op::create(rewriter, loc, outTy, onePlus);
+  } else {
+    // log1p(exp(-|a - b|)).
+    Value expTerm = AtenExpOp::create(rewriter, loc, outTy, negAbsDiff);
+    logTerm = AtenLog1pOp::create(rewriter, loc, outTy, expTerm);
+  }
+
+  Value alpha =
+      ConstantFloatOp::create(rewriter, loc, rewriter.getF64FloatAttr(1));
+  rewriter.replaceOpWithNewOp<AtenAddTensorOp>(op, outTy, maxAB, logTerm,
+                                               alpha);
+  return success();
+}
+
 namespace {
 class DecomposeAtenLogAddExpOp : public OpRewritePattern<AtenLogaddexpOp> {
 public:
   using OpRewritePattern<AtenLogaddexpOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(AtenLogaddexpOp op,
                                 PatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-    Value self = op.getSelf();
-    Value other = op.getOther();
-    auto outTy = op.getType();
-
-    Value constantOne =
-        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(1));
-    Value expSelf = AtenExpOp::create(rewriter, loc, self.getType(), self);
-    Value expOther = AtenExpOp::create(rewriter, loc, other.getType(), other);
-    Value addValue = AtenAddTensorOp::create(rewriter, loc, outTy, expSelf,
-                                             expOther, constantOne);
-    rewriter.replaceOpWithNewOp<AtenLogOp>(op, outTy, addValue);
-    return success();
+    return decomposeLogAddExp(op, rewriter, /*useBase2=*/false);
   }
 };
 } // namespace
@@ -3270,19 +3304,7 @@ public:
   using OpRewritePattern<AtenLogaddexp2Op>::OpRewritePattern;
   LogicalResult matchAndRewrite(AtenLogaddexp2Op op,
                                 PatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-    Value self = op.getSelf();
-    Value other = op.getOther();
-    auto outTy = op.getType();
-
-    Value constantOne =
-        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(1));
-    Value expSelf = AtenExp2Op::create(rewriter, loc, self.getType(), self);
-    Value expOther = AtenExp2Op::create(rewriter, loc, other.getType(), other);
-    Value addValue = AtenAddTensorOp::create(rewriter, loc, outTy, expSelf,
-                                             expOther, constantOne);
-    rewriter.replaceOpWithNewOp<AtenLog2Op>(op, outTy, addValue);
-    return success();
+    return decomposeLogAddExp(op, rewriter, /*useBase2=*/true);
   }
 };
 } // namespace

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -3282,8 +3282,26 @@ static LogicalResult decomposeLogAddExp(OpTy op, PatternRewriter &rewriter,
 
   Value alpha =
       ConstantFloatOp::create(rewriter, loc, rewriter.getF64FloatAttr(1));
-  rewriter.replaceOpWithNewOp<AtenAddTensorOp>(op, outTy, maxAB, logTerm,
-                                               alpha);
+  Value stable =
+      AtenAddTensorOp::create(rewriter, loc, outTy, maxAB, logTerm, alpha);
+
+  // When both inputs are the same infinity (a == b == +/-inf) the diff a - b
+  // is NaN, which poisons `stable` into NaN. PyTorch instead returns that
+  // shared infinity. Guard with an inf-mask that selects `self` in that case:
+  //   inf_mask = isinf(a) && (a == b)
+  //   result   = where(inf_mask, a, stable)
+  // PyTorch's `_refs.logaddexp` writes this as `!isfinite(a) && a == b`; since
+  // `a == b` is already false when either operand is NaN, `isinf(a)` is
+  // equivalent there and (unlike aten.isfinite) lowers to the linalg backend.
+  Type boolTy = outTy.getWithSizesAndDtype(outTy.getOptionalSizes(),
+                                           rewriter.getI1Type());
+  Value selfIsInf = AtenIsinfOp::create(rewriter, loc, boolTy, self);
+  Value selfEqOther =
+      AtenEqTensorOp::create(rewriter, loc, boolTy, self, other);
+  Value infMask =
+      AtenLogicalAndOp::create(rewriter, loc, boolTy, selfIsInf, selfEqOther);
+  rewriter.replaceOpWithNewOp<AtenWhereSelfOp>(op, outTy, infMask, self,
+                                               stable);
   return success();
 }
 

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -2997,6 +2997,12 @@ ONNX_XFAIL_SET = {
     "LinalgNormKeepDimComplexModule_basic",
     "LinalgVectorNormComplexModule_basic",
     "LinalgVectorNormRank0Module_basic",
+    # The ONNX exporter expands logaddexp/logaddexp2 into a form that
+    # overflows fp32 on these large-magnitude inputs before torch-mlir sees
+    # the op; the mismatch is inherent to the exported graph, not the
+    # torch-mlir decomposition.
+    "ElementwiseLogAddExpLargeMagnitudeModule_basic",
+    "ElementwiseLogAddExp2LargeMagnitudeModule_basic",
     "MaxPool1dWithIndicesModule_basic",
     "MaxPool1dCeilModeTrueModule_basic",
     "MaxPool1dModule_basic",

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -3290,6 +3290,37 @@ def ElementwiseLogAddExpBroadcastModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwiseLogAddExpLargeMagnitudeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, x, y):
+        return torch.ops.aten.logaddexp(x, y)
+
+
+@register_test_case(module_factory=lambda: ElementwiseLogAddExpLargeMagnitudeModule())
+def ElementwiseLogAddExpLargeMagnitudeModule_basic(module, tu: TestUtils):
+    # Inputs beyond the fp32 exp overflow threshold (~88). The naive
+    # log(exp(a) + exp(b)) decomposition overflows these to +inf; the stable
+    # max + log1p(exp(-|a - b|)) form used by DecomposeAtenLogAddExpOp stays
+    # finite and matches eager.
+    module.forward(
+        torch.tensor([[100.0, 90.0, -50.0], [120.0, 88.0, 200.0]]),
+        torch.tensor([[95.0, 88.0, 200.0], [119.0, 90.0, 199.0]]),
+    )
+
+
+# ==============================================================================
+
+
 class ElementwiseLogAddExp2Module(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -3333,6 +3364,36 @@ class ElementwiseLogAddExp2BroadcastModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseLogAddExp2BroadcastModule())
 def ElementwiseLogAddExp2BroadcastModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 2, 4), tu.rand(3, 1, 4))
+
+
+# ==============================================================================
+
+
+class ElementwiseLogAddExp2LargeMagnitudeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, x, y):
+        return torch.ops.aten.logaddexp2(x, y)
+
+
+@register_test_case(module_factory=lambda: ElementwiseLogAddExp2LargeMagnitudeModule())
+def ElementwiseLogAddExp2LargeMagnitudeModule_basic(module, tu: TestUtils):
+    # Base-2 analogue: inputs beyond the fp32 exp2 overflow threshold (~127).
+    # The naive log2(2^a + 2^b) form overflows to +inf; the stable
+    # max + log2(1 + 2^(-|a - b|)) form stays finite and matches eager.
+    module.forward(
+        torch.tensor([[130.0, 120.0, -60.0], [150.0, 127.0, 240.0]]),
+        torch.tensor([[125.0, 118.0, 240.0], [149.0, 120.0, 239.0]]),
+    )
 
 
 # ==============================================================================

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/elementwise.py
@@ -3321,6 +3321,38 @@ def ElementwiseLogAddExpLargeMagnitudeModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwiseLogAddExpInfModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, x, y):
+        return torch.ops.aten.logaddexp(x, y)
+
+
+@register_test_case(module_factory=lambda: ElementwiseLogAddExpInfModule())
+def ElementwiseLogAddExpInfModule_basic(module, tu: TestUtils):
+    # When both inputs are the same infinity, a - b is NaN. The inf-mask guard
+    # in DecomposeAtenLogAddExpOp selects the shared infinity so the result
+    # matches eager (+inf / -inf) instead of degenerating to NaN. The remaining
+    # columns cover mixed and finite cases where the mask must stay inactive.
+    inf = float("inf")
+    module.forward(
+        torch.tensor([[inf, -inf, inf, 2.0], [inf, -inf, -inf, inf]]),
+        torch.tensor([[inf, -inf, -inf, 3.0], [1.0, 2.0, inf, -inf]]),
+    )
+
+
+# ==============================================================================
+
+
 class ElementwiseLogAddExp2Module(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -3393,6 +3425,37 @@ def ElementwiseLogAddExp2LargeMagnitudeModule_basic(module, tu: TestUtils):
     module.forward(
         torch.tensor([[130.0, 120.0, -60.0], [150.0, 127.0, 240.0]]),
         torch.tensor([[125.0, 118.0, 240.0], [149.0, 120.0, 239.0]]),
+    )
+
+
+# ==============================================================================
+
+
+class ElementwiseLogAddExp2InfModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, x, y):
+        return torch.ops.aten.logaddexp2(x, y)
+
+
+@register_test_case(module_factory=lambda: ElementwiseLogAddExp2InfModule())
+def ElementwiseLogAddExp2InfModule_basic(module, tu: TestUtils):
+    # Base-2 analogue of the shared-infinity guard: matching +/-inf inputs must
+    # return that infinity rather than NaN, while mixed and finite columns keep
+    # the inf-mask inactive.
+    inf = float("inf")
+    module.forward(
+        torch.tensor([[inf, -inf, inf, 2.0], [inf, -inf, -inf, inf]]),
+        torch.tensor([[inf, -inf, -inf, 3.0], [1.0, 2.0, inf, -inf]]),
     )
 
 

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1666,3 +1666,46 @@ func.func @torch.aten.linalg_vector_norm$zero_dim_keepdim(%arg0: !torch.vtensor<
   %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[3,4],f32>, !torch.float, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[3,1],f32>
   return %0 : !torch.vtensor<[3,1],f32>
 }
+
+// -----
+
+// logaddexp is decomposed to the numerically stable form
+//   max(a, b) + log1p(exp(-|a - b|))
+// rather than the naive log(exp(a) + exp(b)) (which overflows to +inf in fp32
+// once a or b exceeds ~88). Only ever exponentiating -|a - b| <= 0 avoids this.
+// CHECK-LABEL: func.func @torch.aten.logaddexp(
+// CHECK-SAME:      %[[A:.*]]: !torch.vtensor<[3,4],f32>, %[[B:.*]]: !torch.vtensor<[3,4],f32>
+// CHECK:         %[[SUB:.*]] = torch.aten.sub.Tensor %[[A]], %[[B]]
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %[[SUB]]
+// CHECK:         %[[NEG:.*]] = torch.aten.neg %[[ABS]]
+// CHECK:         %[[MAX:.*]] = torch.aten.maximum %[[A]], %[[B]]
+// CHECK:         %[[EXP:.*]] = torch.aten.exp %[[NEG]]
+// CHECK:         %[[LOG1P:.*]] = torch.aten.log1p %[[EXP]]
+// CHECK:         %[[RES:.*]] = torch.aten.add.Tensor %[[MAX]], %[[LOG1P]]
+// CHECK-NOT:     torch.aten.logaddexp
+// CHECK:         return %[[RES]]
+func.func @torch.aten.logaddexp(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32> {
+  %0 = torch.aten.logaddexp %arg0, %arg1 : !torch.vtensor<[3,4],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor<[3,4],f32>
+  return %0 : !torch.vtensor<[3,4],f32>
+}
+
+// -----
+
+// logaddexp2 uses the base-2 analogue of the stable form:
+//   max(a, b) + log2(1 + 2^(-|a - b|)).
+// CHECK-LABEL: func.func @torch.aten.logaddexp2(
+// CHECK-SAME:      %[[A:.*]]: !torch.vtensor<[3,4],f32>, %[[B:.*]]: !torch.vtensor<[3,4],f32>
+// CHECK:         %[[SUB:.*]] = torch.aten.sub.Tensor %[[A]], %[[B]]
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %[[SUB]]
+// CHECK:         %[[NEG:.*]] = torch.aten.neg %[[ABS]]
+// CHECK:         %[[MAX:.*]] = torch.aten.maximum %[[A]], %[[B]]
+// CHECK:         %[[POW:.*]] = torch.aten.pow.Scalar %{{.*}}, %[[NEG]]
+// CHECK:         %[[ADD1:.*]] = torch.aten.add.Scalar %[[POW]]
+// CHECK:         %[[LOG2:.*]] = torch.aten.log2 %[[ADD1]]
+// CHECK:         %[[RES:.*]] = torch.aten.add.Tensor %[[MAX]], %[[LOG2]]
+// CHECK-NOT:     torch.aten.logaddexp2
+// CHECK:         return %[[RES]]
+func.func @torch.aten.logaddexp2(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32> {
+  %0 = torch.aten.logaddexp2 %arg0, %arg1 : !torch.vtensor<[3,4],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor<[3,4],f32>
+  return %0 : !torch.vtensor<[3,4],f32>
+}

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1673,6 +1673,8 @@ func.func @torch.aten.linalg_vector_norm$zero_dim_keepdim(%arg0: !torch.vtensor<
 //   max(a, b) + log1p(exp(-|a - b|))
 // rather than the naive log(exp(a) + exp(b)) (which overflows to +inf in fp32
 // once a or b exceeds ~88). Only ever exponentiating -|a - b| <= 0 avoids this.
+// When a == b == +/-inf the diff is NaN, so an inf-mask selects the shared
+// infinity (matching PyTorch) instead of returning NaN.
 // CHECK-LABEL: func.func @torch.aten.logaddexp(
 // CHECK-SAME:      %[[A:.*]]: !torch.vtensor<[3,4],f32>, %[[B:.*]]: !torch.vtensor<[3,4],f32>
 // CHECK:         %[[SUB:.*]] = torch.aten.sub.Tensor %[[A]], %[[B]]
@@ -1681,7 +1683,13 @@ func.func @torch.aten.linalg_vector_norm$zero_dim_keepdim(%arg0: !torch.vtensor<
 // CHECK:         %[[MAX:.*]] = torch.aten.maximum %[[A]], %[[B]]
 // CHECK:         %[[EXP:.*]] = torch.aten.exp %[[NEG]]
 // CHECK:         %[[LOG1P:.*]] = torch.aten.log1p %[[EXP]]
-// CHECK:         %[[RES:.*]] = torch.aten.add.Tensor %[[MAX]], %[[LOG1P]]
+// CHECK:         %[[STABLE:.*]] = torch.aten.add.Tensor %[[MAX]], %[[LOG1P]]
+// isinf(a) is itself decomposed within this pass to abs(a) == inf.
+// CHECK:         %[[ABSA:.*]] = torch.aten.abs %[[A]]
+// CHECK:         %[[ISINF:.*]] = torch.aten.eq.Scalar %[[ABSA]], %{{.*}}
+// CHECK:         %[[EQ:.*]] = torch.aten.eq.Tensor %[[A]], %[[B]]
+// CHECK:         %[[MASK:.*]] = torch.aten.logical_and %[[ISINF]], %[[EQ]]
+// CHECK:         %[[RES:.*]] = torch.aten.where.self %[[MASK]], %[[A]], %[[STABLE]]
 // CHECK-NOT:     torch.aten.logaddexp
 // CHECK:         return %[[RES]]
 func.func @torch.aten.logaddexp(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32> {
@@ -1693,6 +1701,7 @@ func.func @torch.aten.logaddexp(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.
 
 // logaddexp2 uses the base-2 analogue of the stable form:
 //   max(a, b) + log2(1 + 2^(-|a - b|)).
+// The same inf-mask guard selects a shared +/-inf input over the NaN diff.
 // CHECK-LABEL: func.func @torch.aten.logaddexp2(
 // CHECK-SAME:      %[[A:.*]]: !torch.vtensor<[3,4],f32>, %[[B:.*]]: !torch.vtensor<[3,4],f32>
 // CHECK:         %[[SUB:.*]] = torch.aten.sub.Tensor %[[A]], %[[B]]
@@ -1702,7 +1711,13 @@ func.func @torch.aten.logaddexp(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.
 // CHECK:         %[[POW:.*]] = torch.aten.pow.Scalar %{{.*}}, %[[NEG]]
 // CHECK:         %[[ADD1:.*]] = torch.aten.add.Scalar %[[POW]]
 // CHECK:         %[[LOG2:.*]] = torch.aten.log2 %[[ADD1]]
-// CHECK:         %[[RES:.*]] = torch.aten.add.Tensor %[[MAX]], %[[LOG2]]
+// CHECK:         %[[STABLE:.*]] = torch.aten.add.Tensor %[[MAX]], %[[LOG2]]
+// isinf(a) is itself decomposed within this pass to abs(a) == inf.
+// CHECK:         %[[ABSA:.*]] = torch.aten.abs %[[A]]
+// CHECK:         %[[ISINF:.*]] = torch.aten.eq.Scalar %[[ABSA]], %{{.*}}
+// CHECK:         %[[EQ:.*]] = torch.aten.eq.Tensor %[[A]], %[[B]]
+// CHECK:         %[[MASK:.*]] = torch.aten.logical_and %[[ISINF]], %[[EQ]]
+// CHECK:         %[[RES:.*]] = torch.aten.where.self %[[MASK]], %[[A]], %[[STABLE]]
 // CHECK-NOT:     torch.aten.logaddexp2
 // CHECK:         return %[[RES]]
 func.func @torch.aten.logaddexp2(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32> {


### PR DESCRIPTION
## Summary

Numerically stabilizes the decompositions of `aten.logaddexp` and `aten.logaddexp2`.

Previously both ops decomposed to the naive form `log(exp(a) + exp(b))` (and the base-2 analogue). This overflows float32 to `+inf` as soon as either `a` or `b` exceeds ~88, so `logaddexp(100.0, 100.0)` returned `inf` instead of the correct `~100.69`.

This PR rewrites the decompositions to the standard log-sum-exp trick:

```
logaddexp(a, b)  = m + log1p(exp(-|a - b|)),  where m = max(a, b)
logaddexp2(a, b) = m + log2(1 + exp2(-|a - b|))
```

By carrying the max outside the exponential and only ever exponentiating `-|a - b| <= 0`, the intermediate never exceeds 1, so the result no longer overflows. This matches PyTorch's own numerically-stable implementation.

## Details: derivation of the identity

Let `m = max(a, b)`. Factor `e^m` out of the sum inside the logarithm:

```
logaddexp(a, b) = log(e^a + e^b)
                = log( e^m * (e^(a-m) + e^(b-m)) )
                = m + log( e^(a-m) + e^(b-m) )
```

Because `m` is the maximum, one of the two exponents `a-m`, `b-m` is exactly `0` and the other is `<= 0`:

- if `a >= b`, then `m = a`, so `a - m = 0` and `b - m = b - a = -|a - b|`;
- if `b >  a`, then `m = b`, so `b - m = 0` and `a - m = a - b = -|a - b|`.

In both cases `{e^(a-m), e^(b-m)} = {1, e^(-|a-b|)}`, so the sum is `1 + e^(-|a-b|)` and

```
logaddexp(a, b) = m + log(1 + e^(-|a - b|)) = m + log1p(e^(-|a - b|)).
```

`log1p` is used rather than `log(1 + x)` for accuracy when `e^(-|a-b|)` is small (i.e. when `a` and `b` are far apart).

The base-2 case is identical with `e` replaced by `2` and `log` by `log2`:

```
logaddexp2(a, b) = log2(2^a + 2^b)
                 = m + log2( 2^(a-m) + 2^(b-m) )
                 = m + log2(1 + 2^(-|a - b|)).
```

(There is no `log2p1` op, so `1 + 2^(-|a-b|)` is formed explicitly before `log2`.)

**Why this is stable.** The only exponentiation is of `-|a - b| <= 0`, so `exp(-|a-b|) in (0, 1]` and `1 + exp(-|a-b|) in (1, 2]` — both always finite in float32 regardless of the magnitude of `a` or `b`. The unbounded term `m` only ever appears as a plain add, never inside an exponential, so it cannot overflow. The naive form, by contrast, exponentiates `a` and `b` directly and overflows once either exceeds ~88 in float32.

## Changes

- **`DecomposeComplexOps.cpp`** — `DecomposeAtenLogAddExpOp` and `DecomposeAtenLogAddExp2Op` rewritten to the stable form via a shared `decomposeLogAddExp` helper. All intermediate ops are typed to the broadcasted result type, so broadcasting behavior is unchanged.
- **`elementwise.py`** — adds `ElementwiseLogAddExpLargeMagnitudeModule` and `ElementwiseLogAddExp2LargeMagnitudeModule`, regression tests with large-magnitude inputs that overflow under the old decomposition and pass under the new one.
- **`xfail_sets.py`** — the two new large-magnitude tests are added to `ONNX_XFAIL_SET`. The ONNX exporter expands logaddexp into a form that overflows fp32 *before* torch-mlir sees the op, so the mismatch is inherent to the exported graph, not this decomposition.
- **`decompose-complex-ops.mlir`** — FileCheck coverage for the new lowering of both ops.

## Testing

Verified manually:

- **lit / FileCheck**: `test/Dialect/Torch/decompose-complex-ops.mlir` passes.
- **e2e** across the CI gate configs — the new large-magnitude tests plus the existing `ElementwiseLogAddExp{,2}Module` and `ElementwiseLogAddExp{,2}BroadcastModule` tests pass under `fx_importer`, and pass / expectedly-xfail under `onnx`, `fx_importer_tosa`, and `fx_importer_stablehlo` as appropriate.

The existing broadcast tests continue to behave exactly as before (broadcasting is handled by shared `TorchToLinalg` machinery that this change does not touch).
