### PR TITLE
[TorchOnnxToTorch] Numerically stabilize ONNX Softplus lowering

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -2618,11 +2618,26 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
             binder.tensorResultType(resultType)) {
           return failure();
         }
-        // out = ln(exp(x) + 1)
-        Value exp = Torch::AtenExpOp::create(rewriter, binder.getLoc(),
-                                             resultType, input);
-        rewriter.replaceOpWithNewOp<Torch::AtenLog1pOp>(binder.op, resultType,
-                                                        exp);
+        Location loc = binder.getLoc();
+        // Softplus(x) = ln(exp(x) + 1), computed in the numerically stable form
+        //   max(x, 0) + log1p(exp(-|x|))
+        // to avoid overflowing exp(x) to +inf (in fp32, exp overflows once
+        // x exceeds ~88). The naive ln(exp(x) + 1) poisons every downstream
+        // value with +inf for large activations; factoring out max(x, 0) keeps
+        // the exponent's argument <= 0, so exp(-|x|) stays in (0, 1].
+        Value absX = Torch::AtenAbsOp::create(rewriter, loc, resultType, input);
+        Value negAbsX =
+            Torch::AtenNegOp::create(rewriter, loc, resultType, absX);
+        Value expNegAbsX =
+            Torch::AtenExpOp::create(rewriter, loc, resultType, negAbsX);
+        Value log1p =
+            Torch::AtenLog1pOp::create(rewriter, loc, resultType, expNegAbsX);
+        Value reluX =
+            Torch::AtenReluOp::create(rewriter, loc, resultType, input);
+        Value one = Torch::ConstantIntOp::create(rewriter, loc,
+                                                 rewriter.getI64IntegerAttr(1));
+        rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
+            binder.op, resultType, reluX, log1p, one);
         return success();
       });
   patterns.onOp(

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -2610,36 +2610,44 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
                       binder.op, resultType, operand);
                   return success();
                 });
-  patterns.onOp(
-      "Softplus", 1, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
-        Torch::ValueTensorType resultType;
-        Value input;
-        if (binder.tensorOperand(input) ||
-            binder.tensorResultType(resultType)) {
-          return failure();
-        }
-        Location loc = binder.getLoc();
-        // Softplus(x) = ln(exp(x) + 1), computed in the numerically stable form
-        //   max(x, 0) + log1p(exp(-|x|))
-        // to avoid overflowing exp(x) to +inf (in fp32, exp overflows once
-        // x exceeds ~88). The naive ln(exp(x) + 1) poisons every downstream
-        // value with +inf for large activations; factoring out max(x, 0) keeps
-        // the exponent's argument <= 0, so exp(-|x|) stays in (0, 1].
-        Value absX = Torch::AtenAbsOp::create(rewriter, loc, resultType, input);
-        Value negAbsX =
-            Torch::AtenNegOp::create(rewriter, loc, resultType, absX);
-        Value expNegAbsX =
-            Torch::AtenExpOp::create(rewriter, loc, resultType, negAbsX);
-        Value log1p =
-            Torch::AtenLog1pOp::create(rewriter, loc, resultType, expNegAbsX);
-        Value reluX =
-            Torch::AtenReluOp::create(rewriter, loc, resultType, input);
-        Value alpha = Torch::ConstantIntOp::create(
-            rewriter, loc, rewriter.getI64IntegerAttr(1));
-        rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
-            binder.op, resultType, reluX, log1p, /*alpha=*/alpha);
-        return success();
-      });
+  patterns.onOp("Softplus", 1,
+                [](OpBinder binder, ConversionPatternRewriter &rewriter) {
+                  Torch::ValueTensorType resultType;
+                  Value input;
+                  if (binder.tensorOperand(input) ||
+                      binder.tensorResultType(resultType)) {
+                    return failure();
+                  }
+                  Location loc = binder.getLoc();
+                  // ONNX Softplus(x) = ln(exp(x) + 1). Emit aten.softplus (beta
+                  // = 1) and let DecomposeAtenSoftplusOp expand it to the
+                  // numerically stable form max(beta*x, 0) +
+                  // log1p(exp(-|beta*x|)) rather than the overflow-prone
+                  // ln(exp(x) + 1). Routing through the shared op keeps the
+                  // ONNX, FX, and TorchScript frontends on identical numerics.
+                  //
+                  // beta = 1 matches the ONNX spec. threshold = 20 is PyTorch's
+                  // default: for beta*x > threshold aten.softplus returns x
+                  // directly instead of the full formula. That shortcut is
+                  // bit-exact against ONNX in fp32, because what it drops is
+                  // below the fp32 rounding granularity at x = 20:
+                  //   - dropped tail: ln(1 + exp(x)) - x = ln(1 + exp(-x))
+                  //     ~= exp(-x) for large x; at x = 20 that is
+                  //     exp(-20) ~= 2.06e-9.
+                  //   - fp32 ulp at 20: since 16 <= 20 < 32 the exponent is 4
+                  //     and, with 23 mantissa bits, ulp = 2^(4-23) = 2^-19
+                  //     ~= 1.9e-6.
+                  // The tail (~2.06e-9) is ~1000x smaller than ulp(20)
+                  // (~1.9e-6), so ln(1 + exp(20)) rounds to the same fp32 bits
+                  // as 20 and returning x is spec-exact.
+                  Value beta = Torch::ConstantIntOp::create(
+                      rewriter, loc, rewriter.getI64IntegerAttr(1));
+                  Value threshold = Torch::ConstantIntOp::create(
+                      rewriter, loc, rewriter.getI64IntegerAttr(20));
+                  rewriter.replaceOpWithNewOp<Torch::AtenSoftplusOp>(
+                      binder.op, resultType, input, beta, threshold);
+                  return success();
+                });
   patterns.onOp(
       "Softsign", 22, [](OpBinder binder, ConversionPatternRewriter &rewriter) {
         Torch::ValueTensorType resultType;

--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainQtoZ.cpp
@@ -2634,10 +2634,10 @@ void mlir::torch::onnx_c::populateDefaultDomainQtoZ(
             Torch::AtenLog1pOp::create(rewriter, loc, resultType, expNegAbsX);
         Value reluX =
             Torch::AtenReluOp::create(rewriter, loc, resultType, input);
-        Value one = Torch::ConstantIntOp::create(rewriter, loc,
-                                                 rewriter.getI64IntegerAttr(1));
+        Value alpha = Torch::ConstantIntOp::create(
+            rewriter, loc, rewriter.getI64IntegerAttr(1));
         rewriter.replaceOpWithNewOp<Torch::AtenAddTensorOp>(
-            binder.op, resultType, reluX, log1p, one);
+            binder.op, resultType, reluX, log1p, /*alpha=*/alpha);
         return success();
       });
   patterns.onOp(

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -7392,13 +7392,25 @@ public:
     Value inputTimesBeta =
         AtenMulScalarOp::create(rewriter, loc, inputType, input, op.getBeta());
 
-    // out = log1p(exp(input * beta)) / beta
-    Value exp = AtenExpOp::create(rewriter, loc, inputType, inputTimesBeta);
-    Value log1p = AtenLog1pOp::create(rewriter, loc, inputType, exp);
-    Value out =
-        AtenDivScalarOp::create(rewriter, loc, inputType, log1p, op.getBeta());
+    // out = log1p(exp(z)) / beta, with z = input * beta, computed in the
+    // numerically stable form (max(z, 0) + log1p(exp(-|z|))) / beta. Only ever
+    // exponentiating -|z| <= 0 keeps exp in (0, 1], so the arm never overflows
+    // to +inf the way the naive log1p(exp(z)) does once z exceeds ~88 in fp32.
+    Value absZ = AtenAbsOp::create(rewriter, loc, inputType, inputTimesBeta);
+    Value negAbsZ = AtenNegOp::create(rewriter, loc, inputType, absZ);
+    Value expNegAbsZ = AtenExpOp::create(rewriter, loc, inputType, negAbsZ);
+    Value log1p = AtenLog1pOp::create(rewriter, loc, inputType, expNegAbsZ);
+    Value reluZ = AtenReluOp::create(rewriter, loc, inputType, inputTimesBeta);
+    Value one =
+        ConstantIntOp::create(rewriter, loc, rewriter.getI64IntegerAttr(1));
+    Value stableSum = AtenAddTensorOp::create(rewriter, loc, inputType, reluZ,
+                                              log1p, /*alpha=*/one);
+    Value out = AtenDivScalarOp::create(rewriter, loc, inputType, stableSum,
+                                        op.getBeta());
 
-    // Select where x * beta > threshold
+    // Select where x * beta > threshold. The threshold arm returns x directly
+    // (matching eager); the stable arm above is finite for all inputs, so the
+    // select never has to discard a +inf.
     auto boolResType = inputType.getWithSizesAndDtype(inputType.getSizes(),
                                                       rewriter.getI1Type());
     Value condition = AtenGtScalarOp::create(rewriter, loc, boolResType,

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -2389,6 +2389,35 @@ def SoftplusModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class SoftplusLargeMagnitudeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args(
+        [
+            None,
+            ([-1, -1], torch.float32, True),
+        ]
+    )
+    def forward(self, x):
+        return torch.ops.aten.softplus(x)
+
+
+@register_test_case(module_factory=lambda: SoftplusLargeMagnitudeModule())
+def SoftplusLargeMagnitudeModule_basic(module, tu: TestUtils):
+    # Inputs on both sides of the fp32 exp overflow threshold (~88). The stable
+    # (max(z, 0) + log1p(exp(-|z|))) / beta arm in DecomposeAtenSoftplusOp keeps
+    # these finite and matches eager, where the old naive log1p(exp(z)) arm
+    # would materialize +inf before the threshold select discards it.
+    module.forward(
+        torch.tensor([[100.0, -100.0, 90.0], [-90.0, 0.5, -0.5], [200.0, -200.0, 1.0]])
+    )
+
+
+# ==============================================================================
+
+
 class HardsigmoidModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -2258,8 +2258,13 @@ func.func @test_size(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[],si
 
 // CHECK-LABEL: func.func @test_softplus
 func.func @test_softplus(%arg0: !torch.vtensor<[3],f32>) -> !torch.vtensor<[3],f32> attributes {torch.onnx_meta.ir_version = 3 : si64, torch.onnx_meta.opset_version = 1 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-  // CHECK: %[[EXP:.*]] = torch.aten.exp %arg0 : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
-  // CHECK: torch.aten.log1p %[[EXP]] : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
+  // CHECK: %[[ABS:.*]] = torch.aten.abs %arg0 : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
+  // CHECK: %[[NEG:.*]] = torch.aten.neg %[[ABS]] : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
+  // CHECK: %[[EXP:.*]] = torch.aten.exp %[[NEG]] : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
+  // CHECK: %[[LOG1P:.*]] = torch.aten.log1p %[[EXP]] : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
+  // CHECK: %[[RELU:.*]] = torch.aten.relu %arg0 : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
+  // CHECK: %[[ONE:.*]] = torch.constant.int 1
+  // CHECK: torch.aten.add.Tensor %[[RELU]], %[[LOG1P]], %[[ONE]] : !torch.vtensor<[3],f32>, !torch.vtensor<[3],f32>, !torch.int -> !torch.vtensor<[3],f32>
   %0 = torch.operator "onnx.Softplus"(%arg0) : (!torch.vtensor<[3],f32>) -> !torch.vtensor<[3],f32>
   return %0 : !torch.vtensor<[3],f32>
 }

--- a/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
+++ b/test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir
@@ -2258,13 +2258,11 @@ func.func @test_size(%arg0: !torch.vtensor<[3,4,5],f32>) -> !torch.vtensor<[],si
 
 // CHECK-LABEL: func.func @test_softplus
 func.func @test_softplus(%arg0: !torch.vtensor<[3],f32>) -> !torch.vtensor<[3],f32> attributes {torch.onnx_meta.ir_version = 3 : si64, torch.onnx_meta.opset_version = 1 : si64, torch.onnx_meta.producer_name = "backend-test", torch.onnx_meta.producer_version = ""} {
-  // CHECK: %[[ABS:.*]] = torch.aten.abs %arg0 : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
-  // CHECK: %[[NEG:.*]] = torch.aten.neg %[[ABS]] : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
-  // CHECK: %[[EXP:.*]] = torch.aten.exp %[[NEG]] : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
-  // CHECK: %[[LOG1P:.*]] = torch.aten.log1p %[[EXP]] : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
-  // CHECK: %[[RELU:.*]] = torch.aten.relu %arg0 : !torch.vtensor<[3],f32> -> !torch.vtensor<[3],f32>
-  // CHECK: %[[ONE:.*]] = torch.constant.int 1
-  // CHECK: torch.aten.add.Tensor %[[RELU]], %[[LOG1P]], %[[ONE]] : !torch.vtensor<[3],f32>, !torch.vtensor<[3],f32>, !torch.int -> !torch.vtensor<[3],f32>
+  // ONNX Softplus lowers to aten.softplus (beta = 1, threshold = 20); the
+  // numerically stable expansion happens in DecomposeAtenSoftplusOp.
+  // CHECK: %[[BETA:.*]] = torch.constant.int 1
+  // CHECK: %[[THRESHOLD:.*]] = torch.constant.int 20
+  // CHECK: torch.aten.softplus %arg0, %[[BETA]], %[[THRESHOLD]] : !torch.vtensor<[3],f32>, !torch.int, !torch.int -> !torch.vtensor<[3],f32>
   %0 = torch.operator "onnx.Softplus"(%arg0) : (!torch.vtensor<[3],f32>) -> !torch.vtensor<[3],f32>
   return %0 : !torch.vtensor<[3],f32>
 }

--- a/test/Dialect/Torch/decompose-complex-ops.mlir
+++ b/test/Dialect/Torch/decompose-complex-ops.mlir
@@ -1256,9 +1256,13 @@ func.func @channel_shuffle(%arg0: !torch.vtensor<[1,8,4,4],f32>) -> !torch.vtens
 // CHECK:         %[[ONE:.*]] = torch.constant.float 1.000000e+00
 // CHECK:         %[[THRESHOLD:.*]] = torch.constant.float 2.000000e+01
 // CHECK:         %[[SCALED:.*]] = torch.aten.mul.Scalar %arg0, %[[ONE]]
-// CHECK:         %[[EXP:.*]] = torch.aten.exp %[[SCALED]]
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %[[SCALED]]
+// CHECK:         %[[NEG:.*]] = torch.aten.neg %[[ABS]]
+// CHECK:         %[[EXP:.*]] = torch.aten.exp %[[NEG]]
 // CHECK:         %[[LOG1P:.*]] = torch.aten.log1p %[[EXP]]
-// CHECK:         %[[SOFTPLUS:.*]] = torch.aten.div.Scalar %[[LOG1P]], %[[ONE]]
+// CHECK:         %[[RELU:.*]] = torch.aten.relu %[[SCALED]]
+// CHECK:         %[[SUM:.*]] = torch.aten.add.Tensor %[[RELU]], %[[LOG1P]]
+// CHECK:         %[[SOFTPLUS:.*]] = torch.aten.div.Scalar %[[SUM]], %[[ONE]]
 // CHECK:         %[[GT:.*]] = torch.aten.gt.Scalar %[[SCALED]], %[[THRESHOLD]]
 // CHECK:         %[[SOFTPLUS_STABLE:.*]] = torch.aten.where.self %[[GT]], %arg0, %[[SOFTPLUS]]
 // CHECK:         %[[TANH:.*]] = torch.aten.tanh %[[SOFTPLUS_STABLE]]
@@ -1665,4 +1669,32 @@ func.func @torch.aten.linalg_vector_norm$zero_dim_keepdim(%arg0: !torch.vtensor<
   %dtype = torch.constant.none
   %0 = torch.aten.linalg_vector_norm %arg0, %ord, %dim, %keepdim, %dtype : !torch.vtensor<[3,4],f32>, !torch.float, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[3,1],f32>
   return %0 : !torch.vtensor<[3,1],f32>
+}
+
+// -----
+
+// softplus(x, beta, threshold) uses the numerically stable inner arm
+//   (max(z, 0) + log1p(exp(-|z|))) / beta,  z = x * beta
+// rather than the naive log1p(exp(z)) / beta (which overflows to +inf in fp32
+// once z exceeds ~88). Only ever exponentiating -|z| <= 0 avoids that; the
+// threshold select is kept so the op still honors its `threshold` argument.
+// CHECK-LABEL: func.func @torch.aten.softplus(
+// CHECK-SAME:      %[[X:.*]]: !torch.vtensor<[3,4],f32>
+// CHECK:         %[[Z:.*]] = torch.aten.mul.Scalar %[[X]], %{{.*}}
+// CHECK:         %[[ABS:.*]] = torch.aten.abs %[[Z]]
+// CHECK:         %[[NEG:.*]] = torch.aten.neg %[[ABS]]
+// CHECK:         %[[EXP:.*]] = torch.aten.exp %[[NEG]]
+// CHECK:         %[[LOG1P:.*]] = torch.aten.log1p %[[EXP]]
+// CHECK:         %[[RELU:.*]] = torch.aten.relu %[[Z]]
+// CHECK:         %[[SUM:.*]] = torch.aten.add.Tensor %[[RELU]], %[[LOG1P]]
+// CHECK:         %[[OUT:.*]] = torch.aten.div.Scalar %[[SUM]], %{{.*}}
+// CHECK:         %[[COND:.*]] = torch.aten.gt.Scalar %[[Z]], %{{.*}}
+// CHECK:         %[[RES:.*]] = torch.aten.where.self %[[COND]], %[[X]], %[[OUT]]
+// CHECK-NOT:     torch.aten.softplus
+// CHECK:         return %[[RES]]
+func.func @torch.aten.softplus(%arg0: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32> {
+  %beta = torch.constant.int 1
+  %threshold = torch.constant.int 20
+  %0 = torch.aten.softplus %arg0, %beta, %threshold : !torch.vtensor<[3,4],f32>, !torch.int, !torch.int -> !torch.vtensor<[3,4],f32>
+  return %0 : !torch.vtensor<[3,4],f32>
 }


### PR DESCRIPTION
## Summary

Numerically stabilizes the `TorchOnnxToTorch` lowering of ONNX `Softplus`.

The conversion previously emitted the naive form `ln(exp(x) + 1)`, which overflows float32 to `+inf` once `x` exceeds ~88 (`exp(88) ≈ 1.65e38`, near the fp32 max `3.4e38`). A single overflowing activation poisons every downstream value with `+inf`, diverging from the numerically stable form used by ONNX Runtime and other importers.

This PR rewrites the lowering to the standard stable identity:

```
softplus(x) = ln(exp(x) + 1) = max(x, 0) + log1p(exp(-|x|))
```

which keeps the exponent's argument `<= 0`, so `exp(-|x|)` stays in `(0, 1]` and never overflows.

## Details: derivation of the identity

Let `m = max(x, 0)`. Factor `e^m` out of the sum inside the logarithm:

```
softplus(x) = ln(e^x + 1)
            = ln(e^x + e^0)
            = ln( e^m * (e^(x-m) + e^(-m)) )
            = m + ln( e^(x-m) + e^(-m) )
```

Because `m = max(x, 0)`, one of the two exponents `x-m`, `-m` is exactly `0` and the other is `<= 0`:

- if `x >= 0`, then `m = x`, so `x - m = 0` and `-m = -x = -|x|`;
- if `x <  0`, then `m = 0`, so `-m = 0` and `x - m = x = -|x|`.

In both cases `{e^(x-m), e^(-m)} = {1, e^(-|x|)}`, so the sum is `1 + e^(-|x|)` and

```
softplus(x) = m + ln(1 + e^(-|x|)) = max(x, 0) + log1p(exp(-|x|)).
```

`log1p` is used rather than `log(1 + x)` for accuracy when `e^(-|x|)` is small (i.e. large `|x|`).

**Why this is stable.** The only exponentiation is of `-|x| <= 0`, so `exp(-|x|) in (0, 1]` and `1 + exp(-|x|) in (1, 2]` — both always finite in float32 regardless of the magnitude of `x`. The unbounded term `max(x, 0)` only ever appears as a plain add, never inside an exponential, so it cannot overflow. The naive form, by contrast, exponentiates `x` directly and overflows once `x` exceeds ~88 in float32.

## Changes

- **`DefaultDomainQtoZ.cpp`** — the ONNX `Softplus` binder now emits `relu(x) + log1p(exp(-|x|))` (using `relu(x) = max(x, 0)`) instead of `log1p(exp(x))`.
- **`simple_ops_q_to_z.mlir`** — FileCheck coverage updated to match the new op sequence (`abs → neg → exp → log1p → relu → add`).

## Testing

Verified manually:

- **lit / FileCheck**: `test/Conversion/TorchOnnxToTorch/simple_ops_q_to_z.mlir` passes.
- Matches `torch.nn.functional.softplus` exactly (max abs diff `0.0` over `x` in `[-50, 200]`, including `x = 109` where the naive form returns `inf`), and lowers cleanly to linalg and TOSA.
