### PR TITLE
[TorchToStablehlo] Add lowering for AtenPolarOp

### DIFF
--- a/lib/Conversion/TorchToStablehlo/Basic.cpp
+++ b/lib/Conversion/TorchToStablehlo/Basic.cpp
@@ -1058,6 +1058,56 @@ LogicalResult ConvertAtenOp<AtenReluOp>::matchAndRewrite(
   return success();
 }
 
+// AtenPolarOp
+// Polar(abs, angle) = abs * cos(angle) + abs * sin(angle) * j
+template <>
+LogicalResult ConvertAtenOp<AtenPolarOp>::matchAndRewrite(
+    AtenPolarOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  Location loc = op.getLoc();
+
+  Value abs = adaptor.getAbs();
+  Value angle = adaptor.getAngle();
+  auto absTy = dyn_cast<RankedTensorType>(abs.getType());
+  auto angleTy = dyn_cast<RankedTensorType>(angle.getType());
+  if (!absTy || !angleTy)
+    return op.emitError("only ranked tensor type is supported in polar op");
+
+  auto outType =
+      cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
+  auto complexTy = dyn_cast<mlir::ComplexType>(outType.getElementType());
+  if (!complexTy)
+    return op.emitError("expected polar to produce a complex tensor");
+
+  // stablehlo.complex only takes f32/f64 operands, which lines up with
+  // aten.polar requiring abs and angle to be float or double.
+  Type elemTy = complexTy.getElementType();
+  if (!elemTy.isF32() && !elemTy.isF64())
+    return op.emitError("only complex<f32> and complex<f64> results are "
+                        "supported in polar op");
+
+  // aten.polar's shape function is unary(abs), so abs, angle and the result
+  // all share a shape. Multiplying with chlo.broadcast_multiply instead would
+  // emit a shape.assuming + stablehlo.dynamic_broadcast_in_dim pair that the
+  // stablehlo-to-linalg conversion leaves behind, failing bufferization.
+  if (absTy.getShape() != outType.getShape() ||
+      angleTy.getShape() != outType.getShape())
+    return op.emitError(
+        "expected abs, angle and the result to have the same shape");
+
+  abs = hlo::promoteType(rewriter, loc, abs, elemTy);
+  angle = hlo::promoteType(rewriter, loc, angle, elemTy);
+
+  auto partTy = RankedTensorType::get(outType.getShape(), elemTy);
+  Value cos = stablehlo::CosineOp::create(rewriter, loc, partTy, angle);
+  Value sin = stablehlo::SineOp::create(rewriter, loc, partTy, angle);
+  Value real = stablehlo::MulOp::create(rewriter, loc, partTy, abs, cos);
+  Value imag = stablehlo::MulOp::create(rewriter, loc, partTy, abs, sin);
+
+  rewriter.replaceOpWithNewOp<stablehlo::ComplexOp>(op, outType, real, imag);
+  return success();
+}
+
 // Convert a Aten::GELU to HLO
 // Gelu(x, "none") = x * 0.5 * (1 + erf(x/(sqrt(2))))
 // Gelu(x, "tanh") = x * 0.5 * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
@@ -2472,6 +2522,7 @@ void mlir::torch::torch_to_stablehlo::populateBasicOpPatternsAndLegality(
   INSERT_ATENOP_PATTERN(AtenReflectionPad1dOp);
 
   INSERT_ATENOP_PATTERN(AtenReluOp);
+  INSERT_ATENOP_PATTERN(AtenPolarOp);
   INSERT_ATENOP_PATTERN(AtenGeluOp);
   INSERT_ATENOP_PATTERN(AtenLog2Op);
   INSERT_ATENOP_PATTERN(AtenLog10Op);

--- a/projects/pt1/e2e_testing/xfail_sets.py
+++ b/projects/pt1/e2e_testing/xfail_sets.py
@@ -539,8 +539,6 @@ FX_IMPORTER_STABLEHLO_XFAIL_SET = {
     "AtenKthvalueFloat64Module_basic",
     "AtenKthvalueKeepDimModule_basic",
     "AtenKthvalueModule_basic",
-    "AtenPolarDoubleModule_basic",
-    "AtenPolarFloatModule_basic",
     "DiagonalWithStaticShapeModule_basic",
     "EinsumStaticDiagonalDimensionModule_basic",
     # StableHLO does not support non-default embedding forward flags.
@@ -1047,6 +1045,8 @@ STABLEHLO_PASS_SET = {
     "AtenMmFloatTypes_basic",
     "AtenMmIntTypes_basic",
     "AtenIntMM_basic",
+    "AtenPolarDoubleModule_basic",
+    "AtenPolarFloatModule_basic",
     "AtenRoundFloatHalfToEvenModule_basic",
     "AtenRoundFloatModule_basic",
     "AtenRoundIntModule_basic",

--- a/test/Conversion/TorchToStablehlo/elementwise.mlir
+++ b/test/Conversion/TorchToStablehlo/elementwise.mlir
@@ -640,3 +640,50 @@ func.func @torch.aten.abs(%arg0: !torch.vtensor<[15,15],si64>) -> !torch.vtensor
   %0 = torch.aten.abs %arg0 : !torch.vtensor<[15,15],si64> -> !torch.vtensor<[15,15],si64>
   return %0 : !torch.vtensor<[15,15],si64>
 }
+
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.polar$f32(
+// CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[3,4],f32>,
+// CHECK-SAME:         %[[ARG1:.*]]: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],complex<f32>> {
+// CHECK:         %[[ANGLE:.*]] = torch_c.to_builtin_tensor %[[ARG1]] : !torch.vtensor<[3,4],f32> -> tensor<3x4xf32>
+// CHECK:         %[[ABS:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[3,4],f32> -> tensor<3x4xf32>
+// CHECK:         %[[COS:.*]] = stablehlo.cosine %[[ANGLE]] : tensor<3x4xf32>
+// CHECK:         %[[SIN:.*]] = stablehlo.sine %[[ANGLE]] : tensor<3x4xf32>
+// CHECK:         %[[RE:.*]] = stablehlo.multiply %[[ABS]], %[[COS]] : tensor<3x4xf32>
+// CHECK:         %[[IM:.*]] = stablehlo.multiply %[[ABS]], %[[SIN]] : tensor<3x4xf32>
+// CHECK:         %[[OUT:.*]] = stablehlo.complex %[[RE]], %[[IM]] : tensor<3x4xcomplex<f32>>
+// CHECK:         %[[RES:.*]] = torch_c.from_builtin_tensor %[[OUT]] : tensor<3x4xcomplex<f32>> -> !torch.vtensor<[3,4],complex<f32>>
+// CHECK:         return %[[RES]] : !torch.vtensor<[3,4],complex<f32>>
+func.func @torch.aten.polar$f32(%arg0: !torch.vtensor<[3,4],f32>, %arg1: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],complex<f32>> {
+  %0 = torch.aten.polar %arg0, %arg1 : !torch.vtensor<[3,4],f32>, !torch.vtensor<[3,4],f32> -> !torch.vtensor<[3,4],complex<f32>>
+  return %0 : !torch.vtensor<[3,4],complex<f32>>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.polar$f64(
+// CHECK:         %[[COS:.*]] = stablehlo.cosine %{{.*}} : tensor<2xf64>
+// CHECK:         %[[SIN:.*]] = stablehlo.sine %{{.*}} : tensor<2xf64>
+// CHECK:         %[[RE:.*]] = stablehlo.multiply %{{.*}}, %[[COS]] : tensor<2xf64>
+// CHECK:         %[[IM:.*]] = stablehlo.multiply %{{.*}}, %[[SIN]] : tensor<2xf64>
+// CHECK:         stablehlo.complex %[[RE]], %[[IM]] : tensor<2xcomplex<f64>>
+func.func @torch.aten.polar$f64(%arg0: !torch.vtensor<[2],f64>, %arg1: !torch.vtensor<[2],f64>) -> !torch.vtensor<[2],complex<f64>> {
+  %0 = torch.aten.polar %arg0, %arg1 : !torch.vtensor<[2],f64>, !torch.vtensor<[2],f64> -> !torch.vtensor<[2],complex<f64>>
+  return %0 : !torch.vtensor<[2],complex<f64>>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.polar$dynamic(
+// CHECK:         %[[COS:.*]] = stablehlo.cosine %{{.*}} : tensor<?x?xf32>
+// CHECK:         %[[SIN:.*]] = stablehlo.sine %{{.*}} : tensor<?x?xf32>
+// COM: No shape.assuming / dynamic_broadcast_in_dim: the shapes already match.
+// CHECK-NOT:     chlo.broadcast_multiply
+// CHECK:         %[[RE:.*]] = stablehlo.multiply %{{.*}}, %[[COS]] : tensor<?x?xf32>
+// CHECK:         %[[IM:.*]] = stablehlo.multiply %{{.*}}, %[[SIN]] : tensor<?x?xf32>
+// CHECK:         stablehlo.complex %[[RE]], %[[IM]] : tensor<?x?xcomplex<f32>>
+func.func @torch.aten.polar$dynamic(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],complex<f32>> {
+  %0 = torch.aten.polar %arg0, %arg1 : !torch.vtensor<[?,?],f32>, !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],complex<f32>>
+  return %0 : !torch.vtensor<[?,?],complex<f32>>
+}


### PR DESCRIPTION
## Description 
  - Adds a `TorchToStablehlo` conversion pattern for `aten.polar`, which builds a
    complex tensor from polar coordinates (`out = abs*cos(angle) + abs*sin(angle)*j`).
  - Lowers to `stablehlo.cosine` / `stablehlo.sine`, two `stablehlo.multiply`, and
    `stablehlo.complex`.
  - `stablehlo.complex` takes `f32`/`f64` operands only, matching `aten.polar`'s
    requirement that `abs` and `angle` be float or double.