### PR TITLE
[TorchToLinalg] Use the end pad for the avg_pool window-end clamp

### DIFF
--- a/lib/Conversion/TorchToLinalg/Pooling.cpp
+++ b/lib/Conversion/TorchToLinalg/Pooling.cpp
@@ -1017,12 +1017,19 @@ Value PoolSizeCalculator<NumOfDims>::getPoolSize(
     Value ODim = castIndexToInt64(b, location, IndexODim);
     Value DDim = b.createOrFold<arith::ConstantOp>(
         location, b.getI64IntegerAttr(strideInts[i]));
-    Value PadDim = b.createOrFold<arith::ConstantOp>(
+    Value PadBeginDim = b.createOrFold<arith::ConstantOp>(
         location, b.getI64IntegerAttr(paddingInts[i]));
+    // Asymmetric padding is encoded as [begin..., end...].
+    int64_t padEndInt = (int64_t)paddingInts.size() == 2 * NumOfDims
+                            ? paddingInts[i + NumOfDims]
+                            : paddingInts[i];
+    Value PadEndDim = b.createOrFold<arith::ConstantOp>(
+        location, b.getI64IntegerAttr(padEndInt));
     Value DilDim = b.createOrFold<arith::ConstantOp>(
         location, b.getI64IntegerAttr(dilationInts[i]));
     Value ODimDDim = b.createOrFold<arith::MulIOp>(location, ODim, DDim);
-    Value IDim0 = b.createOrFold<arith::SubIOp>(location, ODimDDim, PadDim);
+    Value IDim0 =
+        b.createOrFold<arith::SubIOp>(location, ODimDDim, PadBeginDim);
     Value IDim = castIndexToInt64(b, location, InputSpatialDimSizes[i]);
 
     // Effective window end: IDim0 + (kernel - 1) * dilation + 1
@@ -1034,9 +1041,10 @@ Value PoolSizeCalculator<NumOfDims>::getPoolSize(
         b.createOrFold<arith::AddIOp>(location, KernelM1Dil, cstOne);
     Value IDim0KDim =
         b.createOrFold<arith::AddIOp>(location, IDim0, EffectiveKernel);
-    Value IDimPadDim = b.createOrFold<arith::AddIOp>(location, IDim, PadDim);
+    Value IDimPadEndDim =
+        b.createOrFold<arith::AddIOp>(location, IDim, PadEndDim);
     Value IDim1 =
-        b.createOrFold<arith::MinSIOp>(location, IDim0KDim, IDimPadDim);
+        b.createOrFold<arith::MinSIOp>(location, IDim0KDim, IDimPadEndDim);
 
     Value IDim1Clamped = b.createOrFold<arith::MinSIOp>(location, IDim1, IDim);
 

--- a/test/Conversion/TorchToLinalg/pooling.mlir
+++ b/test/Conversion/TorchToLinalg/pooling.mlir
@@ -393,3 +393,50 @@ func.func @forward_avgpool_2d_exclude_pad_dilated_edge(%arg0: !torch.vtensor<[1,
   %3 = torch.aten.avg_pool2d %arg0, %0, %2, %1, %false, %false_1, %none : !torch.vtensor<[1,1,11,11],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[1,1,1,1],f32>
   return %3 : !torch.vtensor<[1,1,1,1],f32>
 }
+
+// -----
+
+// All four padding entries differ, so confusing begin with end, or height with
+// width, cannot pass. effective_kernel = (3-1)*2+1 = 5, so the output is
+// floor((6+1+2-5)/2)+1 = 3 by floor((6+0+1-5)/2)+1 = 2. Height pads begin 1,
+// end 2: its trailing window spans [3, 8) with taps at 3, 5 and 7, so
+// count_include_pad divides by 3; the old clamp to 6+1 kept 2. Width pads
+// begin 0, end 1 and clamps to 7.
+// CHECK-LABEL: func @forward_avgpool_2d_count_include_pad_asymmetric
+// CHECK: linalg.pooling_nchw_sum {dilations = dense<2> : vector<2xi64>, strides = dense<2> : vector<2xi64>}
+// CHECK: linalg.generic
+// Height: the start subtracts the begin pad, the limit adds the end pad.
+// CHECK: linalg.index 2
+// CHECK: %[[H_BEGIN:.*]] = arith.constant 1 : i64
+// CHECK: %[[H_STRIDED:.*]] = arith.muli
+// CHECK: %[[H_START:.*]] = arith.subi %[[H_STRIDED]], %[[H_BEGIN]] : i64
+// CHECK: %[[H_KERNEL:.*]] = arith.constant 5 : i64
+// CHECK: %[[H_END:.*]] = arith.addi %[[H_START]], %[[H_KERNEL]] : i64
+// CHECK: %[[H_LIMIT:.*]] = arith.constant 8 : i64
+// CHECK: arith.minsi %[[H_END]], %[[H_LIMIT]] : i64
+// Width: a begin pad of 0 folds out of the start, and the limit is 6 + 1.
+// CHECK: linalg.index 3
+// CHECK: %[[W_STRIDED:.*]] = arith.muli
+// CHECK: %[[W_KERNEL:.*]] = arith.constant 5 : i64
+// CHECK: %[[W_END:.*]] = arith.addi %[[W_STRIDED]], %[[W_KERNEL]] : i64
+// CHECK: %[[W_LIMIT:.*]] = arith.constant 7 : i64
+// CHECK: arith.minsi %[[W_END]], %[[W_LIMIT]] : i64
+// CHECK: arith.divf
+// CHECK: linalg.yield
+func.func @forward_avgpool_2d_count_include_pad_asymmetric(%arg0: !torch.vtensor<[1,1,6,6],f32>) -> !torch.vtensor<[1,1,3,2],f32> {
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %kernel = torch.prim.ListConstruct %int3, %int3 : (!torch.int, !torch.int) -> !torch.list<int>
+  // padding = [begin_h, begin_w, end_h, end_w]
+  %padding = torch.prim.ListConstruct %int1, %int0, %int2, %int1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  // avg_pool has no dilation operand; an over-long stride list carries it as
+  // [stride_h, stride_w, dilation_h, dilation_w].
+  %stride = torch.prim.ListConstruct %int2, %int2, %int2, %int2 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %false = torch.constant.bool false
+  %true = torch.constant.bool true
+  %none = torch.constant.none
+  %0 = torch.aten.avg_pool2d %arg0, %kernel, %stride, %padding, %false, %true, %none : !torch.vtensor<[1,1,6,6],f32>, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[1,1,3,2],f32>
+  return %0 : !torch.vtensor<[1,1,3,2],f32>
+}


### PR DESCRIPTION
`PoolSizeCalculator::getPoolSize` used `paddingInts[i]` for both the window start and the window-end clamp.

For asymmetric padding, the ONNX AveragePool importer encodes padding as `[begin..., end...]`. The window start should use the begin pad, but the upper bound of the padded input should use the end pad. Using the begin pad for both causes the divisor for `count_include_pad=true` to be too small in trailing windows.

For example, with kernel 3, dilation 2, stride 2, padding `[1,0,2,1]`, and a 6x6 input, the trailing height window has taps at 3, 5, and 7. The end padding extends the valid padded range far enough to include all three taps, so the divisor should be 3. Using the begin padding for the upper bound instead produces a divisor of 2.

`padInputTensor` and `computeOutputTensor` already distinguish begin and end padding. This change makes `getPoolSize` use the same convention.

Symmetric padding is unchanged, since the begin and end padding are equal. `count_include_pad=false` is also unaffected because the divisor is clamped to the input extent.

This case was not previously covered because asymmetric padding took the regular-divisor path. The dilation handling added in #4671 routes it through the clamped-divisor path and exposes the bug.

Assisted by: Claude